### PR TITLE
Fix carbs event time

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
@@ -105,6 +105,12 @@ class CarbsDialog : DialogFragmentWithDate() {
     ): View {
         onCreateViewGeneral()
         _binding = DialogCarbsBinding.inflate(inflater, container, false)
+        binding.time.setOnValueChangedListener { timeOffset: Double ->
+            run {
+                val newTime = eventTimeOriginal + timeOffset.toLong() * 1000 * 60
+                updateDateTime(newTime)
+            }
+        }
         return binding.root
     }
 
@@ -157,6 +163,13 @@ class CarbsDialog : DialogFragmentWithDate() {
                     + sp.getInt(R.string.key_carbs_button_increment_3, FAV3_DEFAULT)
             )
             validateInputs()
+        }
+
+        setOnValueChangedListener { eventTime: Long ->
+            run {
+                val timeOffset = ((eventTime - eventTimeOriginal) / (1000 * 60)).toDouble()
+                binding.time.value = timeOffset
+            }
         }
 
         iobCobCalculator.ads.actualBg()?.let { bgReading ->
@@ -229,10 +242,6 @@ class CarbsDialog : DialogFragmentWithDate() {
             )
 
         val timeOffset = binding.time.value.toInt()
-        eventTime -= eventTime % 1000
-        val time = eventTime + timeOffset * 1000 * 60
-        if (timeOffset != 0)
-            actions.add(rh.gs(R.string.time) + ": " + dateUtil.dateAndTimeString(time))
         if (useAlarm && carbs > 0 && timeOffset > 0)
             actions.add(rh.gs(R.string.alarminxmin, timeOffset).formatColor(rh, R.color.info))
         val duration = binding.duration.value.toInt()
@@ -330,7 +339,7 @@ class CarbsDialog : DialogFragmentWithDate() {
                         detailedBolusInfo.context = context
                         detailedBolusInfo.notes = notes
                         detailedBolusInfo.carbsDuration = T.hours(duration.toLong()).msecs()
-                        detailedBolusInfo.carbsTimestamp = time
+                        detailedBolusInfo.carbsTimestamp = eventTime
                         uel.log(if (duration == 0) Action.CARBS else Action.EXTENDED_CARBS, Sources.CarbDialog,
                                 notes,
                                 ValueWithUnit.Timestamp(eventTime).takeIf { eventTimeChanged },

--- a/app/src/main/res/layout/dialog_insulin.xml
+++ b/app/src/main/res/layout/dialog_insulin.xml
@@ -81,11 +81,11 @@
                 android:layout_gravity="center_horizontal"
                 android:width="120dp"
                 android:padding="10dp"
-                android:text="@string/time"
+                android:text="@string/time_offset"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 android:textStyle="bold" />
 
-            <info.nightscout.androidaps.utils.ui.NumberPicker
+            <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/time"
                 android:layout_width="130dp"
                 android:layout_height="40dp" />


### PR DESCRIPTION
The carb dialog allows a user to enter an offset in minutes, and an event time through the date/time picker. This gave an inconsistent UI
Where it was possible to change both.

The expected behaviour;
1. When the `Offset time` is changed, the `Event time` is updated.
1. When the `Event time` date is changed the `Offset time` is updated.
1. When the `Event time` time is changed the `Offset time` is updated.
1. The + and - 12 hours limit set through the `Offset time` will be enforced on the `Event time` too, working together with PR #1233 

Note: no side effects are expected on the other dialogs that are using the DialogFragmentWithDate in combination with Number/Minute picker.

* Additional I made the insulin dialog with the "Do not bolus, record only" option to use the minutes picker too

![image](https://user-images.githubusercontent.com/6724749/151434261-c6333754-05d2-4b19-bba9-e2f600c273d5.png)
