### PR TITLE
Fix notification color contrast

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/notifications/NotificationStore.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/notifications/NotificationStore.kt
@@ -164,11 +164,11 @@ class NotificationStore @Inject constructor(
             @Suppress("SetTextI18n")
             holder.binding.text.text = dateUtil.timeString(notification.date) + " " + notification.text
             when (notification.level) {
-                Notification.URGENT       -> holder.binding.cv.setBackgroundColor(rh.gc(R.color.notificationUrgent))
-                Notification.NORMAL       -> holder.binding.cv.setBackgroundColor(rh.gc(R.color.notificationNormal))
-                Notification.LOW          -> holder.binding.cv.setBackgroundColor(rh.gc(R.color.notificationLow))
-                Notification.INFO         -> holder.binding.cv.setBackgroundColor(rh.gc(R.color.notificationInfo))
-                Notification.ANNOUNCEMENT -> holder.binding.cv.setBackgroundColor(rh.gc(R.color.notificationAnnouncement))
+                Notification.URGENT       -> holder.binding.cv.setBackgroundColor(rh.gac(R.attr.notificationUrgent))
+                Notification.NORMAL       -> holder.binding.cv.setBackgroundColor(rh.gac(R.attr.notificationNormal))
+                Notification.LOW          -> holder.binding.cv.setBackgroundColor(rh.gac(R.attr.notificationLow))
+                Notification.INFO         -> holder.binding.cv.setBackgroundColor(rh.gac(R.attr.notificationInfo))
+                Notification.ANNOUNCEMENT -> holder.binding.cv.setBackgroundColor(rh.gac(R.attr.notificationAnnouncement))
             }
         }
 

--- a/app/src/main/res/layout/overview_notification_item.xml
+++ b/app/src/main/res/layout/overview_notification_item.xml
@@ -22,7 +22,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="5dp"
             android:layout_weight="1"
-            android:textColor="@color/black"
+            android:textColor="?attr/colorOnError"
             android:maxLines="4"
             android:textStyle="bold"
             android:text="Notification text. Notification text. Notification text. Notification text. Notification text. Notification text. "

--- a/app/src/main/res/layout/overview_notification_item.xml
+++ b/app/src/main/res/layout/overview_notification_item.xml
@@ -7,7 +7,7 @@
     android:layout_height="wrap_content"
     android:layout_gravity="center"
     android:layout_margin="1dp"
-    card_view:cardBackgroundColor="@color/cardColorBackground"
+    card_view:cardBackgroundColor="@color/notificationUrgent"
     card_view:cardCornerRadius="6dp">
 
     <LinearLayout
@@ -22,7 +22,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="5dp"
             android:layout_weight="1"
+            android:textColor="@color/black"
             android:maxLines="4"
+            android:textStyle="bold"
             android:text="Notification text. Notification text. Notification text. Notification text. Notification text. Notification text. "
             tools:ignore="HardcodedText" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -43,7 +43,7 @@
     <color name="notificationUrgent">#ff0400</color>
     <color name="notificationNormal">#ff5e55</color>
     <color name="notificationLow">#ff827c</color>
-    <color name="notificationInfo">#009705</color>
+    <color name="notificationInfo">#24DF2B</color>
 
     <color name="deviationgrey">#c8666666</color>
     <color name="deviationgreen">#7200FF00</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -40,11 +40,6 @@
     <color name="colorScheduled">#de7550</color>
     <color name="colorActive">#25912e</color>
 
-    <color name="notificationUrgent">#ff0400</color>
-    <color name="notificationNormal">#ff5e55</color>
-    <color name="notificationLow">#ff827c</color>
-    <color name="notificationInfo">#24DF2B</color>
-
     <color name="deviationgrey">#c8666666</color>
     <color name="deviationgreen">#7200FF00</color>
     <color name="deviationred">#72FF0000</color>

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelper.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.utils.resources
 
+import android.content.Context
 import android.content.res.AssetFileDescriptor
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
@@ -11,7 +12,7 @@ interface ResourceHelper {
     fun gs(@StringRes id: Int, vararg args: Any?): String
     fun gq(@PluralsRes id: Int, quantity: Int, vararg args: Any?): String
     fun gsNotLocalised(@StringRes id: Int, vararg args: Any?): String
-    fun gc(@ColorRes id: Int): Int
+    @ColorInt fun gc(@ColorRes id: Int): Int
     fun gd(@DrawableRes id: Int): Drawable?
     fun gb(@BoolRes id :Int) : Boolean
     fun gcs(@ColorRes id: Int): String
@@ -23,4 +24,13 @@ interface ResourceHelper {
     fun dpToPx(dp: Int): Int
     fun dpToPx(dp: Float): Int
     fun shortTextMode(): Boolean
+
+    /**
+     * Get Attribute Color based on theme style
+     */
+    @ColorInt fun gac(@AttrRes attributeId: Int): Int
+    /**
+     * Get Attribute Color based on theme style for specified context
+     */
+    @ColorInt fun gac(context: Context, @AttrRes attributeId: Int): Int
 }

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperExtensions.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperExtensions.kt
@@ -1,0 +1,13 @@
+package info.nightscout.androidaps.utils.resources
+
+import android.content.Context
+import android.util.TypedValue
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
+
+@ColorInt
+fun Context.getThemeColor(@AttrRes attribute: Int) =
+    TypedValue().let {
+        theme.resolveAttribute(attribute, it, true)
+        it.data
+    }

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
@@ -9,6 +9,7 @@ import android.graphics.BitmapFactory
 import android.graphics.drawable.Drawable
 import android.util.DisplayMetrics
 import androidx.annotation.*
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.utils.FabricPrivacy
@@ -83,4 +84,10 @@ class ResourceHelperImplementation @Inject constructor(private val context: Cont
     }
 
     override fun shortTextMode(): Boolean = !gb(R.bool.isTablet)
+
+    override fun gac(context: Context, attributeId: Int): Int =
+        context.getThemeColor(attributeId)
+
+    override fun gac(attributeId: Int): Int =
+        ContextThemeWrapper(this.context, R.style.AppTheme).getThemeColor(attributeId)
 }

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -7,4 +7,12 @@
     <declare-styleable name="NumberPicker">
         <attr name="customContentDescription" format="string" />
     </declare-styleable>
+
+    <!---Notification -->
+    <attr name="notificationUrgent" format="reference|color" />
+    <attr name="notificationNormal" format="reference|color" />
+    <attr name="notificationLow" format="reference|color" />
+    <attr name="notificationInfo" format="reference|color" />
+    <attr name="notificationAnnouncement" format="reference|color" />
+
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -92,8 +92,14 @@
     <color name="weekdayOutline">#1ea3e5</color>
     <color name="weekendOutline">#1e88e5</color>
 
-    <!--    CareportalEvent-->
+    <!-- Notification-->
     <color name="notificationAnnouncement">#FF8C00</color>
+    <color name="notificationUrgent">#ff0400</color>
+    <color name="notificationNormal">#ff5e55</color>
+    <color name="notificationLow">#ff827c</color>
+
+    <!-- Green Colors -->
+    <color name="notificationInfo">#009705</color>
 
     <!--    Toasts-->
     <color name="toastBorder">#666666</color>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -22,6 +22,12 @@
         <item name="android:textColorSecondary">@color/white</item>
         <item name="android:textColorPrimary">@color/white</item>
         <item name="android:textColor">@color/white</item>
+        <!---Notification -->
+        <item name="notificationUrgent">@color/notificationUrgent</item>
+        <item name="notificationNormal">@color/notificationNormal</item>
+        <item name="notificationLow">@color/notificationLow</item>
+        <item name="notificationInfo">@color/notificationInfo</item>
+        <item name="notificationAnnouncement">@color/notificationAnnouncement</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="Theme.MaterialComponents.NoActionBar">


### PR DESCRIPTION
Color contract is imported for some users, but making for all users text easier to read.
Current 1.86:1, Suggested 4.5:1
To fix this, the background color has to change or the text color. Because the background color has a meaning, it should not be changed to much. The PR fixes #446 by suggesting to change:
* Text color to black, 
* Text style bold
* Tweak green notificationInfo color for background with black text

![image](https://user-images.githubusercontent.com/6724749/156898168-92181674-781a-4954-9c50-d6338c794c3f.png)
