### PR TITLE
Increase height of Compact Tab and Profile/TT row

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -225,7 +225,11 @@ class MainActivity : NoSplashAppCompatActivity() {
         if (sp.getBoolean(R.string.key_short_tabtitles, false)) {
             tabs_normal.visibility = View.GONE
             tabs_compact.visibility = View.VISIBLE
-            toolbar.layoutParams = LinearLayout.LayoutParams(Toolbar.LayoutParams.MATCH_PARENT, resources.getDimension(R.dimen.compact_height).toInt())
+            val typedValue = TypedValue()
+            if (theme.resolveAttribute(R.attr.actionBarSize, typedValue, true)) {
+                toolbar.layoutParams = LinearLayout.LayoutParams(Toolbar.LayoutParams.MATCH_PARENT,
+                    TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics))
+            }
             TabLayoutMediator(tabs_compact, main_pager) { tab, position ->
                 tab.text = (main_pager.adapter as TabPageAdapter).getPluginAt(position).nameShort
             }.attach()

--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -225,11 +225,7 @@ class MainActivity : NoSplashAppCompatActivity() {
         if (sp.getBoolean(R.string.key_short_tabtitles, false)) {
             tabs_normal.visibility = View.GONE
             tabs_compact.visibility = View.VISIBLE
-            val typedValue = TypedValue()
-            if (theme.resolveAttribute(R.attr.actionBarSize, typedValue, true)) {
-                toolbar.layoutParams = LinearLayout.LayoutParams(Toolbar.LayoutParams.MATCH_PARENT,
-                    TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics))
-            }
+            toolbar.layoutParams = LinearLayout.LayoutParams(Toolbar.LayoutParams.MATCH_PARENT, resources.getDimension(R.dimen.compact_height).toInt())
             TabLayoutMediator(tabs_compact, main_pager) { tab, position ->
                 tab.text = (main_pager.adapter as TabPageAdapter).getPluginAt(position).nameShort
             }.attach()

--- a/app/src/main/res/layout/overview_loop_pumpstatus_layout.xml
+++ b/app/src/main/res/layout/overview_loop_pumpstatus_layout.xml
@@ -19,8 +19,8 @@
             android:layout_marginEnd="5dp"
             android:layout_weight="1"
             android:gravity="center_vertical|center_horizontal"
-            android:paddingTop="3dp"
-            android:paddingBottom="3dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
             android:text="Profile"
             android:textAppearance="?android:attr/textAppearanceSmall" />
 
@@ -31,8 +31,8 @@
             android:layout_gravity="end"
             android:layout_weight="1"
             android:gravity="center_vertical|center_horizontal"
-            android:paddingTop="3dp"
-            android:paddingBottom="3dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
             android:text="TempTarget"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="@color/mdtp_white" />
@@ -53,8 +53,8 @@
             android:layout_marginLeft="5dp"
             android:layout_marginRight="5dp"
             android:gravity="center_vertical|center_horizontal"
-            android:paddingTop="3dp"
-            android:paddingBottom="3dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
             android:text="@string/initializing"
             android:textAppearance="?android:attr/textAppearanceSmall" />
 

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="compact_height">30dp</dimen>
+    <dimen name="compact_height">42dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
 </resources>


### PR DESCRIPTION
Some users have difficulties in Compact mode to select the 3 dots or hamburger menus due to height too small.
=> I propose to use same Height for Compact tabs than Standard tabs
=> I increased a little bit height of Profile / Target buttons for the same reason