### PR TITLE
Modify Constraint of Carbs Dialog for Time Offset in past

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
@@ -72,7 +72,7 @@ class CarbsDialog : DialogFragmentWithDate() {
     private fun validateInputs() {
         val maxCarbs = constraintChecker.getMaxCarbsAllowed().value().toDouble()
         val time = binding.time.value.toInt()
-        if (time > 12 * 60 || time < -12 * 60) {
+        if (time > 12 * 60 || time < -7 * 24 * 60) {
             binding.time.value = 0.0
             ToastUtils.showToastInUiThread(ctx, rh.gs(R.string.constraintapllied))
         }
@@ -125,7 +125,7 @@ class CarbsDialog : DialogFragmentWithDate() {
         val maxCarbs = constraintChecker.getMaxCarbsAllowed().value().toDouble()
         binding.time.setParams(
             savedInstanceState?.getDouble("time")
-                ?: 0.0, -12 * 60.0, 12 * 60.0, 5.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher
+                ?: 0.0, -7 * 24 * 60.0, 12 * 60.0, 5.0, DecimalFormat("0"), false, binding.okcancel.ok, textWatcher
         )
 
         binding.duration.setParams(


### PR DESCRIPTION
I propose to change the time offset in the past from -12 hours to -7 days
=> It's the visibility of statistic (so if we see missing carbs entries we can update them
=> I didn't completly removed the constraint because of links between date/time pikcker and time offset field...
Fix #1380 