### PR TITLE
Layout improvement

### DIFF
--- a/app/src/main/res/layout/automation_event_item.xml
+++ b/app/src/main/res/layout/automation_event_item.xml
@@ -65,6 +65,7 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/reorder_label"
         android:orientation="horizontal"
+        android:layout_marginEnd="8dp"
         app:layout_constraintBottom_toTopOf="@+id/iconLayout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/iconTrash"

--- a/app/src/main/res/layout/datetime.xml
+++ b/app/src/main/res/layout/datetime.xml
@@ -7,9 +7,10 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="center"
         android:width="120dp"
-        android:padding="10dp"
+        android:paddingLeft="10dp"
+        android:paddingRight="4dp"
         android:text="@string/event_time_label"
         android:textAppearance="@style/TextAppearance.AppCompat.Small"
         android:textStyle="bold" />
@@ -19,7 +20,7 @@
         android:id="@+id/overview_eventdate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="center"
         android:padding="10dp"
         android:text="2017/05/05" />
 
@@ -27,7 +28,7 @@
         android:id="@+id/overview_eventtime"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
+        android:layout_gravity="center"
         android:padding="10dp"
         android:text="08:20pm" />
 


### PR DESCRIPTION
datetime vertical center for languages with "long translations" (more than one line)
Add marging for sort icon of automation (icon currently too close to border)