### PR TITLE
BugFix - test that profile is valid before adding it in TreatmentsProfileSwitchFragment

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsProfileSwitchFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsProfileSwitchFragment.kt
@@ -145,8 +145,12 @@ class TreatmentsProfileSwitchFragment : DaggerFragment() {
                             OKDialog.showConfirmation(activity, resourceHelper.gs(R.string.careportal_profileswitch), resourceHelper.gs(R.string.copytolocalprofile) + "\n" + profileSwitch.customizedName + "\n" + dateUtil.dateAndTimeString(profileSwitch.date), Runnable {
                                 profileSwitch.profileObject?.let {
                                     val nonCustomized = it.convertToNonCustomizedProfile()
-                                    localProfilePlugin.addProfile(localProfilePlugin.copyFrom(nonCustomized, profileSwitch.customizedName + " " + dateUtil.dateAndTimeString(profileSwitch.date).replace(".", "_")))
-                                    rxBus.send(EventLocalProfileChanged())
+                                    if (nonCustomized.isValid(resourceHelper.gs(R.string.careportal_profileswitch, false))) {
+                                        localProfilePlugin.addProfile(localProfilePlugin.copyFrom(nonCustomized, profileSwitch.customizedName + " " + dateUtil.dateAndTimeString(profileSwitch.date).replace(".", "_")))
+                                        rxBus.send(EventLocalProfileChanged())
+                                    } else {
+                                        OKDialog.show(activity, resourceHelper.gs(R.string.careportal_profileswitch), resourceHelper.gs(R.string.copytolocalprofile_invalid))
+                                    }
                                 }
                             })
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1466,5 +1466,6 @@
     <string name="the_following_data_will_be_uploaded_to_your_open_humans_account">The following data will be uploaded to your Open Humans account: Glucose values, boluses, carbs, careportal events (except notes), extended boluses, profile switches, total daily doses, temporary basals, temp targets, preferences, application version, device model and screen dimensions. Secret or private information such as your Nightscout URL or API secret will not be uploaded.</string>
     <string name="setupwizard_pump_riley_link_status">RileyLink status:</string>
     <string name="filter">Filter</string>
+    <string name="copytolocalprofile_invalid">Unable to create local profile. Profile is invalid.</string>
 
 </resources>


### PR DESCRIPTION
Cloning a profile that is invalid causes a fatal exception

Appears as 'LocalProfilePlugin.kt line 213' in my Crashlytics