### PR TITLE
Stats: inRange percentage to always get a sum equal to 100%

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/stats/TIR.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/stats/TIR.kt
@@ -18,7 +18,7 @@ class TIR(val date: Long, val lowThreshold: Double, val highThreshold: Double) {
     fun above() = run { above++; count++ }
 
     fun belowPct() = if (count > 0) (below.toDouble() / count * 100.0).roundToInt() else 0
-    fun inRangePct() = if (count > 0) (inRange.toDouble() / count * 100.0).roundToInt() else 0
+    fun inRangePct() = if (count > 0) 100 - belowPct() - abovePct() else 0
     fun abovePct() = if (count > 0) (above.toDouble() / count * 100.0).roundToInt() else 0
 
     fun toText(resourceHelper: ResourceHelper, dateUtil: DateUtil): String = resourceHelper.gs(R.string.tirformat, dateUtil.dateStringShort(date), belowPct(), inRangePct(), abovePct())


### PR DESCRIPTION
Due to rounding, the sum (below+in+above) can be between 98% to 101%
=> With this modification In range result is modified to always a sum equal to 100%