### PR TITLE
Xstream permission

### DIFF
--- a/pump-common/src/main/java/info/nightscout/androidaps/plugins/pump/common/sync/PumpSyncStorage.kt
+++ b/pump-common/src/main/java/info/nightscout/androidaps/plugins/pump/common/sync/PumpSyncStorage.kt
@@ -2,6 +2,7 @@ package info.nightscout.androidaps.plugins.pump.common.sync
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.thoughtworks.xstream.security.AnyTypePermission
 import com.thoughtworks.xstream.XStream
 import info.nightscout.androidaps.data.DetailedBolusInfo
 import info.nightscout.androidaps.interfaces.PumpSync
@@ -45,6 +46,7 @@ class PumpSyncStorage @Inject constructor(
             val jsonData: String = sp.getString(pumpSyncStorageKey, "");
 
             if (jsonData.isNotBlank()) {
+                xstream.addPermission(AnyTypePermission.ANY)
                 pumpSyncStorage = xstream.fromXML(jsonData, MutableMap::class.java) as MutableMap<String, MutableList<PumpDbEntry>>
 
                 aapsLogger.debug(LTag.PUMP, String.format("Loading Pump Sync Storage: boluses=%d, tbrs=%d.", pumpSyncStorage[BOLUS]!!.size, pumpSyncStorage[TBR]!!.size))


### PR DESCRIPTION
App crashing on startup:

```
2021-09-02 23:19:30.353 24996-24996/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: info.nightscout.androidaps, PID: 24996
    java.lang.RuntimeException: Unable to create application info.nightscout.androidaps.MainApp: com.thoughtworks.xstream.converters.ConversionException: 
    ---- Debugging information ----
    cause-exception     : com.thoughtworks.xstream.security.ForbiddenClassException
    cause-message       : info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntry
    class               : java.util.ArrayList
    required-type       : java.util.ArrayList
    converter-type      : com.thoughtworks.xstream.converters.collections.CollectionConverter
    path                : /linked-hash-map/entry/list/info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntry
    line number         : 5
    class[1]            : java.util.LinkedHashMap
    required-type[1]    : java.util.LinkedHashMap
    converter-type[1]   : com.thoughtworks.xstream.converters.collections.MapConverter
    version             : 0.0
    -------------------------------
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7207)
        at android.app.ActivityThread.access$1600(ActivityThread.java:287)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2155)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:255)
        at android.app.ActivityThread.main(ActivityThread.java:8192)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
     Caused by: com.thoughtworks.xstream.converters.ConversionException: 
    ---- Debugging information ----
    cause-exception     : com.thoughtworks.xstream.security.ForbiddenClassException
    cause-message       : info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntry
    class               : java.util.ArrayList
    required-type       : java.util.ArrayList
    converter-type      : com.thoughtworks.xstream.converters.collections.CollectionConverter
    path                : /linked-hash-map/entry/list/info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntry
    line number         : 5
    class[1]            : java.util.LinkedHashMap
    required-type[1]    : java.util.LinkedHashMap
    converter-type[1]   : com.thoughtworks.xstream.converters.collections.MapConverter
    version             : 0.0
    -------------------------------
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:77)
        at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readBareItem(AbstractCollectionConverter.java:132)
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readItem(AbstractCollectionConverter.java:117)
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readCompleteItem(AbstractCollectionConverter.java:147)
        at com.thoughtworks.xstream.converters.collections.MapConverter.putCurrentEntryIntoMap(MapConverter.java:106)
        at com.thoughtworks.xstream.converters.collections.MapConverter.populateMap(MapConverter.java:98)
        at com.thoughtworks.xstream.converters.collections.MapConverter.populateMap(MapConverter.java:92)
        at com.thoughtworks.xstream.converters.collections.MapConverter.unmarshal(MapConverter.java:87)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
        at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:134)
2021-09-02 23:19:30.354 24996-24996/? E/AndroidRuntime:     at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
        at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1391)
        at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1376)
        at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1314)
        at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1303)
        at info.nightscout.androidaps.plugins.pump.common.sync.PumpSyncStorage.initStorage(PumpSyncStorage.kt:48)
        at info.nightscout.androidaps.plugins.pump.common.sync.PumpSyncStorage.<init>(PumpSyncStorage.kt:34)
        at info.nightscout.androidaps.plugins.pump.common.di.PumpCommonModule.providesPumpSyncStorage(PumpCommonModule.kt:22)
        at info.nightscout.androidaps.plugins.pump.common.di.PumpCommonModule_ProvidesPumpSyncStorageFactory.providesPumpSyncStorage(PumpCommonModule_ProvidesPumpSyncStorageFactory.java:49)
        at info.nightscout.androidaps.plugins.pump.common.di.PumpCommonModule_ProvidesPumpSyncStorageFactory.get(PumpCommonModule_ProvidesPumpSyncStorageFactory.java:38)
        at info.nightscout.androidaps.plugins.pump.common.di.PumpCommonModule_ProvidesPumpSyncStorageFactory.get(PumpCommonModule_ProvidesPumpSyncStorageFactory.java:13)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at info.nightscout.androidaps.plugins.pump.medtronic.data.MedtronicHistoryData_Factory.get(MedtronicHistoryData_Factory.java:60)
        at info.nightscout.androidaps.plugins.pump.medtronic.data.MedtronicHistoryData_Factory.get(MedtronicHistoryData_Factory.java:17)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at info.nightscout.androidaps.plugins.pump.medtronic.MedtronicPumpPlugin_Factory.get(MedtronicPumpPlugin_Factory.java:102)
        at info.nightscout.androidaps.plugins.pump.medtronic.MedtronicPumpPlugin_Factory.get(MedtronicPumpPlugin_Factory.java:26)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at dagger.internal.MapFactory.get(MapFactory.java:58)
        at dagger.internal.MapFactory.get(MapFactory.java:31)
        at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
        at info.nightscout.androidaps.dependencyInjection.AppModule.providesPlugins(AppModule.kt:49)
        at info.nightscout.androidaps.dependencyInjection.AppModule_ProvidesPluginsFactory.providesPlugins(AppModule_ProvidesPluginsFactory.java:62)
        at info.nightscout.androidaps.dependencyInjection.DaggerAppComponent.listOfPluginBase(DaggerAppComponent.java:2782)
        at info.nightscout.androidaps.dependencyInjection.DaggerAppComponent.injectMainApp(DaggerAppComponent.java:6103)
        at info.nightscout.androidaps.dependencyInjection.DaggerAppComponent.inject(DaggerAppComponent.java:6089)
        at info.nightscout.androidaps.dependencyInjection.DaggerAppComponent.inject(DaggerAppComponent.java:1462)
        at dagger.android.DaggerApplication.injectIfNecessary(DaggerApplication.java:63)
        at dagger.android.DaggerApplication.onCreate(DaggerApplication.java:38)
        at info.nightscout.androidaps.MainApp.onCreate(MainApp.kt:61)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7202)
        	... 8 more
     Caused by: com.thoughtworks.xstream.security.ForbiddenClassException: info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntry
        at com.thoughtworks.xstream.security.NoTypePermission.allows(NoTypePermission.java:26)
        at com.thoughtworks.xstream.mapper.SecurityMapper.realClass(SecurityMapper.java:74)
        at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125)
        at com.thoughtworks.xstream.mapper.CachingMapper.realClass(CachingMapper.java:47)
        at com.thoughtworks.xstream.core.util.HierarchicalStreams.readClassType(HierarchicalStreams.java:29)
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readBareItem(AbstractCollectionConverter.java:131)
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readItem(AbstractCollectionConverter.java:117)
2021-09-02 23:19:30.354 24996-24996/? E/AndroidRuntime:     at com.thoughtworks.xstream.converters.collections.CollectionConverter.addCurrentElementToCollection(CollectionConverter.java:98)
        at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:91)
        at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:85)
        at com.thoughtworks.xstream.converters.collections.CollectionConverter.unmarshal(CollectionConverter.java:80)
        at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
        	... 55 more
```