### PR TITLE
Add capabilities for the MDI pump

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpCapability.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpCapability.java
@@ -26,6 +26,7 @@ public enum PumpCapability {
     MedtronicCapabilities(Bolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD), //
     OmnipodCapabilities(Bolus, TempBasal, BasalProfileSet, BasalRate30min), //
     YpsomedCapabilities(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD, ManualTDDLoad),
+    MDICapabilities,
 
     // BasalRates (separately grouped)
     BasalRate_Duration15minAllowed, //

--- a/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpCapability.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpCapability.java
@@ -26,7 +26,7 @@ public enum PumpCapability {
     MedtronicCapabilities(Bolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD), //
     OmnipodCapabilities(Bolus, TempBasal, BasalProfileSet, BasalRate30min), //
     YpsomedCapabilities(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD, ManualTDDLoad),
-    MDICapabilities,
+    MDICapabilities(Bolus),
 
     // BasalRates (separately grouped)
     BasalRate_Duration15minAllowed, //

--- a/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpType.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpType.java
@@ -148,7 +148,11 @@ public enum PumpType {
 
 
     // MDI
-    MDI("MDI", ManufacturerType.AndroidAPS, "MDI", PumpCapability.MDICapabilities);
+    MDI("MDI", ManufacturerType.AndroidAPS, "MDI", 0.5d, null, //
+            new DoseSettings(0.5d, 30, 8 * 60, 0.5d), //
+            PumpTempBasalType.Percent, //
+            new DoseSettings(0.05d, 60, 12 * 60, 0d, 30.0d), PumpCapability.BasalRate_Duration15and30minNotAllowed, //
+            0.05d, 0.05d, null, PumpCapability.MDICapabilities);
 
 
     private final String description;
@@ -192,13 +196,6 @@ public enum PumpType {
         this.model = model;
     }
 
-
-    PumpType(String description, ManufacturerType manufacturer, String model, PumpCapability pumpCapability) {
-        this.description = description;
-        this.manufacturer = manufacturer;
-        this.model = model;
-        this.pumpCapability = pumpCapability;
-    }
 
     PumpType(String description, String model, PumpType parent, PumpCapability pumpCapability) {
         this.description = description;

--- a/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpType.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/pump/common/defs/PumpType.java
@@ -148,7 +148,7 @@ public enum PumpType {
 
 
     // MDI
-    MDI("MDI", ManufacturerType.AndroidAPS, "MDI");
+    MDI("MDI", ManufacturerType.AndroidAPS, "MDI", PumpCapability.MDICapabilities);
 
 
     private final String description;
@@ -192,6 +192,13 @@ public enum PumpType {
         this.model = model;
     }
 
+
+    PumpType(String description, ManufacturerType manufacturer, String model, PumpCapability pumpCapability) {
+        this.description = description;
+        this.manufacturer = manufacturer;
+        this.model = model;
+        this.pumpCapability = pumpCapability;
+    }
 
     PumpType(String description, String model, PumpType parent, PumpCapability pumpCapability) {
         this.description = description;


### PR DESCRIPTION
I've run into the following crash when trying to set up an NSClient installation for a Nightscout instance that's using an MDI pump. I've (naively, not knowing the code base at all tbh) created this fix, feel free to use and/or tell me what I've done wrong :)
```
2021-03-06 10:44:31.734 13490-13490/? D/CORE: [main]: [MainApp.onCreate():86]: Version: 2.8.2-nsclient
2021-03-06 10:44:31.735 13490-13490/? D/CORE: [main]: [MainApp.onCreate():87]: BuildVersion: c07465b0c-2021.03.06-10:02
2021-03-06 10:44:31.735 13490-13490/? D/CORE: [main]: [MainApp.onCreate():88]: Remote: git@github.com:nightscout/AndroidAPS.git
2021-03-06 10:44:31.738 13490-13490/? D/CORE: [main]: [PluginBase.setPluginEnabled():79]: Starting: Rapid-Acting Oref
2021-03-06 10:44:31.738 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.verifySelectionInCategories():89]: Defaulting InsulinInterface
2021-03-06 10:44:31.739 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.setFragmentVisiblities():185]: Selected interface: Rapid-Acting Oref
2021-03-06 10:44:31.739 13490-13490/? D/CORE: [main]: [PluginBase.setPluginEnabled():79]: Starting: Sensitivity Oref1
2021-03-06 10:44:31.739 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.verifySelectionInCategories():99]: Defaulting SensitivityInterface
2021-03-06 10:44:31.739 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.setFragmentVisiblities():185]: Selected interface: Sensitivity Oref1
2021-03-06 10:44:31.739 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.setFragmentVisiblities():185]: Selected interface: NS Profile
2021-03-06 10:44:31.739 13490-13490/? D/CONFIGBUILDER: [main]: [PluginStore.setFragmentVisiblities():185]: Selected interface: NSClient BG
2021-03-06 10:44:31.739 13490-13490/? D/CORE: [main]: [PluginBase.setPluginEnabled():79]: Starting: Virtual Pump
2021-03-06 10:44:31.740 13490-13490/? D/PUMP: [main]: [VirtualPumpPlugin.refreshConfiguration():410]: Pump in configuration: MDI, PumpType object: MDI
2021-03-06 10:44:31.740 13490-13490/? D/PUMP: [main]: [VirtualPumpPlugin.refreshConfiguration():412]: New pump configuration found (MDI), changing from previous (null)
2021-03-06 10:44:31.740 13490-13490/? D/AndroidRuntime: Shutting down VM
2021-03-06 10:44:31.740 13490-13490/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: info.nightscout.nsclient, PID: 13490
    java.lang.RuntimeException: Unable to create application info.nightscout.androidaps.MainApp: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean info.nightscout.androidaps.plugins.pump.common.defs.PumpCapability.hasCapability(info.nightscout.androidaps.plugins.pump.common.defs.PumpCapability)' on a null object reference
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6991)
        at android.app.ActivityThread.access$1700(ActivityThread.java:274)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2093)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:233)
        at android.app.ActivityThread.main(ActivityThread.java:8010)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean info.nightscout.androidaps.plugins.pump.common.defs.PumpCapability.hasCapability(info.nightscout.androidaps.plugins.pump.common.defs.PumpCapability)' on a null object reference
        at info.nightscout.androidaps.interfaces.PumpDescription.setPumpDescription(PumpDescription.java:108)
        at info.nightscout.androidaps.plugins.pump.virtual.VirtualPumpPlugin.refreshConfiguration(VirtualPumpPlugin.kt:413)
        at info.nightscout.androidaps.plugins.pump.virtual.VirtualPumpPlugin.onStart(VirtualPumpPlugin.kt:117)
        at info.nightscout.androidaps.interfaces.PluginBase.setPluginEnabled(PluginBase.kt:80)
        at info.nightscout.androidaps.plugins.configBuilder.PluginStore.verifySelectionInCategories(PluginStore.kt:128)
        at info.nightscout.androidaps.plugins.configBuilder.PluginStore.loadDefaults(PluginStore.kt:27)
        at info.nightscout.androidaps.plugins.configBuilder.ConfigBuilderPlugin.initialize(ConfigBuilderPlugin.kt:43)
        at info.nightscout.androidaps.MainApp.onCreate(MainApp.java:97)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1208)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6986)
        at android.app.ActivityThread.access$1700(ActivityThread.java:274) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2093) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:233) 
        at android.app.ActivityThread.main(ActivityThread.java:8010) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978) 
```