### PR TITLE
Seconds to Int for AlarmClock Intent

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/utils/TimerUtil.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/TimerUtil.kt
@@ -3,17 +3,11 @@ package info.nightscout.androidaps.utils
 import android.content.Context
 import android.content.Intent
 import android.provider.AlarmClock
-import info.nightscout.androidaps.core.R
-import info.nightscout.androidaps.utils.resources.ResourceHelper
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class TimerUtil @Inject constructor(
-    private val context: Context,
-    private val rh: ResourceHelper,
-    private val dateUtil: DateUtil
-) {
+class TimerUtil @Inject constructor(private val context: Context) {
 
     /**
      * Schedule alarm in @seconds
@@ -21,10 +15,12 @@ class TimerUtil @Inject constructor(
     fun scheduleReminder(seconds: Long, text: String) {
         Intent(AlarmClock.ACTION_SET_TIMER).apply {
             flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
-            putExtra(AlarmClock.EXTRA_LENGTH, seconds)
+            putExtra(AlarmClock.EXTRA_LENGTH, seconds.toTimerSeconds())
             putExtra(AlarmClock.EXTRA_SKIP_UI, true)
             putExtra(AlarmClock.EXTRA_MESSAGE, text)
             context.startActivity(this)
         }
     }
 }
+
+private fun Long.toTimerSeconds() = coerceIn(0L, Integer.MAX_VALUE.toLong()).toInt()


### PR DESCRIPTION
The expected datatype for the `AlarmClock.EXTRA_LENGTH` extra is `Integer`.

As we usually use Long to represent time, I'd convert it directly before passing it to the Intent.
In the case that the alarm is extremely in the future (technically possible with `Long`, practically not), it is capped to `Integer.MAX_VALUE`