### PR TITLE
Remove extra minus sign from Bolus Wizard timeshift result

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
@@ -300,7 +300,7 @@ class BolusWizard @Inject constructor(
             if (carbTime > 0) {
                 timeShift += " (+" + resourceHelper.gs(R.string.mins, carbTime) + ")"
             } else if (carbTime < 0) {
-                timeShift += " (-" + resourceHelper.gs(R.string.mins, carbTime) + ")"
+                timeShift += " (" + resourceHelper.gs(R.string.mins, carbTime) + ")"
             }
             actions.add(resourceHelper.gs(R.string.carbs) + ": " + resourceHelper.gs(R.string.format_carbs, carbs).formatColor(resourceHelper, R.color.carbs) + timeShift)
         }


### PR DESCRIPTION
When giving a time for carbs, the confirmation dialog adds a positive (`+`) or negative (`-`) sign in front of the number of carbs. Unfortunately this results in a double dash when giving a time in the past (a negative number already).

Entry dialog:
![Screenshot_20210104-162355](https://user-images.githubusercontent.com/1148665/103590441-1c884980-4eab-11eb-94f6-1cf7271b6327.png)

Before this change `(--10 min)`:
![Screenshot_20210104-162404](https://user-images.githubusercontent.com/1148665/103590459-27db7500-4eab-11eb-9251-ad89bc77c06b.png)

After this change `(-10 min)`:
![Screenshot_20210104-163422](https://user-images.githubusercontent.com/1148665/103590491-3aee4500-4eab-11eb-830b-ee6c74bb4c97.png)
