### PR TITLE
Fix Low Glucose Constraint

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConstraintChecker.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConstraintChecker.kt
@@ -18,6 +18,9 @@ class ConstraintChecker @Inject constructor(private val activePlugin: ActivePlug
     fun isClosedLoopAllowed(): Constraint<Boolean> =
         isClosedLoopAllowed(Constraint(true))
 
+    fun isLgsAllowed(): Constraint<Boolean> =
+        isLgsAllowed(Constraint(true))
+
     fun isAutosensModeEnabled(): Constraint<Boolean> =
         isAutosensModeEnabled(Constraint(true))
 
@@ -73,6 +76,16 @@ class ConstraintChecker @Inject constructor(private val activePlugin: ActivePlug
             val constraint = p as ConstraintsInterface
             if (!p.isEnabled(PluginType.CONSTRAINTS)) continue
             constraint.isClosedLoopAllowed(value)
+        }
+        return value
+    }
+
+    override fun isLgsAllowed(value: Constraint<Boolean>): Constraint<Boolean> {
+        val constraintsPlugins = activePlugin.getSpecificPluginsListByInterface(ConstraintsInterface::class.java)
+        for (p in constraintsPlugins) {
+            val constraint = p as ConstraintsInterface
+            if (!p.isEnabled(PluginType.CONSTRAINTS)) continue
+            constraint.isLgsAllowed(value)
         }
         return value
     }


### PR DESCRIPTION
Fixes an issue where LGS is allowed as APS option in the main Loop Menu when it shouldn't be allowed.

Cause: `isLgsAllowed` was never added to the constraint checker and never got checked, so reported a false positive that it was allowed when it wasn't.

This PR fixes this issue.