### PR TITLE
Combo PumpSync update

### DIFF
--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
@@ -639,10 +639,10 @@ public class ComboPlugin extends PumpPluginBase implements PumpInterface, Constr
     private boolean addBolusToTreatments(DetailedBolusInfo detailedBolusInfo, Bolus lastPumpBolus) {
         try {
             pumpSync.syncBolusWithPumpId(
-                    calculateFakeBolusDate(lastPumpBolus),
+                    lastPumpBolus.timestamp,
                     lastPumpBolus.amount,
                     detailedBolusInfo.getBolusType(),
-                    detailedBolusInfo.timestamp,
+                    generatePumpBolusId(lastPumpBolus),
                     PumpType.ACCU_CHEK_COMBO,
                     serialNumber()
             );
@@ -1149,10 +1149,10 @@ public class ComboPlugin extends PumpPluginBase implements PumpInterface, Constr
         boolean updated = false;
         for (Bolus pumpBolus : history.bolusHistory) {
             if (pumpSync.syncBolusWithPumpId(
-                    calculateFakeBolusDate(pumpBolus),
+                    pumpBolus.timestamp,
                     pumpBolus.amount,
                     DetailedBolusInfo.BolusType.NORMAL,
-                    System.currentTimeMillis(),
+                    generatePumpBolusId(pumpBolus),
                     PumpType.ACCU_CHEK_COMBO,
                     serialNumber()
             )) {
@@ -1169,7 +1169,7 @@ public class ComboPlugin extends PumpPluginBase implements PumpInterface, Constr
      * Should be good enough, even with command mode, it's a challenge to create that situation
      * and most time clashes will be around SMBs which are covered.
      */
-    long calculateFakeBolusDate(Bolus pumpBolus) {
+    long generatePumpBolusId(Bolus pumpBolus) {
         double bolus = pumpBolus.amount - 0.1;
         int secondsFromBolus = (int) (bolus * 10 * 1000);
         return pumpBolus.timestamp + Math.min(secondsFromBolus, 59 * 1000);

--- a/combo/src/test/java/info/nightscout/androidaps/plugins/pump/combo/ComboPluginTest.kt
+++ b/combo/src/test/java/info/nightscout/androidaps/plugins/pump/combo/ComboPluginTest.kt
@@ -64,22 +64,22 @@ class ComboPluginTest : TestBase() {
     }
 
     @Test
-    fun calculateFakePumpTimestamp() {
+    fun `generate bolus ID from timestamp and amount`() {
         val now = System.currentTimeMillis()
         val pumpTimestamp = now - now % 1000
         // same timestamp, different bolus leads to different fake timestamp
         Assert.assertNotEquals(
-            comboPlugin.calculateFakeBolusDate(Bolus(pumpTimestamp, 0.1, true)),
-            comboPlugin.calculateFakeBolusDate(Bolus(pumpTimestamp, 0.3, true))
+            comboPlugin.generatePumpBolusId(Bolus(pumpTimestamp, 0.1, true)),
+            comboPlugin.generatePumpBolusId(Bolus(pumpTimestamp, 0.3, true))
         )
         // different timestamp, same bolus leads to different fake timestamp
         Assert.assertNotEquals(
-            comboPlugin.calculateFakeBolusDate(Bolus(pumpTimestamp, 0.3, true)),
-            comboPlugin.calculateFakeBolusDate(Bolus(pumpTimestamp + 60 * 1000, 0.3, true))
+            comboPlugin.generatePumpBolusId(Bolus(pumpTimestamp, 0.3, true)),
+            comboPlugin.generatePumpBolusId(Bolus(pumpTimestamp + 60 * 1000, 0.3, true))
         )
         // generated timestamp has second-precision
         val bolus = Bolus(pumpTimestamp, 0.2, true)
-        val calculatedTimestamp = comboPlugin.calculateFakeBolusDate(bolus)
+        val calculatedTimestamp = comboPlugin.generatePumpBolusId(bolus)
         Assert.assertEquals(calculatedTimestamp, calculatedTimestamp - calculatedTimestamp % 1000)
     }
 }


### PR DESCRIPTION
- Mostly removing unneeded code (after ensuring in `deliverTreatment` the request is sound). 
- Updated docs, added explanation on lack of TBR IDs
- Untangled date vs ID, now that they're different fields, yay!

Test protocol:

- [x] User-initiated bolus
- [x] User-initiated bolus with carbs
- [x] User-initiated carbs
- [x] Cancelling bolus during pump delivery  
- [x] User requested TBR
- [x] User requested TBR cancellation
- [x] TBR requested by OpenAPS
- [x] SMB requested by OpenAPS
- [x] Ending TBR when user cancelled TBR on pump
- [x] Starting TBR when user started a TBR on the pump
- [x] TBR end and start record when user changed TBR on pump
- [x] Adding bolus issued on pump
- [x] (User) suspended pump creates 15m 0% TBR
- [x] Nightscout uploads still work (bolus, carbs, TBR, announcements)