### PR TITLE
Ignore changes to codeStyles and stray files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,13 +103,15 @@ def allCommited = { ->
             commandLine 'git', 'status', '-s'
             standardOutput = stdout
         }
-        String commitObject = stdout.toString().trim()
-        stringBuilder.append(commitObject)
+        // ignore all changes done in .idea/codeStyles
+        String cleanedList = stdout.toString().replaceAll(/(?m)^\s*(M|A|D|\?\?)\s*.*?\.idea\/codeStyles\/.*?\s*$/, "")
+        // ignore all files added to project dir but not staged/known to GIT
+        cleanedList = cleanedList.replaceAll(/(?m)^\s*(\?\?)\s*.*?\s*$/, "")
+        stringBuilder.append(cleanedList.trim())
     } catch (ignored) {
         return false // NoGitSystemAvailable
     }
     return stringBuilder.toString().isEmpty()
-
 }
 
 tasks.matching { it instanceof Test }.all {


### PR DESCRIPTION
When app is built from master branch, gradle checks if repository is clean and does not have uncommitted changes.
Unfortunately, some versions of Android Studio auto-magically update files inside `.idea/codeStyle` preventing user from building stable versions of app.

To prevent that, function that check if all changes are commited is extended to **ignore**:
* all changes inside `.idea/codeStyle`
* all new files not yet added/known to GIT

while still not allowing changes/staged additions to other parts of the code, if built from master