### PR TITLE
Fix user entry units convertion

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
@@ -161,12 +161,17 @@ class DexcomPlugin @Inject constructor(
                                 ValueWithUnit.TherapyEventType(it.type))
                             aapsLogger.debug(LTag.DATABASE, "Inserted sensor insertion $it")
                         }
-                        result.calibrationsInserted.forEach {
-                            uel.log(Action.CAREPORTAL,
-                                Sources.Dexcom,
-                                ValueWithUnit.Timestamp(it.timestamp),
-                                ValueWithUnit.TherapyEventType(it.type))
-                            aapsLogger.debug(LTag.DATABASE, "Inserted calibration $it")
+                        result.calibrationsInserted.forEach {   calibration ->
+                            calibration.glucose?.let {  glucosevalue ->
+                                uel.log(
+                                    Action.CAREPORTAL,
+                                    Sources.Dexcom,
+                                    ValueWithUnit.Timestamp(calibration.timestamp),
+                                    ValueWithUnit.TherapyEventType(calibration.type),
+                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString())
+                                )
+                            }
+                            aapsLogger.debug(LTag.DATABASE, "Inserted calibration $calibration")
                         }
                     }
             } catch (e: Exception) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
@@ -164,11 +164,11 @@ class DexcomPlugin @Inject constructor(
                         result.calibrationsInserted.forEach {   calibration ->
                             calibration.glucose?.let {  glucosevalue ->
                                 uel.log(
-                                    Action.CAREPORTAL,
+                                    Action.CALIBRATION,
                                     Sources.Dexcom,
                                     ValueWithUnit.Timestamp(calibration.timestamp),
                                     ValueWithUnit.TherapyEventType(calibration.type),
-                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString())
+                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString)
                                 )
                             }
                             aapsLogger.debug(LTag.DATABASE, "Inserted calibration $calibration")

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
@@ -153,11 +153,11 @@ class GlunovoPlugin @Inject constructor(
                         savedValues.calibrationsInserted.forEach {  calibration ->
                             calibration.glucose?.let { glucosevalue ->
                                 uel.log(
-                                    UserEntry.Action.CAREPORTAL,
+                                    UserEntry.Action.CALIBRATION,
                                     UserEntry.Sources.Dexcom,
                                     ValueWithUnit.Timestamp(calibration.timestamp),
                                     ValueWithUnit.TherapyEventType(calibration.type),
-                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString())
+                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString)
                                 )
                             }
                             aapsLogger.debug(LTag.DATABASE, "Inserted calibration $calibration")

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
@@ -10,6 +10,8 @@ import info.nightscout.androidaps.R
 import info.nightscout.androidaps.database.AppRepository
 import info.nightscout.androidaps.database.entities.GlucoseValue
 import info.nightscout.androidaps.database.entities.TherapyEvent
+import info.nightscout.androidaps.database.entities.UserEntry
+import info.nightscout.androidaps.database.entities.ValueWithUnit
 import info.nightscout.androidaps.database.transactions.CgmSourceTransaction
 import info.nightscout.androidaps.interfaces.BgSource
 import info.nightscout.androidaps.interfaces.PluginBase
@@ -17,6 +19,7 @@ import info.nightscout.androidaps.interfaces.PluginDescription
 import info.nightscout.androidaps.interfaces.PluginType
 import info.nightscout.androidaps.logging.AAPSLogger
 import info.nightscout.androidaps.logging.LTag
+import info.nightscout.androidaps.logging.UserEntryLogger
 import info.nightscout.androidaps.utils.DateUtil
 import info.nightscout.androidaps.utils.FabricPrivacy
 import info.nightscout.androidaps.utils.T
@@ -37,6 +40,7 @@ class GlunovoPlugin @Inject constructor(
     private val repository: AppRepository,
     private val xDripBroadcast: XDripBroadcast,
     private val dateUtil: DateUtil,
+    private val uel: UserEntryLogger,
     private val fabricPrivacy: FabricPrivacy
 ) : PluginBase(
     PluginDescription()
@@ -145,6 +149,18 @@ class GlunovoPlugin @Inject constructor(
                         savedValues.inserted.forEach {
                             xDripBroadcast.send(it)
                             aapsLogger.debug(LTag.DATABASE, "Inserted bg $it")
+                        }
+                        savedValues.calibrationsInserted.forEach {  calibration ->
+                            calibration.glucose?.let { glucosevalue ->
+                                uel.log(
+                                    UserEntry.Action.CAREPORTAL,
+                                    UserEntry.Sources.Dexcom,
+                                    ValueWithUnit.Timestamp(calibration.timestamp),
+                                    ValueWithUnit.TherapyEventType(calibration.type),
+                                    ValueWithUnit.fromGlucoseUnit(glucosevalue, calibration.glucoseUnit.toString())
+                                )
+                            }
+                            aapsLogger.debug(LTag.DATABASE, "Inserted calibration $calibration")
                         }
                     }
         }

--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/ActionCarePortalEvent.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/ActionCarePortalEvent.kt
@@ -71,7 +71,7 @@ class ActionCarePortalEvent(injector: HasAndroidInjector) : Action(injector) {
             if (glucoseStatus != null) {
                 therapyEvent.glucose = glucoseStatus.glucose
                 therapyEvent.glucoseType = TherapyEvent.MeterType.SENSOR
-                valuesWithUnit.add(ValueWithUnit.fromGlucoseUnit(glucoseStatus.glucose, profileFunction.getUnits().asText))
+                valuesWithUnit.add(ValueWithUnit.Mgdl(glucoseStatus.glucose))
                 valuesWithUnit.add(ValueWithUnit.TherapyEventMeterType(TherapyEvent.MeterType.SENSOR))
             }
         } else {

--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/ActionStartTempTarget.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/actions/ActionStartTempTarget.kt
@@ -63,8 +63,8 @@ class ActionStartTempTarget(injector: HasAndroidInjector) : Action(injector) {
                 result.updated.forEach { aapsLogger.debug(LTag.DATABASE, "Updated temp target $it") }
                 uel.log(UserEntry.Action.TT, Sources.Automation, title,
                     ValueWithUnit.TherapyEventTTReason(TemporaryTarget.Reason.AUTOMATION),
-                    ValueWithUnit.fromGlucoseUnit(tt().lowTarget, value.units.asText),
-                    ValueWithUnit.fromGlucoseUnit(tt().highTarget, value.units.asText).takeIf { tt().lowTarget != tt().highTarget },
+                    ValueWithUnit.Mgdl(tt().lowTarget),
+                    ValueWithUnit.Mgdl(tt().highTarget).takeIf { tt().lowTarget != tt().highTarget },
                     ValueWithUnit.Minute(TimeUnit.MILLISECONDS.toMinutes(tt().duration).toInt()))
                 callback.result(PumpEnactResult(injector).success(true).comment(R.string.ok))?.run()
             }, {

--- a/core/src/main/java/info/nightscout/androidaps/utils/userEntry/UserEntryPresentationHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/userEntry/UserEntryPresentationHelper.kt
@@ -131,13 +131,13 @@ class UserEntryPresentationHelper @Inject constructor(
         is ValueWithUnit.Timestamp             -> dateUtil.dateAndTimeAndSecondsString(valueWithUnit.value)
 
         is ValueWithUnit.Mgdl                  -> {
-            if (profileFunction.getUnits() == GlucoseUnit.MGDL) DecimalFormatter.to0Decimal(valueWithUnit.value) + translator.translate(valueWithUnit)
-            else DecimalFormatter.to1Decimal(valueWithUnit.value * Constants.MGDL_TO_MMOLL) + translator.translate(valueWithUnit)
+            if (profileFunction.getUnits() == GlucoseUnit.MGDL) DecimalFormatter.to0Decimal(valueWithUnit.value) + rh.gs(R.string.mgdl)
+            else DecimalFormatter.to1Decimal(valueWithUnit.value * Constants.MGDL_TO_MMOLL) + rh.gs(R.string.mmol)
         }
 
         is ValueWithUnit.Mmoll                 -> {
-            if (profileFunction.getUnits() == GlucoseUnit.MMOL) DecimalFormatter.to1Decimal(valueWithUnit.value) + translator.translate(valueWithUnit)
-            else DecimalFormatter.to0Decimal(valueWithUnit.value * Constants.MMOLL_TO_MGDL) + translator.translate(valueWithUnit)
+            if (profileFunction.getUnits() == GlucoseUnit.MMOL) DecimalFormatter.to1Decimal(valueWithUnit.value) + rh.gs(R.string.mmol)
+            else DecimalFormatter.to0Decimal(valueWithUnit.value * Constants.MMOLL_TO_MGDL) + rh.gs(R.string.mgdl)
         }
 
         ValueWithUnit.UNKNOWN                  -> ""

--- a/core/src/main/java/info/nightscout/androidaps/utils/userEntry/UserEntryPresentationHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/userEntry/UserEntryPresentationHelper.kt
@@ -205,10 +205,10 @@ class UserEntryPresentationHelper @Inject constructor(
                 is ValueWithUnit.Timestamp             -> timestamp = dateUtil.dateAndTimeAndSecondsString(valueWithUnit.value)
 
                 is ValueWithUnit.Mgdl                  ->
-                    bg = Profile.toUnitsString(valueWithUnit.value, valueWithUnit.value * Constants.MMOLL_TO_MGDL, profileFunction.getUnits())
+                    bg = Profile.toUnitsString(valueWithUnit.value, valueWithUnit.value * Constants.MGDL_TO_MMOLL, profileFunction.getUnits())
 
                 is ValueWithUnit.Mmoll                 ->
-                    bg = Profile.toUnitsString(valueWithUnit.value, valueWithUnit.value * Constants.MMOLL_TO_MGDL, profileFunction.getUnits())
+                    bg = Profile.toUnitsString(valueWithUnit.value * Constants.MMOLL_TO_MGDL, valueWithUnit.value , profileFunction.getUnits())
 
                 ValueWithUnit.UNKNOWN                  -> Unit
             }

--- a/database/src/main/java/info/nightscout/androidaps/database/entities/TherapyEvent.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/entities/TherapyEvent.kt
@@ -66,9 +66,9 @@ data class TherapyEvent(
             previous.interfaceIDs.nightscoutId == null &&
             interfaceIDs.nightscoutId != null
 
-    enum class GlucoseUnit {
-        MGDL,
-        MMOL;
+    enum class GlucoseUnit (val toString: String) {
+        MGDL (ValueWithUnit.MGDL),
+        MMOL (ValueWithUnit.MMOL);
 
         companion object
     }


### PR DESCRIPTION
Fix #993 (I hope)
Add values for calibration (Tested BYODA mg/dl but not with BYODA mmol and not tested for Glunovo...)
Fix mmol units in automation rule, in csv export and in presentation helper
=> For Automation, I recorded TT and BG values in mgdl (because it's internal AAPS unit) (for presentation and csv it's always converted to user's unit)
It's seems to be Ok now on my dev phone switched in mmol....