### PR TITLE
dash: connection quality

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
@@ -60,7 +60,6 @@ class QueueThread internal constructor(
                         //write time
                         sp.putLong(R.string.key_btwatchdog_lastbark, System.currentTimeMillis())
                         //toggle BT
-                        pump.stopConnecting()
                         pump.disconnect("watchdog")
                         SystemClock.sleep(1000)
                         val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()

--- a/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
+++ b/app/src/main/java/info/nightscout/androidaps/queue/QueueThread.kt
@@ -111,14 +111,18 @@ class QueueThread internal constructor(
                     // Pickup 1st command and set performing variable
                     if (queue.size() > 0) {
                         queue.pickup()
-                        if (queue.performing() != null) {
-                            aapsLogger.debug(LTag.PUMPQUEUE, "performing " + queue.performing()?.status())
+                        val cont = queue.performing()?.let {
+                            aapsLogger.debug(LTag.PUMPQUEUE, "performing " + it.status())
                             rxBus.send(EventQueueChanged())
-                            queue.performing()?.execute()
+                            rxBus.send(EventPumpStatusChanged(it.status()))
+                            it.execute()
                             queue.resetPerforming()
                             rxBus.send(EventQueueChanged())
                             lastCommandTime = System.currentTimeMillis()
                             SystemClock.sleep(100)
+                            true
+                        } ?: false
+                        if (cont) {
                             continue
                         }
                     }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -243,7 +243,6 @@ class OmnipodDashPumpPlugin @Inject constructor(
             val stop = CountDownLatch(1)
             stopConnecting = stop
         }
-        podStateManager.incrementConnectionAttemptsWithRetries()
         thread(
             start = true,
             name = "ConnectionThread",
@@ -252,6 +251,9 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 stopConnecting?.let {
                     val error = omnipodManager.connect(it).ignoreElements().blockingGet()
                     aapsLogger.info(LTag.PUMPCOMM, "connect error=$error")
+                    if (error == null) {
+                        podStateManager.incrementSuccessfulConnectionAttemptsAfterRetries()
+                    }
                 }
             } finally {
                 synchronized(this) {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -235,7 +235,6 @@ class OmnipodDashPumpPlugin @Inject constructor(
     override fun connect(reason: String) {
         aapsLogger.info(LTag.PUMP, "connect reason=$reason")
         podStateManager.bluetoothConnectionState = OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTING
-
         synchronized(this) {
             stopConnecting?.let {
                 aapsLogger.warn(LTag.PUMP, "Already connecting: $stopConnecting")
@@ -244,7 +243,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
             val stop = CountDownLatch(1)
             stopConnecting = stop
         }
-
+        podStateManager.incrementConnectionAttemptsWithRetries()
         thread(
             start = true,
             name = "ConnectionThread",
@@ -270,6 +269,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
 
     override fun stopConnecting() {
         aapsLogger.info(LTag.PUMP, "stopConnecting")
+        podStateManager.incrementFailedConnectionsAfterRetries()
         stopConnecting?.countDown()
         omnipodManager.disconnect(true)
     }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -33,7 +33,7 @@ interface OmnipodDashPodStateManager {
     var bluetoothConnectionState: BluetoothConnectionState
     var connectionAttempts: Int
     var successfulConnections: Int
-    val connectionAttemptsWithRetries: Int
+    val successfulConnectionAttemptsAfterRetries: Int
     val failedConnectionsAfterRetries: Int
 
     var timeZone: TimeZone
@@ -87,7 +87,7 @@ interface OmnipodDashPodStateManager {
     fun updateFromPairing(uniqueId: Id, pairResult: PairResult)
     fun reset()
     fun connectionSuccessRatio(): Float
-    fun incrementConnectionAttemptsWithRetries()
+    fun incrementSuccessfulConnectionAttemptsAfterRetries()
     fun incrementFailedConnectionsAfterRetries()
 
     fun createActiveCommand(

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -33,6 +33,8 @@ interface OmnipodDashPodStateManager {
     var bluetoothConnectionState: BluetoothConnectionState
     var connectionAttempts: Int
     var successfulConnections: Int
+    val connectionAttemptsWithRetries: Int
+    val failedConnectionsAfterRetries: Int
 
     var timeZone: TimeZone
     val sameTimeZone: Boolean // The TimeZone is the same on the phone and on the pod
@@ -85,6 +87,8 @@ interface OmnipodDashPodStateManager {
     fun updateFromPairing(uniqueId: Id, pairResult: PairResult)
     fun reset()
     fun connectionSuccessRatio(): Float
+    fun incrementConnectionAttemptsWithRetries()
+    fun incrementFailedConnectionsAfterRetries()
 
     fun createActiveCommand(
         historyId: String,

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -114,13 +114,13 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             podState.successfulConnections = value
         }
 
-    override val connectionAttemptsWithRetries: Int
+    override val successfulConnectionAttemptsAfterRetries: Int
         @Synchronized
-        get() = podState.connectionAttemptsWithRetries
+        get() = podState.successfulConnectionAttemptsAfterRetries
 
     @Synchronized
-    override fun incrementConnectionAttemptsWithRetries() {
-        podState.connectionAttemptsWithRetries++
+    override fun incrementSuccessfulConnectionAttemptsAfterRetries() {
+        podState.successfulConnectionAttemptsAfterRetries++
     }
 
     override val failedConnectionsAfterRetries: Int
@@ -646,10 +646,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     }
 
     override fun connectionSuccessRatio(): Float {
-        if (connectionAttemptsWithRetries == 0) {
+        if (failedConnectionsAfterRetries + successfulConnectionAttemptsAfterRetries == 0) {
             return 0.0F
         }
-        return 1 - (failedConnectionsAfterRetries.toFloat() / connectionAttemptsWithRetries)
+        return successfulConnectionAttemptsAfterRetries.toFloat() / (successfulConnectionAttemptsAfterRetries + failedConnectionsAfterRetries)
     }
 
     override fun reset() {
@@ -691,7 +691,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             OmnipodDashPodStateManager.BluetoothConnectionState.DISCONNECTED
         var connectionAttempts = 0
         var successfulConnections = 0
-        var connectionAttemptsWithRetries = 0
+        var successfulConnectionAttemptsAfterRetries = 0
         var failedConnectionsAfterRetries = 0
         var messageSequenceNumber: Short = 0
         var sequenceNumberOfLastProgrammingCommand: Short? = null

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -50,6 +50,7 @@ import org.apache.commons.lang3.StringUtils
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.*
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.collections.ArrayList
 
@@ -213,6 +214,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         disposables += rxBus
             .toObservable(EventPumpStatusChanged::class.java)
             .observeOn(aapsSchedulers.main)
+            .delay(30, TimeUnit.MILLISECONDS, aapsSchedulers.main)
             .subscribe(
                 {
                     updateBluetoothConnectionStatus(it)

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -256,14 +256,15 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
             ?: PLACEHOLDER
 
         val connectionSuccessPercentage = podStateManager.connectionSuccessRatio() * 100
+        val connectionAttempts = podStateManager.failedConnectionsAfterRetries + podStateManager.successfulConnectionAttemptsAfterRetries
         val successPercentageString = String.format("%.2f %%", connectionSuccessPercentage)
         val quality =
-            "${podStateManager.connectionAttemptsWithRetries - podStateManager.failedConnectionsAfterRetries}/${podStateManager.connectionAttemptsWithRetries} :: $successPercentageString"
+            "${podStateManager.successfulConnectionAttemptsAfterRetries}/$connectionAttempts :: $successPercentageString"
         bluetoothStatusBinding.omnipodDashBluetoothConnectionQuality.text = quality
         val connectionStatsColor = when {
-            connectionSuccessPercentage < 70 && podStateManager.connectionAttemptsWithRetries > 50 ->
+            connectionSuccessPercentage < 70 && podStateManager.successfulConnectionAttemptsAfterRetries > 50 ->
                 Color.RED
-            connectionSuccessPercentage < 90 && podStateManager.connectionAttemptsWithRetries > 50 ->
+            connectionSuccessPercentage < 90 && podStateManager.successfulConnectionAttemptsAfterRetries > 50 ->
                 Color.YELLOW
             else ->
                 Color.WHITE

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -256,15 +256,15 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         val connectionSuccessPercentage = podStateManager.connectionSuccessRatio() * 100
         val successPercentageString = String.format("%.2f %%", connectionSuccessPercentage)
         val quality =
-            "${podStateManager.successfulConnections}/${podStateManager.connectionAttempts} :: $successPercentageString"
+            "${podStateManager.connectionAttemptsWithRetries - podStateManager.failedConnectionsAfterRetries}/${podStateManager.connectionAttemptsWithRetries} :: $successPercentageString"
         bluetoothStatusBinding.omnipodDashBluetoothConnectionQuality.text = quality
         val connectionStatsColor = when {
-            connectionSuccessPercentage > 90 ->
-                Color.WHITE
-            connectionSuccessPercentage > 60 ->
+            connectionSuccessPercentage < 70 && podStateManager.connectionAttemptsWithRetries > 50 ->
+                Color.RED
+            connectionSuccessPercentage < 90 && podStateManager.connectionAttemptsWithRetries > 50 ->
                 Color.YELLOW
             else ->
-                Color.RED
+                Color.WHITE
         }
         bluetoothStatusBinding.omnipodDashBluetoothConnectionQuality.setTextColor(connectionStatsColor)
         bluetoothStatusBinding.omnipodDashDeliveryStatus.text = podStateManager.deliveryStatus?.let {


### PR DESCRIPTION
This change contains https://github.com/nightscout/AndroidAPS/pull/902. It's easier if you review that PR first.
With this PR we change the way connection quality for dash is calculated.
Before: count all connection attempts
After: count connection attempts after retries. That way, we can better see the impact on the commands that are not executed.