### PR TITLE
Add feature to suppress food intake warning until a configurable threshold is reached.

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -689,6 +689,8 @@
 Unerwartetes Verhalten.</string>
     <string name="loop_openmode_min_change">Minimaler Wert zur Anfrage einer Änderung [%]</string>
     <string name="loop_openmode_min_change_summary" formatted="false">Open Loop schlägt neue Änderungen nur dann vor, wenn die Änderung größer als dieser Wert ist. Der Standard-Wert ist 20%.</string>
+    <string name="food_intake_warning_threshold" formatted="false">Fehlende Kohlenhydrate Warnungsschwelle</string>
+    <string name="food_intake_warning_threshold_summary" formatted="false">Der Loop schlägt die Einnahme von Kohlenhydrate nur dann vor, wenn die Menge größer als dieser Wert ist. Der Standard-Wert ist 0g.</string>
     <string name="profile_total">== ∑  %1$s IE</string>
     <string name="dexcom_lognssensorchange_title">Speichere Sensor Wechsel in Nightscout</string>
     <string name="dexcom_lognssensorchange_summary">Ereignis \"Sensorwechsel\" bei Sensorstart automatisch in NS erstellen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -857,6 +857,8 @@
     <string name="sendlogfiles">Send today\'s log files to developers along with this time. Unexpected situation.</string>
     <string name="loop_openmode_min_change">Minimal request change [%]</string>
     <string name="loop_openmode_min_change_summary" formatted="false">Open Loop will popup new change request only if change is bigger than this value in %. Default value is 20%</string>
+    <string name="food_intake_warning_threshold" formatted="false">Food Intake Warning Threshold</string>
+    <string name="food_intake_warning_threshold_summary" formatted="false">Loop will popup new request for food intake only if required carbs are more than this value in g. Default value is 0g</string>
     <string name="key_short_tabtitles" translatable="false">short_tabtitles</string>
 
     <string name="profile_total">== ∑  %1$s U</string>

--- a/app/src/main/res/xml/pref_loop.xml
+++ b/app/src/main/res/xml/pref_loop.xml
@@ -29,6 +29,20 @@
             validate:minNumber="0"
             validate:testType="numericRange" />
 
+        <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference
+            android:defaultValue="0"
+            android:dialogMessage="@string/food_intake_warning_threshold_summary"
+            android:digits="0123456789"
+            android:inputType="number"
+            android:key="@string/key_food_intake_warning_threshold"
+            android:maxLines="1"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/food_intake_warning_threshold"
+            validate:maxNumber="30"
+            validate:minNumber="0"
+            validate:testType="numericRange" />
+
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
@@ -300,7 +300,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
             return latest
         }
     val isCarbsRequired: Boolean
-        get() = carbsReq > 0
+        get() = carbsReq > sp.getInt(R.string.key_food_intake_warning_threshold, 0);
 
     val isChangeRequested: Boolean
         get() {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="key_active_pump_change_timestamp" translatable="false">active_pump_change_timestamp</string>
     <string name="key_active_pump_type" translatable="false">active_pump_type</string>
     <string name="key_active_pump_serial_number" translatable="false">active_pump_serial_number</string>
+    <string name="key_food_intake_warning_threshold" translatable="false">food_intake_warning_threshold</string>
 
     <!--    General-->
     <string name="refresh">Refresh</string>


### PR DESCRIPTION
Code modifications are fairly simple. Default behavior does not change. Threshold can be defined in preference menu in subentry "loop". Tested on my dev rig (Pixel 3a + Insight).