### PR TITLE
fix menu crash and make graph label translatable

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
@@ -88,7 +88,8 @@ class OverviewMenus @Inject constructor(
 
     fun setupChartMenu(chartButton: ImageButton) {
         loadGraphConfig()
-        val numOfGraphs = _setting.size // 1 main + x secondary
+        val settingsCopy = setting
+        val numOfGraphs = settingsCopy.size // 1 main + x secondary
 
         chartButton.setOnClickListener { v: View ->
             val predictionsAvailable: Boolean = when {
@@ -100,7 +101,7 @@ class OverviewMenus @Inject constructor(
 
             for (g in 0 until numOfGraphs) {
                 if (g != 0 && g < numOfGraphs) {
-                    val dividerItem = popup.menu.add(Menu.NONE, g, Menu.NONE, "------- " + "Graph" + " " + g + " -------")
+                    val dividerItem = popup.menu.add(Menu.NONE, g, Menu.NONE, "------- ${resourceHelper.gs(R.string.graph_menu_divider_header)} $g -------")
                     dividerItem.isCheckable = true
                     dividerItem.isChecked = true
                 }
@@ -117,12 +118,12 @@ class OverviewMenus @Inject constructor(
                         s.setSpan(ForegroundColorSpan(resourceHelper.gc(m.colorId)), 0, s.length, 0)
                         item.title = s
                         item.isCheckable = true
-                        item.isChecked = _setting[g][m.ordinal]
+                        item.isChecked = settingsCopy[g][m.ordinal]
                     }
                 }
             }
             if (numOfGraphs < MAX_GRAPHS) {
-                val dividerItem = popup.menu.add(Menu.NONE, numOfGraphs, Menu.NONE, "------- " + "Graph" + " " + numOfGraphs + " -------")
+                val dividerItem = popup.menu.add(Menu.NONE, numOfGraphs, Menu.NONE, "------- ${resourceHelper.gs(R.string.graph_menu_divider_header)} $numOfGraphs -------")
                 dividerItem.isCheckable = true
                 dividerItem.isChecked = false
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1429,5 +1429,6 @@
     <string name="time_to_eat">Time to eat!\nRun Bolus wizard and do calculation again.</string>
     <string name="timetoeat">Time to eat</string>
     <string name="fabric_upload_disabled">Crash logs upload disabled!</string>
+    <string name="graph_menu_divider_header">Graph</string>
 
 </resources>


### PR DESCRIPTION
fixes https://console.firebase.google.com/u/0/project/androidaps-c34f8/crashlytics/app/android:info.nightscout.androidaps/issues/15f66224e6110535cf0d7ff2bcfdf4b8?time=last-seven-days&versions=2.8.0%20(1500)&sessionEventKey=5FF763A702890001453E180FDE7159CC_1493795618502157073

Also makes the word "Graph" in the menu divider/header translatable