### PR TITLE
downgrade gradle and fix mixed localisation comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/menus/MainMenuActivity.java
@@ -39,8 +39,8 @@ public class MainMenuActivity extends MenuListActivity {
 
         if(!sharedPreferences.getBoolean("wearcontrol", false)){
             return new String[] {
-                    "Settings",
-                    "Re-Sync"};
+                    aaps.gs(R.string.menu_settings),
+                    aaps.gs(R.string.menu_resync)};
         }
 
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="menu_ecarb">eCarb</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_status">Status</string>
+    <string name="menu_resync">Re-Sync</string>
     <string name="menu_prime_fill">Prime/Fill</string>
     <string name="menu_none">None</string>
     <string name="menu_default">Default</string>


### PR DESCRIPTION
Fixes two issues:

**1) Downgrades gradle so that the wear apk gets bundled again with the main apk.**
Unfortunately google made it only simple to distribute the wear app via PlayStore. Sideloading to a watch needs to enable developer mode to push it via adb. (quite cumbersome on a watch). I hope we will be able to find a solution here so we can update gradle again.

**2) Strings were hardcoded in the menu but compared with localised versions**
Menus will now open again.