### PR TITLE
fix race on pod activation

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -668,11 +668,9 @@ class OmnipodDashManagerImpl @Inject constructor(
 
             when (event) {
                 is PodEvent.AlreadyConnected -> {
-                    podStateManager.bluetoothAddress = event.bluetoothAddress
                 }
 
                 is PodEvent.BluetoothConnected -> {
-                    podStateManager.bluetoothAddress = event.bluetoothAddress
                 }
 
                 is PodEvent.Connected -> {


### PR DESCRIPTION
Set Bluetooth address only once, after pod scanning. 
Do not set it on each connect.
Fixes: https://github.com/nightscout/AndroidAPS/issues/1159