### PR TITLE
Add 'pregnant' age option to allow for higher insulin requirements during pregnancy

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSAMA/OpenAPSAMAPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSAMA/OpenAPSAMAPlugin.java
@@ -189,9 +189,9 @@ public class OpenAPSAMAPlugin extends PluginBase implements APSInterface {
         }
 
 
-        if (!hardLimits.checkOnlyHardLimits(profile.getDia(), "dia", hardLimits.getMINDIA(), hardLimits.getMAXDIA()))
+        if (!hardLimits.checkOnlyHardLimits(profile.getDia(), "dia", hardLimits.minDia(), hardLimits.maxDia()))
             return;
-        if (!hardLimits.checkOnlyHardLimits(profile.getIcTimeFromMidnight(Profile.secondsFromMidnight()), "carbratio", hardLimits.getMINIC(), hardLimits.getMAXIC()))
+        if (!hardLimits.checkOnlyHardLimits(profile.getIcTimeFromMidnight(Profile.secondsFromMidnight()), "carbratio", hardLimits.minIC(), hardLimits.maxIC()))
             return;
         if (!hardLimits.checkOnlyHardLimits(profile.getIsfMgdl(), "sens", hardLimits.getMINISF(), hardLimits.getMAXISF()))
             return;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.java
@@ -220,9 +220,9 @@ public class OpenAPSSMBPlugin extends PluginBase implements APSInterface, Constr
         }
 
 
-        if (!hardLimits.checkOnlyHardLimits(profile.getDia(), "dia", hardLimits.getMINDIA(), hardLimits.getMAXDIA()))
+        if (!hardLimits.checkOnlyHardLimits(profile.getDia(), "dia", hardLimits.minDia(), hardLimits.maxDia()))
             return;
-        if (!hardLimits.checkOnlyHardLimits(profile.getIcTimeFromMidnight(Profile.secondsFromMidnight()), "carbratio", hardLimits.getMINIC(), hardLimits.getMAXIC()))
+        if (!hardLimits.checkOnlyHardLimits(profile.getIcTimeFromMidnight(Profile.secondsFromMidnight()), "carbratio", hardLimits.minIC(), hardLimits.maxIC()))
             return;
         if (!hardLimits.checkOnlyHardLimits(profile.getIsfMgdl(), "sens", hardLimits.getMINISF(), hardLimits.getMAXISF()))
             return;

--- a/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
@@ -106,9 +106,9 @@ class LocalProfileFragment : DaggerFragment() {
         localprofile_name.removeTextChangedListener(textWatch)
         localprofile_name.setText(currentProfile.name)
         localprofile_name.addTextChangedListener(textWatch)
-        localprofile_dia.setParams(currentProfile.dia, hardLimits.MINDIA, hardLimits.MAXDIA, 0.1, DecimalFormat("0.0"), false, localprofile_save, textWatch)
+        localprofile_dia.setParams(currentProfile.dia, hardLimits.minDia(), hardLimits.maxDia(), 0.1, DecimalFormat("0.0"), false, localprofile_save, textWatch)
         localprofile_dia.tag = "LP_DIA"
-        TimeListEdit(context, aapsLogger, dateUtil, view, R.id.localprofile_ic, "IC", resourceHelper.gs(R.string.ic_label), currentProfile.ic, null, hardLimits.MINIC, hardLimits.MAXIC, 0.1, DecimalFormat("0.0"), save)
+        TimeListEdit(context, aapsLogger, dateUtil, view, R.id.localprofile_ic, "IC", resourceHelper.gs(R.string.ic_label), currentProfile.ic, null, hardLimits.minIC(), hardLimits.maxIC(), 0.1, DecimalFormat("0.0"), save)
         basalView = TimeListEdit(context, aapsLogger, dateUtil, view, R.id.localprofile_basal, "BASAL", resourceHelper.gs(R.string.basal_label) + ": " + sumLabel(), currentProfile.basal, null, pumpDescription.basalMinimumRate, 10.0, 0.01, DecimalFormat("0.00"), save)
         if (units == Constants.MGDL) {
             TimeListEdit(context, aapsLogger, dateUtil, view, R.id.localprofile_isf, "ISF", resourceHelper.gs(R.string.isf_label), currentProfile.isf, null, hardLimits.MINISF, hardLimits.MAXISF, 1.0, DecimalFormat("0"), save)

--- a/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
@@ -24,8 +24,8 @@ class HardLimits @Inject constructor(
     val TEENAGE = 1
     val ADULT = 2
     val RESISTANTADULT = 3
-    val PREGNANT = 3
-    val MAXBOLUS = doubleArrayOf(5.0, 10.0, 17.0, 25.0)
+    val PREGNANT = 4
+    val MAXBOLUS = doubleArrayOf(5.0, 10.0, 17.0, 25.0, 30.0)
 
     // Very Hard Limits Ranges
     // First value is the Lowest and second value is the Highest a Limit can define
@@ -37,15 +37,15 @@ class HardLimits @Inject constructor(
     val VERY_HARD_LIMIT_TEMP_MIN_BG = intArrayOf(72, 180)
     val VERY_HARD_LIMIT_TEMP_MAX_BG = intArrayOf(72, 270)
     val VERY_HARD_LIMIT_TEMP_TARGET_BG = intArrayOf(72, 200)
-    val MINDIA = doubleArrayOf(5.0, 5.0, 5.0, 5.0)
-    val MAXDIA = doubleArrayOf(7.0, 7.0, 7.0, 10.0)
-    val MINIC = doubleArrayOf(2.0, 2.0, 2.0, 0.5)
+    val MINDIA = doubleArrayOf(5.0, 5.0, 5.0, 5.0, 5.0)
+    val MAXDIA = doubleArrayOf(7.0, 7.0, 7.0, 7.0, 10.0)
+    val MINIC = doubleArrayOf(2.0, 2.0, 2.0, 2.0, 0.5)
     val MAXIC = doubleArrayOf(100.0, 100.0, 100.0, 100.0)
     val MINISF = 2.0 // mgdl
     val MAXISF = 720.0 // mgdl
-    val MAXIOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0)
-    val MAXIOB_SMB = doubleArrayOf(3.0, 7.0, 12.0, 25.0)
-    val MAXBASAL = doubleArrayOf(2.0, 5.0, 10.0, 12.0)
+    val MAXIOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0, 15.0)
+    val MAXIOB_SMB = doubleArrayOf(3.0, 7.0, 12.0, 25.0, 30.0)
+    val MAXBASAL = doubleArrayOf(2.0, 5.0, 10.0, 12.0, 15.0)
 
     //LGS Hard limits
     //No IOB at all
@@ -58,7 +58,7 @@ class HardLimits @Inject constructor(
         else if (sp_age == resourceHelper.gs(R.string.key_teenage)) TEENAGE
         else if (sp_age == resourceHelper.gs(R.string.key_adult)) ADULT
         else if (sp_age == resourceHelper.gs(R.string.key_resistantadult)) RESISTANTADULT
-        else if (sp_age == resourceHelper.gs(R.string.key_resistantadult)) PREGNANT
+        else if (sp_age == resourceHelper.gs(R.string.key_pregnant)) PREGNANT
         else ADULT
         return age
     }

--- a/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
@@ -25,7 +25,7 @@ class HardLimits @Inject constructor(
     val ADULT = 2
     val RESISTANTADULT = 3
     val PREGNANT = 4
-    val MAXBOLUS = doubleArrayOf(5.0, 10.0, 17.0, 25.0, 30.0)
+    val MAXBOLUS = doubleArrayOf(5.0, 10.0, 17.0, 25.0, 60.0)
 
     // Very Hard Limits Ranges
     // First value is the Lowest and second value is the Highest a Limit can define
@@ -39,13 +39,13 @@ class HardLimits @Inject constructor(
     val VERY_HARD_LIMIT_TEMP_TARGET_BG = intArrayOf(72, 200)
     val MINDIA = doubleArrayOf(5.0, 5.0, 5.0, 5.0, 5.0)
     val MAXDIA = doubleArrayOf(7.0, 7.0, 7.0, 7.0, 10.0)
-    val MINIC = doubleArrayOf(2.0, 2.0, 2.0, 2.0, 0.5)
-    val MAXIC = doubleArrayOf(100.0, 100.0, 100.0, 100.0)
+    val MINIC = doubleArrayOf(2.0, 2.0, 2.0, 2.0, 0.3)
+    val MAXIC = doubleArrayOf(100.0, 100.0, 100.0, 100.0, 100.0)
     val MINISF = 2.0 // mgdl
     val MAXISF = 720.0 // mgdl
-    val MAXIOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0, 15.0)
-    val MAXIOB_SMB = doubleArrayOf(3.0, 7.0, 12.0, 25.0, 30.0)
-    val MAXBASAL = doubleArrayOf(2.0, 5.0, 10.0, 12.0, 15.0)
+    val MAXIOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0, 25.0)
+    val MAXIOB_SMB = doubleArrayOf(3.0, 7.0, 12.0, 25.0, 40.0)
+    val MAXBASAL = doubleArrayOf(2.0, 5.0, 10.0, 12.0, 25.0)
 
     //LGS Hard limits
     //No IOB at all

--- a/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
@@ -24,6 +24,7 @@ class HardLimits @Inject constructor(
     val TEENAGE = 1
     val ADULT = 2
     val RESISTANTADULT = 3
+    val PREGNANT = 3
     val MAXBOLUS = doubleArrayOf(5.0, 10.0, 17.0, 25.0)
 
     // Very Hard Limits Ranges
@@ -36,10 +37,10 @@ class HardLimits @Inject constructor(
     val VERY_HARD_LIMIT_TEMP_MIN_BG = intArrayOf(72, 180)
     val VERY_HARD_LIMIT_TEMP_MAX_BG = intArrayOf(72, 270)
     val VERY_HARD_LIMIT_TEMP_TARGET_BG = intArrayOf(72, 200)
-    val MINDIA = 5.0
-    val MAXDIA = 7.0
-    val MINIC = 2.0
-    val MAXIC = 100.0
+    val MINDIA = doubleArrayOf(5.0, 5.0, 5.0, 5.0)
+    val MAXDIA = doubleArrayOf(7.0, 7.0, 7.0, 10.0)
+    val MINIC = doubleArrayOf(2.0, 2.0, 2.0, 0.5)
+    val MAXIC = doubleArrayOf(100.0, 100.0, 100.0, 100.0)
     val MINISF = 2.0 // mgdl
     val MAXISF = 720.0 // mgdl
     val MAXIOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0)
@@ -57,6 +58,7 @@ class HardLimits @Inject constructor(
         else if (sp_age == resourceHelper.gs(R.string.key_teenage)) TEENAGE
         else if (sp_age == resourceHelper.gs(R.string.key_adult)) ADULT
         else if (sp_age == resourceHelper.gs(R.string.key_resistantadult)) RESISTANTADULT
+        else if (sp_age == resourceHelper.gs(R.string.key_resistantadult)) PREGNANT
         else ADULT
         return age
     }
@@ -75,6 +77,22 @@ class HardLimits @Inject constructor(
 
     fun maxBasal(): Double {
         return MAXBASAL[loadAge()]
+    }
+
+    fun minDia(): Double {
+        return MINDIA[loadAge()]
+    }
+
+    fun maxDia(): Double {
+        return MAXDIA[loadAge()]
+    }
+
+    fun minIC(): Double {
+        return MINIC[loadAge()]
+    }
+
+    fun maxIC(): Double {
+        return MAXIC[loadAge()]
     }
 
     // safety checks

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -77,12 +77,14 @@
         <item>@string/teenage</item>
         <item>@string/adult</item>
         <item>@string/resistantadult</item>
+        <item>@string/pregnant</item>
     </string-array>
     <string-array name="ageValues" translatable="false">
         <item>@string/key_child</item>
         <item>@string/key_teenage</item>
         <item>@string/key_adult</item>
         <item>@string/key_resistantadult</item>
+        <item>@string/key_pregnant</item>
     </string-array>
 
     <string-array name="quickWizardYesNo">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,11 +469,13 @@
     <string name="teenage">Teenage</string>
     <string name="adult">Adult</string>
     <string name="resistantadult">Insulin resistant adult</string>
+    <string name="pregnant">Pregnancy</string>
     <string name="key_age" translatable="false">age</string>
     <string name="key_child" translatable="false">child</string>
     <string name="key_teenage" translatable="false">teenage</string>
     <string name="key_adult" translatable="false">adult</string>
     <string name="key_resistantadult" translatable="false">resistantadult</string>
+    <string name="key_pregnant" translatable="false">pregnant</string>
     <string name="patientage_summary">Please select patient age to setup safety limits</string>
     <string name="patient_name">Patient name</string>
     <string name="patient_name_summary">Please provide patient name or nickname to differentiate among multiple setups</string>


### PR DESCRIPTION
Pregnancy results in increased insulin usage for carbs - this code allow for more flexible limits.

Max DIA has also been increased.  Not sure why but pregnancy seems (for us) to have resulted in insulin hanging around longer, maybe because large doses are taking a long time to absorb. Increasing DIA up to 10 hours has resulted in a reasonable approximation so I've added the option to make this maximum 'age' dependant.

IC is also now adjustable by 'age'. Carb rations in pregnancy are unreasonable for any other time so do not way to modify the global values.