### PR TITLE
Fix add missing protection

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/actions/ActionsFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/actions/ActionsFragment.kt
@@ -157,10 +157,20 @@ class ActionsFragment : DaggerFragment() {
         cannulaOrPatch = view.findViewById(R.id.cannula_or_patch)
 
         profileSwitch?.setOnClickListener {
-            ProfileSwitchDialog().show(childFragmentManager, "ProfileSwitchDialog")
+            activity?.let { activity ->
+                protectionCheck.queryProtection(
+                    activity,
+                    ProtectionCheck.Protection.BOLUS,
+                    UIRunnable { ProfileSwitchDialog().show(childFragmentManager, "ProfileSwitchDialog")})
+            }
         }
         tempTarget?.setOnClickListener {
-            TempTargetDialog().show(childFragmentManager, "Actions")
+            activity?.let { activity ->
+                protectionCheck.queryProtection(
+                    activity,
+                    ProtectionCheck.Protection.BOLUS,
+                    UIRunnable { TempTargetDialog().show(childFragmentManager, "Actions") })
+            }
         }
         extendedBolus?.setOnClickListener {
             activity?.let { activity ->
@@ -187,7 +197,12 @@ class ActionsFragment : DaggerFragment() {
             }
         }
         setTempBasal?.setOnClickListener {
-            TempBasalDialog().show(childFragmentManager, "Actions")
+            activity?.let { activity ->
+                protectionCheck.queryProtection(
+                    activity,
+                    ProtectionCheck.Protection.BOLUS,
+                    UIRunnable { TempBasalDialog().show(childFragmentManager, "Actions") })
+            }
         }
         cancelTempBasal?.setOnClickListener {
             if (iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now()) != null) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenanceFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/maintenance/MaintenanceFragment.kt
@@ -27,6 +27,7 @@ import info.nightscout.androidaps.plugins.general.overview.OverviewData
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.history.database.DashHistoryDatabase
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.history.database.ErosHistoryDatabase
 import info.nightscout.androidaps.utils.alertDialogs.OKDialog
+import info.nightscout.androidaps.utils.protection.ProtectionCheck
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import info.nightscout.androidaps.utils.rx.AapsSchedulers
 import io.reactivex.Completable.fromAction
@@ -48,6 +49,7 @@ class MaintenanceFragment : DaggerFragment() {
     @Inject lateinit var diaconnDatabase: DiaconnHistoryDatabase
     @Inject lateinit var erosDatabase: ErosHistoryDatabase
     @Inject lateinit var dashDatabase: DashHistoryDatabase
+    @Inject lateinit var protectionCheck: ProtectionCheck
     @Inject lateinit var uel: UserEntryLogger
     @Inject lateinit var dataSyncSelector: DataSyncSelector
     @Inject lateinit var pumpSync: PumpSync
@@ -126,6 +128,23 @@ class MaintenanceFragment : DaggerFragment() {
                     uel.log(Action.EXPORT_CSV, Sources.Maintenance)
                     importExportPrefs.exportUserEntriesCsv(activity)
                 }
+            }
+        }
+
+        if (protectionCheck.isLocked(ProtectionCheck.Protection.PREFERENCES)) {
+            binding.mainLayout.visibility = View.GONE
+        } else {
+            binding.unlock.visibility = View.GONE
+        }
+
+        binding.unlock.setOnClickListener {
+            activity?.let { activity ->
+                protectionCheck.queryProtection(activity, ProtectionCheck.Protection.PREFERENCES, {
+                    activity.runOnUiThread {
+                        binding.mainLayout.visibility = View.VISIBLE
+                        binding.unlock.visibility = View.GONE
+                    }
+                })
             }
         }
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
@@ -29,6 +29,7 @@ import info.nightscout.androidaps.utils.DecimalFormatter
 import info.nightscout.androidaps.utils.FabricPrivacy
 import info.nightscout.androidaps.utils.HardLimits
 import info.nightscout.androidaps.utils.alertDialogs.OKDialog
+import info.nightscout.androidaps.utils.protection.ProtectionCheck
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import info.nightscout.androidaps.utils.rx.AapsSchedulers
 import info.nightscout.androidaps.utils.ui.TimeListEdit
@@ -49,6 +50,7 @@ class LocalProfileFragment : DaggerFragment() {
     @Inject lateinit var fabricPrivacy: FabricPrivacy
     @Inject lateinit var localProfilePlugin: LocalProfilePlugin
     @Inject lateinit var hardLimits: HardLimits
+    @Inject lateinit var protectionCheck: ProtectionCheck
     @Inject lateinit var dateUtil: DateUtil
     @Inject lateinit var aapsSchedulers: AapsSchedulers
     @Inject lateinit var uel: UserEntryLogger
@@ -88,8 +90,7 @@ class LocalProfileFragment : DaggerFragment() {
 
     private var _binding: LocalprofileFragmentBinding? = null
 
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    // This property is only valid between onCreateView and onDestroyView.
     private val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -124,6 +125,23 @@ class LocalProfileFragment : DaggerFragment() {
             binding.target.visibility = View.VISIBLE
         }
         binding.dia.editText?.id?.let { binding.diaLabel.labelFor = it }
+
+        if (protectionCheck.isLocked(ProtectionCheck.Protection.PREFERENCES)) {
+            binding.mainLayout.visibility = View.GONE
+        } else {
+            binding.unlock.visibility = View.GONE
+        }
+
+        binding.unlock.setOnClickListener {
+            activity?.let { activity ->
+                protectionCheck.queryProtection(activity, ProtectionCheck.Protection.PREFERENCES, {
+                    activity.runOnUiThread {
+                        binding.mainLayout.visibility = View.VISIBLE
+                        binding.unlock.visibility = View.GONE
+                    }
+                })
+            }
+        }
     }
 
     fun build() {

--- a/app/src/main/res/layout/localprofile_fragment.xml
+++ b/app/src/main/res/layout/localprofile_fragment.xml
@@ -10,353 +10,369 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-            android:layout_width="match_parent"
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/unlock"
+            style="@style/GrayButton"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
-            android:layout_marginEnd="5dp"
-            android:hint="@string/select_profile"
-            android:textColorHint="@color/white"
-            app:boxStrokeColor="@color/list_delimiter">
-
-            <androidx.appcompat.widget.AppCompatAutoCompleteTextView
-                android:id="@+id/profileList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:clickable="true"
-                android:enabled="false"
-                tools:ignore="KeyboardInaccessibleWidget" />
-
-        </com.google.android.material.textfield.TextInputLayout>
+            android:layout_gravity="center"
+            android:text="@string/unlock_settings" />
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_marginBottom="10dp"
-                android:labelFor="@+id/name"
-                android:text="@string/profile_name"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <EditText
-                android:id="@+id/name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_weight="1"
-                android:ems="10"
-                android:importantForAutofill="no"
-                android:inputType="text" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="10dp"
-            android:gravity="start"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/units"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="10dp"
-                android:text="@string/units_colon"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="1" />
-
-            <ImageView
-                android:id="@+id/profile_add"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="15dp"
-                android:contentDescription="@string/a11y_add_new_profile"
-                app:srcCompat="@drawable/ic_add" />
-
-            <ImageView
-                android:id="@+id/profile_clone"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="15dp"
-                android:contentDescription="@string/a11y_clone_profile"
-                app:srcCompat="@drawable/ic_clone" />
-
-            <ImageView
-                android:id="@+id/profile_remove"
-                android:layout_width="35dp"
-                android:layout_height="35dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="15dp"
-                android:contentDescription="@string/a11y_delete_current_profile"
-                android:scaleX="1"
-                android:scaleY="1"
-                app:srcCompat="@drawable/ic_remove" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal"
-            android:paddingBottom="10dp"
-            android:weightSum="5">
-
-            <TextView
-                android:id="@+id/dia_tab"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/dia_short"
-                android:textAlignment="center"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/ic_tab"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/ic_short"
-                android:textAlignment="center"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/isf_tab"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/isf_short"
-                android:textAlignment="center"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/basal_tab"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/basal_short"
-                android:textAlignment="center"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/target_tab"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/target_short"
-                android:textAlignment="center"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textStyle="bold" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/dia_placeholder"
+            android:id="@+id/main_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <TextView
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                android:text="@string/dia_long_label"
-                android:textColor="@android:color/white"
-                android:textSize="20sp" />
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="5dp"
+                android:hint="@string/select_profile"
+                android:textColorHint="@color/white"
+                app:boxStrokeColor="@color/list_delimiter">
+
+                <androidx.appcompat.widget.AppCompatAutoCompleteTextView
+                    android:id="@+id/profileList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:enabled="false"
+                    tools:ignore="KeyboardInaccessibleWidget" />
+
+            </com.google.android.material.textfield.TextInputLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                android:orientation="horizontal"
-                android:paddingTop="5dp">
+                android:layout_marginBottom="10dp"
+                android:orientation="horizontal">
 
                 <TextView
-                    android:id="@+id/dia_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginEnd="10dp"
-                    android:text="@string/dia"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:labelFor="@+id/name"
+                    android:text="@string/profile_name"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <info.nightscout.androidaps.utils.ui.NumberPicker
-                    android:id="@+id/dia"
-                    android:layout_width="130dp"
-                    android:layout_height="40dp"
-                    android:layout_marginEnd="10dp"
-                    android:layout_marginBottom="10dp"
-                    app:customContentDescription="@string/dia" />
-
-                <TextView
-                    android:layout_width="wrap_content"
+                <EditText
+                    android:id="@+id/name"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:text="@string/hours"
-                    android:textAppearance="?android:attr/textAppearanceSmall" />
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:ems="10"
+                    android:importantForAutofill="no"
+                    android:inputType="text" />
 
             </LinearLayout>
 
-            <info.nightscout.androidaps.plugins.insulin.ActivityGraph
-                android:id="@+id/insulin_graph"
-                android:layout_width="match_parent"
-                android:layout_height="100dip"
-                android:layout_margin="20dp" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/ic"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
             <LinearLayout
-                android:id="@+id/ic_holder"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginBottom="10dp"
-                android:orientation="vertical" />
+                android:gravity="start"
+                android:orientation="horizontal">
 
-            <info.nightscout.androidaps.utils.ui.IcProfileGraph
-                android:id="@+id/ic_graph"
-                android:layout_width="match_parent"
-                android:layout_height="100dip"
-                android:layout_margin="20dp" />
+                <TextView
+                    android:id="@+id/units"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="10dp"
+                    android:text="@string/units_colon"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-        </LinearLayout>
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1" />
 
-        <LinearLayout
-            android:id="@+id/isf"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+                <ImageView
+                    android:id="@+id/profile_add"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_add_new_profile"
+                    app:srcCompat="@drawable/ic_add" />
 
-            <LinearLayout
-                android:id="@+id/isf_holder"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginBottom="10dp"
-                android:orientation="vertical" />
+                <ImageView
+                    android:id="@+id/profile_clone"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_clone_profile"
+                    app:srcCompat="@drawable/ic_clone" />
 
-            <info.nightscout.androidaps.utils.ui.IsfProfileGraph
-                android:id="@+id/isf_graph"
-                android:layout_width="match_parent"
-                android:layout_height="100dip"
-                android:layout_margin="20dp" />
+                <ImageView
+                    android:id="@+id/profile_remove"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_delete_current_profile"
+                    android:scaleX="1"
+                    android:scaleY="1"
+                    app:srcCompat="@drawable/ic_remove" />
 
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/basal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <LinearLayout
-                android:id="@+id/basal_holder"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginBottom="10dp"
-                android:orientation="vertical" />
-
-            <info.nightscout.androidaps.utils.ui.BasalProfileGraph
-                android:id="@+id/basal_graph"
-                android:layout_width="match_parent"
-                android:layout_height="100dip"
-                android:layout_margin="20dp" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/target"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/target_holder"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginBottom="10dp"
-                android:orientation="vertical" />
+                android:orientation="horizontal"
+                android:paddingBottom="10dp"
+                android:weightSum="5">
 
-            <info.nightscout.androidaps.utils.ui.TargetBgProfileGraph
-                android:id="@+id/target_graph"
+                <TextView
+                    android:id="@+id/dia_tab"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/dia_short"
+                    android:textAlignment="center"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/ic_tab"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/ic_short"
+                    android:textAlignment="center"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/isf_tab"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/isf_short"
+                    android:textAlignment="center"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/basal_tab"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/basal_short"
+                    android:textAlignment="center"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/target_tab"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/target_short"
+                    android:textAlignment="center"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/dia_placeholder"
                 android:layout_width="match_parent"
-                android:layout_height="100dip"
-                android:layout_margin="20dp" />
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-        </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:text="@string/dia_long_label"
+                    android:textColor="@android:color/white"
+                    android:textSize="20sp" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/profileswitch"
-            style="@style/GrayButton"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="10dp"
-            android:layout_marginRight="10dp"
-            android:layout_weight="1"
-            android:paddingLeft="10dp"
-            android:paddingRight="10dp"
-            android:text="@string/activate_profile"
-            app:icon="@drawable/ic_local_activate"
-            app:iconTint="@color/ic_local_activate" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="horizontal"
+                    android:paddingTop="5dp">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/dia_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/dia"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <info.nightscout.androidaps.utils.ui.NumberPicker
+                        android:id="@+id/dia"
+                        android:layout_width="130dp"
+                        android:layout_height="40dp"
+                        android:layout_marginEnd="10dp"
+                        android:layout_marginBottom="10dp"
+                        app:customContentDescription="@string/dia" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:text="@string/hours"
+                        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                </LinearLayout>
+
+                <info.nightscout.androidaps.plugins.insulin.ActivityGraph
+                    android:id="@+id/insulin_graph"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dip"
+                    android:layout_margin="20dp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/ic"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/ic_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginBottom="10dp"
+                    android:orientation="vertical" />
+
+                <info.nightscout.androidaps.utils.ui.IcProfileGraph
+                    android:id="@+id/ic_graph"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dip"
+                    android:layout_margin="20dp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/isf"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/isf_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginBottom="10dp"
+                    android:orientation="vertical" />
+
+                <info.nightscout.androidaps.utils.ui.IsfProfileGraph
+                    android:id="@+id/isf_graph"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dip"
+                    android:layout_margin="20dp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/basal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/basal_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginBottom="10dp"
+                    android:orientation="vertical" />
+
+                <info.nightscout.androidaps.utils.ui.BasalProfileGraph
+                    android:id="@+id/basal_graph"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dip"
+                    android:layout_margin="20dp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/target"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/target_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginBottom="10dp"
+                    android:orientation="vertical" />
+
+                <info.nightscout.androidaps.utils.ui.TargetBgProfileGraph
+                    android:id="@+id/target_graph"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dip"
+                    android:layout_margin="20dp" />
+
+            </LinearLayout>
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/reset"
+                android:id="@+id/profileswitch"
                 style="@style/GrayButton"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="10dp"
+                android:layout_marginRight="10dp"
+                android:layout_weight="1"
+                android:paddingLeft="10dp"
+                android:paddingRight="10dp"
+                android:text="@string/activate_profile"
+                app:icon="@drawable/ic_local_activate"
+                app:iconTint="@color/ic_local_activate" />
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginLeft="5dp"
-                android:layout_marginRight="5dp"
-                android:layout_weight="1"
-                android:paddingLeft="1dp"
-                android:paddingRight="1dp"
-                android:text="@string/reset"
-                app:icon="@drawable/ic_local_reset"
-                app:iconTint="@color/ic_local_reset" />
+                android:orientation="horizontal">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/save"
-                style="@style/GrayButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginLeft="5dp"
-                android:layout_marginRight="5dp"
-                android:layout_weight="1"
-                android:paddingLeft="1dp"
-                android:paddingRight="1dp"
-                android:text="@string/save"
-                app:icon="@drawable/ic_local_save"
-                app:iconTint="@color/ic_local_save" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/reset"
+                    style="@style/GrayButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginLeft="5dp"
+                    android:layout_marginRight="5dp"
+                    android:layout_weight="1"
+                    android:paddingLeft="1dp"
+                    android:paddingRight="1dp"
+                    android:text="@string/reset"
+                    app:icon="@drawable/ic_local_reset"
+                    app:iconTint="@color/ic_local_reset" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/save"
+                    style="@style/GrayButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginLeft="5dp"
+                    android:layout_marginRight="5dp"
+                    android:layout_weight="1"
+                    android:paddingLeft="1dp"
+                    android:paddingRight="1dp"
+                    android:text="@string/save"
+                    app:icon="@drawable/ic_local_save"
+                    app:iconTint="@color/ic_local_save" />
+            </LinearLayout>
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/maintenance_fragment.xml
+++ b/app/src/main/res/layout/maintenance_fragment.xml
@@ -5,7 +5,16 @@
     android:paddingTop="2dp"
     tools:context=".plugins.general.maintenance.MaintenanceFragment">
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/unlock"
+        style="@style/GrayButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/unlock_settings" />
+
     <LinearLayout
+        android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -40,6 +40,7 @@ import info.nightscout.androidaps.utils.DateUtil
 import info.nightscout.androidaps.utils.FabricPrivacy
 import info.nightscout.androidaps.utils.alertDialogs.OKDialog
 import info.nightscout.androidaps.utils.buildHelper.BuildHelper
+import info.nightscout.androidaps.utils.protection.ProtectionCheck
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 import info.nightscout.androidaps.utils.rx.AapsSchedulers
 import info.nightscout.shared.sharedPreferences.SP
@@ -64,6 +65,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     @Inject lateinit var omnipodDashPumpPlugin: OmnipodDashPumpPlugin
     @Inject lateinit var podStateManager: OmnipodDashPodStateManager
     @Inject lateinit var sp: SP
+    @Inject lateinit var protectionCheck: ProtectionCheck
     @Inject lateinit var dateUtil: DateUtil
     @Inject lateinit var aapsSchedulers: AapsSchedulers
     @Inject lateinit var pumpSync: PumpSync
@@ -93,8 +95,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     private var _podInfoBinding: OmnipodCommonOverviewPodInfoBinding? = null
     private var _buttonBinding: OmnipodCommonOverviewButtonsBinding? = null
 
-    // These properties are only valid between onCreateView and
-    // onDestroyView.
+    // These properties are only valid between onCreateView and onDestroyView.
     val binding get() = _binding!!
     private val bluetoothStatusBinding get() = _bluetoothStatusBinding!!
     private val podInfoBinding get() = _podInfoBinding!!
@@ -112,8 +113,12 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         buttonBinding.buttonPodManagement.setOnClickListener {
-            // TODO add protection
-            startActivity(Intent(context, DashPodManagementActivity::class.java))
+            activity?.let { activity ->
+                protectionCheck.queryProtection(
+                    activity,
+                    ProtectionCheck.Protection.PREFERENCES,
+                    UIRunnable { startActivity(Intent(context, DashPodManagementActivity::class.java)) })
+            }
         }
 
         buttonBinding.buttonResumeDelivery.setOnClickListener {


### PR DESCRIPTION
Protection was implemented in the overview, other ways to access bolus and preferences should be protected to:
1. Actions (Bolus Protection)
   - Temp target 
   - Profile switch 
   - Temp basal
2. Local profile, add unlock button (Settings Protection)
3. Omnipod Dash overview,  Pod management (Settings Protection, equal to Eros)
4. Maintenance, add unlock button (Settings Protection)

Open for discussion, should the pod management, should it use settings protection or bolus protection?
"As a child, which can handle the responsibility of the bolus treatments, he should be able to change my pod too"
