### PR TITLE
Dash alarms: fix notification

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -342,15 +342,16 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     aapsLogger.info(LTag.PUMP, "syncBolusWithPumpId on CANCEL_BOLUS returned: $sync")
                 }
             }
-
-            podStateManager.alarmType?.let {
-                showNotification(
-                    Notification.OMNIPOD_POD_FAULT,
-                    it.toString(),
-                    Notification.URGENT,
-                    R.raw.boluserror
-                )
-                if (!podStateManager.alarmSynced) {
+            if (!podStateManager.alarmSynced) {
+                podStateManager.alarmType?.let {
+                    if (!commandQueue.isCustomCommandInQueue(CommandDeactivatePod::class.java)) {
+                        showNotification(
+                            Notification.OMNIPOD_POD_FAULT,
+                            it.toString(),
+                            Notification.URGENT,
+                            R.raw.boluserror
+                        )
+                    }
                     pumpSync.insertAnnouncement(
                         error = it.toString(),
                         pumpId = Random.Default.nextLong(),


### PR DESCRIPTION
- show notification only once
- and if there is no 'deactivate pod' command in progress
Fixes: https://github.com/nightscout/AndroidAPS/issues/903