### PR TITLE
Change text size to see buttons on small screens

### DIFF
--- a/core/src/main/res/layout/dialog_error.xml
+++ b/core/src/main/res/layout/dialog_error.xml
@@ -48,7 +48,7 @@
         android:layout_gravity="center_horizontal"
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
     <Button
         android:id="@+id/mute_5min"


### PR DESCRIPTION
Depending on the length of the explanatory text, not all buttons can be seen on small displays (Jelly2, Atom). Some alarms can only be muted by restarting the programme.