### PR TITLE
Fix double Entries in Treatment Dialog (+ add new uel.log for plugin enabled/disabled

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
@@ -167,18 +167,18 @@ class TreatmentDialog : DialogFragmentWithDate() {
                                     { aapsLogger.error(LTag.DATABASE, "Error while saving carbs", it) }
                                 )
                     } else {
-                        if (detailedBolusInfo.insulin > 0)
+                        if (detailedBolusInfo.insulin > 0) {
+                            uel.log(action, Sources.TreatmentDialog,
+                                ValueWithUnit.Insulin(insulinAfterConstraints),
+                                ValueWithUnit.Gram(carbsAfterConstraints).takeIf { carbsAfterConstraints != 0 })
                             commandQueue.bolus(detailedBolusInfo, object : Callback() {
                                 override fun run() {
                                     if (!result.success) {
                                         ErrorHelperActivity.runAlarm(ctx, result.comment, resourceHelper.gs(R.string.treatmentdeliveryerror), info.nightscout.androidaps.dana.R.raw.boluserror)
-                                    } else
-                                        uel.log(action, Sources.TreatmentDialog,
-                                            ValueWithUnit.Insulin(insulinAfterConstraints),
-                                            ValueWithUnit.Gram(carbsAfterConstraints).takeIf { carbsAfterConstraints != 0 })
+                                    }
                                 }
                             })
-                        else
+                        } else
                             uel.log(action, Sources.TreatmentDialog,
                                 ValueWithUnit.Gram(carbsAfterConstraints).takeIf { carbs != 0 })
                     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConfigBuilderPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/configBuilder/ConfigBuilderPlugin.kt
@@ -5,6 +5,7 @@ import dagger.android.HasAndroidInjector
 import info.nightscout.androidaps.R
 import info.nightscout.androidaps.database.entities.UserEntry.Action
 import info.nightscout.androidaps.database.entities.UserEntry.Sources
+import info.nightscout.androidaps.database.entities.ValueWithUnit
 import info.nightscout.androidaps.events.EventAppInitialized
 import info.nightscout.androidaps.events.EventConfigBuilderChange
 import info.nightscout.androidaps.events.EventRebuildTabs
@@ -144,7 +145,8 @@ class ConfigBuilderPlugin @Inject constructor(
             OKDialog.showConfirmation(activity, resourceHelper.gs(R.string.allow_hardware_pump_text), Runnable {
                 performPluginSwitch(changedPlugin, newState, type)
                 sp.putBoolean("allow_hardware_pump", true)
-                uel.log(Action.HW_PUMP_ALLOWED, Sources.ConfigBuilder)
+                uel.log(Action.HW_PUMP_ALLOWED, Sources.ConfigBuilder,
+                    ValueWithUnit.StringResource(changedPlugin.pluginDescription.pluginName))
                 aapsLogger.debug(LTag.PUMP, "First time HW pump allowed!")
             }, Runnable {
                 rxBus.send(EventConfigBuilderUpdateGui())
@@ -154,6 +156,14 @@ class ConfigBuilderPlugin @Inject constructor(
     }
 
     override fun performPluginSwitch(changedPlugin: PluginBase, enabled: Boolean, type: PluginType) {
+        if(enabled && !changedPlugin.isEnabled()) {
+            uel.log(Action.PLUGIN_ENABLED, Sources.ConfigBuilder,
+                ValueWithUnit.StringResource(changedPlugin.pluginDescription.pluginName))
+        }
+        else if(!enabled) {
+            uel.log(Action.PLUGIN_DISABLED, Sources.ConfigBuilder,
+                ValueWithUnit.StringResource(changedPlugin.pluginDescription.pluginName))
+        }
         changedPlugin.setPluginEnabled(type, enabled)
         changedPlugin.setFragmentVisible(type, enabled)
         processOnEnabledCategoryChanged(changedPlugin, type)

--- a/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/Translator.kt
@@ -96,6 +96,8 @@ class Translator @Inject internal constructor(
         Action.STOP_SMS                            -> resourceHelper.gs(R.string.uel_stop_sms)
         Action.START_AAPS                          -> resourceHelper.gs(R.string.uel_start_aaps)
         Action.EXIT_AAPS                           -> resourceHelper.gs(R.string.uel_exit_aaps)
+        Action.PLUGIN_ENABLED                      -> resourceHelper.gs(R.string.uel_plugin_enabled)
+        Action.PLUGIN_DISABLED                     -> resourceHelper.gs(R.string.uel_plugin_disabled)
         Action.UNKNOWN                             -> resourceHelper.gs(R.string.unknown)
     }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -479,6 +479,8 @@
     <string name="uel_export_csv">EXPORT USER ENTRIES</string>
     <string name="uel_start_aaps">START AAPS</string>
     <string name="uel_exit_aaps">EXIT AAPS</string>
+    <string name="uel_plugin_enabled">PLUGIN ENABLED</string>
+    <string name="uel_plugin_disabled">PLUGIN DISABLED</string>
     <string name="uel_unknown">UNKNOWN</string>
     <string name="ue_formated_string">Formated string</string>
     <string name="ue_source">Source</string>

--- a/database/src/main/java/info/nightscout/androidaps/database/entities/UserEntry.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/entities/UserEntry.kt
@@ -96,6 +96,8 @@ data class UserEntry(
         EXPORT_CSV (ColorGroup.Aaps),
         START_AAPS (ColorGroup.Aaps),
         EXIT_AAPS (ColorGroup.Aaps),
+        PLUGIN_ENABLED (ColorGroup.Aaps),
+        PLUGIN_DISABLED (ColorGroup.Aaps),
         UNKNOWN (ColorGroup.Aaps)
         ;
 


### PR DESCRIPTION
With VirtualPump (not tested with real pump), if I enter Carbs + Insulin in TreatmentDialog, I get 2 userEntries (uel.log executed twice)
@MilosKozak I saw you put some uel.log inside `commandQueue` (TreatmentDialog and InsulinDialog)
=> I suggest to always move uel.log before `commandQueue` (sometimes if a problem occurs during callback, we can miss an uel.log or get redundant entries...)

I added an uel.log for new plugin selection