### PR TITLE
confirm dialog scroll + title fixes

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
+++ b/wear/src/main/java/info/nightscout/androidaps/data/ListenerService.java
@@ -522,7 +522,7 @@ public class ListenerService extends WearableListenerService implements GoogleAp
                         intent.putExtras(params);
                         startActivity(intent);
                     } else {
-                        showConfirmationDialog(message, actionstring);
+                        showConfirmationDialog(title, message, actionstring);
                     }
 
                 } else if (path.equals(NEW_STATUS_PATH)) {
@@ -680,10 +680,11 @@ public class ListenerService extends WearableListenerService implements GoogleAp
         notificationManager.createNotificationChannel(channel);
     }
 
-    private void showConfirmationDialog(String message, String actionstring) {
+    private void showConfirmationDialog(String title, String message, String actionstring) {
         Intent intent = new Intent(this, AcceptActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         Bundle params = new Bundle();
+        params.putString("title", title);
         params.putString("message", message);
         params.putString("actionstring", actionstring);
         intent.putExtras(params);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/AcceptActivity.java
@@ -7,10 +7,16 @@ import android.os.SystemClock;
 import android.os.Vibrator;
 import android.support.wearable.view.GridPagerAdapter;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import androidx.core.view.InputDeviceCompat;
+import androidx.core.view.MotionEventCompat;
+import androidx.core.view.ViewConfigurationCompat;
 
 import info.nightscout.androidaps.R;
 import info.nightscout.androidaps.data.ListenerService;
@@ -71,8 +77,28 @@ public class AcceptActivity extends ViewSelectorActivity {
             if (col == 0) {
                 final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_confirm_text, container, false);
                 final TextView textView = view.findViewById(R.id.message);
+                final View scrollView = view.findViewById(R.id.message_scroll);
                 textView.setText(message);
                 container.addView(view);
+                scrollView.setOnGenericMotionListener(new View.OnGenericMotionListener() {
+                    @Override
+                    public boolean onGenericMotion(View v, MotionEvent ev) {
+                        if (ev.getAction() == MotionEvent.ACTION_SCROLL &&
+                                ev.isFromSource(InputDeviceCompat.SOURCE_ROTARY_ENCODER)
+                        ) {
+                            float delta = -ev.getAxisValue(MotionEventCompat.AXIS_SCROLL) *
+                                    ViewConfigurationCompat.getScaledVerticalScrollFactor(
+                                            ViewConfiguration.get(container.getContext()),
+                                            container.getContext());
+                            v.scrollBy(0, Math.round(delta));
+
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+
+                scrollView.requestFocus();
                 return view;
             } else {
                 final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_send_item, container, false);

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/ViewSelectorActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/ViewSelectorActivity.java
@@ -29,7 +29,7 @@ public class ViewSelectorActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.grid_layout);
 
-        setTitleBasedOnScreenShape(String.valueOf(getTitle()));
+        setTitleBasedOnScreenShape();
 
         pager = findViewById(R.id.pager);
         DotsPageIndicator dotsPageIndicator = findViewById(R.id.page_indicator);
@@ -59,7 +59,12 @@ public class ViewSelectorActivity extends Activity {
         pager.setAdapter(adapter);
     }
 
-    private void setTitleBasedOnScreenShape(String title) {
+    private void setTitleBasedOnScreenShape() {
+        // intents can inject dynamic titles, otherwise we'll use the default
+        String title = String.valueOf(getTitle());
+        if (getIntent().getExtras() != null)
+            title = getIntent().getExtras().getString("title", title);
+
         CurvedTextView titleViewCurved = findViewById(R.id.title_curved);
         TextView titleView = findViewById(R.id.title);
         if (this.getResources().getConfiguration().isScreenRound()) {
@@ -91,18 +96,8 @@ public class ViewSelectorActivity extends Activity {
     }
 
     void setLabelToPlusMinusView(View view, String labelText) {
-        SharedPreferences sharedPrefs = PreferenceManager
-                .getDefaultSharedPreferences(this);
-        int design = Integer.parseInt(sharedPrefs.getString("input_design", "1"));
-
-        if (design == 4) {
-            //@LadyViktoria: Here the label can be set differently, if you like.
             final TextView textView = view.findViewById(R.id.label);
             textView.setText(labelText);
-        } else {
-            final TextView textView = view.findViewById(R.id.label);
-            textView.setText(labelText);
-        }
     }
 
 }

--- a/wear/src/main/res/layout/action_confirm_text.xml
+++ b/wear/src/main/res/layout/action_confirm_text.xml
@@ -11,6 +11,9 @@
         app:boxedEdges="all">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/message_scroll"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
             <TextView


### PR DESCRIPTION
#1080 changed AcceptActivity to always have `CONFIRM` as its top title (with no secondary title), but I later realized that pump and loop status use AcceptActivity and had a secondary title that no longer showed up -- so after that PR they just said `CONFIRM` on top.

I still like a single title better since there is not much room on the screen for text, but this restores the  `title` Intent Bundle attribute and will use it to set the top title if it is supplied. Loop status, for example, will now set the title to `STATUS LOOP` (which I think used to be the secondary title). I tried to look through the code to see if the secondary title needed the primary title for context and I can't find an example of that.

I also made the message text for all confirm dialog screens scrollable using the rotating bezel since it already worked on the plus/minus screen. Feels very nice on a Galaxy Watch 4 Classic.

I have been using this branch build on my live rig for the last few days and haven't had any issues. I'm trying not to look at my phone so much 🙈 
