### PR TITLE
Fixes import of legacy preferences

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/formats/ClassicPrefsFormat.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/formats/ClassicPrefsFormat.kt
@@ -22,7 +22,7 @@ class ClassicPrefsFormat @Inject constructor(
 
     override fun isPreferencesFile(file: File, preloadedContents: String?): Boolean {
         val contents = preloadedContents ?: storage.getFileContents(file)
-        return contents.contains("units::" + Constants.MGDL) || contents.contains("units::" + Constants.MMOL)
+        return contents.contains("units::" + Constants.MGDL) || contents.contains("units::" + Constants.MMOL) || contents.contains("language::") || contents.contains("I_understand::")
     }
 
     override fun savePreferences(file: File, prefs: Prefs, masterPassword: String?) {


### PR DESCRIPTION
Fixes bug that prevent some kind of old preference files from being imported.

During listing files to import, lister checks if file contents contains `units::mg/dl` or `units::mmol` keys.
It happen that some valid preference files does not contain those key(s) - preventing them from being recognized as valid export file of old format.

By fix two new keys are added `language::` used when user configures app language and `I_understand::` which is persisted when user accepts Terms & Conditions - both existing since 2017 and should be present in valid `AndroidAPSPreferences` export family of files, but not in other random files with `Preferences` in file name