### PR TITLE
[FIX] Make enginering mode enabled only when turned on

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelper.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelper.kt
@@ -25,7 +25,7 @@ class BuildHelper @Inject constructor(private val config: Config) {
         if (!config.APS) true else engineeringMode || !devBranch
 
     fun isEngineeringMode(): Boolean =
-        if (!config.APS) true else engineeringMode || !devBranch
+        engineeringMode
 
     fun isDev(): Boolean = devBranch
 }


### PR DESCRIPTION
Fixes #6, bug that made engineering mode enabled for all on non-development branch or not-full flavours
After fix isEngineeringMode() is back simple getter to private property that checked if engineering mode was enabled