### PR TITLE
Fix Automation regression (Add missing return)

### DIFF
--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/Action.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/Action.kt
@@ -48,7 +48,7 @@ abstract class Action(val injector: HasAndroidInjector) {
         try {
             val type = obj.getString("type")
             val data = obj.getJSONObject("data")
-            when (type) {
+            return when (type) {
                 ActionAlarm::class.java.name,              // backward compatibility
                 ActionAlarm::class.java.simpleName                -> ActionAlarm(injector).fromJSON(data.toString())
                 ActionDummy::class.java.name,


### PR DESCRIPTION
Add missing `return` in `fun instantiate` (it works, just "else" in when block not tested...)
fix #662 