### PR TITLE
Move Ago below Arrow

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -582,10 +582,12 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 overview_delta_large?.text = Profile.toSignedUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units)
                 overview_delta_large?.setTextColor(color)
                 overview_delta?.text = Profile.toSignedUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units)
-                overview_avgdelta?.text = "${Profile.toSignedUnitsString(glucoseStatus.short_avgdelta, glucoseStatus.short_avgdelta * Constants.MGDL_TO_MMOLL, units)}\n${Profile.toSignedUnitsString(glucoseStatus.long_avgdelta, glucoseStatus.long_avgdelta * Constants.MGDL_TO_MMOLL, units)}"
+                overview_avgdelta?.text = "${Profile.toSignedUnitsString(glucoseStatus.short_avgdelta, glucoseStatus.short_avgdelta * Constants.MGDL_TO_MMOLL, units)}"
+                overview_long_avgdelta?.text = "${Profile.toSignedUnitsString(glucoseStatus.long_avgdelta, glucoseStatus.long_avgdelta * Constants.MGDL_TO_MMOLL, units)}"
             } else {
                 overview_delta?.text = "Δ " + resourceHelper.gs(R.string.notavailable)
                 overview_avgdelta?.text = ""
+                overview_long_avgdelta?.text = ""
             }
 
             // strike through if BG is old

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -612,16 +612,19 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 loopPlugin.isEnabled() && loopPlugin.isSuperBolus                       -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_superbolus)
                     overview_apsmode_text?.text = DateUtil.age(loopPlugin.minutesToEndOfSuspend() * 60000L, true, resourceHelper)
+                    overview_apsmode_text?.visibility = View.VISIBLE
                 }
 
                 loopPlugin.isDisconnected                                               -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_disconnected)
                     overview_apsmode_text?.text = DateUtil.age(loopPlugin.minutesToEndOfSuspend() * 60000L, true, resourceHelper)
+                    overview_apsmode_text?.visibility = View.VISIBLE
                 }
 
                 loopPlugin.isEnabled() && loopPlugin.isSuspended                        -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_paused)
                     overview_apsmode_text?.text = DateUtil.age(loopPlugin.minutesToEndOfSuspend() * 60000L, true, resourceHelper)
+                    overview_apsmode_text?.visibility = View.VISIBLE
                 }
 
                 pump.isSuspended                                                        -> {
@@ -632,27 +635,27 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                     } else {
                         R.drawable.ic_loop_paused
                     })
-                    overview_apsmode_text?.text = ""
+                    overview_apsmode_text?.visibility = View.GONE
                 }
 
                 loopPlugin.isEnabled() && closedLoopEnabled.value() && loopPlugin.isLGS -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_lgs)
-                    overview_apsmode_text?.text = ""
+                    overview_apsmode_text?.visibility = View.GONE
                 }
 
                 loopPlugin.isEnabled() && closedLoopEnabled.value()                     -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_closed)
-                    overview_apsmode_text?.text = ""
+                    overview_apsmode_text?.visibility = View.GONE
                 }
 
                 loopPlugin.isEnabled() && !closedLoopEnabled.value()                    -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_open)
-                    overview_apsmode_text?.text = ""
+                    overview_apsmode_text?.visibility = View.GONE
                 }
 
                 else                                                                    -> {
                     overview_apsmode?.setImageResource(R.drawable.ic_loop_disabled)
-                    overview_apsmode_text?.text = ""
+                    overview_apsmode_text?.visibility = View.GONE
                 }
             }
         } else {

--- a/app/src/main/res/layout/overview_info_layout.xml
+++ b/app/src/main/res/layout/overview_info_layout.xml
@@ -27,97 +27,122 @@
         android:textStyle="bold"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/overview_bg"
-        app:layout_constraintEnd_toStartOf="@+id/overview_arrow"
+        app:layout_constraintEnd_toStartOf="@+id/overview_arrows_llayout"
         app:layout_constraintStart_toEndOf="@+id/overview_bg"
         app:layout_constraintTop_toTopOf="@+id/overview_bg" />
 
 
-    <ImageView
-        android:id="@+id/overview_arrow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        app:layout_constraintEnd_toStartOf="@+id/overview_deltas_llayout"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/overview_delta_large"
-        app:layout_constraintTop_toTopOf="@+id/overview_delta_large"
-        android:paddingTop="18dp"
-        app:srcCompat="@drawable/ic_flat" />
-
     <LinearLayout
-        android:id="@+id/overview_deltas_llayout"
+        android:id="@+id/overview_arrows_llayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="@+id/overview_bg"
-        app:layout_constraintEnd_toStartOf="@+id/overview_apsmode_llayout"
-        app:layout_constraintStart_toEndOf="@+id/overview_arrow"
+        app:layout_constraintEnd_toStartOf="@+id/overview_deltas_llayout"
+        app:layout_constraintStart_toEndOf="@+id/overview_delta_large"
         app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/overview_arrow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:srcCompat="@drawable/ic_flat" />
 
         <TextView
             android:id="@+id/overview_timeago"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            app:layout_constraintTop_toTopOf="@+id/overview_long_avgdelta"
             android:text="n/a"
             android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-            <LinearLayout
+    </LinearLayout>
+
+    <TableLayout
+        android:id="@+id/overview_deltas_llayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toStartOf="@+id/overview_apsmode_llayout"
+        app:layout_constraintStart_toEndOf="@+id/overview_arrows_llayout"
+        app:layout_constraintBottom_toBottomOf="@+id/overview_arrows_llayout">
+
+        <TableRow
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="Δ: "
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
+            <TextView
+                android:id="@+id/overview_delta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="n/a"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end"
-                        android:textAlignment="textEnd"
-                        android:text="Δ: "
-                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        </TableRow>
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end"
-                        android:textAlignment="textEnd"
-                        android:text="15m Δ: \n40m Δ: "
-                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        <TableRow
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-                </LinearLayout>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="15m Δ: "
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
+            <TextView
+                android:id="@+id/overview_avgdelta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="n/a"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-                    <TextView
-                        android:id="@+id/overview_delta"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end"
-                        android:textAlignment="textEnd"
-                        android:text="n/a"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        </TableRow>
 
-                    <TextView
-                        android:id="@+id/overview_avgdelta"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end"
-                        android:textAlignment="textEnd"
-                        android:text="n/a"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+        <TableRow
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-                </LinearLayout>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="40m Δ: "
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-            </LinearLayout>
+            <TextView
+                android:id="@+id/overview_long_avgdelta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:textAlignment="textEnd"
+                android:text="n/a"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
-    </LinearLayout>
+        </TableRow>
+
+    </TableLayout>
 
     <LinearLayout
         android:id="@+id/overview_apsmode_llayout"


### PR DESCRIPTION
Move ago below arrow (and fix arrow position too low in latest dev)

Replace complex Linear layout by table layout for delta area (cleaner I think)
Split average delta (15min and 40min) in 2 textviews (I think 2 TextViews is cleaner than one TextView with CRLF)

![Screenshot_20201211-101727_AndroidAPS](https://user-images.githubusercontent.com/52934600/101886742-32506a80-3b9c-11eb-8524-9ace6a4a7534.jpg)