### PR TITLE
CareDialog.kt: exercises - enable note field

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
@@ -149,7 +149,7 @@ class CareDialog : DialogFragmentWithDate() {
         }
         binding.duration.setParams(savedInstanceState?.getDouble("duration")
             ?: 0.0, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, binding.okcancel.ok)
-        if (options == EventType.NOTE || options == EventType.QUESTION || options == EventType.ANNOUNCEMENT)
+        if (options == EventType.NOTE || options == EventType.QUESTION || options == EventType.ANNOUNCEMENT || options == EventType.EXERCISE)
             binding.notesLayout.root.visibility = View.VISIBLE // independent to preferences
     }
 


### PR DESCRIPTION
Allows notes (e.g. type of sport, intensity, etc.) when logging exercises.