### PR TITLE
Fix crash of charts if no bg data exists in mg/dl

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
@@ -66,7 +66,7 @@ class GraphData(
         bgReadingsArray = iobCobCalculatorPlugin.bgReadings
         if (bgReadingsArray?.isEmpty() != false) {
             aapsLogger.debug("No BG data.")
-            maxY = 10.0
+            maxY = if (units == Constants.MGDL) 180.0 else 10.0
             minY = 0.0
             return
         }


### PR DESCRIPTION
Reason: The library cannot handle less than two vertical labels. It will divide by zero when calculating the space distribution and crash. In mmol/l the chart therefore has a min height of 10mmol/l. In mg/dl it should have the same.