### PR TITLE
Fix eligibility of Open Humans text for labels 

### DIFF
--- a/openhumans/src/main/res/layout/fragment_open_humans_new.xml
+++ b/openhumans/src/main/res/layout/fragment_open_humans_new.xml
@@ -37,7 +37,8 @@
             android:layout_marginTop="8dp"
             android:gravity="center"
             android:text="@string/setup_completed_info"
-            android:textAppearance="?textAppearanceBody2" />
+            android:textAppearance="?textAppearanceBody2"
+            android:textColor="@color/open_humans_text" />
 
         <TextView
             android:id="@+id/member_id"
@@ -46,6 +47,7 @@
             android:layout_marginTop="16dp"
             android:gravity="center"
             android:textAppearance="?textAppearanceBody1"
+            android:textColor="@color/open_humans_text"
             tools:text="Project Member ID: 5151515" />
 
         <com.google.android.material.button.MaterialButton

--- a/openhumans/src/main/res/values/colors.xml
+++ b/openhumans/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="open_humans_orange_variant">#fe6315</color>
     <color name="open_humans_blue">#009fa8</color>
     <color name="open_humans_blue_variant">#036866</color>
+    <color name="open_humans_text">@android:color/white</color>
 </resources>


### PR DESCRIPTION
Fix eligibility of Open Humans text for labels when user have default, non-dark theme https://github.com/nightscout/AndroidAPS/issues/750