### PR TITLE
Remove patch for sensor batery level in Action Tab / Careportal

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
@@ -46,7 +46,7 @@ class XdripPlugin @Inject constructor(
         bgReading.direction = bundle.getString(Intents.EXTRA_BG_SLOPE_NAME)
         bgReading.date = bundle.getLong(Intents.EXTRA_TIMESTAMP)
         bgReading.raw = bundle.getDouble(Intents.EXTRA_RAW)
-        //if (bundle.containsKey(Intents.EXTRA_SENSOR_BATTERY)) sensorBatteryLevel = bundle.getInt(Intents.EXTRA_SENSOR_BATTERY)
+        if (bundle.containsKey(Intents.EXTRA_SENSOR_BATTERY)) sensorBatteryLevel = bundle.getInt(Intents.EXTRA_SENSOR_BATTERY)
         val source = bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION, "no Source specified")
         setSource(source)
         MainApp.getDbHelper().createIfNotExists(bgReading, "XDRIP")


### PR DESCRIPTION
Now my PR in xDrip is merged (https://github.com/NightscoutFoundation/xDrip/pull/1471), so I propose to remove my patch that hide Sensor Battery Level information in Careportal zone of Action Tab:

This information is OK only with latest Nightly build 10th Dec 2020 of xDrip: https://github.com/NightscoutFoundation/xDrip/releases/tag/2020.12.10
Note: With previous version of xDrip, information shown here is phone battery level and not Sensor battery level

=> If Sensor Battery level is not available (according to sensor used) or is equal to zero in xDrip, this info is hidden in AAPS
=> Dedicated settings for threshold warning and critical are available in settings

![SensorBatLevel_AndroidAPS](https://user-images.githubusercontent.com/52934600/101835184-af97c300-3b3b-11eb-926f-0dadfb5bdb75.jpg)
