### PR TITLE
Wear: simple UI menu text translatbale

### DIFF
--- a/wear/src/main/res/values/arrays.xml
+++ b/wear/src/main/res/values/arrays.xml
@@ -66,10 +66,10 @@
     </string-array>
 
     <string-array name="watchface_simplify_ui_name">
-        <item>Off</item>
-        <item>During Charging</item>
-        <item>Always On Mode</item>
-        <item>Always On and Charging</item>
+        <item>@string/simple_ui_off</item>
+        <item>@string/simple_ui_charging</item>
+        <item>@string/simple_ui_always_on</item>
+        <item>@string/simple_ui_always_on_charging</item>
     </string-array>
 
     <string-array name="watchface_simplify_ui_values">

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -157,5 +157,9 @@
     <string name="bolus_progress_channel_description">Bolus progress and cancel</string>
     <string name="bolus_progress_silent_channel_description">Bolus progress and cancel with less vibrations</string>
 
+    <string name="simple_ui_off">Off</string>
+    <string name="simple_ui_charging">During Charging</string>
+    <string name="simple_ui_always_on">Always On Mode</string>
+    <string name="simple_ui_always_on_charging">Always On and Charging</string>
 
 </resources>


### PR DESCRIPTION
In follow up of PR #1147 comments.
Move text of `Simplify UI` menu options into translatable string file