### PR TITLE
prevent 049 pod fault

### DIFF
--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -49,4 +49,6 @@
     <string name="dash_bolusdelivering">Delivering %1$.2f U</string>
     <string name="omnipod_common_alert_delivery_suspended">Insulin delivery is suspended</string>
     <string name="omnipod_dash_connection_lost">Lost connection to pod</string>
+    <string name="omnipod_dash_bolus_already_in_progress">Another bolus is being delivered</string>
+    <string name="omnipod_dash_not_enough_insulin">Not enough insulin left in the reservoir</string>
 </resources>


### PR DESCRIPTION
Fixes https://github.com/nightscout/AndroidAPS/issues/1182

Check if there is another bolus in progress before starting another one.
Translate error messages.