### PR TITLE
Improve a11y wizard dialog

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -4,11 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.view.Window
-import android.view.WindowManager
+import android.view.*
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.ArrayAdapter
@@ -136,33 +132,36 @@ class WizardDialog : DaggerDialogFragment() {
         val maxCorrection = constraintChecker.getMaxBolusAllowed().value()
         bolusStep = activePlugin.activePump.pumpDescription.bolusStep
 
-        if (profileFunction.getUnits() == GlucoseUnit.MGDL)
-            binding.bgInput.setParams(savedInstanceState?.getDouble("bg_input")
-                ?: 0.0, 0.0, 500.0, 1.0, DecimalFormat("0"), false, binding.ok, timeTextWatcher)
-        else
-            binding.bgInput.setParams(savedInstanceState?.getDouble("bg_input")
-                ?: 0.0, 0.0, 30.0, 0.1, DecimalFormat("0.0"), false, binding.ok, textWatcher)
+        if (profileFunction.getUnits() == GlucoseUnit.MGDL) {
+            binding.bgInput.setParams(
+                savedInstanceState?.getDouble("bg_input")
+                    ?: 0.0, 0.0, 500.0, 1.0, DecimalFormat("0"), false, binding.okcancel.ok, timeTextWatcher)
+        } else {
+            binding.bgInput.setParams(
+                savedInstanceState?.getDouble("bg_input")
+                    ?: 0.0, 0.0, 30.0, 0.1, DecimalFormat("0.0"), false, binding.okcancel.ok, textWatcher)
+        }
         binding.carbsInput.setParams(savedInstanceState?.getDouble("carbs_input")
-            ?: 0.0, 0.0, maxCarbs.toDouble(), 1.0, DecimalFormat("0"), false, binding.ok, textWatcher)
+            ?: 0.0, 0.0, maxCarbs.toDouble(), 1.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher)
 
         if (correctionPercent) {
             calculatedPercentage = sp.getInt(R.string.key_boluswizard_percentage, 100).toDouble()
-            binding.correctionInput.setParams(calculatedPercentage, 10.0, 200.0, 1.0, DecimalFormat("0"), false, binding.ok, textWatcher)
+            binding.correctionInput.setParams(calculatedPercentage, 10.0, 200.0, 1.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher)
             binding.correctionInput.value = calculatedPercentage
             binding.correctionUnit.text = "%"
         } else {
             binding.correctionInput.setParams(
                 savedInstanceState?.getDouble("correction_input")
-                    ?: 0.0, -maxCorrection, maxCorrection, bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.ok, textWatcher)
+                    ?: 0.0, -maxCorrection, maxCorrection, bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.okcancel.ok, textWatcher)
             binding.correctionUnit.text = rh.gs(R.string.insulin_unit_shortname)
         }
         binding.carbTimeInput.setParams(savedInstanceState?.getDouble("carb_time_input")
-            ?: 0.0, -60.0, 60.0, 5.0, DecimalFormat("0"), false, binding.ok, timeTextWatcher)
+            ?: 0.0, -60.0, 60.0, 5.0, DecimalFormat("0"), false, binding.okcancel.ok, timeTextWatcher)
         initDialog()
         calculatedPercentage = sp.getInt(R.string.key_boluswizard_percentage, 100).toDouble()
         binding.percentUsed.text = rh.gs(R.string.format_percent, sp.getInt(R.string.key_boluswizard_percentage, 100))
         // ok button
-        binding.ok.setOnClickListener {
+        binding.okcancel.ok.setOnClickListener {
             if (okClicked) {
                 aapsLogger.debug(LTag.UI, "guarding: ok already clicked")
             } else {
@@ -175,12 +174,12 @@ class WizardDialog : DaggerDialogFragment() {
             }
             dismiss()
         }
-        binding.bgEnabledIcon.setOnClickListener { binding.bgCheckbox.isChecked = !binding.bgCheckbox.isChecked }
-        binding.trendEnabledIcon.setOnClickListener { binding.bgTrendCheckbox.isChecked = !binding.bgTrendCheckbox.isChecked }
-        binding.cobEnabledIcon.setOnClickListener { binding.cobCheckbox.isChecked = !binding.cobCheckbox.isChecked; processCobCheckBox(); }
-        binding.iobEnabledIcon.setOnClickListener { if (!binding.cobCheckbox.isChecked) binding.iobCheckbox.isChecked = !binding.iobCheckbox.isChecked }
+        binding.bgCheckboxIcon.setOnClickListener { binding.bgCheckbox.isChecked = !binding.bgCheckbox.isChecked }
+        binding.trendCheckboxIcon.setOnClickListener { binding.bgTrendCheckbox.isChecked = !binding.bgTrendCheckbox.isChecked }
+        binding.cobCheckboxIcon.setOnClickListener { binding.cobCheckbox.isChecked = !binding.cobCheckbox.isChecked; processCobCheckBox(); }
+        binding.iobCheckboxIcon.setOnClickListener { if (!binding.cobCheckbox.isChecked) binding.iobCheckbox.isChecked = !binding.iobCheckbox.isChecked }
         // cancel button
-        binding.cancel.setOnClickListener {
+        binding.okcancel.cancel.setOnClickListener {
             aapsLogger.debug(LTag.APS, "Dialog canceled: ${this.javaClass.name}")
             dismiss()
         }
@@ -212,11 +211,17 @@ class WizardDialog : DaggerDialogFragment() {
                 sp.putBoolean(rh.gs(R.string.key_wizard_correction_percent), isChecked)
                 binding.correctionUnit.text = if (isChecked) "%" else rh.gs(R.string.insulin_unit_shortname)
                 correctionPercent = binding.correctionPercent.isChecked
-                if (correctionPercent)
-                    binding.correctionInput.setParams(calculatedPercentage, 10.0, 200.0, 1.0, DecimalFormat("0"), false, binding.ok, textWatcher)
-                else
-                    binding.correctionInput.setParams(savedInstanceState?.getDouble("correction_input")
-                                                      ?: 0.0, -maxCorrection, maxCorrection, bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.ok, textWatcher)
+                if (correctionPercent) {
+                    binding.correctionInput.setParams(calculatedPercentage, 10.0, 200.0, 1.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher)
+                    binding.correctionInput.customContentDescription = rh.gs(R.string.a11_correction_percentage)
+                } else {
+                    binding.correctionInput.setParams(
+                        savedInstanceState?.getDouble("correction_input")
+                            ?: 0.0, -maxCorrection, maxCorrection, bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.okcancel.ok, textWatcher
+                    )
+                    binding.correctionInput.customContentDescription = rh.gs(R.string.a11_correction_units)
+                }
+                binding.correctionInput.updateA11yDescription()
                 binding.correctionInput.value = if (correctionPercent) calculatedPercentage else Round.roundTo(calculatedCorrection, bolusStep)
             }
         }
@@ -224,12 +229,12 @@ class WizardDialog : DaggerDialogFragment() {
         binding.profile.onItemSelectedListener = object : OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 ToastUtils.showToastInUiThread(ctx, rh.gs(R.string.noprofileset))
-                binding.ok.visibility = View.GONE
+                binding.okcancel.ok.visibility = View.GONE
             }
 
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 calculateInsulin()
-                binding.ok.visibility = View.VISIBLE
+                binding.okcancel.ok.visibility = View.VISIBLE
             }
         }
         // bus
@@ -241,6 +246,26 @@ class WizardDialog : DaggerDialogFragment() {
             }, fabricPrivacy::logException)
         )
 
+        setA11yLabels()
+    }
+
+    private fun setA11yLabels() {
+        val bgInputTextId = binding.bgInput.editText?.id
+        if (bgInputTextId != null) {
+            binding.bgInputLabel.labelFor = bgInputTextId
+        }
+        val carbsTextId = binding.carbsInput.editText?.id
+        if (carbsTextId != null) {
+            binding.carbsInputLabel.labelFor = carbsTextId
+        }
+        val corrTextId = binding.correctionInput.editText?.id
+        if (corrTextId != null) {
+            binding.correctionInputLabel.labelFor = corrTextId
+        }
+        val carbTimeTextId = binding.carbTimeInput.editText?.id
+        if (carbTimeTextId != null) {
+            binding.carbTimeInputLabel.labelFor = carbTimeTextId
+        }
     }
 
     override fun onDestroyView() {
@@ -268,14 +293,14 @@ class WizardDialog : DaggerDialogFragment() {
     }
 
     private fun processEnabledIcons() {
-        binding.bgEnabledIcon.alpha = if (binding.bgCheckbox.isChecked) 1.0f else 0.2f
-        binding.trendEnabledIcon.alpha = if (binding.bgTrendCheckbox.isChecked) 1.0f else 0.2f
-        binding.iobEnabledIcon.alpha = if (binding.iobCheckbox.isChecked) 1.0f else 0.2f
-        binding.cobEnabledIcon.alpha = if (binding.cobCheckbox.isChecked) 1.0f else 0.2f
-        binding.bgEnabledIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
-        binding.trendEnabledIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
-        binding.iobEnabledIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
-        binding.cobEnabledIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
+        binding.bgCheckboxIcon.alpha = if (binding.bgCheckbox.isChecked) 1.0f else 0.2f
+        binding.trendCheckboxIcon.alpha = if (binding.bgTrendCheckbox.isChecked) 1.0f else 0.2f
+        binding.iobCheckboxIcon.alpha = if (binding.iobCheckbox.isChecked) 1.0f else 0.2f
+        binding.cobCheckboxIcon.alpha = if (binding.cobCheckbox.isChecked) 1.0f else 0.2f
+        binding.bgCheckboxIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
+        binding.trendCheckboxIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
+        binding.iobCheckboxIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
+        binding.cobCheckboxIcon.visibility = binding.calculationCheckbox.isChecked.not().toVisibility()
     }
 
     private fun saveCheckedStates() {
@@ -442,10 +467,10 @@ class WizardDialog : DaggerDialogFragment() {
                 val insulinText = if (wizard.calculatedTotalInsulin > 0.0) rh.gs(R.string.formatinsulinunits, wizard.calculatedTotalInsulin).formatColor(rh, R.color.bolus) else ""
                 val carbsText = if (carbsAfterConstraint > 0.0) rh.gs(R.string.format_carbs, carbsAfterConstraint).formatColor(rh, R.color.carbs) else ""
                 binding.total.text = HtmlHelper.fromHtml(rh.gs(R.string.result_insulin_carbs, insulinText, carbsText))
-                binding.ok.visibility = View.VISIBLE
+                binding.okcancel.ok.visibility = View.VISIBLE
             } else {
                 binding.total.text = HtmlHelper.fromHtml(rh.gs(R.string.missing_carbs, wizard.carbsEquivalent.toInt()).formatColor(rh, R.color.carbs))
-                binding.ok.visibility = View.INVISIBLE
+                binding.okcancel.ok.visibility = View.INVISIBLE
             }
             binding.percentUsed.text = rh.gs(R.string.format_percent, wizard.percentageCorrection)
             calculatedPercentage = wizard.calculatedPercentage

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -250,22 +250,10 @@ class WizardDialog : DaggerDialogFragment() {
     }
 
     private fun setA11yLabels() {
-        val bgInputTextId = binding.bgInput.editText?.id
-        if (bgInputTextId != null) {
-            binding.bgInputLabel.labelFor = bgInputTextId
-        }
-        val carbsTextId = binding.carbsInput.editText?.id
-        if (carbsTextId != null) {
-            binding.carbsInputLabel.labelFor = carbsTextId
-        }
-        val corrTextId = binding.correctionInput.editText?.id
-        if (corrTextId != null) {
-            binding.correctionInputLabel.labelFor = corrTextId
-        }
-        val carbTimeTextId = binding.carbTimeInput.editText?.id
-        if (carbTimeTextId != null) {
-            binding.carbTimeInputLabel.labelFor = carbTimeTextId
-        }
+        binding.bgInput.editText?.id?.let { binding.bgInputLabel.labelFor = it }
+        binding.carbsInput.editText?.id?.let { binding.carbsInputLabel.labelFor = it }
+        binding.correctionInput.editText?.id?.let { binding.correctionInputLabel.labelFor = it }
+        binding.carbTimeInput.editText?.id?.let { binding.carbTimeInputLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
@@ -347,6 +347,8 @@ class BolusWizard @Inject constructor(
                 )
             else
                 commonProcessing(ctx)
+        } else {
+            OKDialog.show(ctx, rh.gs(R.string.boluswizard), rh.gs(R.string.no_action_selected))
         }
     }
 

--- a/app/src/main/res/drawable/cb_backgroud_bg.xml
+++ b/app/src/main/res/drawable/cb_backgroud_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="26dp"
+        android:height="26dp"
+        android:drawable="@drawable/ic_xdrip" />
+</layer-list>

--- a/app/src/main/res/drawable/cb_backgroud_cob.xml
+++ b/app/src/main/res/drawable/cb_backgroud_cob.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="26dp"
+        android:height="26dp"
+        android:drawable="@drawable/ic_cp_bolus_carbs" />
+</layer-list>

--- a/app/src/main/res/drawable/cb_backgroud_iob.xml
+++ b/app/src/main/res/drawable/cb_backgroud_iob.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="26dp"
+        android:height="26dp"
+        android:drawable="@drawable/ic_bolus" />
+</layer-list>

--- a/app/src/main/res/drawable/cb_backgroud_trend.xml
+++ b/app/src/main/res/drawable/cb_backgroud_trend.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="26dp"
+        android:height="26dp"
+        android:drawable="@drawable/ic_fortyfiveup" />
+</layer-list>

--- a/app/src/main/res/drawable/checkbox_bg_icon.xml
+++ b/app/src/main/res/drawable/checkbox_bg_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:drawable="@drawable/cb_backgroud_bg" />
+</selector>

--- a/app/src/main/res/drawable/checkbox_cob_icon.xml
+++ b/app/src/main/res/drawable/checkbox_cob_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:drawable="@drawable/cb_backgroud_cob" />
+</selector>

--- a/app/src/main/res/drawable/checkbox_iob_icon.xml
+++ b/app/src/main/res/drawable/checkbox_iob_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:drawable="@drawable/cb_backgroud_iob" />
+</selector>

--- a/app/src/main/res/drawable/checkbox_trend_icon.xml
+++ b/app/src/main/res/drawable/checkbox_trend_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:drawable="@drawable/cb_backgroud_trend" />
+</selector>

--- a/app/src/main/res/layout/dialog_wizard.xml
+++ b/app/src/main/res/layout/dialog_wizard.xml
@@ -59,6 +59,7 @@
                 android:layout_height="match_parent">
 
                 <TextView
+                    android:id="@+id/bg_input_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -70,7 +71,8 @@
                 <info.nightscout.androidaps.utils.ui.NumberPicker
                     android:id="@+id/bg_input"
                     android:layout_width="130dp"
-                    android:layout_height="40dp" />
+                    android:layout_height="40dp"
+                    app:customContentDescription="@string/a11y_current_bg" />
 
                 <TextView
                     android:id="@+id/bg_units"
@@ -89,9 +91,11 @@
                 android:layout_height="match_parent">
 
                 <TextView
+                    android:id="@+id/carbs_input_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
+                    android:labelFor="@id/carbs_input"
                     android:padding="10dp"
                     android:text="@string/treatments_wizard_carbs_label"
                     android:textAppearance="@style/TextAppearance.AppCompat.Small"
@@ -101,8 +105,8 @@
                     android:id="@+id/carbs_input"
                     android:layout_width="130dp"
                     android:layout_height="40dp"
-                    android:layout_gravity="center_horizontal" />
-
+                    android:layout_gravity="center_horizontal"
+                    app:customContentDescription="@string/treatments_wizard_carbs_label" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -127,6 +131,7 @@
                     android:orientation="horizontal">
 
                     <TextView
+                        android:id="@+id/correction_input_label"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -135,32 +140,26 @@
                         android:textAppearance="@style/TextAppearance.AppCompat.Small"
                         android:textStyle="bold" />
 
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text=" %"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                        android:textStyle="bold"
-                        tools:ignore="HardcodedText" />
-
                     <CheckBox
                         android:id="@+id/correction_percent"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:checked="false"
-                        android:padding="2dp" />
+                        android:layoutDirection="rtl"
+                        android:padding="2dp"
+                        android:text="%"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                        android:textStyle="bold" />
 
                 </LinearLayout>
-
 
                 <info.nightscout.androidaps.utils.ui.NumberPicker
                     android:id="@+id/correction_input"
                     android:layout_width="130dp"
                     android:layout_height="40dp"
-                    android:layout_gravity="center_horizontal" />
+                    android:layout_gravity="center_horizontal"
+                    app:customContentDescription="@string/a11_correction_units" />
 
                 <TextView
                     android:id="@+id/correction_unit"
@@ -255,77 +254,48 @@
             <CheckBox
                 android:id="@+id/calculation_checkbox"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="fill_parent"
                 android:layout_gravity="center_vertical"
-                android:checked="false" />
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
+                android:checked="false"
                 android:contentDescription="@string/show_calculation"
-                app:srcCompat="@drawable/ic_visibility" />
+                android:drawableEnd="@drawable/ic_visibility" />
 
-            <ImageView
-                android:id="@+id/bg_enabled_icon"
+            <CheckBox
+                android:id="@+id/bg_checkbox_icon"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:paddingStart="-11dp"
-                android:paddingEnd="-11dp"
-                android:scaleX="0.5"
-                android:scaleY="0.5"
-                app:srcCompat="@drawable/ic_xdrip"/>
+                android:layout_height="fill_parent"
+                android:button="@drawable/checkbox_bg_icon"
+                android:checked="true"
+                android:contentDescription="@string/treatments_wizard_bg_label" />
 
-            <ImageView
-                android:id="@+id/trend_enabled_icon"
+            <CheckBox
+                android:id="@+id/trend_checkbox_icon"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:paddingStart="-11dp"
-                android:paddingEnd="-11dp"
-                android:scaleX="0.5"
-                android:scaleY="0.5"
-                app:srcCompat="@drawable/ic_fortyfiveup" />
+                android:layout_height="fill_parent"
+                android:button="@drawable/checkbox_trend_icon"
+                android:checked="true"
+                android:contentDescription="@string/bg_trend_label" />
 
-            <ImageView
-                android:id="@+id/iob_enabled_icon"
+            <CheckBox
+                android:id="@+id/iob_checkbox_icon"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:paddingStart="-11dp"
-                android:paddingEnd="-11dp"
-                android:scaleX="0.5"
-                android:scaleY="0.5"
-                app:srcCompat="@drawable/ic_bolus" />
+                android:layout_height="fill_parent"
+                android:button="@drawable/checkbox_iob_icon"
+                android:checked="true"
+                android:contentDescription="@string/iob" />
 
-            <ImageView
-                android:id="@+id/cob_enabled_icon"
+            <CheckBox
+                android:id="@+id/cob_checkbox_icon"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:paddingStart="-11dp"
-                android:paddingEnd="-11dp"
-                android:scaleX="0.5"
-                android:scaleY="0.5"
-                app:srcCompat="@drawable/ic_cp_bolus_carbs" />
+                android:layout_height="fill_parent"
+                android:button="@drawable/checkbox_cob_icon"
+                android:checked="true"
+                android:contentDescription="@string/treatments_wizard_cob_label" />
 
-            <Button
-                android:id="@+id/cancel"
-                style="@style/mdtp_ActionButton.Text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/mdtp_cancel"
-                android:textAlignment="textEnd" />
+            <include
+                android:id="@+id/okcancel"
+                layout="@layout/okcancel" />
 
-            <Button
-                android:id="@+id/ok"
-                style="@style/mdtp_ActionButton.Text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:text="@string/mdtp_ok" />
         </LinearLayout>
 
         <View
@@ -350,6 +320,7 @@
                 android:orientation="horizontal">
 
                 <TextView
+                    android:id="@+id/carb_time_input_label"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -360,27 +331,23 @@
                     android:textAppearance="@style/TextAppearance.AppCompat.Small"
                     android:textStyle="bold" />
 
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:contentDescription="@string/alarm"
-                    android:src="@drawable/ic_access_alarm_24dp" />
-
                 <CheckBox
                     android:id="@+id/alarm"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:checked="false"
+                    android:contentDescription="set carb timer alarm"
+                    android:drawableEnd="@drawable/ic_access_alarm_24dp"
+                    android:layoutDirection="rtl"
                     android:padding="2dp" />
 
                 <info.nightscout.androidaps.utils.ui.NumberPicker
                     android:id="@+id/carb_time_input"
                     android:layout_width="130dp"
                     android:layout_height="40dp"
-                    android:layout_gravity="center" />
+                    android:layout_gravity="center"
+                    app:contentDescription="carb time" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -402,6 +369,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:labelFor="@id/profile"
                     android:padding="10dp"
                     android:text="@string/profile_label"
                     android:textAppearance="@style/TextAppearance.AppCompat.Small"
@@ -413,7 +381,6 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical|center_horizontal"
                     android:layout_weight="0.5" />
-
 
                 <CheckBox
                     android:id="@+id/sb_checkbox"
@@ -445,38 +412,24 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent">
 
-                    <CheckBox
-                        android:id="@+id/bg_checkbox"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="32dp"
-                        android:checked="true" />
-
                     <LinearLayout
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="match_parent"
                         android:orientation="horizontal">
 
-                        <TextView
+                        <CheckBox
+                            android:id="@+id/bg_checkbox"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:width="24dp"
-                            android:text="@string/treatments_wizard_bg_label"
-                            android:textAppearance="?android:attr/textAppearanceSmall" />
+                            android:checked="true"
+                            android:text="@string/treatments_wizard_bg_label" />
 
                         <CheckBox
                             android:id="@+id/tt_checkbox"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:width="32dp"
-                            android:checked="false" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:width="30dp"
-                            android:text="@string/treatments_wizard_tt_label"
-                            android:textAppearance="?android:attr/textAppearanceSmall" />
+                            android:checked="false"
+                            android:text="@string/treatments_wizard_tt_label" />
 
                     </LinearLayout>
 
@@ -506,15 +459,9 @@
                         android:id="@+id/bg_trend_checkbox"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:width="32dp"
-                        android:checked="false" />
+                        android:checked="false"
+                        android:text="@string/bg_trend_label" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="86dp"
-                        android:text="@string/bg_trend_label"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
 
                     <TextView
                         android:id="@+id/bg_trend"
@@ -542,15 +489,8 @@
                         android:id="@+id/iob_checkbox"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:width="32dp"
-                        android:checked="true" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="130dp"
-                        android:text="@string/iob"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:checked="true"
+                        android:text="@string/iob" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -578,14 +518,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:width="32dp"
-                        android:checked="false" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="86dp"
-                        android:text="@string/treatments_wizard_cob_label"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        android:checked="false"
+                        android:text="@string/treatments_wizard_cob_label" />
 
                     <TextView
                         android:id="@+id/cob"
@@ -607,19 +541,27 @@
 
                 <TableRow
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="match_parent"
+                    android:focusable="true">
 
-                    <TextView
+                    <LinearLayout
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="32dp" />
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="86dp"
-                        android:text="@string/treatments_wizard_carbs_label"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="32dp" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="86dp"
+                            android:text="@string/treatments_wizard_carbs_label"
+                            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/carbs"
@@ -642,19 +584,27 @@
 
                 <TableRow
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="match_parent"
+                    android:focusable="true">
 
-                    <TextView
+                    <LinearLayout
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="32dp" />
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="86dp"
-                        android:text="@string/superbolus"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="32dp" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="86dp"
+                            android:text="@string/superbolus"
+                            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/sb"
@@ -676,19 +626,27 @@
 
                 <TableRow
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent">
+                    android:layout_height="match_parent"
+                    android:focusable="true">
 
-                    <TextView
+                    <LinearLayout
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="32dp" />
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:width="86dp"
-                        android:text="@string/treatments_wizard_correction_label"
-                        android:textAppearance="?android:attr/textAppearanceSmall" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="32dp" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:width="86dp"
+                            android:text="@string/treatments_wizard_correction_label"
+                            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -704,6 +662,7 @@
                         android:width="50dp"
                         android:gravity="end"
                         android:textAppearance="?android:attr/textAppearanceSmall" />
+
                 </TableRow>
 
             </TableLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1138,6 +1138,27 @@
     <string name="key_last_processed_glunovo_timestamp" translatable="false">last_processed_glunovo_timestamp</string>
     <string name="identification">Identification (email, FB or Discord nick etc)</string>
     <string name="identification_not_set">Identification not set in dev mode</string>
+    <string name="a11y_high">heigh</string>
+    <string name="a11y_inrange">in range</string>
+    <string name="a11y_low">low</string>
+    <string name="a11y_arrow_double_down">down fast</string>
+    <string name="a11y_arrow_single_down">down</string>
+    <string name="a11y_arrow_forty_five_down">down trending</string>
+    <string name="a11y_arrow_flat">flat</string>
+    <string name="a11y_arrow_forty_five_up">up trending</string>
+    <string name="a11y_arrow_single_up">up</string>
+    <string name="a11y_arrow_double_up">up fast</string>
+    <string name="a11y_arrow_none">none</string>
+    <string name="a11y_arrow_unknown">unknown</string>
+    <string name="a11y_graph">graph</string>
+    <string name="a11y_bg_quality">Blood glucose quality</string>
+    <string name="a11_bg_quality_recalculated">recalculated</string>
+    <string name="a11_bg_quality_doubles">double entries</string>
+    <string name="a11y_insulin_label">insulin</string>
+    <string name="a11y_dialog">dialog</string>
+    <string name="a11y_current_bg">current blood glucode</string>
+    <string name="a11_correction_percentage">correct outcome with %</string>
+    <string name="a11_correction_units">correct outcome with units</string>
     <string name="not_available_full">Not available</string>
 
 </resources>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -4,4 +4,7 @@
     <attr name="dialogTitleColor" format="reference" />
     <attr name="dialogTitleIconTint" format="reference" />
 
+    <declare-styleable name="NumberPicker">
+        <attr name="customContentDescription" format="string" />
+    </declare-styleable>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -535,6 +535,8 @@
     <string name="bolus_ok" comment="26 characters max for translation">Bolus OK</string>
     <string name="pump_paired" comment="26 characters max for translation">Pump paired</string>
     <string name="insight_refresh_button" comment="26 characters max for translation">Insight Refresh Button</string>
+    <string name="a11y_min_button_description">decrement %1$s by %2$s</string>
+    <string name="a11y_plus_button_description">increment %1$s by %2$s</string>
 
     <plurals name="days">
         <item quantity="one">%1$d day</item>


### PR DESCRIPTION
Wizard dialog is complex to navigate, improving accessibility by
* All checkboxes use a label, labels are clickable, making the touch target larger
* Number picker 
  * Number support custom description
  * Announce value change on +/ - button
  * Text input uses labelFor
* Checkbox with image label, uses the image as a label, making the touch target larger
* Converted the image controls for calculation parameters into real checkboxes, leveraging on standard a11y features
* Converted the ok cancel button to okcancel layout, fixed left linking of cancel button to close the dialogue
* Show confirmation "no action" dialog, when no action is taken (0 carbs, 0 insulin)