### PR TITLE
temp Dir for log export

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefsImpl.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/ImportExportPrefsImpl.kt
@@ -363,7 +363,7 @@ class ImportExportPrefsImpl @Inject constructor(
     override fun exportUserEntriesCsv(activity: FragmentActivity, singleEntries: Single<List<UserEntry>>) {
         val entries = singleEntries.blockingGet()
         prefFileList.ensureExportDirExists()
-        val newFile = prefFileList.newExportXmlFile()
+        val newFile = prefFileList.newExportCsvFile()
 
         try {
             classicPrefsFormat.saveCsv(newFile, entries)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenancePlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenancePlugin.kt
@@ -54,7 +54,7 @@ class MaintenancePlugin @Inject constructor(
         val recipient = sp.getString(R.string.key_maintenance_logs_email, "logs@androidaps.org")
         val amount = sp.getInt(R.string.key_maintenance_logs_amount, 2)
         val logs = getLogFiles(amount)
-        val zipDir = fileListProvider.ensureExportDirExists()
+        val zipDir = fileListProvider.ensureTempDirExists()
         val zipFile = File(zipDir, constructName())
         aapsLogger.debug("zipFile: ${zipFile.absolutePath}")
         val zip = zipLogs(zipFile, logs)
@@ -81,7 +81,7 @@ class MaintenancePlugin @Inject constructor(
                 file.delete()
             }
         }
-        val exportDir = fileListProvider.ensureExportDirExists()
+        val exportDir = fileListProvider.ensureTempDirExists()
         if (exportDir.exists()) {
             val expFiles = exportDir.listFiles()
             for (file in expFiles) {

--- a/app/src/test/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenancePluginTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenancePluginTest.kt
@@ -38,7 +38,7 @@ class MaintenancePluginTest : TestBase() {
         sut = MaintenancePlugin(injector, context, resourceHelper, sp, nsSettingsStatus, aapsLogger, buildHelper, ConfigImpl(), fileListProvider, loggerUtils)
         `when`(loggerUtils.suffix).thenReturn(".log.zip")
         `when`(loggerUtils.logDirectory).thenReturn("src/test/res/logger")
-        `when`(fileListProvider.ensureExportDirExists()).thenReturn(File("src/test/res/logger"))
+        `when`(fileListProvider.ensureTempDirExists()).thenReturn(File("src/test/res/logger"))
     }
 
     @Test fun logFilesTest() {

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/PrefFileListProvider.kt
@@ -31,6 +31,7 @@ class PrefFileListProvider @Inject constructor(
     private val path = File(Environment.getExternalStorageDirectory().toString())
     private val aapsPath = File(path, "AAPS" + File.separator + "preferences")
     private val exportsPath = File(path, "AAPS" + File.separator + "exports")
+    private val tempPath = File(path, "AAPS" + File.separator + "temp")
     private val extraPath = File(path, "AAPS" + File.separator + "extra")
 
     companion object {
@@ -103,6 +104,13 @@ class PrefFileListProvider @Inject constructor(
         return exportsPath
     }
 
+    fun ensureTempDirExists(): File {
+        if (!tempPath.exists()) {
+            tempPath.mkdirs()
+        }
+        return tempPath
+    }
+
     fun ensureExtraDirExists(): File {
         if (!extraPath.exists()) {
             extraPath.mkdirs()
@@ -115,7 +123,7 @@ class PrefFileListProvider @Inject constructor(
         return File(aapsPath, timeLocal + "_" + config.FLAVOR + ".json")
     }
 
-    fun newExportXmlFile(): File {
+    fun newExportCsvFile(): File {
         val timeLocal = LocalDateTime.now().toString(DateTimeFormat.forPattern("yyyy-MM-dd'_'HHmmss"))
         return File(exportsPath, timeLocal + "_UserEntry.csv")
     }


### PR DESCRIPTION
I propose to create a "temp" folder for log and use "exports" folder for other exports done manually by user (ex csv export for user entries)
I have in mind (I don't know if it's planned or not) an import/export database function to be able to migrate database when we change phone that could also be exported in thhis exports folder...