### PR TITLE
Allow/reenable the setting of TempTargets while pump is suspended or …

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -361,13 +361,10 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                     activity,
                     ProtectionCheck.Protection.BOLUS,
                     UIRunnable { if (isAdded) CarbsDialog().show(childFragmentManager, "Overview") })
-                R.id.temp_target         ->
-                    if (loop.isDisconnected) OKDialog.show(activity, rh.gs(R.string.not_available_full), rh.gs(R.string.smscommunicator_pumpdisconnected))
-                    else
-                        protectionCheck.queryProtection(
-                            activity,
-                            ProtectionCheck.Protection.BOLUS,
-                            UIRunnable { if (isAdded) TempTargetDialog().show(childFragmentManager, "Overview") })
+                R.id.temp_target         -> protectionCheck.queryProtection(
+                    activity,
+                    ProtectionCheck.Protection.BOLUS,
+                    UIRunnable { if (isAdded) TempTargetDialog().show(childFragmentManager, "Overview") })
 
                 R.id.active_profile      -> {
                     ProfileViewerDialog().also { pvd ->


### PR DESCRIPTION
…disconnected

Unfortunately, it is currently no longer possible to set a TempTarget when the pump is disconnected or suspended (TBR: 0%). This seems logical at first sight (why a TempTarget when the pump is not connected or the loop suspended!), but prevents many useful possibilities, namely when the TempTarget should be set immediately after the disconnection or suspension has expired.
An example of this are f. e. sport activities: To reduce IOB, I set a 0% TBR half an hour before sport for one hour with the function "pump disconnected", so that the associated 0% TBR continues for a while while sport starts. I also set a three hour Activity TempTarget. This continues to be active when the pump loops again with the pump disconnected time expired.
The fix allows/reenables setting a TempTarget even if the pump is suspended or disconnected.