### PR TITLE
Allow click on wizard icons

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -175,6 +175,10 @@ class WizardDialog : DaggerDialogFragment() {
             }
             dismiss()
         }
+        binding.bgEnabledIcon.setOnClickListener { binding.bgCheckbox.isChecked = !binding.bgCheckbox.isChecked }
+        binding.trendEnabledIcon.setOnClickListener { binding.bgTrendCheckbox.isChecked = !binding.bgTrendCheckbox.isChecked }
+        binding.cobEnabledIcon.setOnClickListener { binding.cobCheckbox.isChecked = !binding.cobCheckbox.isChecked }
+        binding.iobEnabledIcon.setOnClickListener { binding.iobCheckbox.isChecked = !binding.iobCheckbox.isChecked }
         // cancel button
         binding.cancel.setOnClickListener {
             aapsLogger.debug(LTag.APS, "Dialog canceled: ${this.javaClass.name}")

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -177,8 +177,8 @@ class WizardDialog : DaggerDialogFragment() {
         }
         binding.bgEnabledIcon.setOnClickListener { binding.bgCheckbox.isChecked = !binding.bgCheckbox.isChecked }
         binding.trendEnabledIcon.setOnClickListener { binding.bgTrendCheckbox.isChecked = !binding.bgTrendCheckbox.isChecked }
-        binding.cobEnabledIcon.setOnClickListener { binding.cobCheckbox.isChecked = !binding.cobCheckbox.isChecked }
-        binding.iobEnabledIcon.setOnClickListener { binding.iobCheckbox.isChecked = !binding.iobCheckbox.isChecked }
+        binding.cobEnabledIcon.setOnClickListener { binding.cobCheckbox.isChecked = !binding.cobCheckbox.isChecked; processCobCheckBox(); }
+        binding.iobEnabledIcon.setOnClickListener { if (!binding.cobCheckbox.isChecked) binding.iobCheckbox.isChecked = !binding.iobCheckbox.isChecked }
         // cancel button
         binding.cancel.setOnClickListener {
             aapsLogger.debug(LTag.APS, "Dialog canceled: ${this.javaClass.name}")


### PR DESCRIPTION
Just a proposal to be able to change selection (bg, bg trend, cob, iob checkboxes) directly in simplified UI of wizard dialog
=> It's easy for me to select each icons on 6" screen but I didn't test it on smaller phones

Just close this PR if you think it's a bad idea (icons too small for big fingers and/or risks of unwanted wrong selection...)