### PR TITLE
Added the ability to trigger the calculator from the food tab

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/MyPreferenceFragment.kt
@@ -28,6 +28,7 @@ import info.nightscout.androidaps.plugins.bus.RxBus
 import info.nightscout.androidaps.plugins.configBuilder.PluginStore
 import info.nightscout.androidaps.plugins.constraints.safety.SafetyPlugin
 import info.nightscout.androidaps.plugins.general.automation.AutomationPlugin
+import info.nightscout.androidaps.plugins.general.food.FoodPlugin
 import info.nightscout.androidaps.plugins.general.maintenance.MaintenancePlugin
 import info.nightscout.androidaps.plugins.general.nsclient.NSClientPlugin
 import info.nightscout.androidaps.plugins.general.nsclient.data.NSSettingsStatus
@@ -96,6 +97,7 @@ class MyPreferenceFragment : PreferenceFragmentCompat(), OnSharedPreferenceChang
     @Inject lateinit var statusLinePlugin: StatusLinePlugin
     @Inject lateinit var tidepoolPlugin: TidepoolPlugin
     @Inject lateinit var virtualPumpPlugin: VirtualPumpPlugin
+    @Inject lateinit var foodPlugin: FoodPlugin
     @Inject lateinit var wearPlugin: WearPlugin
     @Inject lateinit var maintenancePlugin: MaintenancePlugin
 
@@ -186,6 +188,7 @@ class MyPreferenceFragment : PreferenceFragmentCompat(), OnSharedPreferenceChang
             addPreferencesFromResourceIfEnabled(tidepoolPlugin, rootKey)
             addPreferencesFromResourceIfEnabled(smsCommunicatorPlugin, rootKey)
             addPreferencesFromResourceIfEnabled(automationPlugin, rootKey)
+            addPreferencesFromResourceIfEnabled(foodPlugin, rootKey)
             addPreferencesFromResourceIfEnabled(wearPlugin, rootKey)
             addPreferencesFromResourceIfEnabled(statusLinePlugin, rootKey)
             addPreferencesFromResource(R.xml.pref_alerts, rootKey)

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -64,6 +64,8 @@ class WizardDialog : DaggerDialogFragment() {
     private var calculatedPercentage = 100.0
     private var calculatedCorrection = 0.0
     private var correctionPercent = false
+    private var carbsPassedIntoWizard = 0.0
+    private var notesPassedIntoWizard = ""
 
     //one shot guards
     private var okClicked: Boolean = false
@@ -109,6 +111,11 @@ class WizardDialog : DaggerDialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
+        this.arguments?.let { bundle ->
+            carbsPassedIntoWizard = bundle.getInt("carbs_input")?.toDouble()
+            notesPassedIntoWizard = bundle.getString("notes_input").toString()
+        }
+
         dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
         dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
         isCancelable = true
@@ -269,6 +276,12 @@ class WizardDialog : DaggerDialogFragment() {
         else DecimalFormatter.to1Decimal(value * Constants.MGDL_TO_MMOLL)
 
     private fun initDialog() {
+        if(carbsPassedIntoWizard != 0.0) {
+            binding.carbsInput.value = carbsPassedIntoWizard
+        }
+        if(!notesPassedIntoWizard.isBlank()) {
+            binding.notes.setText(notesPassedIntoWizard.toString())
+        }
         val profile = profileFunction.getProfile()
         val profileStore = activePlugin.activeProfileSource.profile
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/food/FoodPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/food/FoodPlugin.kt
@@ -34,6 +34,7 @@ class FoodPlugin @Inject constructor(
     .pluginIcon(R.drawable.ic_food)
     .pluginName(R.string.food)
     .shortName(R.string.food_short)
+    .preferencesId(R.xml.pref_food)
     .description(R.string.description_food),
     aapsLogger, rh, injector
 ) {

--- a/app/src/main/res/layout/food_item.xml
+++ b/app/src/main/res/layout/food_item.xml
@@ -8,102 +8,130 @@
     card_view:cardBackgroundColor="?android:colorBackground">
 
     <LinearLayout
+        android:id="@+id/food_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/left_right_split"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:paddingLeft="3dp"
+            android:paddingRight="3dp">
 
-            <TextView
-                android:id="@+id/name"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:id="@+id/name_and_info_container"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
                 android:layout_weight="1"
-                android:text="Name"
-                android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                android:gravity="start">
 
-            <TextView
-                android:id="@+id/portion"
-                android:layout_width="60dp"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:text="Portion"
-                tools:ignore="HardcodedText" />
+                <LinearLayout
+                    android:id="@+id/name_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/carbs"
-                android:layout_width="50dp"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:text="Carbs"
-                tools:ignore="HardcodedText" />
+                    <TextView
+                        android:id="@+id/name"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Name"
+                        android:textStyle="bold"
+                        android:textSize="@dimen/twenty_four_dp"
+                        tools:ignore="HardcodedText" />
 
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/info_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="start"
+                    android:orientation="horizontal"
+                    android:layout_marginLeft="5dp">
+
+                    <TextView
+                        android:id="@+id/carbs"
+                        android:layout_width="50dp"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="Carbs"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/portion"
+                        android:layout_width="50dp"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="Portion"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/fat"
+                        android:layout_width="50dp"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="Fat"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/protein"
+                        android:layout_width="50dp"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="Protein"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/energy"
+                        android:layout_width="50dp"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:text="Energy"
+                        tools:ignore="HardcodedText" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/buttons_container"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:gravity="end">
+
+                <ImageView
+                    android:id="@+id/ic_calculator"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:padding="2dp"
+                    android:orientation="horizontal"
+                    android:src="@drawable/ic_calculator" />
+                <ImageView
+                    android:id="@+id/ic_remove"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:padding="2dp"
+                    android:orientation="horizontal"
+                    android:src="@drawable/ic_trash_outline" />
+
+            </LinearLayout>
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:gravity="end"
-            android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/fat"
-                android:layout_width="70dp"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:text="Fat"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/protein"
-                android:layout_width="70dp"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:text="Protein"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/energy"
-                android:layout_width="70dp"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:text="Energy"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/ns_sign"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:width="30dp"
-                android:text="NS"
-                android:textAlignment="viewEnd"
-                android:textColor="@color/colorSetTempButton"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/remove"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingEnd="5dp"
-                android:paddingStart="10dp"
-                android:text="@string/remove_button"
-                android:textAlignment="viewEnd"
-                android:textColor="@android:color/holo_orange_light" />
-
-        </LinearLayout>
 
         <View
             android:layout_width="fill_parent"
             android:layout_height="2dip"
             android:layout_marginBottom="5dp"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
             android:layout_marginTop="5dp"
             android:background="@color/list_delimiter" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1139,5 +1139,14 @@
     <string name="identification">Identification (email, FB or Discord nick etc)</string>
     <string name="identification_not_set">Identification not set in dev mode</string>
     <string name="not_available_full">Not available</string>
+    <string name="key_food_carbs_calc_protein_percent">key_food_carbs_calc_protein_percent</string>
+    <string name="food_carbs_calc_protein_percent">The percentage of protein to convert to
+        carbs (defaults is 25%, can set to zero to not include protein in carb counts)</string>
+    <string name="key_food_carbs_calc_fat_percent">key_food_carbs_calc_fat_percent</string>
+    <string name="food_carbs_calc_fat_percent">The percentage of fat to convert to carbs
+        (default is 25%, can set to zero to not include fat in carb counts)</string>
+    <string name="key_food_settings">key_food_settings</string>
+
+
 
 </resources>

--- a/app/src/main/res/xml/pref_food.xml
+++ b/app/src/main/res/xml/pref_food.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:validate="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:key="@string/key_food_settings"
+        android:title="@string/food"
+        app:initialExpandedChildrenCount="1">
+
+        <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference
+            android:defaultValue="25.0"
+            android:dialogMessage="@string/food_carbs_calc_protein_percent"
+            android:digits="0123456789"
+            android:inputType="number"
+            android:key="@string/key_food_carbs_calc_protein_percent"
+            android:maxLines="1"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/food_carbs_calc_protein_percent"
+            validate:maxNumber="100"
+            validate:minNumber="0"
+            validate:testType="numericRange" />
+
+        <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference
+            android:defaultValue="25.0"
+            android:dialogMessage="@string/food_carbs_calc_fat_percent"
+            android:digits="0123456789"
+            android:inputType="number"
+            android:key="@string/key_food_carbs_calc_fat_percent"
+            android:maxLines="1"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/food_carbs_calc_fat_percent"
+            validate:maxNumber="100"
+            validate:minNumber="0"
+            validate:testType="numericRange" />
+
+    </PreferenceCategory>
+
+</androidx.preference.PreferenceScreen>
+


### PR DESCRIPTION
Added the ability to bring up the bolus calculator from the food tab. This would allow users to quickly bolus for frequently consumed foods/meals. Working on making a more robust meal calculator where you can add foods & portions, etc. Wanted to create an initial PR for the small changes to get feedback and add initial enhancements.

![Screenshot_20211228-224253](https://user-images.githubusercontent.com/1564297/147625483-e227336e-8a92-403b-a481-ea2eabbe9981.jpg)

![Screenshot_20211228-224325](https://user-images.githubusercontent.com/1564297/147625478-e5161b07-1759-4bab-94c5-9bfb6cc3697b.jpg)



https://github.com/nightscout/AndroidAPS/issues/1105
