### PR TITLE
fix profile ic graph

### DIFF
--- a/app/src/main/res/layout/localprofile_fragment.xml
+++ b/app/src/main/res/layout/localprofile_fragment.xml
@@ -225,7 +225,7 @@
                 android:layout_marginBottom="10dp"
                 android:orientation="vertical" />
 
-            <info.nightscout.androidaps.utils.ui.BasalProfileGraph
+            <info.nightscout.androidaps.utils.ui.IcProfileGraph
                 android:id="@+id/ic_graph"
                 android:layout_width="match_parent"
                 android:layout_height="100dip"


### PR DESCRIPTION
The wrong graph was used in the layout, caused the basal graph to show in the IC tab
Fixes #1266