### PR TITLE
A11y/apply labels number picker

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/ProfileHelperActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/ProfileHelperActivity.kt
@@ -239,6 +239,10 @@ class ProfileHelperActivity : NoSplashAppCompatActivity() {
             }
             ToastUtils.showToastInUiThread(this, R.string.invalidinput)
         }
+        binding.age.editText?.id?.let { binding.ageLabel.labelFor = it }
+        binding.tdd.editText?.id?.let { binding.tddLabel.labelFor = it }
+        binding.weight.editText?.id?.let { binding.weightLabel.labelFor = it }
+        binding.basalpctfromtdd.editText?.id?.let { binding.basalpctfromtddLabel.labelFor = it }
 
         switchTab(0, typeSelected[0], false)
     }

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CalibrationDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CalibrationDialog.kt
@@ -64,6 +64,7 @@ class CalibrationDialog : DialogFragmentWithDate() {
             binding.bg.setParams(savedInstanceState?.getDouble("bg")
                 ?: bg, 36.0, 500.0, 1.0, DecimalFormat("0"), false, binding.okcancel.ok)
         binding.units.text = if (units == GlucoseUnit.MMOL) rh.gs(R.string.mmol) else rh.gs(R.string.mgdl)
+        binding.bg.editText?.id?.let { binding.bgLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
@@ -137,32 +137,39 @@ class CarbsDialog : DialogFragmentWithDate() {
             savedInstanceState?.getDouble("carbs")
                 ?: 0.0, 0.0, maxCarbs, 1.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher
         )
-
-        binding.plus1.text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_1, FAV1_DEFAULT))
+        val plus1text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_1, FAV1_DEFAULT))
+        binding.plus1.text = plus1text
+        binding.plus1.contentDescription = rh.gs(R.string.treatments_wizard_carbs_label) +  " " + plus1text
         binding.plus1.setOnClickListener {
             binding.carbs.value = max(
                 0.0, binding.carbs.value
                     + sp.getInt(R.string.key_carbs_button_increment_1, FAV1_DEFAULT)
             )
             validateInputs()
+            binding.carbs.announceValue()
         }
 
-        binding.plus2.text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_2, FAV2_DEFAULT))
+        val plus2text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_2, FAV2_DEFAULT))
+        binding.plus2.text = plus2text
+        binding.plus2.contentDescription =  rh.gs(R.string.treatments_wizard_carbs_label) +  " " + plus2text
         binding.plus2.setOnClickListener {
             binding.carbs.value = max(
                 0.0, binding.carbs.value
                     + sp.getInt(R.string.key_carbs_button_increment_2, FAV2_DEFAULT)
             )
             validateInputs()
+            binding.carbs.announceValue()
         }
-
-        binding.plus3.text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_3, FAV3_DEFAULT))
+        val plus3text = toSignedString(sp.getInt(R.string.key_carbs_button_increment_3, FAV3_DEFAULT))
+        binding.plus3.text = plus3text
+        binding.plus2.contentDescription = rh.gs(R.string.treatments_wizard_carbs_label) +  " " + plus3text
         binding.plus3.setOnClickListener {
             binding.carbs.value = max(
                 0.0, binding.carbs.value
                     + sp.getInt(R.string.key_carbs_button_increment_3, FAV3_DEFAULT)
             )
             validateInputs()
+            binding.carbs.announceValue()
         }
 
         setOnValueChangedListener { eventTime: Long ->
@@ -188,6 +195,9 @@ class CarbsDialog : DialogFragmentWithDate() {
             binding.hypoTt.isChecked = false
             binding.activityTt.isChecked = false
         }
+        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+        binding.time.editText?.id?.let { binding.timeLabel.labelFor = it }
+        binding.carbs.editText?.id?.let { binding.carbsLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
@@ -165,6 +165,8 @@ class CareDialog : DialogFragmentWithDate() {
             ?: 0.0, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, binding.okcancel.ok)
         if (options == EventType.NOTE || options == EventType.QUESTION || options == EventType.ANNOUNCEMENT || options == EventType.EXERCISE)
             binding.notesLayout.root.visibility = View.VISIBLE // independent to preferences
+        binding.bg.editText?.id?.let { binding.bgLabel.labelFor = it }
+        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
@@ -70,6 +70,8 @@ class ExtendedBolusDialog : DialogFragmentWithDate() {
         val extendedMaxDuration = pumpDescription.extendedBolusMaxDuration
         binding.duration.setParams(savedInstanceState?.getDouble("duration")
             ?: extendedDurationStep, extendedDurationStep, extendedMaxDuration, extendedDurationStep, DecimalFormat("0"), false, binding.okcancel.ok)
+        binding.insulin.editText?.id?.let { binding.insulinLabel.labelFor = it }
+        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/FillDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/FillDialog.kt
@@ -96,7 +96,7 @@ class FillDialog : DialogFragmentWithDate() {
         } else {
             binding.fillPresetButton3.visibility = View.GONE
         }
-
+        binding.fillInsulinamount.editText?.id?.let { binding.fillLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/InsulinDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/InsulinDialog.kt
@@ -116,29 +116,40 @@ class InsulinDialog : DialogFragmentWithDate() {
         binding.amount.setParams(savedInstanceState?.getDouble("amount")
             ?: 0.0, 0.0, maxInsulin, activePlugin.activePump.pumpDescription.bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.okcancel.ok, textWatcher)
 
-        binding.plus05.text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_1), PLUS1_DEFAULT).toSignedString(activePlugin.activePump)
+        val plus05Text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_1), PLUS1_DEFAULT).toSignedString(activePlugin.activePump)
+        binding.plus05.text = plus05Text
+        binding.plus05.contentDescription = rh.gs(R.string.overview_insulin_label) + " " + plus05Text
         binding.plus05.setOnClickListener {
             binding.amount.value = max(0.0, binding.amount.value
                 + sp.getDouble(rh.gs(R.string.key_insulin_button_increment_1), PLUS1_DEFAULT))
             validateInputs()
+            binding.amount.announceValue()
         }
-        binding.plus10.text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_2), PLUS2_DEFAULT).toSignedString(activePlugin.activePump)
+        val plus10Text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_2), PLUS2_DEFAULT).toSignedString(activePlugin.activePump)
+        binding.plus10.text = plus10Text
+        binding.plus10.contentDescription = rh.gs(R.string.overview_insulin_label) + " " + plus10Text
         binding.plus10.setOnClickListener {
             binding.amount.value = max(0.0, binding.amount.value
                 + sp.getDouble(rh.gs(R.string.key_insulin_button_increment_2), PLUS2_DEFAULT))
             validateInputs()
+            binding.amount.announceValue()
         }
-        binding.plus20.text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_3), PLUS3_DEFAULT).toSignedString(activePlugin.activePump)
+        val plus20Text = sp.getDouble(rh.gs(R.string.key_insulin_button_increment_3), PLUS3_DEFAULT).toSignedString(activePlugin.activePump)
+        binding.plus20.text = plus20Text
+        binding.plus20.contentDescription = rh.gs(R.string.overview_insulin_label) + " " + plus20Text
         binding.plus20.setOnClickListener {
             binding.amount.value = max(0.0, binding.amount.value
                 + sp.getDouble(rh.gs(R.string.key_insulin_button_increment_3), PLUS3_DEFAULT))
             validateInputs()
+            binding.amount.announceValue()
         }
 
         binding.timeLayout.visibility = View.GONE
         binding.recordOnly.setOnCheckedChangeListener { _, isChecked: Boolean ->
             binding.timeLayout.visibility = isChecked.toVisibility()
         }
+        binding.amount.editText?.id?.let { binding.insulinLabel.labelFor = it }
+        binding.time.editText?.id?.let { binding.timeLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
@@ -148,6 +148,9 @@ class ProfileSwitchDialog : DialogFragmentWithDate() {
                 }
         }
         binding.ttLayout.visibility = View.GONE
+        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+        binding.percentage.editText?.id?.let { binding.percentageLabel.labelFor = it }
+        binding.timeshift.editText?.id?.let { binding.timeshiftLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TempBasalDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TempBasalDialog.kt
@@ -86,6 +86,9 @@ class TempBasalDialog : DialogFragmentWithDate() {
             binding.percentLayout.visibility = View.GONE
             binding.absoluteLayout.visibility = View.VISIBLE
         }
+        binding.basalPercentInput.editText?.id?.let { binding.basalPercentLabel.labelFor = it }
+        binding.basalAbsoluteInput.editText?.id?.let { binding.basalAbsoluteLabel.labelFor = it }
+        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TempTargetDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TempTargetDialog.kt
@@ -120,6 +120,8 @@ class TempTargetDialog : DialogFragmentWithDate() {
                 longClick(it)
                 return@setOnLongClickListener true
             }
+            binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+            binding.temptarget.editText?.id?.let { binding.temptargetLabel.labelFor = it }
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
@@ -106,6 +106,8 @@ class TreatmentDialog : DialogFragmentWithDate() {
         binding.insulin.setParams(savedInstanceState?.getDouble("insulin")
             ?: 0.0, 0.0, maxInsulin, pumpDescription.bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.okcancel.ok, textWatcher)
         binding.recordOnlyLayout.visibility = View.GONE
+        binding.insulin.editText?.id?.let { binding.insulinLabel.labelFor = it }
+        binding.carbs.editText?.id?.let { binding.carbsLabel.labelFor = it }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
@@ -121,6 +121,7 @@ class LocalProfileFragment : DaggerFragment() {
             processVisibilityOnClick(it)
             binding.target.visibility = View.VISIBLE
         }
+        binding.dia.editText?.id?.let { binding.diaLabel.labelFor = it }
     }
 
     fun build() {

--- a/app/src/main/java/info/nightscout/androidaps/utils/ui/TimeListEdit.java
+++ b/app/src/main/java/info/nightscout/androidaps/utils/ui/TimeListEdit.java
@@ -112,7 +112,7 @@ public class TimeListEdit {
         float factor = layout.getContext().getResources().getDisplayMetrics().density;
         finalAdd = new ImageView(context);
         finalAdd.setImageResource(R.drawable.ic_add);
-        finalAdd.setContentDescription(layout.getContext().getResources().getString(R.string.addnew));
+        finalAdd.setContentDescription(layout.getContext().getResources().getString(R.string.a11y_add_new_to_list));
         LinearLayout.LayoutParams illp = new LinearLayout.LayoutParams((int) (35d * factor), (int) (35 * factor));
         illp.setMargins(0, 25, 0, 25); // llp.setMargins(left, top, right, bottom);
         illp.gravity = Gravity.CENTER;

--- a/app/src/main/res/layout/activity_profilehelper.xml
+++ b/app/src/main/res/layout/activity_profilehelper.xml
@@ -83,14 +83,14 @@
                         android:layout_width="150dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="10dp"
-                        android:labelFor="@+id/age"
                         android:text="@string/age"
                         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                     <info.nightscout.androidaps.utils.ui.NumberPicker
                         android:id="@+id/age"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/age" />
 
                 </TableRow>
 
@@ -105,14 +105,14 @@
                         android:layout_width="150dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="10dp"
-                        android:labelFor="@+id/weight"
                         android:text="@string/tdd_total"
                         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                     <info.nightscout.androidaps.utils.ui.NumberPicker
                         android:id="@+id/tdd"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/tdd_total" />
 
                 </TableRow>
 
@@ -123,18 +123,18 @@
                     android:gravity="center_vertical">
 
                     <TextView
-                        android:id="@+id/weigth_label"
+                        android:id="@+id/weight_label"
                         android:layout_width="150dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="10dp"
-                        android:labelFor="@+id/weight"
                         android:text="@string/weight_label"
                         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                     <info.nightscout.androidaps.utils.ui.NumberPicker
                         android:id="@+id/weight"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/weight_label" />
 
                 </TableRow>
 
@@ -149,14 +149,14 @@
                         android:layout_width="150dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="10dp"
-                        android:labelFor="@+id/basalpctfromtdd"
                         android:text="@string/basalpctfromtdd_label"
                         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                     <info.nightscout.androidaps.utils.ui.NumberPicker
                         android:id="@+id/basalpctfromtdd"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/basalpctfromtdd_label" />
 
                 </TableRow>
 

--- a/app/src/main/res/layout/dialog_calibration.xml
+++ b/app/src/main/res/layout/dialog_calibration.xml
@@ -58,6 +58,7 @@
             android:paddingTop="10dp">
 
             <TextView
+                android:id="@+id/bg_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -70,7 +71,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/bg"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/treatments_wizard_bg_label" />
 
             <TextView
                 android:id="@+id/units"

--- a/app/src/main/res/layout/dialog_carbs.xml
+++ b/app/src/main/res/layout/dialog_carbs.xml
@@ -93,6 +93,7 @@
                     android:orientation="horizontal">
 
                     <TextView
+                        android:id="@+id/time_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
@@ -105,25 +106,24 @@
                         android:textAppearance="@style/TextAppearance.AppCompat.Small"
                         android:textStyle="bold" />
 
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:src="@drawable/ic_access_alarm_24dp" />
-
                     <CheckBox
                         android:id="@+id/alarmCheckBox"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:checked="false"
-                        android:padding="2dp" />
+                        android:padding="2dp"
+                        android:layoutDirection="rtl"
+                        android:contentDescription="@string/a11y_carb_reminder"
+                        android:drawableEnd="@drawable/ic_access_alarm_24dp" />
+
                 </LinearLayout>
 
                     <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                         android:id="@+id/time"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/time_offset" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -143,6 +143,7 @@
                 android:layout_gravity="center_vertical">
 
                 <TextView
+                    android:id="@+id/duration_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
@@ -156,7 +157,8 @@
                     android:id="@+id/duration"
                     android:layout_width="130dp"
                     android:layout_height="40dp"
-                    android:layout_gravity="center_horizontal" />
+                    android:layout_gravity="center_horizontal"
+                    app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -176,6 +178,7 @@
                 android:layout_gravity="center_vertical">
 
                     <TextView
+                        android:id="@+id/carbs_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -190,7 +193,8 @@
                     <info.nightscout.androidaps.utils.ui.NumberPicker
                         android:id="@+id/carbs"
                         android:layout_width="130dp"
-                        android:layout_height="40dp" />
+                        android:layout_height="40dp"
+                        app:customContentDescription="@string/treatments_wizard_carbs_label" />
 
                     <TextView
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_care.xml
+++ b/app/src/main/res/layout/dialog_care.xml
@@ -86,6 +86,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/bg_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -98,7 +99,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/bg"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/treatments_wizard_bg_label" />
 
             <TextView
                 android:id="@+id/bg_units"
@@ -121,6 +123,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/duration_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -133,7 +136,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/duration"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_extendedbolus.xml
+++ b/app/src/main/res/layout/dialog_extendedbolus.xml
@@ -53,6 +53,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/insulin_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -65,7 +66,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/insulin"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/overview_insulin_label" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -86,6 +88,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/duration_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -98,7 +101,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/duration"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_duration_label"  />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_fill.xml
+++ b/app/src/main/res/layout/dialog_fill.xml
@@ -75,6 +75,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/fill_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
@@ -89,7 +90,8 @@
                 android:layout_height="40dp"
                 android:layout_gravity="end"
                 android:paddingLeft="5dp"
-                android:paddingRight="5dp" />
+                android:paddingRight="5dp"
+                app:customContentDescription="@string/overview_insulin_label" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_insulin.xml
+++ b/app/src/main/res/layout/dialog_insulin.xml
@@ -76,6 +76,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/time_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -88,7 +89,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/time"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/time_offset"/>
 
             <TextView
                 android:layout_width="wrap_content"
@@ -109,6 +111,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/insulin_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -121,7 +124,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/amount"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/overview_insulin_label"/>
 
             <TextView
                 android:layout_width="wrap_content"
@@ -147,6 +151,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
+                android:contentDescription="Increment insuline with 0.5"
                 android:text="+0.5" />
 
             <Button

--- a/app/src/main/res/layout/dialog_profileswitch.xml
+++ b/app/src/main/res/layout/dialog_profileswitch.xml
@@ -58,6 +58,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:width="120dp"
+                android:labelFor="@+id/profile"
                 android:padding="10dp"
                 android:text="@string/profile_label"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
@@ -95,6 +96,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/duration_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -108,7 +110,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/duration"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_duration_label"/>
 
             <TextView
                 android:layout_width="wrap_content"
@@ -129,6 +132,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/percentage_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -142,7 +146,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/percentage"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_percentage_label"/>
 
             <TextView
                 android:layout_width="wrap_content"
@@ -163,6 +168,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/timeshift_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
@@ -176,7 +182,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/timeshift"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_timeshift_label"/>
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_tempbasal.xml
+++ b/app/src/main/res/layout/dialog_tempbasal.xml
@@ -54,6 +54,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/basal_percent_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -66,7 +67,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/basal_percent_input"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/basal_rate" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -88,6 +90,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/basal_absolute_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -100,7 +103,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/basal_absolute_input"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/basal_rate" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -121,6 +125,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/duration_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -133,7 +138,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/duration"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_temptarget.xml
+++ b/app/src/main/res/layout/dialog_temptarget.xml
@@ -54,6 +54,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/temptarget_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
@@ -67,7 +68,8 @@
                 android:id="@+id/temptarget"
                 android:layout_width="130dp"
                 android:layout_height="40dp"
-                android:layout_gravity="center_vertical" />
+                android:layout_gravity="center_vertical"
+                app:customContentDescription="@string/target_label" />
 
             <TextView
                 android:id="@+id/units"
@@ -89,6 +91,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/duration_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -101,7 +104,8 @@
             <info.nightscout.androidaps.utils.ui.MinutesNumberPicker
                 android:id="@+id/duration"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -127,6 +131,7 @@
                 android:layout_gravity="center_vertical"
                 android:width="120dp"
                 android:padding="10dp"
+                android:labelFor="@+id/reason"
                 android:text="@string/reason"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 android:textStyle="bold" />

--- a/app/src/main/res/layout/dialog_treatment.xml
+++ b/app/src/main/res/layout/dialog_treatment.xml
@@ -63,6 +63,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/insulin_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -75,7 +76,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/insulin"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/overview_insulin_label" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -96,6 +98,7 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/carbs_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -108,7 +111,8 @@
             <info.nightscout.androidaps.utils.ui.NumberPicker
                 android:id="@+id/carbs"
                 android:layout_width="130dp"
-                android:layout_height="40dp" />
+                android:layout_height="40dp"
+                app:customContentDescription="@string/treatments_wizard_carbs_label" />
 
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/localprofile_fragment.xml
+++ b/app/src/main/res/layout/localprofile_fragment.xml
@@ -22,6 +22,7 @@
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
+                android:labelFor="@+id/spinner"
                 android:text="@string/selected_profile"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -97,7 +98,7 @@
                 android:layout_height="35dp"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="15dp"
-                android:contentDescription="@string/addnew"
+                android:contentDescription="@string/a11y_add_new_profile"
                 app:srcCompat="@drawable/ic_add" />
 
             <ImageView
@@ -106,7 +107,7 @@
                 android:layout_height="35dp"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="15dp"
-                android:contentDescription="@string/clone_label"
+                android:contentDescription="@string/a11y_clone_profile"
                 app:srcCompat="@drawable/ic_clone" />
 
             <ImageView
@@ -115,7 +116,7 @@
                 android:layout_height="35dp"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="15dp"
-                android:contentDescription="@string/remove_label"
+                android:contentDescription="@string/a11y_delete_current_profile"
                 android:scaleX="1"
                 android:scaleY="1"
                 app:srcCompat="@drawable/ic_remove" />
@@ -190,7 +191,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center_horizontal"
-                android:text="@string/dia_label"
+                android:text="@string/dia_long_label"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 
@@ -202,6 +203,7 @@
                 android:paddingTop="5dp">
 
                 <TextView
+                    android:id="@+id/dia_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
@@ -214,7 +216,8 @@
                     android:layout_width="130dp"
                     android:layout_height="40dp"
                     android:layout_marginEnd="10dp"
-                    android:layout_marginBottom="10dp" />
+                    android:layout_marginBottom="10dp"
+                    app:customContentDescription="@string/dia"  />
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,7 +313,7 @@
     <string name="wear">Wear</string>
     <string name="resend_all_data">Resend All Data</string>
     <string name="open_settings_on_wear">Open Settings on Wear</string>
-    <string name="basal_rate">Basal rate:</string>
+    <string name="basal_rate">Basal rate</string>
     <string name="basalvaluebelowminimum">Basal value below minimum. Profile not set!</string>
     <string name="sms_actualbg">BG:</string>
     <string name="sms_lastbg">Last BG:</string>
@@ -953,8 +953,8 @@
     <string name="low_mark_comment">Lower value of in range area (display only)</string>
     <string name="high_mark_comment">Higher value of in range area (display only)</string>
 
-    <string name="age">Age:</string>
-    <string name="weight_label">Weight:</string>
+    <string name="age">Age</string>
+    <string name="weight_label">Weight</string>
     <string name="id">ID:</string>
     <string name="submit">Submit</string>
     <string name="mostcommonprofile">Most common profile:</string>
@@ -1164,5 +1164,10 @@
     <string name="a11y_insulin_label">insulin</string>
     <string name="a11y_blood_glucose">blood glucose</string>
     <string name="a11y_bg_outdated">outdated</string>
+    <string name="a11y_carb_reminder">set reminder</string>
+    <string name="a11y_add_new_profile">add new profile</string>
+    <string name="a11y_clone_profile">clone current profile</string>
+    <string name="a11y_delete_current_profile">delete current profile</string>
+    <string name="a11y_add_new_to_list">add new to list</string>
 
 </resources>

--- a/core/src/main/res/drawable-hdpi/border_gray.xml
+++ b/core/src/main/res/drawable-hdpi/border_gray.xml
@@ -11,7 +11,6 @@
             android:shape="rectangle">
             <stroke android:width="1dp" android:color="@color/colorLightGray" />
             <solid android:color="@android:color/white" />
-            <corners android:radius="4dp" />
         </shape>
     </item>
 </layer-list>

--- a/core/src/main/res/layout/datetime.xml
+++ b/core/src/main/res/layout/datetime.xml
@@ -9,12 +9,12 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:width="120dp"
+        android:labelFor="@+id/eventtime"
         android:paddingLeft="10dp"
         android:paddingRight="4dp"
         android:text="@string/event_time_label"
         android:textAppearance="@style/TextAppearance.AppCompat.Small"
         android:textStyle="bold" />
-
 
     <TextView
         android:id="@+id/eventdate"


### PR DESCRIPTION
Set the labels for screen reader for all number pickers based on the #1253 
- Add content description, when focus on - and + button the increment step size is announced
- Announce value change on +/ - button
- Set "labelFor" to announce the label when text input is focused

For the forms and dialogs
- profile helper
- calibration
- carbs
- care
- extended bolus
- fill
- insulin
- profile switch
- temp basal
- temp target
- treatment
- local profile