### PR TITLE
fix crashes

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -122,7 +122,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
             createFakeTBRWhenNoActivePod()
                 .subscribeOn(aapsSchedulers.io)
                 .doOnError { aapsLogger.warn(LTag.PUMP, "Error on createFakeTBRWhenNoActivePod=$it") }
-                .blockingAwait()
+                .blockingSubscribe()
             handler.postDelayed(statusChecker, STATUS_CHECK_INTERVAL_MS)
         }
     }
@@ -249,7 +249,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     omnipodManager.connect(it).ignoreElements()
                         .doOnError { aapsLogger.info(LTag.PUMPCOMM, "connect error=$it") }
                         .doOnComplete { podStateManager.incrementSuccessfulConnectionAttemptsAfterRetries() }
-                        .blockingAwait()
+                        .blockingSubscribe()
                 }
             } finally {
                 synchronized(this) {
@@ -293,7 +293,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
             .doOnError {
                 aapsLogger.error(LTag.PUMP, "Error in getPumpStatus", it)
             }
-            .blockingAwait()
+            .blockingSubscribe()
     }
 
     private fun getPodStatus(): Completable = Completable.concat(
@@ -687,7 +687,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                         aapsLogger.debug(LTag.PUMP, "waitForBolusDeliveryToComplete errorGettingStatus=$errorGettingStatus")
                         Thread.sleep(BOLUS_RETRY_INTERVAL_MS) // retry every 2 sec
                     }
-                    .blockingAwait()
+                    .blockingSubscribe()
             }
             if (errorGettingStatus != null) {
                 // requestedBolusAmount will be updated later, via pumpSync
@@ -727,7 +727,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     aapsLogger.debug(LTag.PUMP, "waitForBolusDeliveryToComplete errorGettingStatus=$errorGettingStatus")
                     Thread.sleep(BOLUS_RETRY_INTERVAL_MS) // retry every 3 sec
                 }
-                .blockingAwait()
+                .blockingSubscribe()
             if (errorGettingStatus != null) {
                 continue
             }


### PR DESCRIPTION
Fix crash:
```
2022-02-28 22:42:23.797 418-676/info.nightscout.androidaps E/PUMP: [RxCachedThreadScheduler-19]: [OmnipodDashPumpPlugin.getPumpStatus$lambda-8():294]: Error in getPumpStatus
    info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.exceptions.FailedToConnectException: Failed to connect: 3D:37:33:24:51:E0
    	at info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.session.Connection.connect(Connection.kt:81) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.OmnipodDashBleManagerImpl.connect$lambda-1(OmnipodDashBleManagerImpl.kt:135) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.OmnipodDashBleManagerImpl.$r8$lambda$5TrAjNnaoab-abmIF0Xgs08Vojo(Unknown Source:0) ~[na:0.0]
    	at info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.OmnipodDashBleManagerImpl$$ExternalSyntheticLambda1.subscribe(Unknown Source:4) ~[na:0.0]
```
It seems that we want to use `blockingSubscribe` here because it doesn't throw exceptions. 