### PR TITLE
Fix: inverse comparator in dash history DAO for `allSince`

### DIFF
--- a/omnipod-dash/src/androidTest/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/DashHistoryTest.kt
+++ b/omnipod-dash/src/androidTest/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/DashHistoryTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.guepardoapps.kulid.ULID
+import info.nightscout.androidaps.logging.AAPSLoggerTest
 import info.nightscout.androidaps.plugins.pump.omnipod.common.definition.OmnipodCommandType
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.database.DashHistoryDatabase
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.database.HistoryRecordDao
@@ -34,7 +35,7 @@ class DashHistoryTest {
             DashHistoryDatabase::class.java
         ).build()
         dao = database.historyRecordDao()
-        dashHistory = DashHistory(dao, HistoryMapper())
+        dashHistory = DashHistory(dao, HistoryMapper(), AAPSLoggerTest())
     }
 
     @Test

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordDao.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordDao.kt
@@ -19,7 +19,7 @@ abstract class HistoryRecordDao {
     @Query("SELECT * from historyrecords")
     abstract fun allBlocking(): List<HistoryRecordEntity>
 
-    @Query("SELECT * from historyrecords WHERE createdAt <= :since")
+    @Query("SELECT * from historyrecords WHERE createdAt >= :since")
     abstract fun allSince(since: Long): Single<List<HistoryRecordEntity>>
 
     @Query("SELECT * FROM historyrecords WHERE id = :id LIMIT 1")


### PR DESCRIPTION
Also added AAPSLoggerTest, since emulator test fails otherwise.

@andyrozman @avereha can you verify this? Thanks!