### PR TITLE
Fix: turn APSResult.bolusRequested into a function.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/loop/LoopPlugin.kt
@@ -403,7 +403,7 @@ open class LoopPlugin @Inject constructor(
                         val waiting = PumpEnactResult(injector)
                         waiting.queued = true
                         if (resultAfterConstraints.tempBasalRequested) lastRun.tbrSetByPump = waiting
-                        if (resultAfterConstraints.bolusRequested) lastRun.smbSetByPump = waiting
+                        if (resultAfterConstraints.bolusRequested()) lastRun.smbSetByPump = waiting
                         rxBus.send(EventLoopUpdateGui())
                         fabricPrivacy.logCustom("APSRequest")
                         applyTBRRequest(resultAfterConstraints, profile, object : Callback() {
@@ -600,7 +600,7 @@ open class LoopPlugin @Inject constructor(
     }
 
     private fun applySMBRequest(request: APSResult, callback: Callback?) {
-        if (!request.bolusRequested) {
+        if (!request.bolusRequested()) {
             return
         }
         val pump = activePlugin.activePump

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSAMA/DetermineBasalResultAMA.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSAMA/DetermineBasalResultAMA.kt
@@ -40,7 +40,6 @@ class DetermineBasalResultAMA private constructor(injector: HasAndroidInjector) 
                 tempBasalRequested = false
             }
         }
-        bolusRequested = false
     }
 
     override fun newAndClone(injector: HasAndroidInjector): DetermineBasalResultAMA {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/DetermineBasalResultSMB.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/aps/openAPSSMB/DetermineBasalResultSMB.kt
@@ -35,7 +35,6 @@ class DetermineBasalResultSMB private constructor(injector: HasAndroidInjector) 
                 duration = -1
             }
             if (result.has("units")) {
-                bolusRequested = true
                 smb = result.getDouble("units")
             } else {
                 smb = 0.0

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
@@ -48,7 +48,6 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
     var usePercent = false
     var duration = 0
     var tempBasalRequested = false
-    var bolusRequested = false
     var iob: IobTotal? = null
     var json: JSONObject? = JSONObject()
     var hasPredictions = false
@@ -161,7 +160,6 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
         newResult.rate = rate
         newResult.duration = duration
         newResult.tempBasalRequested = tempBasalRequested
-        newResult.bolusRequested = bolusRequested
         newResult.iob = iob
         newResult.json = JSONObject(json.toString())
         newResult.hasPredictions = hasPredictions
@@ -309,11 +307,11 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
             // closed loop mode: handle change at driver level
             if (closedLoopEnabled.value()) {
                 aapsLogger.debug(LTag.APS, "DEFAULT: Closed mode")
-                return tempBasalRequested || bolusRequested
+                return tempBasalRequested || bolusRequested()
             }
 
             // open loop mode: try to limit request
-            if (!tempBasalRequested && !bolusRequested) {
+            if (!tempBasalRequested && !bolusRequested()) {
                 aapsLogger.debug(LTag.APS, "FALSE: No request")
                 return false
             }
@@ -399,4 +397,6 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                 }
             }
         }
+
+    fun bolusRequested(): Boolean = smb > 0.0
 }


### PR DESCRIPTION
Previously this var was set while parsing determine-basal output, setting it to true if determine-basal provided a value which was assigned to var smb. However, the variable smb is changed when constraints are applied, making the val bolusRequested invalid afterwards. Hence, dynamically evaluate the smb var by turning bolusRequested into a function.