### PR TITLE
Safety Update for determine-basal.js

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -301,12 +301,18 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
           rT.reason += "TDD: " +TDD+ " due to low or high tdd from pump; ";
           }
 
+        else if (tdd_pump > (1.75 * tdd7)){
+           TDD = tdd7;
+           console.error("TDD set to TDD7 due to high pump usage reported. TDD = "+TDD+"; ");
+           rT.reason += "TDD set to TDD7 due to high pump usage reported. TDD = "+TDD+"; ";
+           }
+  
         else if (tdd_pump < (0.33 * tdd7)){
            TDD = (tdd7 * 0.25) + (tdd_pump * 0.75);
            console.error("TDD weighted to pump due to low insulin usage. TDD = "+TDD+"; ");
            rT.reason += "TDD weighted to pump due to low insulin usage. TDD = "+TDD+"; ";
            }
-
+        
         else {
              console.log("TDD 7 ="+tdd7+", TDD Pump ="+tdd_pump+" and TDD = "+TDD+";");
              rT.reason += "TDD: " +TDD+ " based on standard pump 60/tdd7 40 split; ";


### PR DESCRIPTION
Safety clause added for cases where TDD Pump extrapolation results in very large TDD for current day. This may be linked to TDD data extraction from the Combo, which requires further investigation.

Additional else if statement limits TDD_Pump to TDD7 in cases where the TDD_Pump is more than 1.75x TDD7.