### PR TITLE
call confirm wear event

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.kt
@@ -33,9 +33,10 @@ import info.nightscout.androidaps.plugins.general.nsclient.NSUpload
 import info.nightscout.androidaps.plugins.general.overview.events.EventDismissNotification
 import info.nightscout.androidaps.plugins.general.overview.events.EventNewNotification
 import info.nightscout.androidaps.plugins.general.overview.notifications.Notification
-import info.nightscout.androidaps.plugins.general.wear.events.EventWearDoAction
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearInitiateAction
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
 import info.nightscout.androidaps.events.EventAutosensCalculationFinished
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearConfirmAction
 import info.nightscout.androidaps.plugins.pump.virtual.VirtualPumpPlugin
 import info.nightscout.androidaps.plugins.treatments.TreatmentsPlugin
 import info.nightscout.androidaps.queue.Callback
@@ -368,7 +369,7 @@ open class LoopPlugin @Inject constructor(
                             //only send to wear if Native notifications are turned off
                             if (!sp.getBoolean(R.string.key_raise_notifications_as_android_notifications, true)) {
                                 // Send to Wear
-                                rxBus.send(EventWearDoAction("changeRequest"))
+                                rxBus.send(EventWearInitiateAction("changeRequest"))
                             }
                         }
                     } else {
@@ -472,14 +473,14 @@ open class LoopPlugin @Inject constructor(
         rxBus.send(EventNewOpenLoopNotification())
 
         // Send to Wear
-        rxBus.send(EventWearDoAction("changeRequest"))
+        rxBus.send(EventWearInitiateAction("changeRequest"))
     }
 
     private fun dismissSuggestion() {
         // dismiss notifications
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(Constants.notificationID)
-        rxBus.send(EventWearDoAction("cancelChangeRequest"))
+        rxBus.send(EventWearConfirmAction("cancelChangeRequest"))
     }
 
     fun acceptChangeRequest() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -43,7 +43,7 @@ import info.nightscout.androidaps.plugins.general.nsclient.data.NSDeviceStatus
 import info.nightscout.androidaps.plugins.general.overview.activities.QuickWizardListActivity
 import info.nightscout.androidaps.plugins.general.overview.graphData.GraphData
 import info.nightscout.androidaps.plugins.general.overview.notifications.NotificationStore
-import info.nightscout.androidaps.plugins.general.wear.events.EventWearDoAction
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearInitiateAction
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
 import info.nightscout.androidaps.events.EventAutosensCalculationFinished
@@ -345,7 +345,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                                     uel.log("ACCEPT TEMP BASAL")
                                     binding.buttonsLayout.acceptTempButton.visibility = View.GONE
                                     (context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).cancel(Constants.notificationID)
-                                    rxBus.send(EventWearDoAction("cancelChangeRequest"))
+                                    rxBus.send(EventWearInitiateAction("cancelChangeRequest"))
                                     loopPlugin.acceptChangeRequest()
                                 })
                             })

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
@@ -27,7 +27,8 @@ import info.nightscout.androidaps.plugins.aps.loop.LoopPlugin
 import info.nightscout.androidaps.plugins.bus.RxBusWrapper
 import info.nightscout.androidaps.plugins.configBuilder.ConstraintChecker
 import info.nightscout.androidaps.plugins.general.overview.events.EventDismissNotification
-import info.nightscout.androidaps.plugins.general.wear.events.EventWearDoAction
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearConfirmAction
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearInitiateAction
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
 import info.nightscout.androidaps.plugins.pump.insight.LocalInsightPlugin
 import info.nightscout.androidaps.plugins.treatments.CarbsGenerator
@@ -83,9 +84,14 @@ class ActionStringHandler @Inject constructor(
 
     init {
         disposable += rxBus
-            .toObservable(EventWearDoAction::class.java)
+            .toObservable(EventWearInitiateAction::class.java)
             .observeOn(aapsSchedulers.main)
             .subscribe({ handleInitiate(it.action) }, fabricPrivacy::logException)
+
+        disposable += rxBus
+            .toObservable(EventWearConfirmAction::class.java)
+            .observeOn(aapsSchedulers.main)
+            .subscribe({ handleConfirmation(it.action) }, fabricPrivacy::logException)
     }
 
     @Synchronized

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/events/EventWearConfirmAction.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/events/EventWearConfirmAction.kt
@@ -2,4 +2,4 @@ package info.nightscout.androidaps.plugins.general.wear.events
 
 import info.nightscout.androidaps.events.Event
 
-class EventWearDoAction (val action: String) : Event()
+class EventWearConfirmAction(val action: String) : Event()

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/events/EventWearInitiateAction.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/events/EventWearInitiateAction.kt
@@ -1,0 +1,5 @@
+package info.nightscout.androidaps.plugins.general.wear.events
+
+import info.nightscout.androidaps.events.Event
+
+class EventWearInitiateAction(val action: String) : Event()

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -48,7 +48,7 @@ import info.nightscout.androidaps.plugins.aps.loop.LoopPlugin;
 import info.nightscout.androidaps.plugins.bus.RxBusWrapper;
 import info.nightscout.androidaps.plugins.general.nsclient.data.NSDeviceStatus;
 import info.nightscout.androidaps.plugins.general.wear.WearPlugin;
-import info.nightscout.androidaps.plugins.general.wear.events.EventWearDoAction;
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearInitiateAction;
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus;
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin;
 import info.nightscout.androidaps.plugins.treatments.TreatmentsPlugin;
@@ -261,13 +261,13 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
             if (event != null && event.getPath().equals(WEARABLE_INITIATE_ACTIONSTRING_PATH)) {
                 String actionstring = new String(event.getData());
                 aapsLogger.debug(LTag.WEAR, "Wear: " + actionstring);
-                rxBus.send(new EventWearDoAction(actionstring));
+                rxBus.send(new EventWearInitiateAction(actionstring));
             }
 
             if (event != null && event.getPath().equals(WEARABLE_CONFIRM_ACTIONSTRING_PATH)) {
                 String actionstring = new String(event.getData());
                 aapsLogger.debug(LTag.WEAR, "Wear Confirm: " + actionstring);
-                rxBus.send(new EventWearDoAction(actionstring));
+                rxBus.send(new EventWearConfirmAction(actionstring));
             }
         }
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -48,6 +48,7 @@ import info.nightscout.androidaps.plugins.aps.loop.LoopPlugin;
 import info.nightscout.androidaps.plugins.bus.RxBusWrapper;
 import info.nightscout.androidaps.plugins.general.nsclient.data.NSDeviceStatus;
 import info.nightscout.androidaps.plugins.general.wear.WearPlugin;
+import info.nightscout.androidaps.plugins.general.wear.events.EventWearConfirmAction;
 import info.nightscout.androidaps.plugins.general.wear.events.EventWearInitiateAction;
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatus;
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin;


### PR DESCRIPTION
https://github.com/MilosKozak/AndroidAPS/commit/ed9c8a1d05f48e0623a840f5fdc6fa96514a48b6
always called initiate, never confirm. This introduces a separate event for that.