### PR TITLE
Fix cancel extended bolus (Overview)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -191,7 +191,7 @@ class OverviewData @Inject constructor(
                 if (!extendedBolus.isInProgress(dateUtil)) {
                     this@OverviewData.extendedBolus = null
                     ""
-                } else if (activePlugin.activePump.isFakingTempsByExtendedBoluses) resourceHelper.gs(R.string.pump_basebasalrate, extendedBolus.rate)
+                } else if (!activePlugin.activePump.isFakingTempsByExtendedBoluses) resourceHelper.gs(R.string.pump_basebasalrate, extendedBolus.rate)
                 else ""
             } ?: ""
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -653,7 +653,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
 
             OverviewData.Property.EXTENDED_BOLUS   -> {
                 binding.infoLayout.extendedBolus.text = overviewData.extendedBolusText
-                binding.infoLayout.extendedBolus.setOnClickListener {
+                binding.infoLayout.extendedLayout.setOnClickListener {
                     activity?.let { OKDialog.show(it, resourceHelper.gs(R.string.extended_bolus), overviewData.extendedBolusDialogText) }
                 }
                 binding.infoLayout.extendedLayout.visibility = (overviewData.extendedBolus != null && !pump.isFakingTempsByExtendedBoluses).toVisibility()

--- a/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1450,6 +1450,12 @@ public class LocalInsightPlugin extends PumpPluginBase implements Pump, Constrai
                             bolusID.getId(),
                             PumpType.ACCU_CHEK_INSIGHT,
                             serial);
+            if (!isFakingTempsByExtendedBoluses())
+                pumpSync.syncStopExtendedBolusWithPumpId(
+                    timestamp,
+                    event.getEventPosition(),
+                    PumpType.ACCU_CHEK_INSIGHT,
+                    serialNumber());
         }
     }
 

--- a/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1450,12 +1450,6 @@ public class LocalInsightPlugin extends PumpPluginBase implements Pump, Constrai
                             bolusID.getId(),
                             PumpType.ACCU_CHEK_INSIGHT,
                             serial);
-            if (!isFakingTempsByExtendedBoluses())
-                pumpSync.syncStopExtendedBolusWithPumpId(
-                    timestamp,
-                    event.getEventPosition(),
-                    PumpType.ACCU_CHEK_INSIGHT,
-                    serialNumber());
         }
     }
 


### PR DESCRIPTION
All Pump : Fix Overview (no information visible below icon and allow click on icon to show popup)
Insight Driver : Fix "Cancel Extended Bolus" if `isFakingTempsByExtendedBoluses` is `false`