### PR TITLE
do not stop the fake tbr on pod activation

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
@@ -21,7 +21,6 @@ import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.DashHistory
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.data.BasalValuesRecord
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.data.InitialResult
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.data.ResolvedResult
-import info.nightscout.androidaps.plugins.pump.omnipod.dash.util.Constants
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.util.I8n
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.util.mapProfileToBasalProgram
 import info.nightscout.androidaps.utils.FabricPrivacy
@@ -95,15 +94,6 @@ class DashInsertCannulaViewModel @Inject constructor(
                     onComplete = {
                         logger.debug("Pod activation part 2 completed")
                         podStateManager.basalProgram = basalProgram
-
-                        pumpSync.syncStopTemporaryBasalWithPumpId(
-                            timestamp = System.currentTimeMillis(),
-                            endPumpId = System.currentTimeMillis(),
-                            pumpType = PumpType.OMNIPOD_DASH,
-                            pumpSerial = Constants.PUMP_SERIAL_FOR_FAKE_TBR // cancel the fake TBR with the same pump
-                            // serial that it was created with
-                        )
-
                         pumpSync.connectNewPump()
 
                         pumpSync.insertTherapyEventIfNewWithTimestamp(


### PR DESCRIPTION
I'm reopening this PR.
Calling `syncStopTemporaryBasalWithPumpId` is not needed because `connectNewPump` cancels any active TBRs. Dash calls `connectNewPump` on pod activation.