### PR TITLE
Add friendly relative date display

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
+++ b/core/src/main/java/info/nightscout/androidaps/utils/DateUtil.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import androidx.collection.LongSparseArray;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -167,6 +169,46 @@ public class DateUtil {
             format = "dd/MM";
         }
         return new DateTime(mills).toString(DateTimeFormat.forPattern(format));
+    }
+
+    public  String dateStringRelative(Date date) {
+        LocalDate lDate = LocalDate.fromDateFields(date);
+        LocalDate nowDate = LocalDate.now();
+        String friendlyDate = dateString(date);
+
+        Period diffPeriod = new Period(nowDate.toDateTimeAtStartOfDay(), lDate.toDateTimeAtStartOfDay());
+
+        //When more than a week out, display the date
+        if (diffPeriod.getYears()  != 0 || diffPeriod.getMonths() != 0 || diffPeriod.getWeeks() != 0) {
+            return friendlyDate;
+        }
+
+        switch (diffPeriod.getDays()) {
+            case 0:
+                friendlyDate = resourceHelper.gs(R.string.today);
+                break;
+            case 1:
+                friendlyDate = resourceHelper.gs(R.string.tomorrow);
+                break;
+            case -1:
+                friendlyDate = resourceHelper.gs(R.string.yesterday);
+                break;
+            default: {
+                // When plus or minus a week, but not today, tomorrow or yesterday, display "Next <DayName> or Last <DayName>"
+                SimpleDateFormat format = new SimpleDateFormat("EE",  Locale.getDefault());
+                String dayName = format.format(date);
+               // String modifier = diffPeriod.getDays() > 0 ? resourceHelper.gs(R.string.next) : resourceHelper.gs(R.string.last);
+               // friendlyDate = modifier + " " + dayName;
+                friendlyDate = diffPeriod.getDays() > 0 ? resourceHelper.gs(R.string.next,dayName) : resourceHelper.gs(R.string.last,dayName);
+            }
+        }
+
+        return friendlyDate;
+
+    }
+
+    public  String dateAndTimeStringRelative(Date date) {
+        return dateStringRelative(date) + " " + timeString(date);
     }
 
     public String timeString(Date date) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -137,6 +137,11 @@
     <string name="unit_weeks">weeks</string>
     <string name="shortminute">m</string>
     <string name="shortday">d</string>
+    <string name="yesterday">Yesterday</string>
+    <string name="today">Today</string>
+    <string name="tomorrow">Tomorrow</string>
+    <string name="next">Next %1$s</string>
+    <string name="last">Last %1$s</string>
 
     <!--    Protection-->
     <string name="wrongpassword">Wrong password</string>

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/ui/OmnipodOverviewFragment.kt
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/ui/OmnipodOverviewFragment.kt
@@ -261,7 +261,7 @@ class OmnipodOverviewFragment : DaggerFragment() {
                 omnipod_overview_pod_expiry_date.text = PLACEHOLDER
                 omnipod_overview_pod_expiry_date.setTextColor(Color.WHITE)
             } else {
-                omnipod_overview_pod_expiry_date.text = readableZonedTime(expiresAt)
+                omnipod_overview_pod_expiry_date.text = readableZonedTimeRelative(expiresAt)
                 omnipod_overview_pod_expiry_date.setTextColor(if (DateTime.now().isAfter(expiresAt)) {
                     Color.RED
                 } else {
@@ -540,6 +540,19 @@ class OmnipodOverviewFragment : DaggerFragment() {
                 OKDialog.show(it, title, message, null)
             }.run()
         }
+    }
+
+    private fun readableZonedTimeRelative(time: DateTime): String {
+        val timeAsJavaData = time.toLocalDateTime().toDate()
+        val timeZone = podStateManager.timeZone.toTimeZone()
+        if (timeZone == TimeZone.getDefault()) {
+            return dateUtil.dateAndTimeStringRelative(timeAsJavaData)
+        }
+
+        val isDaylightTime = timeZone.inDaylightTime(timeAsJavaData)
+        val locale = resources.configuration.locales.get(0)
+        val timeZoneDisplayName = timeZone.getDisplayName(isDaylightTime, TimeZone.SHORT, locale) + " " + timeZone.getDisplayName(isDaylightTime, TimeZone.LONG, locale)
+        return resourceHelper.gs(R.string.omnipod_time_with_timezone, dateUtil.dateAndTimeStringRelative(timeAsJavaData), timeZoneDisplayName)
     }
 
     private fun readableZonedTime(time: DateTime): String {


### PR DESCRIPTION
This PR adds a method to DateUtil.java that takes a date and returns a string.

If the date is more than 1 week before or after today, then it returns the original DateUtil.dateString(date)
If the date is today, tomorrow or yesterday then it returns "Today", "Tomorrow" or "Yesterday"
If the date is less than a week out, but not today, tomorrow or yesterday, then it returns "Next (Day Name)" or "Last (Day Name)" e.g.: Next Wednesday 

PR also includes a usage of this method in the Omnipod Overview tab as shown in the screenshot.


Issue: 
https://github.com/MilosKozak/AndroidAPS/issues/3005 


![Screenshot_20210119-173028_AndroidAPS](https://user-images.githubusercontent.com/28458904/105104435-42ebde80-5a80-11eb-966a-1e2aa4330008.png)
