### PR TITLE
Fix hide super bolus calculation when not used

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -125,7 +125,9 @@ class WizardDialog : DaggerDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         loadCheckedStates()
         processCobCheckBox()
-        binding.sbCheckbox.visibility = sp.getBoolean(R.string.key_usesuperbolus, false).toVisibility()
+        val useSuperBolus = sp.getBoolean(R.string.key_usesuperbolus, false)
+        binding.sbCheckbox.visibility = useSuperBolus.toVisibility()
+        binding.superBolusRow.visibility = useSuperBolus.toVisibility()
         binding.notesLayout.visibility = sp.getBoolean(R.string.key_show_notes_entry_dialogs, false).toVisibility()
 
         val maxCarbs = constraintChecker.getMaxCarbsAllowed().value()

--- a/app/src/main/res/layout/dialog_wizard.xml
+++ b/app/src/main/res/layout/dialog_wizard.xml
@@ -623,6 +623,7 @@
                 </TableRow>
 
                 <TableRow
+                    android:id="@+id/super_bolus_row"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:focusable="true">


### PR DESCRIPTION
When disabled in the config the super bolus checkbox is not shown in the wizard. And therefor the calculation line "superbolus" should be hidden too
* hidden when disabled
![image](https://user-images.githubusercontent.com/6724749/155329745-adf703dd-3709-48cb-8cea-a8a0f90b72d0.png)
* Visible when enabled
![image](https://user-images.githubusercontent.com/6724749/155329910-2cce84b5-0461-4fac-a39f-87796f1e6bf9.png)
