### PR TITLE
TempTarget Dialog: Include missing Event Time

### DIFF
--- a/app/src/main/res/layout/dialog_temptarget.xml
+++ b/app/src/main/res/layout/dialog_temptarget.xml
@@ -206,6 +206,10 @@
                 android:textSize="11sp" />
 
         </LinearLayout>
+        
+        <include
+            android:id="@+id/datetime"
+            layout="@layout/datetime" />
 
         <include
             android:id="@+id/okcancel"


### PR DESCRIPTION
In the layout the line "Event Time:" is missing since some time, but in the code (TempTargetDialog.kt) the function is still realised. Here is the fix that adds the line again.
I think some would miss this function ... ;-)