### PR TITLE
fix for small displays that  cannot import settings due to scroll and…

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefs.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefs.kt
@@ -282,7 +282,7 @@ class ImportExportPrefs @Inject constructor(
         askToConfirmImport(activity, importFile) { password ->
 
             val format: PrefsFormat = when (importFile.handler) {
-                PrefsFormatsHandler.CLASSIC   -> classicPrefsFormat
+                PrefsFormatsHandler.CLASSIC -> classicPrefsFormat
                 PrefsFormatsHandler.ENCRYPTED -> encryptedPrefsFormat
             }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefs.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefs.kt
@@ -167,7 +167,7 @@ class ImportExportPrefs @Inject constructor(
         if (!prefsEncryptionIsDisabled() && !assureMasterPasswordSet(activity, R.string.nav_export)) return
 
         TwoMessagesAlertDialog.showAlert(activity, resourceHelper.gs(R.string.nav_export),
-            resourceHelper.gs(R.string.export_to) + " " + fileToExport + " ?",
+            resourceHelper.gs(R.string.export_to) + " " + fileToExport.name + " ?",
             resourceHelper.gs(R.string.password_preferences_encrypt_prompt), {
             askForMasterPassIfNeeded(activity, R.string.preferences_export_canceled, then)
         }, null, R.drawable.ic_header_export)
@@ -177,9 +177,8 @@ class ImportExportPrefs @Inject constructor(
 
         if (fileToImport.handler == PrefsFormatsHandler.ENCRYPTED) {
             if (!assureMasterPasswordSet(activity, R.string.nav_import)) return
-
             TwoMessagesAlertDialog.showAlert(activity, resourceHelper.gs(R.string.nav_import),
-                resourceHelper.gs(R.string.import_from) + " " + fileToImport.file + " ?",
+                resourceHelper.gs(R.string.import_from) + " " + fileToImport.name + " ?",
                 resourceHelper.gs(R.string.password_preferences_decrypt_prompt), {
                 askForMasterPass(activity, R.string.preferences_import_canceled, then)
             }, null, R.drawable.ic_header_import)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
@@ -47,6 +47,7 @@ data class PrefsFile(
 class PrefsFileContract : ActivityResultContract<Void, PrefsFile>() {
 
     companion object {
+
         const val OUTPUT_PARAM = "prefs_file"
     }
 
@@ -75,6 +76,7 @@ class PrefFileListProvider @Inject constructor(
 ) {
 
     companion object {
+
         private val path = File(Environment.getExternalStorageDirectory().toString())
         private val aapsPath = File(path, "AAPS" + File.separator + "preferences")
         private const val IMPORT_AGE_NOT_YET_OLD_DAYS = 60
@@ -97,7 +99,7 @@ class PrefFileListProvider @Inject constructor(
             val detectedOld = !detectedNew && classicPrefsFormat.isPreferencesFile(it, contents)
             if (detectedNew || detectedOld) {
                 val formatHandler = if (detectedNew) PrefsFormatsHandler.ENCRYPTED else PrefsFormatsHandler.CLASSIC
-                prefFiles.add(PrefsFile(it.name , it, path, PrefsImportDir.ROOT_DIR, formatHandler, metadataFor(loadMetadata, formatHandler, contents)))
+                prefFiles.add(PrefsFile(it.name, it, path, PrefsImportDir.ROOT_DIR, formatHandler, metadataFor(loadMetadata, formatHandler, contents)))
             }
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
@@ -34,6 +34,7 @@ enum class PrefsImportDir {
 
 @Parcelize
 data class PrefsFile(
+    val name: String,
     val file: File,
     val baseDir: File,
     val dirKind: PrefsImportDir,
@@ -96,7 +97,7 @@ class PrefFileListProvider @Inject constructor(
             val detectedOld = !detectedNew && classicPrefsFormat.isPreferencesFile(it, contents)
             if (detectedNew || detectedOld) {
                 val formatHandler = if (detectedNew) PrefsFormatsHandler.ENCRYPTED else PrefsFormatsHandler.CLASSIC
-                prefFiles.add(PrefsFile(it, path, PrefsImportDir.ROOT_DIR, formatHandler, metadataFor(loadMetadata, formatHandler, contents)))
+                prefFiles.add(PrefsFile(it.name , it, path, PrefsImportDir.ROOT_DIR, formatHandler, metadataFor(loadMetadata, formatHandler, contents)))
             }
         }
 
@@ -104,7 +105,7 @@ class PrefFileListProvider @Inject constructor(
         aapsPath.walk().filter { it.isFile && it.name.endsWith(".json") }.forEach {
             val contents = storage.getFileContents(it)
             if (encryptedPrefsFormat.isPreferencesFile(it, contents)) {
-                prefFiles.add(PrefsFile(it, aapsPath, PrefsImportDir.AAPS_DIR, PrefsFormatsHandler.ENCRYPTED, metadataFor(loadMetadata, PrefsFormatsHandler.ENCRYPTED, contents)))
+                prefFiles.add(PrefsFile(it.name, it, aapsPath, PrefsImportDir.AAPS_DIR, PrefsFormatsHandler.ENCRYPTED, metadataFor(loadMetadata, PrefsFormatsHandler.ENCRYPTED, contents)))
             }
         }
 

--- a/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/PrefImportSummaryDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/PrefImportSummaryDialog.kt
@@ -66,7 +66,7 @@ object PrefImportSummaryDialog {
                 rowLayout.setOnClickListener {
                     val msg = "[${context.getString(metaKey.label)}] ${metaEntry.info}"
                     when (metaEntry.status) {
-                        PrefsStatus.WARN  -> ToastUtils.Long.warnToast(context, msg)
+                        PrefsStatus.WARN -> ToastUtils.Long.warnToast(context, msg)
                         PrefsStatus.ERROR -> ToastUtils.Long.errorToast(context, msg)
                         else              -> ToastUtils.Long.infoToast(context, msg)
                     }
@@ -132,6 +132,9 @@ object PrefImportSummaryDialog {
         }
 
         val dialog = builder.show()
+        val textView = dialog.findViewById<View>(android.R.id.message) as TextView?
+        textView!!.textSize = 12f
+        textView!!.setPadding(10,0,0,0)
         dialog.setCanceledOnTouchOutside(false)
     }
 

--- a/app/src/main/res/layout/dialog_alert_import_summary.xml
+++ b/app/src/main/res/layout/dialog_alert_import_summary.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/dialog_alert_import_summary.xml
+++ b/app/src/main/res/layout/dialog_alert_import_summary.xml
@@ -7,9 +7,7 @@
     <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_content_frame"
         android:layout_width="match_parent"
-        android:layout_height="210dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-d
+        android:layout_height="210dp">
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -29,7 +27,7 @@ d
                 style="?android:attr/buttonStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="bottom|center_horizontal"
+                android:layout_gravity="center_horizontal"
                 android:gravity="bottom"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"

--- a/app/src/main/res/layout/dialog_alert_import_summary.xml
+++ b/app/src/main/res/layout/dialog_alert_import_summary.xml
@@ -2,15 +2,15 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_content_frame"
         android:layout_width="match_parent"
-        android:layout_height="150dp"
+        android:layout_height="210dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <RelativeLayout
+d
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
@@ -29,7 +29,8 @@
                 style="?android:attr/buttonStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
+                android:layout_gravity="bottom|center_horizontal"
+                android:gravity="bottom"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
                 android:layout_marginEnd="10dp"
@@ -38,7 +39,7 @@
                 android:textColor="@color/colorTreatmentButton"
                 android:visibility="gone" />
 
-        </RelativeLayout>
+        </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/layout/dialog_alert_import_summary.xml
+++ b/app/src/main/res/layout/dialog_alert_import_summary.xml
@@ -1,30 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="10dp">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TableLayout
-        android:id="@+id/summary_table"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
-        android:stretchColumns="2" />
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="150dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <Button
-        android:id="@+id/summary_details_btn"
-        style="?android:attr/buttonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginLeft="10dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginBottom="3dp"
-        android:text="@string/check_preferences_details_btn"
-        android:textColor="@color/colorTreatmentButton"
-        android:visibility="gone" />
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:paddingBottom="10dp">
 
-</LinearLayout>
+            <TableLayout
+                android:id="@+id/summary_table"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:stretchColumns="2" />
+
+            <Button
+                android:id="@+id/summary_details_btn"
+                style="?android:attr/buttonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:layout_marginBottom="3dp"
+                android:text="@string/check_preferences_details_btn"
+                android:textColor="@color/colorTreatmentButton"
+                android:visibility="gone" />
+
+        </RelativeLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_alert_import_summary.xml
+++ b/app/src/main/res/layout/dialog_alert_import_summary.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll_content_frame"

--- a/app/src/main/res/layout/dialog_alert_two_messages.xml
+++ b/app/src/main/res/layout/dialog_alert_two_messages.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="20dp">
+    android:padding="10dp">
 
     <TextView
         android:id="@+id/password_prompt_title"

--- a/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/AlertDialogHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/AlertDialogHelper.kt
@@ -25,6 +25,7 @@ object AlertDialogHelper {
         val titleLayout = LayoutInflater.from(ContextThemeWrapper(context, themeResId)).inflate(layoutResource, null)
         (titleLayout.findViewById<View>(R.id.alertdialog_title) as TextView).text = title
         (titleLayout.findViewById<View>(R.id.alertdialog_icon) as ImageView).setImageResource(iconResource)
+        titleLayout.findViewById<View>(R.id.alertdialog_title).setSelected(true)
         return titleLayout
     }
 

--- a/core/src/main/res/layout/dialog_alert_custom.xml
+++ b/core/src/main/res/layout/dialog_alert_custom.xml
@@ -28,7 +28,7 @@
             android:layout_centerInParent="true"
             android:layout_gravity="center"
             android:layout_marginStart="2dp"
-            android:layout_marginEnd="50dp"
+            android:layout_marginEnd="40dp"
             android:layout_toEndOf="@id/alertdialog_icon"
             android:ellipsize="marquee"
             android:focusable="true"

--- a/core/src/main/res/layout/dialog_alert_custom.xml
+++ b/core/src/main/res/layout/dialog_alert_custom.xml
@@ -32,6 +32,12 @@
             android:layout_marginEnd="50dp"
             android:layout_toEndOf="@id/alertdialog_icon"
             android:textAlignment="center"
+            android:singleLine="true"
+            android:ellipsize="marquee"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:scrollHorizontally="true"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:textColor="?dialogTitleColor" />
 

--- a/core/src/main/res/layout/dialog_alert_custom.xml
+++ b/core/src/main/res/layout/dialog_alert_custom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   Loading this view directly, without proper Theme, will likely result in crash due to lack of ?dialog... attribute definitions
   Please use AlertDialogHelper or wrap inflater context with ContextThemeWrapper(context, R.style.AppTheme)
 -->
@@ -31,13 +30,13 @@
             android:layout_marginStart="2dp"
             android:layout_marginEnd="50dp"
             android:layout_toEndOf="@id/alertdialog_icon"
-            android:textAlignment="center"
-            android:singleLine="true"
             android:ellipsize="marquee"
-            android:marqueeRepeatLimit="marquee_forever"
-            android:scrollHorizontally="true"
             android:focusable="true"
             android:focusableInTouchMode="true"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:scrollHorizontally="true"
+            android:singleLine="true"
+            android:textAlignment="center"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:textColor="?dialogTitleColor" />
 


### PR DESCRIPTION
… display too large texts problem like Jelley

fix the problem with following changes:

- add marquee element to alert dialog header . marquee scrolling will be activated automatic if text is too large
- only show import filename, not the path. To show the filepath is not necessary for a normal user
- add nested scroll behaviour for import summary.
- minor padding and marging changes

due too future gui enhancements nested scroll with coordinator layout is used insted of linear layout with normal scroll element