### PR TITLE
fix: profile time shift use hours

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
@@ -143,7 +143,7 @@ class ProfileSwitchDialog : DialogFragmentWithDate() {
                     binding.reusebutton.text = rh.gs(R.string.reuse_profile_pct_hours, profile.value.originalPercentage, T.msecs(profile.value.originalTimeshift).hours().toInt())
                     binding.reusebutton.setOnClickListener {
                         binding.percentage.value = profile.value.originalPercentage.toDouble()
-                        binding.timeshift.value = profile.value.originalTimeshift.toDouble()
+                        binding.timeshift.value = T.msecs(profile.value.originalTimeshift).hours().toDouble()
                     }
                 }
         }


### PR DESCRIPTION
When clicking the `REUSE` button for a profile with a time shift, the time shift has to be converted to hours, so it can be used by the time shift input. 

Fixes issue #1274