### PR TITLE
Validate durationStep from tbrSettings in Pumptype when setting TBR v…

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -31,6 +31,7 @@ import info.nightscout.androidaps.plugins.general.smsCommunicator.events.EventSm
 import info.nightscout.androidaps.plugins.general.smsCommunicator.otp.OneTimePassword
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
+import info.nightscout.androidaps.plugins.pump.common.defs.PumpType
 import info.nightscout.androidaps.plugins.treatments.TreatmentsPlugin
 import info.nightscout.androidaps.queue.Callback
 import info.nightscout.androidaps.utils.*
@@ -578,12 +579,13 @@ class SmsCommunicatorPlugin @Inject constructor(
             })
         } else if (splitted[1].endsWith("%")) {
             var tempBasalPct = SafeParse.stringToInt(StringUtils.removeEnd(splitted[1], "%"))
+            var durationStep = activePlugin.activePump.model().tbrSettings.durationStep
             var duration = 30
             if (splitted.size > 2) duration = SafeParse.stringToInt(splitted[2])
             val profile = profileFunction.getProfile()
             if (profile == null) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.noprofile)))
             else if (tempBasalPct == 0 && splitted[1] != "0%") sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
-            else if (duration == 0) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
+            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, String.format(resourceHelper.gs(R.string.wrongTbrDuration), durationStep)))
             else {
                 tempBasalPct = constraintChecker.applyBasalPercentConstraints(Constraint(tempBasalPct), profile).value()
                 val passCode = generatePasscode()
@@ -610,12 +612,13 @@ class SmsCommunicatorPlugin @Inject constructor(
             }
         } else {
             var tempBasal = SafeParse.stringToDouble(splitted[1])
+            var durationStep = activePlugin.activePump.model().tbrSettings.durationStep
             var duration = 30
             if (splitted.size > 2) duration = SafeParse.stringToInt(splitted[2])
             val profile = profileFunction.getProfile()
             if (profile == null) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.noprofile)))
             else if (tempBasal == 0.0 && splitted[1] != "0") sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
-            else if (duration == 0) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
+            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, String.format(resourceHelper.gs(R.string.wrongTbrDuration), durationStep)))
             else {
                 tempBasal = constraintChecker.applyBasalConstraints(Constraint(tempBasal), profile).value()
                 val passCode = generatePasscode()

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -31,7 +31,6 @@ import info.nightscout.androidaps.plugins.general.smsCommunicator.events.EventSm
 import info.nightscout.androidaps.plugins.general.smsCommunicator.otp.OneTimePassword
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
-import info.nightscout.androidaps.plugins.pump.common.defs.PumpType
 import info.nightscout.androidaps.plugins.treatments.TreatmentsPlugin
 import info.nightscout.androidaps.queue.Callback
 import info.nightscout.androidaps.utils.*

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -585,7 +585,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             val profile = profileFunction.getProfile()
             if (profile == null) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.noprofile)))
             else if (tempBasalPct == 0 && splitted[1] != "0%") sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
-            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, String.format(resourceHelper.gs(R.string.wrongTbrDuration), durationStep)))
+            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongTbrDuration, durationStep)))
             else {
                 tempBasalPct = constraintChecker.applyBasalPercentConstraints(Constraint(tempBasalPct), profile).value()
                 val passCode = generatePasscode()
@@ -618,7 +618,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             val profile = profileFunction.getProfile()
             if (profile == null) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.noprofile)))
             else if (tempBasal == 0.0 && splitted[1] != "0") sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongformat)))
-            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, String.format(resourceHelper.gs(R.string.wrongTbrDuration), durationStep)))
+            else if (duration <= 0 || duration % durationStep != 0) sendSMS(Sms(receivedSms.phoneNumber, resourceHelper.gs(R.string.wrongTbrDuration, durationStep)))
             else {
                 tempBasal = constraintChecker.applyBasalConstraints(Constraint(tempBasal), profile).value()
                 val passCode = generatePasscode()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1176,7 +1176,7 @@
     <string name="storage">internal storage constraint</string>
     <string name="diskfull">Free at least %1$d MB from internal storage! Loop disabled!</string>
     <string name="wrongformat">Wrong format</string>
-    <string name="wrongTbrDuration">TBR duration must a multiple of %1$d minutes and greater than 0.</string>
+    <string name="wrongTbrDuration">TBR duration must be a multiple of %1$d minutes and greater than 0.</string>
     <string name="sms_wrongcode">Wrong code. Command cancelled.</string>
     <string name="notconfigured">Not configured</string>
     <string name="profileswitchcreated">Profile switch created</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1176,6 +1176,7 @@
     <string name="storage">internal storage constraint</string>
     <string name="diskfull">Free at least %1$d MB from internal storage! Loop disabled!</string>
     <string name="wrongformat">Wrong format</string>
+    <string name="wrongTbrDuration">TBR duration must a multiple of %1$d minutes and greater than 0.</string>
     <string name="sms_wrongcode">Wrong code. Command cancelled.</string>
     <string name="notconfigured">Not configured</string>
     <string name="profileswitchcreated">Profile switch created</string>

--- a/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
@@ -38,6 +38,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
@@ -188,7 +190,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisdisabled)).thenReturn("Loop is disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisenabled)).thenReturn("Loop is enabled")
         `when`(resourceHelper.gs(R.string.wrongformat)).thenReturn("Wrong format")
-        `when`(resourceHelper.gs(R.string.wrongTbrDuration)).thenReturn("TBR duration must a multiple of %1\$d minutes and greater than 0.")
+        `when`(resourceHelper.gs(eq(R.string.wrongTbrDuration), any())).thenAnswer({ i: InvocationOnMock -> "TBR duration must a multiple of " + i.getArguments()[1] + " minutes and greater than 0."})
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeendisabled)).thenReturn("Loop has been disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeenenabled)).thenReturn("Loop has been enabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_tempbasalcanceled)).thenReturn("Temp basal canceled")

--- a/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
@@ -190,7 +190,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisdisabled)).thenReturn("Loop is disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisenabled)).thenReturn("Loop is enabled")
         `when`(resourceHelper.gs(R.string.wrongformat)).thenReturn("Wrong format")
-        `when`(resourceHelper.gs(eq(R.string.wrongTbrDuration), any())).thenAnswer({ i: InvocationOnMock -> "TBR duration must a multiple of " + i.getArguments()[1] + " minutes and greater than 0."})
+        `when`(resourceHelper.gs(eq(R.string.wrongTbrDuration), any())).thenAnswer({ i: InvocationOnMock -> "TBR duration must be a multiple of " + i.getArguments()[1] + " minutes and greater than 0."})
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeendisabled)).thenReturn("Loop has been disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeenenabled)).thenReturn("Loop has been enabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_tempbasalcanceled)).thenReturn("Temp basal canceled")
@@ -782,14 +782,14 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 10% 0")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 10% 0", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        Assert.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
 
         //BASAL 20% 20
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 20% 20")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 20% 20", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        Assert.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
         `when`(constraintChecker.applyBasalPercentConstraints(anyObject(), anyObject())).thenReturn(Constraint<Int>(20))
 
         //BASAL 20% 30
@@ -815,7 +815,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 1 0")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 1 0", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        Assert.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
         `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint<Double>(1.0))
 
         //BASAL 1 20
@@ -823,7 +823,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 1 20")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 1 20", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        Assert.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
         `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint<Double>(1.0))
 
         //BASAL 1 30

--- a/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
@@ -23,6 +23,7 @@ import info.nightscout.androidaps.plugins.iob.iobCobCalculator.CobInfo
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
 import info.nightscout.androidaps.plugins.profile.local.LocalProfilePlugin
+import info.nightscout.androidaps.plugins.pump.common.defs.PumpType
 import info.nightscout.androidaps.plugins.pump.virtual.VirtualPumpPlugin
 import info.nightscout.androidaps.plugins.treatments.TreatmentService
 import info.nightscout.androidaps.queue.Callback
@@ -160,6 +161,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         `when`(virtualPumpPlugin.shortStatus(ArgumentMatchers.anyBoolean())).thenReturn("Virtual Pump")
         `when`(virtualPumpPlugin.isSuspended).thenReturn(false)
         `when`(virtualPumpPlugin.pumpDescription).thenReturn(PumpDescription())
+        `when`(virtualPumpPlugin.model()).thenReturn(PumpType.GenericAAPS);
 
         `when`(treatmentsPlugin.lastCalculationTreatments).thenReturn(IobTotal(0))
         `when`(treatmentsPlugin.lastCalculationTempBasals).thenReturn(IobTotal(0))
@@ -186,6 +188,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisdisabled)).thenReturn("Loop is disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loopisenabled)).thenReturn("Loop is enabled")
         `when`(resourceHelper.gs(R.string.wrongformat)).thenReturn("Wrong format")
+        `when`(resourceHelper.gs(R.string.wrongTbrDuration)).thenReturn("TBR duration must a multiple of %1\$d minutes and greater than 0.")
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeendisabled)).thenReturn("Loop has been disabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_loophasbeenenabled)).thenReturn("Loop has been enabled")
         `when`(resourceHelper.gs(R.string.smscommunicator_tempbasalcanceled)).thenReturn("Temp basal canceled")
@@ -777,19 +780,26 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 10% 0")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 10% 0", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
-        `when`(constraintChecker.applyBasalPercentConstraints(anyObject(), anyObject())).thenReturn(Constraint<Int>(20))
+        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
 
         //BASAL 20% 20
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 20% 20")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 20% 20", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 20% for 20 min reply with code"))
+        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        `when`(constraintChecker.applyBasalPercentConstraints(anyObject(), anyObject())).thenReturn(Constraint<Int>(20))
+
+        //BASAL 20% 30
+        smsCommunicatorPlugin.messages = ArrayList()
+        sms = Sms("1234", "BASAL 20% 30")
+        smsCommunicatorPlugin.processSms(sms)
+        Assert.assertEquals("BASAL 20% 30", smsCommunicatorPlugin.messages[0].text)
+        Assert.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 20% for 30 min reply with code"))
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
         Assert.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assert.assertEquals("Temp basal 20% for 20 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
+        Assert.assertEquals("Temp basal 20% for 30 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
 
         //BASAL a
         smsCommunicatorPlugin.messages = ArrayList()
@@ -803,7 +813,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 1 0")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 1 0", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
         `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint<Double>(1.0))
 
         //BASAL 1 20
@@ -811,11 +821,19 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         sms = Sms("1234", "BASAL 1 20")
         smsCommunicatorPlugin.processSms(sms)
         Assert.assertEquals("BASAL 1 20", smsCommunicatorPlugin.messages[0].text)
-        Assert.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 1.00U/h for 20 min reply with code"))
+        Assert.assertEquals("TBR duration must a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint<Double>(1.0))
+
+        //BASAL 1 30
+        smsCommunicatorPlugin.messages = ArrayList()
+        sms = Sms("1234", "BASAL 1 30")
+        smsCommunicatorPlugin.processSms(sms)
+        Assert.assertEquals("BASAL 1 30", smsCommunicatorPlugin.messages[0].text)
+        Assert.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 1.00U/h for 30 min reply with code"))
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
         Assert.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assert.assertEquals("Temp basal 1.00U/h for 20 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
+        Assert.assertEquals("Temp basal 1.00U/h for 30 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
     }
 
     @Test fun processExtendedTest() {


### PR DESCRIPTION
This fixes Issue nightscout/AndroidAPS#38 in the following way:

TBR Durations sent via SMS that are not multiples of `activePlugin.activePump.model().tbrSettings.durationStep` or less than or equal to 0 cause the treatment to fail. Response message is:

"TBR duration must a multiple of %1$d minutes and greater than 0."