### PR TITLE
dash: suspend alerts

### DIFF
--- a/omnipod-common/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/common/queue/command/CommandDisableSuspendAlerts.kt
+++ b/omnipod-common/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/common/queue/command/CommandDisableSuspendAlerts.kt
@@ -1,0 +1,9 @@
+package info.nightscout.androidaps.plugins.pump.omnipod.common.queue.command
+
+import info.nightscout.androidaps.queue.commands.CustomCommand
+
+class CommandDisableSuspendAlerts: CustomCommand {
+
+    override val statusDescription: String
+        get() = "DISABLE SUSPEND ALERTS"
+}

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -1116,7 +1116,6 @@ class OmnipodDashPumpPlugin @Inject constructor(
         }
     }
 
-
     private fun silenceAlerts(): PumpEnactResult {
         // TODO filter alert types
         return podStateManager.activeAlerts?.let {
@@ -1141,7 +1140,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 BeepRepetitionType.EVERY_MINUTE_AND_EVERY_15_MIN
             ),
         )
-        val ret =  executeProgrammingCommand(
+        val ret = executeProgrammingCommand(
             historyEntry = history.createRecord(OmnipodCommandType.CONFIGURE_ALERTS),
             command = omnipodManager.programAlerts(alerts).ignoreElements(),
         ).toPumpEnactResult()

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
@@ -22,7 +22,7 @@ interface OmnipodDashManager {
     fun setBasalProgram(basalProgram: BasalProgram, hasBasalBeepEnabled: Boolean): Observable<PodEvent>
 
     fun suspendDelivery(hasBasalBeepEnabled: Boolean): Observable<PodEvent>
-    
+
     fun setTempBasal(rate: Double, durationInMinutes: Short, tempBasalBeeps: Boolean): Observable<PodEvent>
 
     fun stopTempBasal(hasTempBasalBeepEnabled: Boolean): Observable<PodEvent>

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
@@ -22,7 +22,7 @@ interface OmnipodDashManager {
     fun setBasalProgram(basalProgram: BasalProgram, hasBasalBeepEnabled: Boolean): Observable<PodEvent>
 
     fun suspendDelivery(hasBasalBeepEnabled: Boolean): Observable<PodEvent>
-
+    
     fun setTempBasal(rate: Double, durationInMinutes: Short, tempBasalBeeps: Boolean): Observable<PodEvent>
 
     fun stopTempBasal(hasTempBasalBeepEnabled: Boolean): Observable<PodEvent>

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -498,7 +498,6 @@ class OmnipodDashManagerImpl @Inject constructor(
         }
     }
 
-
     override fun suspendDelivery(hasBasalBeepEnabled: Boolean): Observable<PodEvent> {
         return Observable.concat(
             observePodRunning,

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -437,7 +437,7 @@ class OmnipodDashManagerImpl @Inject constructor(
                             userExpiryAlertDelay.toMinutes().toShort()
                         ),
                         BeepType.FOUR_TIMES_BIP_BEEP,
-                        BeepRepetitionType.EVERY_MINUTE
+                        BeepRepetitionType.EVERY_MINUTE_AND_EVERY_15_MIN
                     )
                 )
             }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -437,7 +437,7 @@ class OmnipodDashManagerImpl @Inject constructor(
                             userExpiryAlertDelay.toMinutes().toShort()
                         ),
                         BeepType.FOUR_TIMES_BIP_BEEP,
-                        BeepRepetitionType.XXX2
+                        BeepRepetitionType.EVERY_MINUTE
                     )
                 )
             }
@@ -498,12 +498,34 @@ class OmnipodDashManagerImpl @Inject constructor(
         }
     }
 
+
     override fun suspendDelivery(hasBasalBeepEnabled: Boolean): Observable<PodEvent> {
         return Observable.concat(
             observePodRunning,
             observeConnectToPod,
-            observeSendStopDeliveryCommand(StopDeliveryCommand.DeliveryType.ALL, hasBasalBeepEnabled)
-        ).interceptPodEvents()
+            observeSuspendDeliveryCommand(hasBasalBeepEnabled)
+        ).doOnComplete {
+            podStateManager.suspendAlertsEnabled = true
+        }.interceptPodEvents()
+    }
+
+    private fun observeSuspendDeliveryCommand(hasBasalBeepEnabled: Boolean): Observable<PodEvent> {
+        return Observable.defer {
+            val beepType = if (!hasBasalBeepEnabled)
+                BeepType.SILENT
+            else
+                BeepType.LONG_SINGLE_BEEP
+
+            bleManager.sendCommand(
+                SuspendDeliveryCommand.Builder()
+                    .setSequenceNumber(podStateManager.messageSequenceNumber)
+                    .setUniqueId(podStateManager.uniqueId!!.toInt())
+                    .setNonce(NONCE)
+                    .setBeepType(beepType)
+                    .build(),
+                DefaultStatusResponse::class
+            )
+        }
     }
 
     private fun observeSendProgramTempBasalCommand(rate: Double, durationInMinutes: Short, tempBasalBeeps: Boolean): Observable<PodEvent> {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommand.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommand.kt
@@ -38,6 +38,18 @@ class ProgramAlertsCommand private constructor(
             return appendCrc(byteBuffer.array())
         }
 
+    val encodedWithoutHeaderAndCRC32: ByteArray
+        get() {
+            val byteBuffer: ByteBuffer = ByteBuffer.allocate(getLength().toInt())
+                .put(commandType.value)
+                .put(getBodyLength())
+                .putInt(nonce)
+            for (configuration in alertConfigurations) {
+                byteBuffer.put(configuration.encoded)
+            }
+            return byteBuffer.array()
+        }
+
     override fun toString(): String {
         return "ProgramAlertsCommand{" +
             "alertConfigurations=" + alertConfigurations +

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
@@ -1,0 +1,125 @@
+package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.command
+
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.command.base.CommandType
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.command.base.NonceEnabledCommand
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.command.base.builder.NonceEnabledCommandBuilder
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.*
+import java.nio.ByteBuffer
+import java.util.*
+
+// StopDelivery.ALL followed by ProgramAlerts
+class SuspendDeliveryCommand private constructor(
+    uniqueId: Int,
+    sequenceNumber: Short,
+    multiCommandFlag: Boolean,
+    private val beepType: BeepType,
+    nonce: Int
+) : NonceEnabledCommand(CommandType.STOP_DELIVERY, uniqueId, sequenceNumber, multiCommandFlag, nonce) {
+
+    override val encoded: ByteArray
+        get() {
+            val alerts = listOf(
+                AlertConfiguration(
+                    AlertType.SUSPEND_IN_PROGRESS,
+                    enabled = true,
+                    durationInMinutes = 10,
+                    autoOff = false,
+                    AlertTrigger.TimerTrigger(
+                        1
+                    ),
+                    BeepType.XXX,
+                    BeepRepetitionType.XXX4
+                ),
+                AlertConfiguration(
+                    AlertType.SUSPEND_ENDED,
+                    enabled = true,
+                    durationInMinutes = 0,
+                    autoOff = false,
+                    AlertTrigger.TimerTrigger(
+                        10
+                    ),
+                    BeepType.FOUR_TIMES_BIP_BEEP,
+                    BeepRepetitionType.EVERY_MINUTE
+                ),
+            )
+            val programAlerts = ProgramAlertsCommand.Builder()
+                .setNonce(nonce)
+                .setUniqueId(uniqueId)
+                .setAlertConfigurations(alerts)
+                .setSequenceNumber(sequenceNumber)
+                .setMultiCommandFlag(false)
+                .build()
+                .encodedWithoutHeaderAndCRC32
+
+            val byteBuffer = ByteBuffer.allocate(LENGTH + HEADER_LENGTH + programAlerts.size)
+                .put(encodeHeader(uniqueId, sequenceNumber, (LENGTH + programAlerts.size).toShort(), multiCommandFlag))
+                .put(commandType.value)
+                .put(BODY_LENGTH)
+                .putInt(nonce)
+                .put((beepType.value.toInt() shl 4 or DeliveryType.ALL.encoded[0].toInt()).toByte())
+                .put(programAlerts)
+                .array()
+
+            return appendCrc(
+                byteBuffer
+            )
+        }
+
+    override fun toString(): String {
+        return "SuspendDeliveryCommand{" +
+            "deliveryType=" + DeliveryType.ALL +
+            ", beepType=" + beepType +
+            ", nonce=" + nonce +
+            ", commandType=" + commandType +
+            ", uniqueId=" + uniqueId +
+            ", sequenceNumber=" + sequenceNumber +
+            ", multiCommandFlag=" + multiCommandFlag +
+            '}'
+    }
+
+    enum class DeliveryType(
+        private val basal: Boolean,
+        private val tempBasal: Boolean,
+        private val bolus: Boolean
+    ) : Encodable {
+
+        BASAL(true, false, false), TEMP_BASAL(false, true, false), BOLUS(false, false, true), ALL(true, true, true);
+
+        override val encoded: ByteArray
+            get() {
+                val bitSet = BitSet(8)
+                bitSet[0] = basal
+                bitSet[1] = tempBasal
+                bitSet[2] = bolus
+                return bitSet.toByteArray()
+            }
+    }
+
+    class Builder : NonceEnabledCommandBuilder<Builder, SuspendDeliveryCommand>() {
+        private var beepType: BeepType? = BeepType.LONG_SINGLE_BEEP
+
+        fun setBeepType(beepType: BeepType): Builder {
+            this.beepType = beepType
+            return this
+        }
+
+        override fun buildCommand(): SuspendDeliveryCommand {
+            requireNotNull(beepType) { "beepType can not be null" }
+
+            return SuspendDeliveryCommand(
+                uniqueId!!,
+                sequenceNumber!!,
+                multiCommandFlag,
+                beepType!!,
+                nonce!!
+            )
+        }
+    }
+
+    companion object {
+
+        private const val LENGTH: Short = 7
+        private const val BODY_LENGTH: Byte = 5
+    }
+
+}

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
@@ -20,26 +20,15 @@ class SuspendDeliveryCommand private constructor(
         get() {
             val alerts = listOf(
                 AlertConfiguration(
-                    AlertType.SUSPEND_IN_PROGRESS,
-                    enabled = true,
-                    durationInMinutes = 10,
-                    autoOff = false,
-                    AlertTrigger.TimerTrigger(
-                        1
-                    ),
-                    BeepType.XXX,
-                    BeepRepetitionType.XXX4
-                ),
-                AlertConfiguration(
                     AlertType.SUSPEND_ENDED,
                     enabled = true,
                     durationInMinutes = 0,
                     autoOff = false,
                     AlertTrigger.TimerTrigger(
-                        10
+                        20
                     ),
                     BeepType.FOUR_TIMES_BIP_BEEP,
-                    BeepRepetitionType.EVERY_MINUTE
+                    BeepRepetitionType.EVERY_MINUTE_AND_EVERY_15_MIN
                 ),
             )
             val programAlerts = ProgramAlertsCommand.Builder()

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommand.kt
@@ -110,5 +110,4 @@ class SuspendDeliveryCommand private constructor(
         private const val LENGTH: Short = 7
         private const val BODY_LENGTH: Byte = 5
     }
-
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
@@ -6,8 +6,8 @@ enum class BeepRepetitionType(
 ) {
 
     XXX(0x01.toByte()), // Used in lump of coal alert, LOW_RESERVOIR
-    XXX2(0x03.toByte()), // Used in USER_SET_EXPIRATION
+    EVERY_MINUTE(0x03.toByte()), // Used in USER_SET_EXPIRATION, suspend delivery
     XXX3(0x05.toByte()), // published system expiration alert
-    XXX4(0x06.toByte()), // Used in imminent pod expiration alert, suspend in progress
+    XXX4(0x06.toByte()), // Used in imminent pod expiration alert, suspend in progress. No repeat?
     XXX5(0x08.toByte()); // Lump of coal alert
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
@@ -6,7 +6,7 @@ enum class BeepRepetitionType(
 ) {
 
     XXX(0x01.toByte()), // Used in lump of coal alert, LOW_RESERVOIR
-    EVERY_MINUTE(0x03.toByte()), // Used in USER_SET_EXPIRATION, suspend delivery
+    EVERY_MINUTE_AND_EVERY_15_MIN(0x03.toByte()), // Used in USER_SET_EXPIRATION, suspend delivery
     XXX3(0x05.toByte()), // published system expiration alert
     XXX4(0x06.toByte()), // Used in imminent pod expiration alert, suspend in progress. No repeat?
     XXX5(0x08.toByte()); // Lump of coal alert

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -77,6 +77,7 @@ interface OmnipodDashPodStateManager {
     var basalProgram: BasalProgram?
     val activeCommand: ActiveCommand?
     val lastBolus: LastBolus?
+    var suspendAlertsEnabled: Boolean
 
     fun increaseMessageSequenceNumber()
     fun increaseEapAkaSequenceNumber(): ByteArray

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -224,6 +224,13 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             store()
         }
 
+    override var suspendAlertsEnabled: Boolean
+        get() = podState.suspendAlertsEnabled
+        set(enabled) {
+            podState.suspendAlertsEnabled = enabled
+            store()
+        }
+
     override val lastStatusResponseReceived: Long
         get() = podState.lastStatusResponseReceived
 
@@ -713,6 +720,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var timeZoneOffset: Int? = null
         var timeZoneUpdated: Long? = null
         var alarmSynced: Boolean = false
+        var suspendAlertsEnabled: Boolean = false
 
         var bleVersion: SoftwareVersion? = null
         var firmwareVersion: SoftwareVersion? = null

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -442,7 +442,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
             AlertType.SUSPEND_IN_PROGRESS ->
                 R.string.omnipod_common_alert_delivery_suspended
             AlertType.SUSPEND_ENDED ->
-                R.string.omnipod_common_alert_delivery_suspended2
+                R.string.omnipod_common_alert_delivery_suspended
             else ->
                 R.string.omnipod_common_alert_unknown_alert
         }
@@ -633,16 +633,8 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
 
     private fun updateSuspendDeliveryButton() {
         // If the Pod is currently suspended, we show the Resume delivery button instead.
-        if (isSuspendDeliveryButtonEnabled() &&
-            podStateManager.isPodRunning &&
-            (!podStateManager.isSuspended || commandQueue.isCustomCommandInQueue(CommandSuspendDelivery::class.java))
-        ) {
-            buttonBinding.buttonSuspendDelivery.visibility = View.VISIBLE
-            buttonBinding.buttonSuspendDelivery.isEnabled =
-                podStateManager.isPodRunning && !podStateManager.isSuspended && isQueueEmpty()
-        } else {
-            buttonBinding.buttonSuspendDelivery.visibility = View.GONE
-        }
+        // disable the 'suspendDelivery' button.
+        buttonBinding.buttonSuspendDelivery.visibility = View.GONE
     }
 
     private fun updateSetTimeButton() {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -439,6 +439,10 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
                 R.string.omnipod_common_alert_expiration_advisory
             AlertType.AUTO_OFF ->
                 R.string.omnipod_common_alert_shutdown_imminent
+            AlertType.SUSPEND_IN_PROGRESS ->
+                R.string.omnipod_common_alert_delivery_suspended
+            AlertType.SUSPEND_ENDED ->
+                R.string.omnipod_common_alert_delivery_suspended2
             else ->
                 R.string.omnipod_common_alert_unknown_alert
         }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -650,10 +650,6 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         return sp.getBoolean(R.string.omnipod_common_preferences_automatically_silence_alerts, false)
     }
 
-    private fun isSuspendDeliveryButtonEnabled(): Boolean {
-        return sp.getBoolean(R.string.key_omnipod_common_suspend_delivery_button_enabled, false)
-    }
-
     private fun displayErrorDialog(title: String, message: String, withSound: Boolean) {
         context?.let {
             ErrorHelperActivity.runAlarm(it, message, title, if (withSound) R.raw.boluserror else 0)

--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -48,5 +48,4 @@
     <string name="omnipod_common_history_bolus_value">%1$.2f U</string>
     <string name="dash_bolusdelivering">Delivering %1$.2f U</string>
     <string name="omnipod_common_alert_delivery_suspended">Insulin delivery is suspended</string>
-    <string name="omnipod_common_alert_delivery_suspended2">Insulin delivery is suspended 2</string>
 </resources>

--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -47,4 +47,6 @@
     <string name="omnipod_common_history_tbr_value">Rate: %1$.2f U, duration: %2$d minutes</string>
     <string name="omnipod_common_history_bolus_value">%1$.2f U</string>
     <string name="dash_bolusdelivering">Delivering %1$.2f U</string>
+    <string name="omnipod_common_alert_delivery_suspended">Insulin delivery is suspended</string>
+    <string name="omnipod_common_alert_delivery_suspended2">Insulin delivery is suspended 2</string>
 </resources>

--- a/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -104,12 +104,7 @@
         android:key="@string/key_common_preferences_category_other_settings"
         android:title="@string/omnipod_common_preferences_category_other"
         app:initialExpandedChildrenCount="0">
-
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/key_omnipod_common_suspend_delivery_button_enabled"
-            android:title="@string/omnipod_common_preferences_suspend_delivery_button_enabled" />
-
+        
         <SwitchPreference
             android:defaultValue="true"
             android:key="@string/key_omnipod_common_time_change_event_enabled"

--- a/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommandTest.kt
+++ b/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommandTest.kt
@@ -85,7 +85,7 @@ class ProgramAlertsCommandTest {
                 false,
                 AlertTrigger.TimerTrigger(4079.toShort()),
                 BeepType.FOUR_TIMES_BIP_BEEP,
-                BeepRepetitionType.EVERY_MINUTE
+                BeepRepetitionType.EVERY_MINUTE_AND_EVERY_15_MIN
             )
         )
 

--- a/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommandTest.kt
+++ b/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramAlertsCommandTest.kt
@@ -85,7 +85,7 @@ class ProgramAlertsCommandTest {
                 false,
                 AlertTrigger.TimerTrigger(4079.toShort()),
                 BeepType.FOUR_TIMES_BIP_BEEP,
-                BeepRepetitionType.XXX2
+                BeepRepetitionType.EVERY_MINUTE
             )
         )
 

--- a/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommandTest.kt
+++ b/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/SuspendDeliveryCommandTest.kt
@@ -1,0 +1,20 @@
+package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.command
+
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.BeepType
+import org.apache.commons.codec.DecoderException
+import org.apache.commons.codec.binary.Hex
+import org.junit.Assert
+import org.junit.Test
+
+class SuspendDeliveryCommandTest {
+    @Test @Throws(DecoderException::class) fun testSuspendDelivery() {
+        val encoded = SuspendDeliveryCommand.Builder()
+            .setUniqueId(37879811)
+            .setSequenceNumber(0.toShort())
+            .setNonce(1229869870)
+            .setBeepType(BeepType.LONG_SINGLE_BEEP)
+            .build()
+            .encoded
+        Assert.assertArrayEquals(Hex.decodeHex("0242000300131f05494e532e67190a494e532e680000140302811f"), encoded)
+    }
+}


### PR DESCRIPTION
This PR contains multiple changes
 - removed the 'Suspend delivery' button
 - try to resume delivery every time it is suspended. If delivery is suspended it can mean one single thing: profile switching failed.
 - enable beep alerts on pod if delivery is suspended: the alert starts after 20min: 4 beeps every minute and then this is repeated every 15min.
 
Fixes https://github.com/nightscout/AndroidAPS/issues/858, https://github.com/nightscout/AndroidAPS/issues/958