### PR TITLE
Fix dialogs and remove extra CONFIRM. Fixes #1078

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
+++ b/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
@@ -522,7 +522,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                         intent.putExtras(params);
                         startActivity(intent);
                     } else {
-                        showConfirmationDialog(title, message, actionstring);
+                        showConfirmationDialog(message, actionstring);
                     }
 
                 } else if (path.equals(NEW_STATUS_PATH)) {
@@ -680,12 +680,10 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         notificationManager.createNotificationChannel(channel);
     }
 
-    private void showConfirmationDialog(String title, String message, String actionstring) {
-
+    private void showConfirmationDialog(String message, String actionstring) {
         Intent intent = new Intent(this, AcceptActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         Bundle params = new Bundle();
-        params.putString("title", title);
         params.putString("message", message);
         params.putString("actionstring", actionstring);
         intent.putExtras(params);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -21,7 +21,6 @@ import info.nightscout.androidaps.data.ListenerService;
 
 public class AcceptActivity extends ViewSelectorActivity {
 
-    String title = "";
     String message = "";
     String actionstring = "";
     private DismissThread dismissThread;
@@ -34,7 +33,6 @@ public class AcceptActivity extends ViewSelectorActivity {
         dismissThread.start();
 
         Bundle extras = getIntent().getExtras();
-        title = extras.getString("title", "");
         message = extras.getString("message", "");
         actionstring = extras.getString("actionstring", "");
 
@@ -43,7 +41,6 @@ public class AcceptActivity extends ViewSelectorActivity {
             return;
         }
 
-        setContentView(R.layout.grid_layout);
         setAdapter(new MyGridViewPagerAdapter());
 
         Vibrator v = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
@@ -73,8 +70,6 @@ public class AcceptActivity extends ViewSelectorActivity {
 
             if (col == 0) {
                 final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_confirm_text, container, false);
-                final TextView headingView = view.findViewById(R.id.title);
-                headingView.setText(title);
                 final TextView textView = view.findViewById(R.id.message);
                 textView.setText(message);
                 container.addView(view);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/WizardActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/WizardActivity.java
@@ -86,7 +86,7 @@ public class WizardActivity extends ViewSelectorActivity {
                     @Override
                     public void onClick(View v) {
 
-                        //check if it can happen that the fagment is never created that hold data?
+                        // check if it can happen that the fragment is never created that hold data?
                         // (you have to swipe past them anyways - but still)
 
                         int percentage = 100;

--- a/wear/src/main/res/layout/action_confirm_text.xml
+++ b/wear/src/main/res/layout/action_confirm_text.xml
@@ -13,27 +13,13 @@
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-
-            <LinearLayout
+            <TextView
+                android:id="@+id/message"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
-                <TextView
-                    android:id="@+id/title"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="title"
-                    android:textAppearance="@style/TextAppearance.Wearable.Medium"
-                    android:textColor="@color/white" />
-                <TextView
-                    android:id="@+id/message"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:text="message"
-                    android:textAppearance="@style/TextAppearance.Wearable.Small"
-                    android:textColor="@color/white" />
-            </LinearLayout>
-
+                android:text="message"
+                android:textAppearance="@style/TextAppearance.Wearable.Small"
+                android:textColor="@color/white" />
         </androidx.core.widget.NestedScrollView>
 
     </FrameLayout>


### PR DESCRIPTION
Fixes #1078 

Reproduced and tested on a virtual Wear OS Round API 30 and my Galaxy Watch 4.

I also saw that the confirm dialogs said CONFIRM twice, removed one so we can see more of the sometimes very long confirmation message.

Wizard confirmation on current dev:
![Screenshot_1639637001](https://user-images.githubusercontent.com/81067/146323085-8f75c372-44f8-48eb-8803-5346709ca718.png)

Same confirmation after removing the extra `setContentView()`:

![Screenshot_1639635309](https://user-images.githubusercontent.com/81067/146323206-33fa4093-de20-4beb-990a-c5ac2e01d41b.png)

Same confirmation after removing title from the layout:

![Screenshot_1639636403](https://user-images.githubusercontent.com/81067/146323248-0e9f6147-e124-4f18-bf4f-dca73c60ac84.png)

If this is too much change for 3.0, there is a one-line fix that I'll call out in the comments.

Thank you for this amazing project!