### PR TITLE
Delete Automation rule with button

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/AutomationFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/AutomationFragment.kt
@@ -192,6 +192,17 @@ class AutomationFragment : DaggerFragment(), OnStartDragListener {
                 }
                 v.onTouchEvent(motionEvent)
             }
+            // remove event
+            holder.iconTrash.setOnClickListener {
+                showConfirmation(requireContext(), resourceHelper.gs(R.string.removerecord) + " " + automationPlugin.automationEvents[position].title,
+                    Runnable {
+                        automationPlugin.automationEvents.removeAt(position)
+                        notifyItemRemoved(position)
+                        rxBus.send(EventAutomationDataChanged())
+                        rxBus.send(EventAutomationUpdateGui())
+                    }, Runnable { rxBus.send(EventAutomationUpdateGui())
+                })
+            }
         }
 
         override fun getItemCount(): Int = automationPlugin.automationEvents.size
@@ -219,6 +230,7 @@ class AutomationFragment : DaggerFragment(), OnStartDragListener {
             val rootLayout: RelativeLayout = view.findViewById(R.id.rootLayout)
             val iconLayout: LinearLayout = view.findViewById(R.id.iconLayout)
             val eventTitle: TextView = view.findViewById(R.id.viewEventTitle)
+            val iconTrash: ImageView = view.findViewById(R.id.iconTrash)
             val iconSort: ImageView = view.findViewById(R.id.iconSort)
             val enabled: CheckBox = view.findViewById(R.id.automation_enabled)
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/dragHelpers/SimpleItemTouchHelperCallback.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/automation/dragHelpers/SimpleItemTouchHelperCallback.kt
@@ -21,7 +21,7 @@ class SimpleItemTouchHelperCallback(private val mAdapter: ItemTouchHelperAdapter
     }
 
     override fun isItemViewSwipeEnabled(): Boolean {
-        return true
+        return false
     }
 
     override fun getMovementFlags(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder): Int { // Set movement flags based on the layout manager

--- a/app/src/main/res/layout/automation_event_item.xml
+++ b/app/src/main/res/layout/automation_event_item.xml
@@ -28,11 +28,22 @@
         android:layout_alignBottom="@+id/automation_enabled"
         android:layout_centerVertical="true"
         android:layout_marginTop="6dp"
-        android:layout_toStartOf="@+id/iconSort"
+        android:layout_toStartOf="@+id/iconTrash"
         android:layout_toEndOf="@id/automation_enabled"
         android:text="Title"
         android:textAlignment="viewStart"
         android:textStyle="bold" />
+
+    <ImageView
+        android:id="@+id/iconTrash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="20dp"
+        android:layout_toStartOf="@+id/iconSort"
+        android:contentDescription="@string/remove_label"
+        android:orientation="horizontal"
+        android:src="@drawable/ic_trash_outline" />
 
     <ImageView
         android:id="@+id/iconSort"


### PR DESCRIPTION
I propose to replace delete on swipe by delete by a button (I tested both solutions and I think button is really better than swipe)...

See "Swipe / Don't section" in https://material.io/design/interaction/gestures.html#types-of-gestures

> Don't
> Avoid situations where a single gesture might produce two different results.
> https://kstatic.googleusercontent.com/files/d2d7b6dce2efa234cb0b51a0576fb7cfef2a80b0cacc7bb6a23f10537924575a5a03aaed0f0ec143d91ae1c15c3a15fc7e0704ca0c7826fa231ded1e87aa09c0

Screenshot to see buttons size and spacing : 
![Screenshot_20201209-233532_AndroidAPS](https://user-images.githubusercontent.com/52934600/101697057-65e5a480-3a77-11eb-807b-3c42770ba7c0.jpg)
