### PR TITLE
Feat: hide insulin age for omnipod

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
@@ -1,6 +1,7 @@
 package info.nightscout.androidaps.plugins.general.overview
 
 import android.graphics.Color
+import android.view.View
 import android.widget.TextView
 import androidx.annotation.StringRes
 import info.nightscout.androidaps.R
@@ -39,7 +40,12 @@ class StatusLightHandler @Inject constructor(
         val pump = activePlugin.activePump
         val bgSource = activePlugin.activeBgSource
         handleAge(careportal_cannula_age, TherapyEvent.Type.CANNULA_CHANGE, R.string.key_statuslights_cage_warning, 48.0, R.string.key_statuslights_cage_critical, 72.0)
-        handleAge(careportal_insulin_age, TherapyEvent.Type.INSULIN_CHANGE, R.string.key_statuslights_iage_warning, 72.0, R.string.key_statuslights_iage_critical, 144.0)
+        if (pump.model() == PumpType.OMNIPOD_EROS || pump.model() == PumpType.OMNIPOD_DASH) {
+            careportal_insulin_age?.visibility = View.GONE
+        } else {
+            careportal_insulin_age?.visibility = View.VISIBLE
+            handleAge(careportal_insulin_age, TherapyEvent.Type.INSULIN_CHANGE, R.string.key_statuslights_iage_warning, 72.0, R.string.key_statuslights_iage_critical, 144.0)
+        }
         handleAge(careportal_sensor_age, TherapyEvent.Type.SENSOR_CHANGE, R.string.key_statuslights_sage_warning, 216.0, R.string.key_statuslights_sage_critical, 240.0)
         if (pump.pumpDescription.isBatteryReplaceable || (pump is OmnipodErosPumpPlugin && pump.isUseRileyLinkBatteryLevel && pump.isBatteryChangeLoggingEnabled)) {
             handleAge(careportal_pb_age, TherapyEvent.Type.PUMP_BATTERY_CHANGE, R.string.key_statuslights_bage_warning, 216.0, R.string.key_statuslights_bage_critical, 240.0)


### PR DESCRIPTION
The status light indicators shows duplicate data for Omnipod Dash and Eros. The insulin age is always the same age as the pod/canula age, and will never be older than 3 days, therefor it is not necessary to show the age of the insulin and only the units left are relevant.

<img width="477" alt="Image" src="https://user-images.githubusercontent.com/6724749/152031437-90f5713d-6e2e-4ff9-ac0c-382c3784aa81.png">
