### PR TITLE
make processChangedGlucoseValuesCompat tailrec

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/DataSyncSelectorImplementation.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/DataSyncSelectorImplementation.kt
@@ -419,7 +419,7 @@ class DataSyncSelectorImplementation @Inject constructor(
 
     //private var lastGvId = -1L
     //private var lastGvTime = -1L
-    override fun processChangedGlucoseValuesCompat(): Boolean {
+    override tailrec fun processChangedGlucoseValuesCompat() {
         val lastDbIdWrapped = appRepository.getLastGlucoseValueIdWrapped().blockingGet()
         val lastDbId = if (lastDbIdWrapped is ValueWrapper.Existing) lastDbIdWrapped.value else 0L
         var startId = sp.getLong(R.string.key_ns_glucose_value_last_synced_id, 0)
@@ -431,6 +431,7 @@ class DataSyncSelectorImplementation @Inject constructor(
         //lastGvId = startId
         //lastGvTime = dateUtil.now()
         queueCounter.gvsRemaining = lastDbId - startId
+        var tailCall = false
         appRepository.getNextSyncElementGlucoseValue(startId).blockingGet()?.let { gv ->
             aapsLogger.info(LTag.DATABASE, "Loading GlucoseValue data ID: ${gv.first.id} HistoryID: ${gv.second.id} ")
             if (activePlugin.activeBgSource.shouldUploadToNs(gv.first)) {
@@ -439,15 +440,14 @@ class DataSyncSelectorImplementation @Inject constructor(
                     gv.first.onlyNsIdAdded(gv.second)          -> {
                         confirmLastGlucoseValueIdIfGreater(gv.second.id)
                         //lastGvId = -1
-                        processChangedGlucoseValuesCompat()
                         aapsLogger.info(LTag.DATABASE, "Ignoring GlucoseValue. Only NS id changed ID: ${gv.first.id} HistoryID: ${gv.second.id} ")
-                        return false
+                        tailCall = true
                     }
                     // without nsId = create new
                     gv.first.interfaceIDs.nightscoutId == null ->
                         nsClientPlugin.nsClientService?.dbAdd("entries", gv.first.toJson(true, dateUtil), DataSyncSelector.PairGlucoseValue(gv.first, gv.second.id), "$startId/$lastDbId")
                     // with nsId = update
-                    gv.first.interfaceIDs.nightscoutId != null ->
+                    else ->  //  gv.first.interfaceIDs.nightscoutId != null
                         nsClientPlugin.nsClientService?.dbUpdate(
                             "entries",
                             gv.first.interfaceIDs.nightscoutId,
@@ -456,14 +456,15 @@ class DataSyncSelectorImplementation @Inject constructor(
                             "$startId/$lastDbId"
                         )
                 }
-                return true
             } else {
                 confirmLastGlucoseValueIdIfGreater(gv.second.id)
                 //lastGvId = -1
-                processChangedGlucoseValuesCompat()
+                tailCall = true
             }
         }
-        return false
+        if (tailCall) {
+            processChangedGlucoseValuesCompat()
+        }
     }
 
     override fun confirmLastTherapyEventIdIfGreater(lastSynced: Long) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/DataSyncSelectorImplementation.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/DataSyncSelectorImplementation.kt
@@ -469,9 +469,8 @@ class DataSyncSelectorImplementation @Inject constructor(
                     gv.first.id != gv.second.id && gv.second.id <= sp.getLong(R.string.key_ns_glucose_value_new_data_id, 0) -> {
                         confirmLastGlucoseValueIdIfGreater(gv.second.id)
                         //lastGvId = -1
-                        processChangedGlucoseValuesCompat()
                         aapsLogger.info(LTag.DATABASE, "Ignoring GlucoseValue. Change within first sync ID: ${gv.first.id} HistoryID: ${gv.second.id} ")
-                        return false
+                        tailCall = true
                     }
                     // only NsId changed, no need to upload
                     gv.first.onlyNsIdAdded(gv.second)          -> {

--- a/core/src/main/java/info/nightscout/androidaps/interfaces/DataSyncSelector.kt
+++ b/core/src/main/java/info/nightscout/androidaps/interfaces/DataSyncSelector.kt
@@ -49,7 +49,7 @@ interface DataSyncSelector {
     fun confirmLastGlucoseValueIdIfGreater(lastSynced: Long)
     fun changedGlucoseValues() : List<GlucoseValue>
     // Until NS v3
-    fun processChangedGlucoseValuesCompat(): Boolean
+    fun processChangedGlucoseValuesCompat()
 
     fun confirmLastTherapyEventIdIfGreater(lastSynced: Long)
     fun changedTherapyEvents() : List<TherapyEvent>


### PR DESCRIPTION
Made all the recursive calls for `processChangedGlucoseValuesCompat` tail calls and marked the function as `tailrec`. 

That way, we prevent `java.lang.StackOverflowError ` on Full Sync.
If we decide to go this way we probably have to update the same all the other `process...` functions.

This is the crash that I'm trying to fix here:
```
info.nightscout.androidaps.database.daos.GlucoseValueDao_Impl$12.call (GlucoseValueDao_Impl.java:1959)
info.nightscout.androidaps.database.daos.GlucoseValueDao_Impl$12.call (GlucoseValueDao_Impl.java:1933)
io.reactivex.internal.operators.maybe.MaybeFromCallable.subscribeActual (MaybeFromCallable.java:46)
io.reactivex.Maybe.subscribe (Maybe.java:4290)
io.reactivex.internal.operators.maybe.MaybeFlatten.subscribeActual (MaybeFlatten.java:42)
io.reactivex.Maybe.subscribe (Maybe.java:4290)
io.reactivex.Maybe.blockingGet (Maybe.java:2320)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:434)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.processChangedGlucoseValuesCompat (DataSyncSelectorImplementation.kt:463)
info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation.doUpload (DataSyncSelectorImplementation.kt:76) 
```