### PR TITLE
NullPointerException while processing Bolus entries

### DIFF
--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
@@ -473,7 +473,7 @@ class MedtronicHistoryData @Inject constructor(
         for (bolus in entryList) {
 
             val bolusDTO = bolus.decodedData["Object"] as BolusDTO
-            var type: DetailedBolusInfo.BolusType = DetailedBolusInfo.BolusType.NORMAL
+            var type: DetailedBolusInfo.BolusType? = DetailedBolusInfo.BolusType.NORMAL
             var multiwave = false
 
             if (bolusDTO.bolusType == PumpBolusType.Extended) {
@@ -500,7 +500,7 @@ class MedtronicHistoryData @Inject constructor(
                     temporaryId = entryWithTempId.temporaryId
                     pumpSyncStorage.removeBolusWithTemporaryId(temporaryId)
                     boluses.remove(entryWithTempId)
-                    type = entryWithTempId.bolusData!!.bolusType
+                    type = entryWithTempId.bolusData?.bolusType
                 }
             }
 


### PR DESCRIPTION
App crashed continuously after pump sync. I found that pumpSyncStorage.getBoluses() returns an entry with null bolus data - should it work like this?

```
 D/PUMP: [main]: [PumpSyncStorage.initStorage():53]: DD: PumpSyncStorage={BOLUS=[PumpDbEntry(temporaryId=20210907224458, date=1631047498218, pumpType=MEDTRONIC_522_722, serialNumber=[censored], bolusData=null, tbrData=PumpDbEntryTBR(rate=0.0, isAbsolute=true, durationInSeconds=60, tbrType=NORMAL), pumpId=null)], TBR=[PumpDbEntry(temporaryId=20210907224458, date=1631047498218, pumpType=MEDTRONIC_522_722, serialNumber=[censored], bolusData=null, tbrData=PumpDbEntryTBR(rate=0.0, isAbsolute=true, durationInSeconds=60, tbrType=NORMAL), pumpId=null)]}
```

```
2021-09-07 23:28:18.104 15516-15634/? D/PUMP: [Thread-11]: [MedtronicHistoryData.processBolusEntries():495]: DD: entryWithTempId=PumpDbEntry(temporaryId=20210907224458, date=1631047498218, pumpType=MEDTRONIC_522_722, serialNumber=[censored], bolusData=null, tbrData=PumpDbEntryTBR(rate=0.0, isAbsolute=true, durationInSeconds=60, tbrType=NORMAL), pumpId=null)
2021-09-07 23:28:18.105 15516-15634/? D/PUMP: [Thread-11]: [MedtronicHistoryData.processBolusEntries():498]: DD: entryWithTempId.bolusData=null
2021-09-07 23:28:18.111 15516-15634/? E/PUMP: [Thread-11]: [MedtronicHistoryData.processNewHistoryData():342]: ProcessHistoryData: Error processing Bolus entries: null
    java.lang.NullPointerException: null
    	at info.nightscout.androidaps.plugins.pump.medtronic.data.MedtronicHistoryData.processBolusEntries(MedtronicHistoryData.kt:503) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.medtronic.data.MedtronicHistoryData.processNewHistoryData(MedtronicHistoryData.kt:340) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.medtronic.MedtronicPumpPlugin.readPumpHistory(MedtronicPumpPlugin.kt:817) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.medtronic.MedtronicPumpPlugin.initializePump(MedtronicPumpPlugin.kt:430) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.medtronic.MedtronicPumpPlugin.getPumpStatus(MedtronicPumpPlugin.kt:304) ~[na:0.0]
    	at info.nightscout.androidaps.queue.commands.CommandReadStatus.execute(CommandReadStatus.kt:22) ~[na:0.0]
    	at info.nightscout.androidaps.queue.QueueThread.run(QueueThread.kt:118) ~[na:0.0]
2021-09-07 23:28:18.115 15516-15634/? D/PUMPQUEUE: [Thread-11]: [QueueThread.run():145]: thread end

```