### PR TITLE
Fix for AAPS SMB Mode: doesn't work with XDrip anymore - in latest Dev Versions 

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
@@ -50,7 +50,8 @@ class XdripPlugin @Inject constructor(
             GlucoseValue.SourceSensor.DEXCOM_G6_NATIVE,
             GlucoseValue.SourceSensor.DEXCOM_G5_NATIVE,
             GlucoseValue.SourceSensor.DEXCOM_G6_NATIVE_XDRIP,
-            GlucoseValue.SourceSensor.DEXCOM_G5_NATIVE_XDRIP
+            GlucoseValue.SourceSensor.DEXCOM_G5_NATIVE_XDRIP,
+            GlucoseValue.SourceSensor.DEXCOM_G6_G5_NATIVE_XDRIP
         ).any { it == glucoseValue.sourceSensor }
     }
 

--- a/database/src/main/java/info/nightscout/androidaps/database/entities/GlucoseValue.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/entities/GlucoseValue.kt
@@ -77,6 +77,7 @@ data class GlucoseValue(
         @SerializedName("DexcomG5") DEXCOM_G5_XDRIP("DexcomG5"),
         @SerializedName("G6 Native") DEXCOM_G6_NATIVE_XDRIP("G6 Native"),
         @SerializedName("G5 Native") DEXCOM_G5_NATIVE_XDRIP("G5 Native"),
+        @SerializedName("G6 Native / G5 Native") DEXCOM_G6_G5_NATIVE_XDRIP("G6 Native / G5 Native"),
         @SerializedName("Network libre") LIBRE_1_NET("Network libre"),
         @SerializedName("BlueReader") LIBRE_1_BLUE("BlueReader"),
         @SerializedName("Transmiter PL") LIBRE_1_PL("Transmiter PL"),


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/380

In my logfiles I found the following output (for Dexcom G6 in native mode):
`com.eveningoutpost.dexdrip.Extras.SourceDesc => G6 Native / G5 Native;`
This is added now and SMB allways seems to be possible again.