### PR TITLE
Insight Driver accuracy of extended bolus duration

### DIFF
--- a/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1433,7 +1433,7 @@ public class LocalInsightPlugin extends PumpPluginBase implements Pump, Constrai
         bolusID = insightDbHelper.getInsightBolusID(serial, event.getBolusID(), startTimestamp); // Line added to get id
         if (event.getBolusType() == BolusType.STANDARD || event.getBolusType() == BolusType.MULTIWAVE) {
             pumpSync.syncBolusWithPumpId(
-                    bolusID.getTimestamp(),
+                    startTimestamp,
                     event.getImmediateAmount(),
                     null,
                     bolusID.getId(),
@@ -1443,9 +1443,9 @@ public class LocalInsightPlugin extends PumpPluginBase implements Pump, Constrai
         if (event.getBolusType() == BolusType.EXTENDED || event.getBolusType() == BolusType.MULTIWAVE) {
             if (event.getDuration() > 0 && profileFunction.getProfile(bolusID.getTimestamp()) != null)
                     pumpSync.syncExtendedBolusWithPumpId(
-                            bolusID.getTimestamp(),
+                            startTimestamp,
                             event.getExtendedAmount(),
-                            T.mins(event.getDuration()).msecs(),
+                            timestamp - startTimestamp,
                             isFakingTempsByExtendedBoluses(),
                             bolusID.getId(),
                             PumpType.ACCU_CHEK_INSIGHT,


### PR DESCRIPTION
Duration unit sent by pump is minute for extended bolus.
I replace this duration by timestamp delta between end event and start event (accuracy of duration is now second)...
This prevent to have duration equals to 0 even on short extended boluses...