### PR TITLE
Fix typo in russian translations

### DIFF
--- a/core/src/main/res/values-ru-rRU/strings.xml
+++ b/core/src/main/res/values-ru-rRU/strings.xml
@@ -136,8 +136,8 @@
     <string name="careportal_announcement">Оповещение</string>
     <string name="careportal_note">Примечание</string>
     <string name="careportal_question">Вопрос</string>
-    <string name="careportal_exercise">Нгрузка</string>
-    <string name="careportal_pumpsitechange">Сена места катетера помпы</string>
+    <string name="careportal_exercise">Нагрузка</string>
+    <string name="careportal_pumpsitechange">Смена места катетера помпы</string>
     <string name="careportal_cgmsensorinsert">Установка сенсора мониторинга глюкозы</string>
     <string name="careportal_cgmsensorstart">Сарт сенсора</string>
     <string name="careportal_insulincartridgechange">Замена картриджа инсулина</string>


### PR DESCRIPTION
Hello, yes I know, that translations must be changed via CroudIn, but no one cares about my suggestions there.

Can we fix this embarrassing error just in normal way as all programmers over the world it normally do? Via Gtihub PR.

Thank you.

P.S. just to understand what the words are fixed if they would be in english: Lad => Load, Cange the place => Change the place. I think every one who will see it english will fix it without doubts. In the same matter these words look for me in russian.