### PR TITLE
Fix/number picker set limit

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPicker.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPicker.kt
@@ -192,6 +192,14 @@ open class NumberPicker(context: Context, attrs: AttributeSet? = null) : LinearL
         set(value) {
             if (watcher != null) editText?.removeTextChangedListener(watcher)
             currentValue = value
+            if (currentValue > maxValue) {
+                currentValue = maxValue
+                ToastUtils.showToastInUiThread(context, context.getString(R.string.youareonallowedlimit))
+            }
+            if (currentValue < minValue) {
+                currentValue = minValue
+                ToastUtils.showToastInUiThread(context, context.getString(R.string.youareonallowedlimit))
+            }
             callValueChangedListener()
             updateEditText()
             if (watcher != null) editText?.addTextChangedListener(watcher)


### PR DESCRIPTION
Within the Insulin dialog, and Carb dialog, are quick buttons to add x amount; this helps users to enter the values more quickly. When the value is larger than the max, the toast is shown, and the OK button is disabled. 

![image](https://user-images.githubusercontent.com/6724749/151325398-935c4dd8-3798-4198-b22b-a20b94ed6faa.png)


Expected behavior implemented in the PR; similar to the number picker + and - button, is to set the value to the max, show the toast and therefore keep the OK button enabled.

The only one case where the OK buttons will disable when the user enters a value larger than the max with keyboard is it best practice to validate keyboard input and not overwrite them
