### PR TITLE
queue thread changes

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
@@ -60,7 +60,6 @@ class QueueThread internal constructor(
                         //write time
                         sp.putLong(R.string.key_btwatchdog_lastbark, System.currentTimeMillis())
                         //toggle BT
-                        pump.stopConnecting()
                         pump.disconnect("watchdog")
                         SystemClock.sleep(1000)
                         val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()

--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
@@ -111,14 +111,18 @@ class QueueThread internal constructor(
                     // Pickup 1st command and set performing variable
                     if (queue.size() > 0) {
                         queue.pickup()
-                        if (queue.performing() != null) {
-                            aapsLogger.debug(LTag.PUMPQUEUE, "performing " + queue.performing()?.status())
+                        val cont = queue.performing()?.let {
+                            aapsLogger.debug(LTag.PUMPQUEUE, "performing " + it.status())
                             rxBus.send(EventQueueChanged())
-                            queue.performing()?.execute()
+                            rxBus.send(EventPumpStatusChanged(it.status()))
+                            it.execute()
                             queue.resetPerforming()
                             rxBus.send(EventQueueChanged())
                             lastCommandTime = System.currentTimeMillis()
                             SystemClock.sleep(100)
+                            true
+                        } ?: false
+                        if (cont) {
                             continue
                         }
                     }


### PR DESCRIPTION
I noticed that when the bluetooth watchdog is enabled, we call `stopConnecting` twice. Is this double call on purpose?
This PR removes the second call.

My plan is to count the number of calls to stopConnecting in order to measure the number of "failed connections after retries" in a different PR.

This change also displays the current executing operation(`rxBus.send(EventPumpStatusChanged(it.status()))`). Before, it would display: "Handshaking" while the command was executed.
One possible future issue is that those strings are not translated, but from what I see we use them in other places, so they should be i8n-ed anyway.

