### PR TITLE
Fix register carbs only treatment dialog

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
@@ -179,9 +179,17 @@ class TreatmentDialog : DialogFragmentWithDate() {
                                     }
                                 }
                             })
-                        } else
+                        } else {
                             uel.log(action, Sources.TreatmentDialog,
-                                ValueWithUnit.Gram(carbsAfterConstraints).takeIf { carbs != 0 })
+                                    ValueWithUnit.Gram(carbsAfterConstraints).takeIf { carbsAfterConstraints != 0 })
+                            if (detailedBolusInfo.carbs > 0) {
+                                disposable += repository.runTransactionForResult(detailedBolusInfo.insertCarbsTransaction())
+                                    .subscribe(
+                                        { result -> result.inserted.forEach { aapsLogger.debug(LTag.DATABASE, "Inserted carbs $it") } },
+                                        { aapsLogger.error(LTag.DATABASE, "Error while saving carbs", it) }
+                                    )
+                            }
+                        }
                     }
                 })
             }


### PR DESCRIPTION
In the treatment dialog, when only carbs are selected and no insulin, the confirmation dialog says carbs are added, and therefore it should be registered. This was not working before. This PR fixes the issue user reported 
https://m.facebook.com/groups/AndroidAPSUsers/permalink/3195444857343576/

![image](https://user-images.githubusercontent.com/6724749/152425271-6adf4ffb-f1e8-460f-818f-b9991d6d83ab.png)
