### PR TITLE
Combo plugin: provide BaseBasalRate in JSON (for NS). Fixes #1256.

### DIFF
--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
@@ -1309,6 +1309,7 @@ public class ComboPlugin extends PumpPluginBase implements Pump, Constraints {
             if (ps.activeAlert != null && ps.activeAlert.errorCode != null) {
                 extendedJson.put("ErrorCode", ps.activeAlert.errorCode);
             }
+            extendedJson.put("BaseBasalRate", getBaseBasalRate());
             pumpJson.put("extended", extendedJson);
 
             JSONObject batteryJson = new JSONObject();


### PR DESCRIPTION
@ideaweb Can you test this? I don't have a working Nightscout instance at hand.
I simply overlooked this in the code creating the JSON data.