### PR TITLE
- combo changes to display error count

### DIFF
--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboFragment.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboFragment.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -19,6 +20,7 @@ import dagger.android.support.DaggerFragment;
 import info.nightscout.androidaps.combo.R;
 import info.nightscout.androidaps.interfaces.CommandQueue;
 import info.nightscout.androidaps.plugins.bus.RxBus;
+import info.nightscout.androidaps.plugins.pump.combo.data.ComboErrorUtil;
 import info.nightscout.androidaps.plugins.pump.combo.events.EventComboPumpUpdateGUI;
 import info.nightscout.androidaps.plugins.pump.combo.ruffyscripter.PumpState;
 import info.nightscout.androidaps.plugins.pump.combo.ruffyscripter.history.Bolus;
@@ -53,6 +55,12 @@ public class ComboFragment extends DaggerFragment {
     private TextView bolusCount;
     private TextView tbrCount;
 
+    private View errorCountDelimiter;
+    private LinearLayout errorCountLayout;
+    private TextView errorCountLabel;
+    private TextView errorCountDots;
+    private TextView errorCountValue;
+
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -68,6 +76,12 @@ public class ComboFragment extends DaggerFragment {
         tempBasalText = view.findViewById(R.id.combo_temp_basal);
         bolusCount = view.findViewById(R.id.combo_bolus_count);
         tbrCount = view.findViewById(R.id.combo_tbr_count);
+
+        errorCountDelimiter = view.findViewById(R.id.combo_connection_error_delimiter);
+        errorCountLayout = view.findViewById(R.id.combo_connection_error_layout);
+        errorCountLabel = view.findViewById(R.id.combo_connection_error_label);
+        errorCountDots = view.findViewById(R.id.combo_connection_error_dots);
+        errorCountValue = view.findViewById(R.id.combo_connection_error_value);
 
         refreshButton = view.findViewById(R.id.combo_refresh_button);
         refreshButton.setOnClickListener(v -> {
@@ -240,6 +254,47 @@ public class ComboFragment extends DaggerFragment {
             // stats
             bolusCount.setText(String.valueOf(comboPlugin.getBolusesDelivered()));
             tbrCount.setText(String.valueOf(comboPlugin.getTbrsSet()));
+
+            updateErrorDisplay(false);
+        } else {
+            updateErrorDisplay(true);
+        }
+    }
+
+    private void updateErrorDisplay(boolean forceHide) {
+        int errorCount = -1;
+
+        ComboErrorUtil errorUtil = ComboErrorUtil.getInstance();
+
+        if (!forceHide) {
+            ComboErrorUtil.DisplayType displayType = errorUtil.getDisplayType();
+
+            if (displayType== ComboErrorUtil.DisplayType.ON_ERROR || displayType== ComboErrorUtil.DisplayType.ALWAYS) {
+                int errorCountInternal = errorUtil.getErrorCount();
+
+                if (errorCountInternal>0) {
+                    errorCount = errorCountInternal;
+                } else if (displayType== ComboErrorUtil.DisplayType.ALWAYS) {
+                    errorCount = 0;
+                }
+            }
+        }
+
+        if (errorCount >=0) {
+            errorCountDelimiter.setVisibility(View.VISIBLE);
+            errorCountLayout.setVisibility(View.VISIBLE);
+            errorCountLabel.setVisibility(View.VISIBLE);
+            errorCountDots.setVisibility(View.VISIBLE);
+            errorCountValue.setVisibility(View.VISIBLE);
+            errorCountValue.setText(errorCount==0 ?
+                    "-" :
+                    ""+errorCount);
+        } else {
+            errorCountDelimiter.setVisibility(View.GONE);
+            errorCountLayout.setVisibility(View.GONE);
+            errorCountLabel.setVisibility(View.GONE);
+            errorCountDots.setVisibility(View.GONE);
+            errorCountValue.setVisibility(View.GONE);
         }
     }
 }

--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
@@ -38,6 +38,7 @@ import info.nightscout.androidaps.interfaces.Pump;
 import info.nightscout.androidaps.interfaces.PumpDescription;
 import info.nightscout.androidaps.interfaces.PumpPluginBase;
 import info.nightscout.androidaps.interfaces.PumpSync;
+import info.nightscout.androidaps.plugins.pump.combo.data.ComboErrorUtil;
 import info.nightscout.shared.logging.AAPSLogger;
 import info.nightscout.shared.logging.LTag;
 import info.nightscout.androidaps.plugins.bus.RxBus;
@@ -161,6 +162,7 @@ public class ComboPlugin extends PumpPluginBase implements Pump, Constraints {
                         .pluginIcon(R.drawable.ic_combo_128)
                         .pluginName(R.string.combopump)
                         .shortName(R.string.combopump_shortname)
+                        .preferencesId(R.xml.pref_combo)
                         .description(R.string.description_pump_combo),
                 injector, aapsLogger, rh, commandQueue
         );
@@ -171,6 +173,9 @@ public class ComboPlugin extends PumpPluginBase implements Pump, Constraints {
         this.context = context;
         this.pumpSync = pumpSync;
         this.dateUtil = dateUtil;
+
+        ComboErrorUtil.getInstance().setSP(sp);
+        ComboErrorUtil.getInstance().clearErrors();
 
         pumpDescription.fillFor(PumpType.ACCU_CHEK_COMBO);
     }

--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/data/ComboErrorUtil.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/data/ComboErrorUtil.java
@@ -1,0 +1,106 @@
+package info.nightscout.androidaps.plugins.pump.combo.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import info.nightscout.androidaps.combo.R;
+import info.nightscout.shared.sharedPreferences.SP;
+
+/**
+ * Created by andy on 3/17/18.
+ */
+public class ComboErrorUtil {
+
+    private SP sp;
+
+    Map<String, List<ErrorState>> errorMap = new HashMap<>();
+
+    private static final ComboErrorUtil comboDataUtil = new ComboErrorUtil();
+
+    private ComboErrorUtil() {
+    }
+
+    public static ComboErrorUtil getInstance() {
+        return comboDataUtil;
+    }
+
+    public void setSP(SP sp) {
+        this.sp = sp;
+    }
+
+    public void addError(Exception exception) {
+        String exceptionMsg = exception.getMessage();
+
+        if (!errorMap.containsKey(exceptionMsg)) {
+            List<ErrorState> list = new ArrayList<>();
+            list.add(createErrorState(exception));
+
+            errorMap.put(exceptionMsg, list);
+        } else {
+            errorMap.get(exceptionMsg).add(createErrorState(exception));
+        }
+
+        updateErrorCount();
+    }
+
+
+    private void updateErrorCount() {
+        int errorCount = 0;
+
+        if (!isErrorPresent()) {
+            for (List<ErrorState> errorStates : errorMap.values()) {
+                errorCount += errorStates.size();
+            }
+        }
+
+        if (errorCount==0) {
+            if (sp.contains(R.string.key_combo_error_count)) {
+                sp.remove(R.string.key_combo_error_count);
+            }
+        } else {
+            sp.putInt(R.string.key_combo_error_count, errorCount);
+        }
+    }
+
+    private ErrorState createErrorState(Exception exception) {
+        ErrorState errorState = new ErrorState();
+        errorState.setException(exception);
+        errorState.setTimeInMillis(System.currentTimeMillis());
+
+        return errorState;
+    }
+
+    public void clearErrors() {
+        if (errorMap != null)
+            this.errorMap.clear();
+        else
+            this.errorMap = new HashMap<>();
+
+        if (sp.contains(R.string.key_combo_error_count)) {
+            sp.remove(R.string.key_combo_error_count);
+        }
+    }
+
+    public boolean isErrorPresent() {
+        return !this.errorMap.isEmpty();
+    }
+
+    public int getErrorCount() {
+        return sp.contains(R.string.key_combo_error_count) ?
+                sp.getInt(R.string.key_combo_error_count, -1) : -1;
+    }
+
+    public DisplayType getDisplayType() {
+        String displayTypeString = sp.getString(R.string.key_show_comm_error_count, "ON_ERROR");
+        return DisplayType.valueOf(displayTypeString);
+    }
+
+    public enum DisplayType {
+        NEVER,
+        ON_ERROR,
+        ALWAYS
+    }
+
+}

--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/data/ErrorState.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/data/ErrorState.java
@@ -1,0 +1,17 @@
+package info.nightscout.androidaps.plugins.pump.combo.data;
+
+public class ErrorState {
+
+    private Exception exception;
+    private long timeInMillis;
+
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
+
+    public void setTimeInMillis(long timeInMillis) {
+        this.timeInMillis = timeInMillis;
+    }
+}

--- a/combo/src/main/res/layout/combopump_fragment.xml
+++ b/combo/src/main/res/layout/combopump_fragment.xml
@@ -463,6 +463,55 @@
             </LinearLayout>
 
             <View
+                android:id="@+id/combo_connection_error_delimiter"
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginBottom="5dp"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                android:layout_marginTop="5dp"
+                android:background="@color/list_delimiter" />
+
+            <LinearLayout
+                android:id="@+id/combo_connection_error_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/combo_connection_error_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.5"
+                    android:gravity="end"
+                    android:paddingRight="5dp"
+                    android:text="@string/pump_commerror_label"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/combo_connection_error_dots"
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingEnd="2dp"
+                    android:paddingStart="2dp"
+                    android:text=":"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/combo_connection_error_value"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="start"
+                    android:paddingLeft="5dp"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
                 android:layout_marginBottom="5dp"

--- a/combo/src/main/res/values/arrays.xml
+++ b/combo/src/main/res/values/arrays.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="comboErrorDisplay">
+        <item>@string/combo_error_display_never</item>
+        <item>@string/combo_error_display_error</item>
+        <item>@string/combo_error_display_always</item>
+    </string-array>
+
+    <string-array name="comboErrorDisplayValues">
+        <item>@string/key_combo_error_display_never</item>
+        <item>@string/key_combo_error_display_error</item>
+        <item>@string/key_combo_error_display_always</item>
+    </string-array>
+</resources>

--- a/combo/src/main/res/values/strings.xml
+++ b/combo/src/main/res/values/strings.xml
@@ -57,4 +57,19 @@
     <string name="combo_pump_serial" translatable="false">combo_pump_serial</string>
     <string name="combo_tbrs_set" translatable="false">combo_tbrs_set</string>
     <string name="combo_boluses_delivered" translatable="false">combo_boluses_delivered</string>
+    <string name="pump_commerror_label">Comm. Error count</string>
+    <string name="key_combo_error_count" translatable="false">combo_error_count</string>
+    <string name="key_combo_name_settings" translatable="false">combo_name_settings</string>
+    <string name="key_show_comm_error_count" translatable="false">show_error_count</string>
+    <string name="show_comm_error_count_title">Show comm. error count</string>
+    <string name="show_comm_error_count_summary">Shows count of errors, when communicating with Ruffy. In most cases number higher than 0 denotes, Ruffy communication problems (restart might be needed).</string>
+
+    <string name="combo_error_display_never">Never</string>
+    <string name="combo_error_display_error">When Error</string>
+    <string name="combo_error_display_always">Always</string>
+
+    <string name="key_combo_error_display_never" translatable="false">NEVER</string>
+    <string name="key_combo_error_display_error" translatable="false">ON_ERROR</string>
+    <string name="key_combo_error_display_always" translatable="false">ALWAYS</string>
+
 </resources>

--- a/combo/src/main/res/xml/pref_combo.xml
+++ b/combo/src/main/res/xml/pref_combo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:validate="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:key="@string/key_combo_name_settings"
+        android:title="@string/combopump"
+        app:initialExpandedChildrenCount="0">
+
+        <ListPreference
+            android:defaultValue="@string/combo_error_display_error"
+            android:entries="@array/comboErrorDisplay"
+            android:entryValues="@array/comboErrorDisplayValues"
+            android:key="@string/key_show_comm_error_count"
+            android:summary="@string/show_comm_error_count_summary"
+            android:selectable="true"
+            android:title="@string/show_comm_error_count_title" />
+
+    </PreferenceCategory>
+
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This is for displaying error count on Combo tab, if there are communication problem. If communication with Ruffy fails then this count is increased. There is configuration option, to either display: 1. always, 2. when error, 3.never.
I have been using this code for last few years (ever since I started using Combo), but I didn't add configuration option for me (I displayed it always), so that is new.  