### PR TITLE
Sms communicator config fixes

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -1004,7 +1004,7 @@ class SmsCommunicatorPlugin @Inject constructor(
 
     private fun areMoreNumbers(allowednumbers: String?): Boolean {
         return allowednumbers?.let {
-            var countNumbers = 0
+            val knownNumbers = HashSet<String>()
             val substrings = it.split(";").toTypedArray()
             for (number in substrings) {
                 var cleaned = number.replace(Regex("\\s+"), "")
@@ -1012,9 +1012,9 @@ class SmsCommunicatorPlugin @Inject constructor(
                 cleaned = cleaned.replace("+", "")
                 cleaned = cleaned.replace("-", "")
                 if (!cleaned.matches(Regex("[0-9]+"))) continue
-                countNumbers++
+                knownNumbers.add(cleaned)
             }
-            countNumbers > 1
+            knownNumbers.size > 1
         } ?: false
     }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/activities/SmsCommunicatorOtpActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/activities/SmsCommunicatorOtpActivity.kt
@@ -1,5 +1,8 @@
 package info.nightscout.androidaps.plugins.general.smsCommunicator.activities
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Color
 import android.os.Bundle
@@ -16,8 +19,8 @@ import info.nightscout.androidaps.plugins.general.smsCommunicator.SmsCommunicato
 import info.nightscout.androidaps.plugins.general.smsCommunicator.otp.OneTimePassword
 import info.nightscout.androidaps.plugins.general.smsCommunicator.otp.OneTimePasswordValidationResult
 import info.nightscout.androidaps.utils.FabricPrivacy
-import info.nightscout.androidaps.utils.alertDialogs.OKDialog
 import info.nightscout.androidaps.utils.ToastUtils
+import info.nightscout.androidaps.utils.alertDialogs.OKDialog
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import kotlinx.android.synthetic.main.activity_smscommunicator_otp.*
 import net.glxn.qrgen.android.QRCode
@@ -66,8 +69,22 @@ class SmsCommunicatorOtpActivity : NoSplashAppCompatActivity() {
                 Runnable {
                     otp.ensureKey(true)
                     updateGui()
-                    ToastUtils.showToastInUiThread(this, R.string.smscommunicator_otp_reset_successful)
+                    ToastUtils.Long.infoToast(this, resourceHelper.gs(R.string.smscommunicator_otp_reset_successful))
                 })
+        }
+
+        smscommunicator_otp_provisioning.setOnLongClickListener {
+            OKDialog.showConfirmation(this,
+                resourceHelper.gs(R.string.smscommunicator_otp_export_title),
+                resourceHelper.gs(R.string.smscommunicator_otp_export_prompt),
+                Runnable {
+                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    val clip = ClipData.newPlainText("OTP Secret", otp.provisioningSecret())
+                    clipboard.primaryClip = clip
+                    ToastUtils.Long.infoToast(this, resourceHelper.gs(R.string.smscommunicator_otp_export_successful))
+                })
+
+            true
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/activities/SmsCommunicatorOtpActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/activities/SmsCommunicatorOtpActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
+import android.view.WindowManager
 import com.google.common.primitives.Ints.min
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import info.nightscout.androidaps.R
@@ -31,6 +32,7 @@ class SmsCommunicatorOtpActivity : NoSplashAppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.activity_smscommunicator_otp)
 
         smscommunicator_otp_verify_edit.addTextChangedListener(object : TextWatcher {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/otp/OneTimePassword.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/otp/OneTimePassword.kt
@@ -121,4 +121,10 @@ class OneTimePassword @Inject constructor(
     fun provisioningURI(): String? =
         key?.let { "otpauth://totp/AndroidAPS:" + URLEncoder.encode(name(), "utf-8").replace("+", "%20") + "?secret=" + BaseEncoding.base32().encode(it.encoded).replace("=", "") + "&issuer=AndroidAPS" }
 
+    /**
+     * Return secret used to provision Authenticator apps, in Base32 format
+     */
+    fun provisioningSecret(): String? =
+        key?.let { BaseEncoding.base32().encode(it.encoded).replace("=", "") }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1376,6 +1376,10 @@
     <string name="smscommunicator_otp_reset_prompt">Are you sure to reset Authenticator key? It will render all currently configured Authenticators invalid, and you will need to set them up again.</string>
     <string name="smscommunicator_otp_reset_successful">New Authenticator Key was generated! Please use updated QRCode to provision authenticators.</string>
 
+    <string name="smscommunicator_otp_export_title">Exporting OTP secret</string>
+    <string name="smscommunicator_otp_export_prompt">Are you sure you want to copy OTP secret to clipboard?\n\nYou may only need that if your authenticator app have issues scanning QRCode, you want to enter it manually or you want to configure hardware OTP token using dedicated app.</string>
+    <string name="smscommunicator_otp_export_successful">OTP secret (in Base32 format) exported and copied into clipboard. Paste it into authenticator or hardware OTP burner!</string>
+
     <string name="smscommunicator_otp_step1_install_header">1. Install Authenticator</string>
     <string name="smscommunicator_otp_step2_provisioning_header">2. Scan code to setup AndroidAPS OTP codes</string>
     <string name="smscommunicator_otp_step3_test_header">3. Test One-Time-Password</string>

--- a/core/src/main/java/info/nightscout/androidaps/utils/textValidator/validators/MultiPhoneValidator.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/textValidator/validators/MultiPhoneValidator.kt
@@ -7,9 +7,13 @@ class MultiPhoneValidator(val _customErrorMessage: String?) : Validator(_customE
 
     override fun isValid(editText: EditText): Boolean {
         val substrings = editText.text.split(";").toTypedArray()
+        val knownNumbers = HashSet<String>()
         for (number in substrings) {
             if (!PatternValidator(_customErrorMessage, Patterns.PHONE).isValid(number))
                 return false
+            if (knownNumbers.contains(number))
+                return false
+            knownNumbers.add(number)
         }
         return substrings.isNotEmpty()
     }


### PR DESCRIPTION
Fixes related to SMS communicator security:

* Prevent duplicated numbers in SMS communicator
  - before fix it was possible to enter same number twice which was detected as two numbers,
  - after fix: field validator prevents duplicates and function to check if there are > 1 numbers only count unique numbers

<img src="https://user-images.githubusercontent.com/5094588/96958992-49110400-14ff-11eb-85fd-70584e046780.JPG" height="100">


* Prevent taking screenshot of SMS comunicator OTP configuration QRCode 
  - flags OTP configuration dialog as secure, which make Android protect it agains screenshot grabers, preventing sharing QRCode by accident and making malware or social attacks harder

* Allow exporting OTP secret when user long-press on QRCode
  - helpful when someone need provision Authenticator manually, with secret, instead scanning QRCode
  - used to provision programmable TOTP hardware tokens

<img src="https://user-images.githubusercontent.com/5094588/96959122-92f9ea00-14ff-11eb-80f7-417795c397dd.JPG" width="200"> <img src="https://user-images.githubusercontent.com/5094588/96959127-955c4400-14ff-11eb-80a3-6c0a60adbb0c.JPG" width="200">


