### PR TITLE
Fix reservoir changes on MDT pumps being logged as cannula changes

### DIFF
--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.java
@@ -440,6 +440,20 @@ public class MedtronicHistoryData {
             }
         }
 
+        // Rewind (for marking insulin change)
+        List<PumpHistoryEntry> rewindRecords = getFilteredItems(PumpHistoryEntryType.Rewind);
+
+        aapsLogger.debug(LTag.PUMP, "ProcessHistoryData: Rewind [count={}, items={}]", rewindRecords.size(), gson().toJson(rewindRecords));
+
+        if (isCollectionNotEmpty(rewindRecords)) {
+            try {
+                processRewind(rewindRecords);
+            } catch (Exception ex) {
+                aapsLogger.error("ProcessHistoryData: Error processing Rewind entries: " + ex.getMessage(), ex);
+                throw ex;
+            }
+        }
+
         // TDD
         List<PumpHistoryEntry> tdds = getFilteredItems(PumpHistoryEntryType.EndResultTotals, getTDDType());
 
@@ -515,6 +529,14 @@ public class MedtronicHistoryData {
         long lastPrimeRecord = 0L;
 
         for (PumpHistoryEntry primeRecord : primeRecords) {
+            Object fixedAmount = primeRecord.getDecodedDataEntry("FixedAmount");
+
+            if (fixedAmount != null && ((float) fixedAmount) == 0.0f) {
+                // non-fixed primes are used to prime the tubing
+                // fixed primes are used to prime the cannula
+                // so skip the prime entry if it was not a fixed prime
+                continue;
+            }
 
             if (primeRecord.atechDateTime > maxAllowedTimeInPast) {
                 if (lastPrimeRecord < primeRecord.atechDateTime) {
@@ -530,6 +552,29 @@ public class MedtronicHistoryData {
                 uploadCareportalEvent(DateTimeUtil.toMillisFromATD(lastPrimeRecord), CareportalEvent.SITECHANGE);
 
                 sp.putLong(MedtronicConst.Statistics.LastPrime, lastPrimeRecord);
+            }
+        }
+    }
+
+    private void processRewind(List<PumpHistoryEntry> rewindRecords) {
+        long maxAllowedTimeInPast = DateTimeUtil.getATDWithAddedMinutes(new GregorianCalendar(), -30);
+        long lastRewindRecord = 0L;
+
+        for (PumpHistoryEntry rewindRecord : rewindRecords) {
+            if (rewindRecord.atechDateTime > maxAllowedTimeInPast) {
+                if (lastRewindRecord < rewindRecord.atechDateTime) {
+                    lastRewindRecord = rewindRecord.atechDateTime;
+                }
+            }
+        }
+
+        if (lastRewindRecord != 0L) {
+            long lastRewindFromAAPS = sp.getLong(MedtronicConst.Statistics.LastRewind, 0L);
+
+            if (lastRewindRecord != lastRewindFromAAPS) {
+                uploadCareportalEvent(DateTimeUtil.toMillisFromATD(lastRewindRecord), CareportalEvent.INSULINCHANGE);
+
+                sp.putLong(MedtronicConst.Statistics.LastRewind, lastRewindRecord);
             }
         }
     }

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/util/MedtronicConst.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/util/MedtronicConst.java
@@ -33,6 +33,7 @@ public class MedtronicConst {
         public static final String SMBBoluses = StatsPrefix + "smb_boluses_delivered";
         public static final String LastPumpHistoryEntry = StatsPrefix + "pump_history_entry";
         public static final String LastPrime = StatsPrefix + "last_sent_prime";
+        public static final String LastRewind = StatsPrefix + "last_sent_rewind";
     }
 
 }


### PR DESCRIPTION
When the cannula tubing is primed on Medtronic pumps (manual prime), the history entry that gets logged is the same type as a fixed-prime (for priming the cannula after it has been inserted) so any time the reservoir was replaced AAPS would log a site change which reset autosens unnecessarily and also led to Nightscout having an inaccurate amount of insulin/cannula changes (which affects [Nightscout Reporter](https://nightscout-reporter.zreptil.de/)'s information on the frequency of site changes).

This PR aims to fix that by checking the `FixedAmount` data entry of `Prime` history entries to detect whether the prime was a manual-prime (priming tubing) or fixed-prime (priming cannula) and skip logging a site change event if it is the former. In order to automatically log insulin reservoir replacements, this PR also adds a monitor for `Rewind` history entries which logs an `InsulinChange` event for them (similar to the priming monitor).