### PR TITLE
Fix Android 12 Graph artifacts

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/PointsWithLabelGraphSeries.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/PointsWithLabelGraphSeries.java
@@ -370,22 +370,12 @@ public class PointsWithLabelGraphSeries<E extends DataPointWithLabelInterface> e
      * @param paint paint object
      */
     private void drawArrows(Point[] point, Canvas canvas, Paint paint) {
-        float[] points = new float[8];
-        points[0] = point[0].x;
-        points[1] = point[0].y;
-        points[2] = point[1].x;
-        points[3] = point[1].y;
-        points[4] = point[2].x;
-        points[5] = point[2].y;
-        points[6] = point[0].x;
-        points[7] = point[0].y;
-
         canvas.save();
-        canvas.drawVertices(Canvas.VertexMode.TRIANGLES, 8, points, 0, null, 0, null, 0, null, 0, 0, paint);
         Path path = new Path();
         path.moveTo(point[0].x, point[0].y);
         path.lineTo(point[1].x, point[1].y);
         path.lineTo(point[2].x, point[2].y);
+        path.close();
         canvas.drawPath(path, paint);
         canvas.restore();
     }


### PR DESCRIPTION
In A12, there appears to be some heavy drawing optimizations which is causing artifacts on the `canvas.drawVertices` calls.

The result of this shows up with Triangles having artifacts:
![image](https://user-images.githubusercontent.com/2896311/136740476-933006a9-e505-4740-991e-bfaa68f47a11.png)

This drawing function is not needed to achieve the same outcome and fixes the issue.
