### PR TITLE
Fix FakeExtended TBR removal from TreatmentTemporaryBasalsFragment

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/NSClientAddUpdateWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/NSClientAddUpdateWorker.kt
@@ -26,6 +26,7 @@ import info.nightscout.androidaps.receivers.DataWorker
 import info.nightscout.androidaps.utils.DateUtil
 import info.nightscout.androidaps.utils.JsonHelper
 import info.nightscout.androidaps.utils.JsonHelper.safeGetLong
+import info.nightscout.androidaps.utils.T
 import info.nightscout.androidaps.utils.buildHelper.BuildHelper
 import info.nightscout.androidaps.utils.sharedPreferences.SP
 import java.util.concurrent.TimeUnit
@@ -287,7 +288,7 @@ class NSClientAddUpdateWorker(
                                     result.inserted.forEach {
                                         uel.log(Action.TEMP_BASAL, Sources.NSClient,
                                             ValueWithUnit.Timestamp(it.timestamp),
-                                            ValueWithUnit.UnitPerHour(it.rate),
+                                            if (it.isAbsolute) ValueWithUnit.UnitPerHour(it.rate) else ValueWithUnit.Percent(it.rate.toInt()),
                                             ValueWithUnit.Minute(TimeUnit.MILLISECONDS.toMinutes(it.duration).toInt())
                                         )
                                         aapsLogger.debug(LTag.DATABASE, "Inserted TemporaryBasal $it")
@@ -295,7 +296,7 @@ class NSClientAddUpdateWorker(
                                     result.invalidated.forEach {
                                         uel.log(Action.TEMP_BASAL_REMOVED, Sources.NSClient,
                                             ValueWithUnit.Timestamp(it.timestamp),
-                                            ValueWithUnit.UnitPerHour(it.rate),
+                                            if (it.isAbsolute) ValueWithUnit.UnitPerHour(it.rate) else ValueWithUnit.Percent(it.rate.toInt()),
                                             ValueWithUnit.Minute(TimeUnit.MILLISECONDS.toMinutes(it.duration).toInt())
                                         )
                                         aapsLogger.debug(LTag.DATABASE, "Invalidated TemporaryBasal $it")
@@ -303,7 +304,7 @@ class NSClientAddUpdateWorker(
                                     result.ended.forEach {
                                         uel.log(Action.CANCEL_TEMP_BASAL, Sources.NSClient,
                                             ValueWithUnit.Timestamp(it.timestamp),
-                                            ValueWithUnit.UnitPerHour(it.rate),
+                                            if (it.isAbsolute) ValueWithUnit.UnitPerHour(it.rate) else ValueWithUnit.Percent(it.rate.toInt()),
                                             ValueWithUnit.Minute(TimeUnit.MILLISECONDS.toMinutes(it.duration).toInt())
                                         )
                                         aapsLogger.debug(LTag.DATABASE, "Ended TemporaryBasal $it")

--- a/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsExtendedBolusesFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/treatments/fragments/TreatmentsExtendedBolusesFragment.kt
@@ -15,6 +15,7 @@ import info.nightscout.androidaps.database.AppRepository
 import info.nightscout.androidaps.database.entities.ExtendedBolus
 import info.nightscout.androidaps.database.entities.UserEntry.Action
 import info.nightscout.androidaps.database.entities.UserEntry.Sources
+import info.nightscout.androidaps.database.entities.ValueWithUnit
 import info.nightscout.androidaps.database.interfaces.end
 import info.nightscout.androidaps.database.transactions.InvalidateExtendedBolusTransaction
 import info.nightscout.androidaps.databinding.TreatmentsExtendedbolusFragmentBinding
@@ -157,7 +158,11 @@ class TreatmentsExtendedBolusesFragment : DaggerFragment() {
                 ${resourceHelper.gs(R.string.extended_bolus)}
                 ${resourceHelper.gs(R.string.date)}: ${dateUtil.dateAndTimeString(extendedBolus.timestamp)}
                 """.trimIndent(), { _: DialogInterface, _: Int ->
-                            uel.log(Action.EXTENDED_BOLUS_REMOVED, Sources.Treatments)
+                            uel.log(Action.EXTENDED_BOLUS_REMOVED, Sources.Treatments,
+                                ValueWithUnit.Timestamp(extendedBolus.timestamp),
+                                ValueWithUnit.Insulin(extendedBolus.amount),
+                                ValueWithUnit.UnitPerHour(extendedBolus.rate),
+                                ValueWithUnit.Minute(TimeUnit.MILLISECONDS.toMinutes(extendedBolus.duration).toInt()))
                             disposable += repository.runTransactionForResult(InvalidateExtendedBolusTransaction(extendedBolus.id))
                                 .subscribe(
                                     { aapsLogger.debug(LTag.DATABASE, "Removed extended bolus $extendedBolus") },


### PR DESCRIPTION
I also fix information in uel.log concerning TEMPBASAL (Absolute / Percent values)
I added more informations in TEMP_BASAL_REMOVED / EXTENDED_BOLUS_REMOVED (rate/percent, duration)

I don't know if we have an easier way to remove Fake TBR (I tried `v.Tag as ExtendedBolus` but it didn't seems to work here so I search ExtendedBolus in repository with timestamp)
