### PR TITLE
Resource helper safe get string

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/di/CoreModule.kt
+++ b/core/src/main/java/info/nightscout/androidaps/di/CoreModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.telephony.SmsManager
 import dagger.Module
 import dagger.Provides
+import info.nightscout.androidaps.utils.FabricPrivacy
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import info.nightscout.androidaps.utils.resources.ResourceHelperImplementation
 import javax.inject.Singleton
@@ -17,7 +18,7 @@ open class CoreModule {
 
     @Provides
     @Singleton
-    fun provideResources(context: Context): ResourceHelper = ResourceHelperImplementation(context)
+    fun provideResources(context: Context, fabricPrivacy: FabricPrivacy): ResourceHelper = ResourceHelperImplementation(context, fabricPrivacy)
 
     @Provides
     fun smsManager() : SmsManager = SmsManager.getDefault()

--- a/core/src/main/java/info/nightscout/androidaps/utils/FabricPrivacy.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/FabricPrivacy.kt
@@ -77,10 +77,16 @@ class FabricPrivacy @Inject constructor(
         }
     }
 
+    // Crashlytics log message
+    fun logMessage(message: String) {
+        aapsLogger.info(LTag.CORE,"Crashlytics log message: $message")
+        FirebaseCrashlytics.getInstance().log(message)
+    }
+
     // Crashlytics logException
     fun logException(throwable: Throwable) {
+        aapsLogger.error("Crashlytics log exception: ", throwable)
         FirebaseCrashlytics.getInstance().recordException(throwable)
-        aapsLogger.error("Exception: ", throwable)
     }
 
     fun fabricEnabled(): Boolean {

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
@@ -11,17 +11,34 @@ import android.util.DisplayMetrics
 import androidx.annotation.*
 import androidx.core.content.ContextCompat
 import info.nightscout.androidaps.core.R
+import info.nightscout.androidaps.utils.FabricPrivacy
 import java.util.*
 import javax.inject.Inject
 
 /**
  * Created by adrian on 2019-12-23.
  */
-class ResourceHelperImplementation @Inject constructor(private val context: Context) : ResourceHelper {
+class ResourceHelperImplementation @Inject constructor(private val context: Context, private val fabricPrivacy: FabricPrivacy) : ResourceHelper {
 
-    override fun gs(@StringRes id: Int): String = context.getString(id)
+    override fun gs(@StringRes id: Int): String = gs(id, null)
 
-    override fun gs(@StringRes id: Int, vararg args: Any?): String = context.getString(id, *args)
+    override fun gs(@StringRes id: Int, vararg args: Any?) : String {
+        return try {
+            context.getString(id, *args)
+        } catch (exception: Exception) {
+            val resourceName = context.resources.getResourceEntryName(id);
+            val currentLocale: Locale = context.resources.configuration.locale
+            fabricPrivacy.logMessage("Failed to get string for resource $resourceName ($id) for locale $currentLocale with args ${args.map{it.toString()}}")
+            fabricPrivacy.logException(exception)
+            try {
+                gsNotLocalised(id, *args)
+            } catch (exceptionNonLocalized: Exception) {
+                fabricPrivacy.logMessage("Fallback failed to get string for resource $resourceName ($id) with args ${args.map { it.toString() }}")
+                fabricPrivacy.logException(exceptionNonLocalized)
+                "FAILED to get string $resourceName"
+            }
+        }
+    }
 
     override fun gq(@PluralsRes id: Int, quantity: Int, vararg args: Any?): String =
         context.resources.getQuantityString(id, quantity, *args)
@@ -29,7 +46,7 @@ class ResourceHelperImplementation @Inject constructor(private val context: Cont
     override fun gsNotLocalised(@StringRes id: Int, vararg args: Any?): String =
         with(Configuration(context.resources.configuration)) {
             setLocale(Locale.ENGLISH)
-            context.createConfigurationContext(this).getString(id, args)
+            context.createConfigurationContext(this).getString(id, *args)
         }
 
     override fun gc(@ColorRes id: Int): Int = ContextCompat.getColor(context, id)


### PR DESCRIPTION
When the resource helper is used to get a string, and the translated string has a problem, it caused crashes. However, we better fall back to the default language if possible.