### PR TITLE
add  invalidateTemporaryBasalWithPumpId

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/interfaces/PumpSync.kt
+++ b/core/src/main/java/info/nightscout/androidaps/interfaces/PumpSync.kt
@@ -346,7 +346,6 @@ interface PumpSync {
 
     /**
      * Invalidate of temporary basals that failed to start
-     * Dash specific, replace by setting duration to zero ????
      *
      * If exists, isValid is set false
      * If db record doesn't exist data is ignored and false returned

--- a/core/src/main/java/info/nightscout/androidaps/interfaces/PumpSync.kt
+++ b/core/src/main/java/info/nightscout/androidaps/interfaces/PumpSync.kt
@@ -346,6 +346,22 @@ interface PumpSync {
 
     /**
      * Invalidate of temporary basals that failed to start
+     * Dash specific, replace by setting duration to zero ????
+     *
+     * If exists, isValid is set false
+     * If db record doesn't exist data is ignored and false returned
+     *
+     *
+     * @param pumpId        pumpId of temporary basal
+     * @param pumpType      pump type like PumpType.ACCU_CHEK_COMBO
+     * @param pumpSerial    pump serial number
+     * @return true if running record is found and invalidated
+     **/
+
+    fun invalidateTemporaryBasalWithPumpId(pumpId: Long, pumpType: PumpType, pumpSerial: String): Boolean
+
+    /**
+     * Invalidate of temporary basals that failed to start
      * MDT specific
      *
      * If exists, isValid is set false

--- a/core/src/main/java/info/nightscout/androidaps/plugins/pump/PumpSyncImplementation.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/pump/PumpSyncImplementation.kt
@@ -330,6 +330,19 @@ class PumpSyncImplementation @Inject constructor(
             }
     }
 
+    override fun invalidateTemporaryBasalWithPumpId(pumpId: Long, pumpType: PumpType, pumpSerial: String): Boolean {
+        repository.runTransactionForResult(InvalidateTemporaryBasalTransactionWithPumpId(pumpId, pumpType.toDbPumpType(),
+                                                                                         pumpSerial))
+            .doOnError { aapsLogger.error(LTag.DATABASE, "Error while invalidating TemporaryBasal", it) }
+            .blockingGet()
+            .also { result ->
+                result.invalidated.forEach {
+                    aapsLogger.debug(LTag.DATABASE, "Invalidated TemporaryBasal $it")
+                }
+                return result.invalidated.size > 0
+            }
+    }
+
     override fun invalidateTemporaryBasalWithTempId(temporaryId: Long): Boolean {
         repository.runTransactionForResult(InvalidateTemporaryBasalWithTempIdTransaction(temporaryId))
             .doOnError { aapsLogger.error(LTag.DATABASE, "Error while invalidating TemporaryBasal", it) }

--- a/database/src/main/java/info/nightscout/androidaps/database/transactions/InvalidateTemporaryBasalTransactionWithPumpId.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/transactions/InvalidateTemporaryBasalTransactionWithPumpId.kt
@@ -1,0 +1,25 @@
+package info.nightscout.androidaps.database.transactions
+
+import info.nightscout.androidaps.database.embedments.InterfaceIDs
+import info.nightscout.androidaps.database.entities.TemporaryBasal
+
+class InvalidateTemporaryBasalTransactionWithPumpId(val pumpId: Long, val pumpType: InterfaceIDs.PumpType, val
+pumpSerial:
+String) :
+    Transaction<InvalidateTemporaryBasalTransactionWithPumpId.TransactionResult>() {
+
+    override fun run(): TransactionResult {
+        val result = TransactionResult()
+        val temporaryBasal = database.temporaryBasalDao.findByPumpIds(pumpId, pumpType, pumpSerial)
+            ?: throw IllegalArgumentException("There is no such Temporary Basal with the specified temp ID.")
+        temporaryBasal.isValid = false
+        database.temporaryBasalDao.updateExistingEntry(temporaryBasal)
+        result.invalidated.add(temporaryBasal)
+        return result
+    }
+
+    class TransactionResult {
+
+        val invalidated = mutableListOf<TemporaryBasal>()
+    }
+}


### PR DESCRIPTION
Add `invalidateTemporaryBasalWithPumpId`  to the `PumpSync` interface.
I did not rename the existing `invalidateTemporaryBasal` because it is referenced by the Eros codebase.


    


