### PR TITLE
Dialogs: add more logging

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -97,6 +97,7 @@ class WizardDialog : DaggerDialogFragment() {
     override fun onStart() {
         super.onStart()
         dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        aapsLogger.debug(LTag.APS, "Dialog opened: ${this.javaClass.name}")
     }
 
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
@@ -163,11 +164,15 @@ class WizardDialog : DaggerDialogFragment() {
                 context?.let { context ->
                     wizard?.confirmAndExecute(context)
                 }
+                aapsLogger.debug(LTag.APS, "Dialog ok pressed: ${this.javaClass.name}")
             }
             dismiss()
         }
         // cancel button
-        binding.cancel.setOnClickListener { dismiss() }
+        binding.cancel.setOnClickListener {
+            aapsLogger.debug(LTag.APS, "Dialog canceled: ${this.javaClass.name}")
+            dismiss()
+        }
         // checkboxes
         binding.bgCheckbox.setOnCheckedChangeListener(::onCheckedChanged)
         binding.ttCheckbox.setOnCheckedChangeListener(::onCheckedChanged)

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/DialogFragmentWithDate.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/DialogFragmentWithDate.kt
@@ -44,6 +44,7 @@ abstract class DialogFragmentWithDate : DaggerDialogFragment() {
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.WRAP_CONTENT
         )
+        aapsLogger.debug(LTag.APS, "Dialog opened: ${this.javaClass.name}")
     }
 
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
@@ -129,15 +130,24 @@ abstract class DialogFragmentWithDate : DaggerDialogFragment() {
         (view.findViewById(R.id.ok) as Button?)?.setOnClickListener {
             synchronized(okClicked) {
                 if (okClicked) {
-                    aapsLogger.warn(LTag.UI, "guarding: ok already clicked")
+                    aapsLogger.warn(LTag.UI, "guarding: ok already clicked for dialog: ${this.javaClass.name}")
                 } else {
                     okClicked = true
-                    if (submit()) dismiss()
-                    else okClicked = false
+                    if (submit()) {
+                        aapsLogger.debug(LTag.APS, "Submit pressed for Dialog: ${this.javaClass.name}")
+                        dismiss()
+                    } else {
+                        aapsLogger.debug(LTag.APS, "Submit returned false for Dialog: ${this.javaClass.name}")
+                        okClicked = false
+                    }
                 }
             }
         }
-        (view.findViewById(R.id.cancel) as Button?)?.setOnClickListener { dismiss() }
+        (view.findViewById(R.id.cancel) as Button?)?.setOnClickListener {
+            aapsLogger.debug(LTag.APS, "Cancel pressed for dialog: ${this.javaClass.name}")
+            dismiss()
+        }
+
     }
 
     override fun show(manager: FragmentManager, tag: String?) {


### PR DESCRIPTION
After reading the logs for https://github.com/nightscout/AndroidAPS/issues/1040 I did not find anything.
This is why I'm adding more logging to all the Dialogs, that way we can see if the dialogue was opened/cancel was pressed, etc.