### PR TITLE
fix: rounding cob, basal in SMB AMA reason

### DIFF
--- a/app/src/main/assets/OpenAPSAMA/determine-basal.js
+++ b/app/src/main/assets/OpenAPSAMA/determine-basal.js
@@ -69,10 +69,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
         if (basal <= currenttemp.rate * 1.2) { // high temp is running
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         } else { //do nothing.
-            rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + round(basal, 2) + "U/hr";
             return rT;
         }
     }
@@ -291,7 +291,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     rT.COB=meal_data.mealCOB;
     rT.IOB=iob_data.iob;
-    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + "; ";
+    rT.reason="COB: " + round(meal_data.mealCOB, 1) + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + "; ";
     if (typeof autosens_data !== 'undefined' && profile.autosens_adjust_targets && autosens_data.ratio != 1)
         rT.reason += "Autosens: " + autosens_data.ratio + "; ";
     if (bg < threshold) { // low glucose suspend mode: BG is < ~80
@@ -306,10 +306,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             rT.reason += ", min delta " + minDelta.toFixed(2) + ">0";
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
@@ -327,7 +327,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp";
+                rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -338,10 +338,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                 //console.error(currenttemp, basal );
                 if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                    rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+                    rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr";
                     return rT;
                 } else {
-                    rT.reason += "; setting current basal of " + basal + " as temp";
+                    rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
                     return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
                 }
             } else {
@@ -363,7 +363,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 // if required temp < existing temp basal
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
                 if (insulinScheduled < insulinReq - basal*0.3) { // if current temp would deliver a lot (30% of basal) less than the required insulin, raise the rate
-                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " < req " + insulinReq + "-" + basal*0.3;
+                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " < req " + insulinReq + "-" + (basal*0.3).toFixed(2);
                     return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
                 if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate >= currenttemp.rate * 0.8)) {
@@ -405,10 +405,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
@@ -422,10 +422,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(snoozeBG, profile)+" in range: no temp required";
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
@@ -439,10 +439,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + round(basaliob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     } else { // otherwise, calculate 30m high-temp required to get projected BG down to target

--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -169,7 +169,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
             //return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         } else { //do nothing.
-            rT.reason += ". Temp " + currenttemp.rate + " <= current basal " + basal + "U/hr; doing nothing. ";
+            rT.reason += ". Temp " + currenttemp.rate + " <= current basal " + round(basal, 2) + "U/hr; doing nothing. ";
             return rT;
         }
     }
@@ -920,10 +920,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + convert_bg(expectedDelta, profile);
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp. ";
+                rT.reason += "; setting current basal of " + round(basal, 2) + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -992,10 +992,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + convert_bg(expectedDelta, profile);
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp. ";
+                rT.reason += "; setting current basal of " + round(basal, 2) + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -1006,10 +1006,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (! (microBolusAllowed && enableSMB )) {
             rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(minPredBG, profile)+" in range: no temp required";
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp. ";
+                rT.reason += "; setting current basal of " + round(basal, 2) + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -1023,10 +1023,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (iob_data.iob > max_iob) {
         rT.reason += "IOB " + round(iob_data.iob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + round(basal, 2) + "U/hr. ";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp. ";
+            rT.reason += "; setting current basal of " + round(basal, 2) + " as temp. ";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     } else { // otherwise, calculate 30m high-temp required to get projected BG down to target


### PR DESCRIPTION
The values in the reasons of AMA and SMB should be appropriately rounded. This makes the text easier to read, and open-loop users will not see a strange suggestion. (Personally, It gave me a bad feeling and doubts about Android APS the first time I was using it)

Besides this, it is not funny to hear on your screen reader trying to utter o o o o o o o o o o o o o o o 3 

This PR round COB  to 1 digit, rounds the bases to 2 digits (Fixes #165 rounding COB only occurred with AMA)

![image](https://user-images.githubusercontent.com/6724749/152349954-a5b25dde-ddcf-4d39-8f0f-11b48d526dfc.png)

Note to the reviewer: this change should only be limited to the string `reason` and should not impact any calculations.
