### PR TITLE
Wear: add feature: simplified watch face during charging

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -100,6 +100,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
 
@@ -544,6 +547,7 @@
                 <action android:name="watch_face_configuration_largehome" />
                 <action android:name="watch_face_configuration_nochart" />
                 <action android:name="watch_face_configuration_steampunk" />
+
                 <category android:name="com.google.android.wearable.watchface.category.WEARABLE_CONFIGURATION" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -79,6 +79,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
 
@@ -124,6 +127,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
 
@@ -145,6 +151,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
 
@@ -166,6 +175,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
         <service
@@ -207,6 +219,9 @@
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService" />
                 <category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
+
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
             </intent-filter>
         </service>
 

--- a/wear/src/main/java/info/nightscout/androidaps/complications/SgvComplication.java
+++ b/wear/src/main/java/info/nightscout/androidaps/complications/SgvComplication.java
@@ -34,7 +34,7 @@ public class SgvComplication extends BaseComplicationProviderService {
         switch (dataType) {
             case ComplicationData.TYPE_SHORT_TEXT:
                 final ComplicationData.Builder builder = new ComplicationData.Builder(ComplicationData.TYPE_SHORT_TEXT)
-                        .setShortText(ComplicationText.plainText(raw.sSgv + raw.sDirection))
+                        .setShortText(ComplicationText.plainText(raw.sSgv + raw.sDirection + "\uFE0E"))
                         .setShortTitle(ComplicationText.plainText(displayFormat.shortTrend(raw)))
                         .setTapAction(complicationPendingIntent);
 

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
@@ -287,7 +287,7 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
 
         if (mDirection != null) {
             if (sharedPrefs.getBoolean("show_direction", true)) {
-                mDirection.setText(rawData.sDirection);
+                mDirection.setText(rawData.sDirection+"\uFE0E");
                 mDirection.setVisibility(View.VISIBLE);
             } else {
                 mDirection.setVisibility(View.GONE);

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
@@ -72,7 +72,8 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
     public TextView mTime, mHour, mMinute, mSgv, mDirection, mTimestamp, mUploaderBattery, mRigBattery, mDelta, mAvgDelta, mStatus, mBasalRate, mIOB1, mIOB2, mCOB1, mCOB2, mBgi, mLoop, mDay, mDayName, mMonth, isAAPSv2, mHighLight, mLowLight;
     public ImageView mGlucoseDial, mDeltaGauge, mHourHand, mMinuteHand;
     public RelativeLayout mRelativeLayout;
-    public LinearLayout mLinearLayout, mLinearLayout2, mDate, mChartTap, mMainMenuTap;
+    public LinearLayout mLinearLayout, mLinearLayout2, mLinearLayout3, mDate, mChartTap,
+            mMainMenuTap;
     public int ageLevel = 1;
     public int loopLevel = 1;
     public int highColor = Color.YELLOW;
@@ -167,6 +168,7 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
                                                  mHighLight = stub.findViewById(R.id.highLight);
                                                  mLowLight = stub.findViewById(R.id.lowLight);
                                                  mRelativeLayout = stub.findViewById(R.id.main_layout);
+                                                 mLinearLayout3 = stub.findViewById(R.id.primary_layout);
                                                  mLinearLayout = stub.findViewById(R.id.secondary_layout);
                                                  mLinearLayout2 = stub.findViewById(R.id.tertiary_layout);
                                                  mGlucoseDial = stub.findViewById(R.id.glucose_dial);

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/BaseWatchFace.java
@@ -10,6 +10,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.os.BatteryManager;
 import android.os.PowerManager;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
@@ -25,6 +26,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.android.gms.wearable.DataMap;
@@ -40,7 +42,6 @@ import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
 import info.nightscout.androidaps.R;
-import info.nightscout.androidaps.complications.BaseComplicationProviderService;
 import info.nightscout.androidaps.data.ListenerService;
 import info.nightscout.androidaps.data.RawDisplayData;
 import info.nightscout.androidaps.interaction.utils.Persistence;
@@ -59,7 +60,6 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
     @Inject Persistence persistence;
 
     public final static IntentFilter INTENT_FILTER;
-    public static final long[] vibratePattern = {0, 400, 300, 400, 300, 400};
 
     static {
         INTENT_FILTER = new IntentFilter();
@@ -70,10 +70,11 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
 
     public final Point displaySize = new Point();
     public TextView mTime, mHour, mMinute, mSgv, mDirection, mTimestamp, mUploaderBattery, mRigBattery, mDelta, mAvgDelta, mStatus, mBasalRate, mIOB1, mIOB2, mCOB1, mCOB2, mBgi, mLoop, mDay, mDayName, mMonth, isAAPSv2, mHighLight, mLowLight;
+    public TextView mSimpleSvg, mSimpleDirection, mSimpleTime;
     public ImageView mGlucoseDial, mDeltaGauge, mHourHand, mMinuteHand;
+    public View mSimpleUi;
     public RelativeLayout mRelativeLayout;
-    public LinearLayout mLinearLayout, mLinearLayout2, mLinearLayout3, mDate, mChartTap,
-            mMainMenuTap;
+    public LinearLayout mLinearLayout, mLinearLayout2, mDate, mChartTap, mMainMenuTap;
     public int ageLevel = 1;
     public int loopLevel = 1;
     public int highColor = Color.YELLOW;
@@ -101,6 +102,8 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
     protected SharedPreferences sharedPrefs;
     private LocalBroadcastManager localBroadcastManager;
     private MessageReceiver messageReceiver;
+    private BroadcastReceiver batteryReceiver;
+    protected boolean isCharging = false;
 
     @Override
     public void onCreate() {
@@ -122,6 +125,26 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
         sharedPrefs.registerOnSharedPreferenceChangeListener(this);
 
         persistence.turnOff();
+
+        setupBatteryReceiver();
+    }
+
+    private void setupBatteryReceiver() {
+        if (sharedPrefs.getBoolean("simplify_ui_charging", false)) {
+            IntentFilter intentBatteryFilter = new IntentFilter();
+            intentBatteryFilter.addAction(BatteryManager.ACTION_CHARGING);
+            intentBatteryFilter.addAction(BatteryManager.ACTION_DISCHARGING);
+            isCharging = checkIsCharging();
+            batteryReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    isCharging = checkIsCharging();
+                    setDataFields();
+                    invalidate();
+                }
+            };
+            registerReceiver(batteryReceiver, intentBatteryFilter);
+        }
     }
 
     @Override
@@ -168,7 +191,6 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
                                                  mHighLight = stub.findViewById(R.id.highLight);
                                                  mLowLight = stub.findViewById(R.id.lowLight);
                                                  mRelativeLayout = stub.findViewById(R.id.main_layout);
-                                                 mLinearLayout3 = stub.findViewById(R.id.primary_layout);
                                                  mLinearLayout = stub.findViewById(R.id.secondary_layout);
                                                  mLinearLayout2 = stub.findViewById(R.id.tertiary_layout);
                                                  mGlucoseDial = stub.findViewById(R.id.glucose_dial);
@@ -178,8 +200,11 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
                                                  mChartTap = stub.findViewById(R.id.chart_zoom_tap);
                                                  mMainMenuTap = stub.findViewById(R.id.main_menu_tap);
                                                  chart = stub.findViewById(R.id.chart);
+                                                 mSimpleUi = stub.findViewById(R.id.simple_ui);
+                                                 mSimpleSvg = stub.findViewById(R.id.simple_sgv);
+                                                 mSimpleDirection = stub.findViewById(R.id.simple_direction);
+                                                 mSimpleTime = stub.findViewById(R.id.simple_watch_time);
                                                  layoutSet = true;
-
                                                  setDataFields();
                                                  setColor();
                                              }
@@ -218,6 +243,9 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
         }
         if (sharedPrefs != null) {
             sharedPrefs.unregisterOnSharedPreferenceChangeListener(this);
+        }
+        if (batteryReceiver != null) {
+            unregisterReceiver(batteryReceiver);
         }
         super.onDestroy();
     }
@@ -258,8 +286,16 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
         }
     }
 
+    private boolean checkIsCharging() {
+        IntentFilter iFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        Intent batteryStatus = this.registerReceiver(null, iFilter);
+        int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        return status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL;
+    }
+
     private void checkVibrateHourly(WatchFaceTime oldTime, WatchFaceTime newTime) {
-        Boolean hourlyVibratePref = sharedPrefs.getBoolean("vibrate_Hourly", false);
+        boolean hourlyVibratePref = sharedPrefs.getBoolean("vibrate_Hourly", false);
         if (hourlyVibratePref && layoutSet && newTime.hasHourChanged(oldTime)) {
             Log.i("hourlyVibratePref", "true --> " + newTime.toString());
             Vibrator vibrator = (Vibrator) getSystemService(VIBRATOR_SERVICE);
@@ -450,6 +486,37 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
                 mLoop.setVisibility(View.GONE);
             }
         }
+        setDataFieldsSimpleUi();
+    }
+
+    void setDataFieldsSimpleUi() {
+        if (sharedPrefs.getBoolean("simplify_ui_charging", false) && isCharging) {
+            mSimpleUi.setVisibility(View.VISIBLE);
+
+            mSimpleSvg.setText(rawData.sSgv);
+            if (ageLevel() <= 0) {
+                mSimpleSvg.setPaintFlags(mSimpleSvg.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                mSimpleSvg.setPaintFlags(mSimpleSvg.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
+            }
+            if (rawData.sgvLevel == 1) {
+                mSimpleSvg.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_highColor));
+                mSimpleDirection.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_highColor));
+            } else if (rawData.sgvLevel == 0) {
+                mSimpleSvg.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+                mSimpleDirection.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_midColor));
+            } else if (rawData.sgvLevel == -1) {
+                mSimpleSvg.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_lowColor));
+                mSimpleDirection.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.dark_lowColor));
+            }
+
+            mSimpleDirection.setText(rawData.sDirection+"\uFE0E");
+
+            final java.text.DateFormat timeFormat = DateFormat.getTimeFormat(BaseWatchFace.this);
+            mSimpleTime.setText(timeFormat.format(System.currentTimeMillis()));
+        } else {
+            mSimpleUi.setVisibility(View.GONE);
+        }
     }
 
     public void setDateAndTime() {
@@ -528,7 +595,7 @@ public abstract class BaseWatchFace extends WatchFace implements SharedPreferenc
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-
+        setupBatteryReceiver();
         if ("delta_granularity".equals(key)) {
             ListenerService.requestData(this);
         }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.watchfaces;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Color;
@@ -29,7 +31,26 @@ public class Home2 extends BaseWatchFace {
         super.onCreate();
         LayoutInflater inflater = (LayoutInflater) getSystemService(LAYOUT_INFLATER_SERVICE);
         layoutView = inflater.inflate(R.layout.activity_home_2, null);
+
+        IntentFilter intentBatteryFilter = new IntentFilter();
+        intentBatteryFilter.addAction(BatteryManager.ACTION_CHARGING);
+        intentBatteryFilter.addAction(BatteryManager.ACTION_DISCHARGING);
+        registerReceiver(batteryReceiver, intentBatteryFilter);
         performViewSetup();
+    }
+
+    private BroadcastReceiver batteryReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            setDataFields();
+            invalidate();
+        }
+    };
+
+    @Override
+    public void onDestroy() {
+        unregisterReceiver(batteryReceiver);
+        super.onDestroy();
     }
 
     @Override

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat;
 
 import android.os.BatteryManager;
 import android.support.wearable.watchface.WatchFaceStyle;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -32,25 +33,7 @@ public class Home2 extends BaseWatchFace {
         LayoutInflater inflater = (LayoutInflater) getSystemService(LAYOUT_INFLATER_SERVICE);
         layoutView = inflater.inflate(R.layout.activity_home_2, null);
 
-        IntentFilter intentBatteryFilter = new IntentFilter();
-        intentBatteryFilter.addAction(BatteryManager.ACTION_CHARGING);
-        intentBatteryFilter.addAction(BatteryManager.ACTION_DISCHARGING);
-        registerReceiver(batteryReceiver, intentBatteryFilter);
         performViewSetup();
-    }
-
-    private BroadcastReceiver batteryReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            setDataFields();
-            invalidate();
-        }
-    };
-
-    @Override
-    public void onDestroy() {
-        unregisterReceiver(batteryReceiver);
-        super.onDestroy();
     }
 
     @Override
@@ -286,58 +269,4 @@ public class Home2 extends BaseWatchFace {
         }
     }
 
-
-    @Override
-    public void setDataFields() {
-        super.setDataFields();
-        if (sharedPrefs.getBoolean("simplify_ui_charging", false) && isCharging()) {
-            LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    0,
-                    0.5f
-            );
-            mLinearLayout3.setLayoutParams(param);
-            mLinearLayout3.setWeightSum(0.7f);
-            mLinearLayout.setVisibility(View.GONE);
-            mLoop.setVisibility(View.INVISIBLE);
-            chart.setVisibility(View.GONE);
-            mIOB1.setVisibility(View.GONE);
-            mIOB2.setVisibility(View.GONE);
-            mCOB1.setVisibility(View.GONE);
-            mCOB2.setVisibility(View.GONE);
-            mTimestamp.setVisibility(View.GONE);
-            mTime.setTextSize(35);
-            mDirection.setTextSize(35);
-            mSgv.setTextSize(50);
-        } else {
-            TypedValue outValue = new TypedValue();
-            getResources().getValue(R.dimen.home2_primary_layout_height, outValue, true);
-            float layoutHeight = outValue.getFloat();
-            LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    0,
-                    layoutHeight
-            );
-            mLinearLayout3.setLayoutParams(param);
-            mLinearLayout.setVisibility(View.VISIBLE);
-            mLoop.setVisibility(View.VISIBLE);
-            chart.setVisibility(View.VISIBLE);
-            mIOB1.setVisibility(View.VISIBLE);
-            mIOB2.setVisibility(View.VISIBLE);
-            mCOB1.setVisibility(View.VISIBLE);
-            mCOB2.setVisibility(View.VISIBLE);
-            mTimestamp.setVisibility(View.VISIBLE);
-            mDirection.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.home2_direction_text_size));
-            mSgv.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.home2_sgv_text_size));
-            mTime.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.home2_time_text_size));
-        }
-    }
-
-    private boolean isCharging() {
-        IntentFilter iFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
-        Intent batteryStatus = this.registerReceiver(null, iFilter);
-        int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-        return status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                status == BatteryManager.BATTERY_STATUS_FULL;
-    }
 }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/Home2.java
@@ -1,21 +1,13 @@
 package info.nightscout.androidaps.watchfaces;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.graphics.Color;
 
 import androidx.annotation.ColorInt;
 import androidx.core.content.ContextCompat;
 
-import android.os.BatteryManager;
 import android.support.wearable.watchface.WatchFaceStyle;
-import android.util.Log;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.widget.LinearLayout;
 
 import com.ustwo.clockwise.common.WatchMode;
 

--- a/wear/src/main/res/layout/rect_activity_digitalstyle.xml
+++ b/wear/src/main/res/layout/rect_activity_digitalstyle.xml
@@ -317,19 +317,21 @@
                             android:textColor="@color/white"
                             android:textFontWeight="400"
                             android:textSize="18sp" />
+
                         <TextView
                             android:id="@+id/weeknumber"
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
                             android:layout_weight="4"
                             android:fontFamily="@font/roboto_condensed_light"
+                            android:letterSpacing="-0.1"
                             android:text="ww"
                             android:textAllCaps="true"
                             android:textColor="@color/light_grey"
                             android:textFontWeight="400"
                             android:textSize="18sp"
-                            android:letterSpacing="-0.1"
-                            android:visibility="gone"/>
+                            android:visibility="gone" />
+
                         <Space
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
@@ -529,6 +531,22 @@
                         android:layout_gravity="bottom"
                         android:layout_weight="1"
                         android:gravity="center_horizontal|top" />
+
+                    <TextView
+                        android:id="@+id/direction2"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="3"
+                        android:fontFamily="sans-serif-condensed-medium"
+                        android:gravity="center_horizontal"
+                        android:text="--"
+                        android:textAlignment="center"
+                        android:textColor="@color/white"
+                        android:textSize="40sp"
+                        android:textStyle="bold"
+                        android:visibility="gone" />
+
                 </LinearLayout>
 
                 <!--  right side bottom - spacer    2/10 -->
@@ -540,6 +558,10 @@
         </LinearLayout>
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
 
     <!--   FLAGs   -->
 

--- a/wear/src/main/res/layout/rect_activity_digitalstyle.xml
+++ b/wear/src/main/res/layout/rect_activity_digitalstyle.xml
@@ -532,21 +532,6 @@
                         android:layout_weight="1"
                         android:gravity="center_horizontal|top" />
 
-                    <TextView
-                        android:id="@+id/direction2"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center_vertical"
-                        android:layout_weight="3"
-                        android:fontFamily="sans-serif-condensed-medium"
-                        android:gravity="center_horizontal"
-                        android:text="--"
-                        android:textAlignment="center"
-                        android:textColor="@color/white"
-                        android:textSize="40sp"
-                        android:textStyle="bold"
-                        android:visibility="gone" />
-
                 </LinearLayout>
 
                 <!--  right side bottom - spacer    2/10 -->

--- a/wear/src/main/res/layout/rect_activity_home.xml
+++ b/wear/src/main/res/layout/rect_activity_home.xml
@@ -154,4 +154,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/rect_activity_home_2.xml
+++ b/wear/src/main/res/layout/rect_activity_home_2.xml
@@ -20,7 +20,7 @@
             android:layout_width="fill_parent"
             android:layout_height="0px"
             android:layout_gravity="center_horizontal"
-            android:layout_weight="@dimen/home2_primary_layout_height"
+            android:layout_weight="0.27"
             android:gravity="center_horizontal"
             android:orientation="horizontal"
             android:textAlignment="center">
@@ -50,7 +50,7 @@
                 android:paddingRight="5dp"
                 android:text="---"
                 android:textColor="#FFFFFF"
-                android:textSize="@dimen/home2_sgv_text_size" />
+                android:textSize="38sp" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -70,7 +70,7 @@
                     android:text="--"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="@dimen/home2_direction_text_size"
+                    android:textSize="22sp"
                     android:textStyle="bold" />
 
                 <TextView
@@ -275,7 +275,7 @@
                     android:text="12:00"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="@dimen/home2_time_text_size" />
+                    android:textSize="30sp" />
 
                 <LinearLayout
                     android:id="@+id/date_time"
@@ -369,5 +369,10 @@
             android:gravity="center_horizontal|top" />
 
     </LinearLayout>
+
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
 
 </RelativeLayout>

--- a/wear/src/main/res/layout/rect_activity_home_2.xml
+++ b/wear/src/main/res/layout/rect_activity_home_2.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" tools:context=".watchfaces.Home2" tools:deviceIds="wear_square"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@color/black"
-    android:id="@+id/main_layout">
+    tools:context=".watchfaces.Home2"
+    tools:deviceIds="wear_square">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -13,10 +16,11 @@
         android:weightSum="1">
 
         <LinearLayout
+            android:id="@+id/primary_layout"
             android:layout_width="fill_parent"
             android:layout_height="0px"
             android:layout_gravity="center_horizontal"
-            android:layout_weight="0.27"
+            android:layout_weight="@dimen/home2_primary_layout_height"
             android:gravity="center_horizontal"
             android:orientation="horizontal"
             android:textAlignment="center">
@@ -42,11 +46,11 @@
                 android:layout_marginBottom="-2dp"
                 android:gravity="bottom|right"
                 android:paddingLeft="5dp"
-                android:paddingRight="5dp"
                 android:paddingTop="-2dp"
+                android:paddingRight="5dp"
                 android:text="---"
                 android:textColor="#FFFFFF"
-                android:textSize="38sp" />
+                android:textSize="@dimen/home2_sgv_text_size" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -66,7 +70,7 @@
                     android:text="--"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="22sp"
+                    android:textSize="@dimen/home2_direction_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -101,8 +105,8 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:orientation="horizontal"
-                android:paddingEnd="2dp"
                 android:paddingStart="2dp"
+                android:paddingEnd="2dp"
                 android:textAlignment="center">
 
                 <TextView
@@ -271,7 +275,7 @@
                     android:text="12:00"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="26sp" />
+                    android:textSize="@dimen/home2_time_text_size" />
 
                 <LinearLayout
                     android:id="@+id/date_time"

--- a/wear/src/main/res/layout/rect_activity_home_large.xml
+++ b/wear/src/main/res/layout/rect_activity_home_large.xml
@@ -136,4 +136,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/rect_cockpit.xml
+++ b/wear/src/main/res/layout/rect_cockpit.xml
@@ -488,4 +488,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/rect_steampunk.xml
+++ b/wear/src/main/res/layout/rect_steampunk.xml
@@ -378,4 +378,9 @@
         android:layout_height="wrap_content"
         android:visibility="gone"/>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/round_activity_digitalstyle.xml
+++ b/wear/src/main/res/layout/round_activity_digitalstyle.xml
@@ -533,20 +533,6 @@
                         android:layout_weight="1"
                         android:gravity="center_horizontal|top" />
 
-                    <TextView
-                        android:id="@+id/direction2"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center_vertical"
-                        android:layout_weight="3"
-                        android:fontFamily="sans-serif-condensed-medium"
-                        android:gravity="center_horizontal"
-                        android:text="--"
-                        android:textAlignment="center"
-                        android:textColor="@color/white"
-                        android:textSize="40sp"
-                        android:textStyle="bold"
-                        android:visibility="gone" />
                 </LinearLayout>
 
                 <!--  right side bottom - spacer    2/10 -->

--- a/wear/src/main/res/layout/round_activity_digitalstyle.xml
+++ b/wear/src/main/res/layout/round_activity_digitalstyle.xml
@@ -121,6 +121,7 @@
 
                     <!-- 1st line with direction and timestamp-->
                     <LinearLayout
+                        android:id="@+id/directionLayout"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_gravity="center_horizontal"
@@ -317,19 +318,21 @@
                             android:textColor="@color/white"
                             android:textFontWeight="400"
                             android:textSize="18sp" />
+
                         <TextView
                             android:id="@+id/weeknumber"
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
                             android:layout_weight="4"
                             android:fontFamily="@font/roboto_condensed_light"
+                            android:letterSpacing="-0.1"
                             android:text="ww"
                             android:textAllCaps="true"
                             android:textColor="@color/light_grey"
                             android:textFontWeight="400"
                             android:textSize="18sp"
-                            android:letterSpacing="-0.1"
-                            android:visibility="gone"/>
+                            android:visibility="gone" />
+
                         <Space
                             android:layout_width="0dp"
                             android:layout_height="match_parent"
@@ -426,12 +429,12 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
+                android:layout_marginLeft="7dp"
+                android:layout_marginRight="7dp"
                 android:layout_weight="1"
                 android:baselineAligned="false"
                 android:gravity="left|top"
                 android:orientation="vertical"
-                android:layout_marginLeft="7dp"
-                android:layout_marginRight="7dp"
                 android:weightSum="10">
 
                 <!--  right side bottom - statusbar  2/10 -->
@@ -529,6 +532,21 @@
                         android:layout_gravity="bottom"
                         android:layout_weight="1"
                         android:gravity="center_horizontal|top" />
+
+                    <TextView
+                        android:id="@+id/direction2"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="3"
+                        android:fontFamily="sans-serif-condensed-medium"
+                        android:gravity="center_horizontal"
+                        android:text="--"
+                        android:textAlignment="center"
+                        android:textColor="@color/white"
+                        android:textSize="40sp"
+                        android:textStyle="bold"
+                        android:visibility="gone" />
                 </LinearLayout>
 
                 <!--  right side bottom - spacer    2/10 -->
@@ -541,7 +559,10 @@
         </LinearLayout>
     </LinearLayout>
 
-
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
     <!--   FLAGs   -->
 
     <TextView

--- a/wear/src/main/res/layout/round_activity_home.xml
+++ b/wear/src/main/res/layout/round_activity_home.xml
@@ -152,4 +152,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/round_activity_home_2.xml
+++ b/wear/src/main/res/layout/round_activity_home_2.xml
@@ -26,7 +26,7 @@
             android:layout_width="fill_parent"
             android:layout_height="0px"
             android:layout_gravity="center_horizontal"
-            android:layout_weight="@dimen/home2_primary_layout_height"
+            android:layout_weight="0.27"
             android:gravity="center_horizontal"
             android:orientation="horizontal"
             android:textAlignment="center">
@@ -56,7 +56,7 @@
                 android:paddingRight="5dp"
                 android:text="---"
                 android:textColor="#FFFFFF"
-                android:textSize="@dimen/home2_sgv_text_size" />
+                android:textSize="38sp" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -77,7 +77,7 @@
                     android:text="--"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="@dimen/home2_direction_text_size"
+                    android:textSize="22sp"
                     android:textStyle="bold" />
 
                 <TextView
@@ -282,7 +282,7 @@
                     android:text="12:00"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="@dimen/home2_time_text_size" />
+                    android:textSize="30sp" />
 
                 <LinearLayout
                     android:id="@+id/date_time"
@@ -382,5 +382,10 @@
             android:orientation="vertical" />
 
     </LinearLayout>
+
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
 
 </RelativeLayout>

--- a/wear/src/main/res/layout/round_activity_home_2.xml
+++ b/wear/src/main/res/layout/round_activity_home_2.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" tools:context=".watchfaces.Home2" tools:deviceIds="wear_round"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@color/black"
-    android:id="@+id/main_layout">
+    tools:context=".watchfaces.Home2"
+    tools:deviceIds="wear_round">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -15,15 +18,15 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="0px"
-            android:orientation="vertical"
-            android:layout_weight="0.05">
-        </LinearLayout>
+            android:layout_weight="0.05"
+            android:orientation="vertical" />
 
         <LinearLayout
+            android:id="@+id/primary_layout"
             android:layout_width="fill_parent"
             android:layout_height="0px"
             android:layout_gravity="center_horizontal"
-            android:layout_weight="0.27"
+            android:layout_weight="@dimen/home2_primary_layout_height"
             android:gravity="center_horizontal"
             android:orientation="horizontal"
             android:textAlignment="center">
@@ -49,11 +52,11 @@
                 android:layout_marginBottom="-2dp"
                 android:gravity="bottom|right"
                 android:paddingLeft="5dp"
-                android:paddingRight="5dp"
                 android:paddingTop="-2dp"
+                android:paddingRight="5dp"
                 android:text="---"
                 android:textColor="#FFFFFF"
-                android:textSize="38sp" />
+                android:textSize="@dimen/home2_sgv_text_size" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -74,7 +77,7 @@
                     android:text="--"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="22sp"
+                    android:textSize="@dimen/home2_direction_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -109,8 +112,8 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:orientation="horizontal"
-                android:paddingEnd="5dp"
                 android:paddingStart="5dp"
+                android:paddingEnd="5dp"
                 android:textAlignment="center">
 
                 <TextView
@@ -279,7 +282,7 @@
                     android:text="12:00"
                     android:textAlignment="center"
                     android:textColor="#FFFFFF"
-                    android:textSize="30sp" />
+                    android:textSize="@dimen/home2_time_text_size" />
 
                 <LinearLayout
                     android:id="@+id/date_time"
@@ -375,9 +378,8 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="0px"
-            android:orientation="vertical"
-            android:layout_weight="0.05">
-        </LinearLayout>
+            android:layout_weight="0.05"
+            android:orientation="vertical" />
 
     </LinearLayout>
 

--- a/wear/src/main/res/layout/round_activity_home_large.xml
+++ b/wear/src/main/res/layout/round_activity_home_large.xml
@@ -135,4 +135,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/round_cockpit.xml
+++ b/wear/src/main/res/layout/round_cockpit.xml
@@ -488,4 +488,9 @@
 
     </LinearLayout>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/round_steampunk.xml
+++ b/wear/src/main/res/layout/round_steampunk.xml
@@ -378,4 +378,9 @@
         android:layout_height="wrap_content"
         android:visibility="gone"/>
 
+    <include
+        android:id="@+id/simple_ui"
+        layout="@layout/simple_ui"
+        android:visibility="gone" />
+
 </RelativeLayout>

--- a/wear/src/main/res/layout/simple_ui.xml
+++ b/wear/src/main/res/layout/simple_ui.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@color/black"
+    android:orientation="vertical"
+    android:weightSum="100">
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_weight="50"
+        android:gravity="center_horizontal">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="5dp"
+            android:gravity="center_horizontal"
+            android:orientation="horizontal"
+            android:textAlignment="center">
+
+            <TextView
+                android:id="@+id/simple_sgv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_marginBottom="-2dp"
+                android:gravity="bottom|end"
+                android:text="---"
+                android:textColor="@color/white"
+                android:textSize="50sp" />
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_gravity="center_horizontal"
+                android:baselineAligned="false"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:textAlignment="center"
+                android:weightSum="1">
+
+                <TextView
+                    android:id="@+id/simple_direction"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal|bottom"
+                    android:layout_marginTop="-2dp"
+                    android:layout_marginBottom="-5dp"
+                    android:gravity="center_horizontal|bottom"
+                    android:text="--"
+                    android:textColor="@color/white"
+                    android:textSize="35sp"
+                    android:textStyle="bold" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_weight="50"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:id="@+id/simple_watch_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|top"
+            android:layout_marginTop="5dp"
+            android:text="12:00"
+            android:textColor="#FFFFFF"
+            android:textSize="35sp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/wear/src/main/res/values/dimens.xml
+++ b/wear/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <dimen name="home2_primary_layout_height">0.27</dimen>
+    <dimen name="home2_sgv_text_size">38sp</dimen>
+    <dimen name="home2_direction_text_size">22sp</dimen>
+    <dimen name="home2_time_text_size">30sp</dimen>
+</resources>

--- a/wear/src/main/res/values/dimens.xml
+++ b/wear/src/main/res/values/dimens.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <dimen name="home2_primary_layout_height">0.27</dimen>
-    <dimen name="home2_sgv_text_size">38sp</dimen>
-    <dimen name="home2_direction_text_size">22sp</dimen>
-    <dimen name="home2_time_text_size">30sp</dimen>
-</resources>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -136,6 +136,8 @@
     <string name="color_name_white">white</string>
     <string name="color_name_black">black</string>
     <string name="color_name_multicolor">multicolor</string>
+    <string name="pref_simplify_ui_charging">Simplify Charging UI</string>
+    <string name="pref_simplify_ui_charging_sum">Only show time and BG when charging</string>
 
 
     <string name="pref_vibrate_hourly">Vibrate hourly</string>

--- a/wear/src/main/res/xml/watch_face_configuration_cockpit.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_cockpit.xml
@@ -2,13 +2,19 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-
-
-
     <CheckBoxPreference
         android:key="vibrate_Hourly"
         android:title="@string/pref_vibrate_hourly"
         android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_digitalstyle.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_digitalstyle.xml
@@ -50,4 +50,13 @@
         android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_home.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_home.xml
@@ -24,4 +24,13 @@
         android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_home2.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_home2.xml
@@ -8,7 +8,7 @@
         android:summary="Dark theme"
         android:title="@string/pref_dark"
         app:wear_iconOff="@drawable/settings_off"
-        app:wear_iconOn="@drawable/settings_on"/>
+        app:wear_iconOn="@drawable/settings_on" />
 
     <CheckBoxPreference
         android:defaultValue="false"
@@ -16,7 +16,7 @@
         android:summary="Status bar divider background matches watchface background"
         android:title="@string/pref_matching_divider"
         app:wear_iconOff="@drawable/settings_off"
-        app:wear_iconOn="@drawable/settings_on"/>
+        app:wear_iconOn="@drawable/settings_on" />
 
     <CheckBoxPreference
         android:defaultValue="false"
@@ -26,9 +26,18 @@
         app:wear_iconOn="@drawable/settings_on" />
 
     <CheckBoxPreference
+        android:defaultValue="false"
         android:key="vibrate_Hourly"
         android:title="@string/pref_vibrate_hourly"
-        android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_largehome.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_largehome.xml
@@ -24,4 +24,13 @@
         android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_steampunk.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_steampunk.xml
@@ -16,4 +16,13 @@
         android:defaultValue="false"
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simplify_ui_charging"
+        android:summary="@string/pref_simplify_ui_charging_sum"
+        android:title="@string/pref_simplify_ui_charging"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
 </PreferenceScreen>


### PR DESCRIPTION
During the night, while charging, it would be helpful, if the display could stay “always on” and show my blood glucose. The Android developer option “Stay awake when charging” can be used to do so. However,  watch-faces are a bit too bright, has too much information, and the details are hard to read with sleepy eyes. Therefore I added an option for the watch-face, to simplify the UI only during charging when set in the configuration.
Implemented in all watch faces that inherit WatchFaceBase: Home, Home2, Home Big, Digital, Steampunk and cockpit.

(Includes a fix for the trend arrows showing as a blue emoticon)

![image](https://user-images.githubusercontent.com/6724749/146454220-ad1e48a5-4941-4203-b3fd-75f2d8047009.png)

![image](https://user-images.githubusercontent.com/6724749/146454298-19e72c1c-6cce-4f86-98c1-9c153ae536ea.png)

![image](https://user-images.githubusercontent.com/6724749/146454342-2ccfb3e5-3d6b-45b7-85aa-828bd052f474.png)

![image](https://user-images.githubusercontent.com/6724749/146454390-97a30722-fb35-4098-91a1-fe2db7f49720.png)