### PR TITLE
Fix mmol Units for Therapy Event in NS

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/extensions/TherapyEventExtension.kt
+++ b/core/src/main/java/info/nightscout/androidaps/extensions/TherapyEventExtension.kt
@@ -69,12 +69,18 @@ fun therapyEventFromNsIdForInvalidating(nsId: String): TherapyEvent =
     )!!
 
 fun therapyEventFromJson(jsonObject: JSONObject): TherapyEvent? {
-    val glucoseUnit = if (JsonHelper.safeGetString(jsonObject, "units", Constants.MGDL) == Constants.MGDL) TherapyEvent.GlucoseUnit.MGDL else TherapyEvent.GlucoseUnit.MMOL
     val timestamp = JsonHelper.safeGetLongAllowNull(jsonObject, "mills", null) ?: return null
     val type = TherapyEvent.Type.fromString(JsonHelper.safeGetString(jsonObject, "eventType", TherapyEvent.Type.NONE.text))
     val duration = JsonHelper.safeGetLong(jsonObject, "duration")
     val durationInMilliseconds = JsonHelper.safeGetLongAllowNull(jsonObject, "durationInMilliseconds")
     val glucose = JsonHelper.safeGetDoubleAllowNull(jsonObject, "glucose")
+    val glucoseUnit = glucose?.let {
+        if (JsonHelper.safeGetDoubleAllowNull(jsonObject, "mmol") == glucose)
+            TherapyEvent.GlucoseUnit.MMOL
+        else
+            TherapyEvent.GlucoseUnit.MGDL
+    }
+        ?:if (JsonHelper.safeGetString(jsonObject, "units", Constants.MGDL) == Constants.MGDL) TherapyEvent.GlucoseUnit.MGDL else TherapyEvent.GlucoseUnit.MMOL
     val glucoseType = TherapyEvent.MeterType.fromString(JsonHelper.safeGetString(jsonObject, "glucoseType"))
     val enteredBy = JsonHelper.safeGetStringAllowNull(jsonObject, "enteredBy", null)
     val note = JsonHelper.safeGetStringAllowNull(jsonObject, "notes", null)


### PR DESCRIPTION
Fix #1085
But it's a workaround (I suppose root cause is a bug in NS or somewhere else in AAPS but I can't find it)
=> See informations below to help fix root cause (I don't like this kind of workaround...)

When BG value (`glucose`) associated to a therapyEvent is in mmol unit, there are 2 additional entries in json string (`targetTop` and `targetBottom`).
These 2 entries are null but when added, glucose units (`mmol`) is replaced by `mg\/dl` in json string so units is wrong for `glucose` value in received json string.

json string received for BG Check if units is mgdl:
```
{
	"_id":"61c599ee1d52ca0004ae55f7",
	"eventType":"BG Check",
	"isValid":true,
	"created_at":"2021-12-24T09:58:49.000Z",
	"enteredBy":"AndroidAPS",
	"units":"mg\/dl",
	"notes":"test bg",
	"glucose":144,
	"glucoseType":"Sensor",
	"mills":1640339929000,
	"mgdl":144
}
```
json string received for BG Check if units is mmol:
```
{
	"_id":"61c599251d52ca0004ae55f2",
	"eventType":"BG Check",
	"isValid":true,
	"created_at":"2021-12-24T09:55:28.000Z",
	"enteredBy":"AndroidAPS",
	"units":"mg\/dl",
	"notes":"test mmol",
	"glucose":8.055555555555555,
	"glucoseType":"Sensor",
	"mills":1640339728000,
	"mmol":8.055555555555555,
	"targetTop":null,
	"targetBottom":null
}
```