### PR TITLE
Home back button improvements

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -21,6 +21,7 @@ import android.widget.TextView
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.GravityCompat
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -87,6 +88,7 @@ class MainActivity : NoSplashAppCompatActivity() {
     private lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
     private var pluginPreferencesMenuItem: MenuItem? = null
     private var menu: Menu? = null
+    private var menuOpen = false
 
     private lateinit var binding: ActivityMainBinding
 
@@ -258,9 +260,18 @@ class MainActivity : NoSplashAppCompatActivity() {
     }
 
     override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
+        menuOpen = true
+        if (binding.mainDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+            binding.mainDrawerLayout.closeDrawers()
+        }
         val result = super.onMenuOpened(featureId, menu)
         menu.findItem(R.id.nav_treatments)?.isEnabled = profileFunction.getProfile() != null
         return result
+    }
+
+    override fun onPanelClosed(featureId: Int, menu: Menu) {
+        menuOpen = false;
+        super.onPanelClosed(featureId, menu)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -357,6 +368,22 @@ class MainActivity : NoSplashAppCompatActivity() {
             }
         }
         return actionBarDrawerToggle.onOptionsItemSelected(item)
+    }
+
+    override fun onBackPressed() {
+        if (binding.mainDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+            binding.mainDrawerLayout.closeDrawers()
+            return
+        }
+        if (menuOpen) {
+            this.menu?.close()
+            return
+        }
+        if (binding.mainPager.currentItem != 0) {
+            binding.mainPager.currentItem = 0
+            return
+        }
+        super.onBackPressed()
     }
 
     // Correct place for calling setUserStats() would be probably MainApp


### PR DESCRIPTION
Within AAPS the back buttons work consistently, except for view places. This made me, in the beginning, close the app more frequently than intended. 
The PR improves the behaviour:
1. When the `drawer/main/left menu` is open, the back button will close it
2. When the `option/right menu` is opened, the back button will close it
3. When you are not on the `home/first tab`, the back button will bring you back to `home`
4. When the `drawer/main/left menu` is open, opening the `option/right menu` closes the left menu