### PR TITLE
Cockpit watchface font size fix

### DIFF
--- a/wear/src/main/res/layout/rect_cockpit.xml
+++ b/wear/src/main/res/layout/rect_cockpit.xml
@@ -175,7 +175,7 @@
                                 android:layout_weight="1"
                                 android:text="---"
                                 android:textColor="@color/primary_text_dark"
-                                android:textSize="26sp" />
+                                android:textSize="30sp" />
 
                         </LinearLayout>
 

--- a/wear/src/main/res/layout/round_cockpit.xml
+++ b/wear/src/main/res/layout/round_cockpit.xml
@@ -175,7 +175,7 @@
                                 android:layout_weight="1"
                                 android:text="---"
                                 android:textColor="@color/primary_text_dark"
-                                android:textSize="34sp" />
+                                android:textSize="30sp" />
 
                         </LinearLayout>
 


### PR DESCRIPTION
Updated SVG text size in Cockpit following testing on a new watch model. Text size reduced slightly as it was too large to fit when glucose in mmol/L was higher than 10.