### PR TITLE
Replace Gitter references with Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,5 @@ Hints
 * Start small, it is easier to review smaller changes that affect fewer parts of code 
 * Take a look into Issues list (https://github.com/nightscout/AndroidAPS/issues) - maybe there is something you can fix or implement
 * For new features, make sure there is Issue to track progress and have on-topic discussion
-* Reach out to community, discuss idea on Gitter (https://gitter.im/MilosKozak/AndroidAPS)
+* Reach out to community, discuss idea on Discord (https://discord.gg/4fQUWHZ4Mw)
 * Speak with other developers to minimise merge conflicts. Find out who worked, working or plan to work on speciffic issue or part of app

--- a/app/src/main/res/values/exam.xml
+++ b/app/src/main/res/values/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Where can you look for help with AndroidAPS?</string>
     <string name="troubleshooting_fb">You can ask for advice in the AndroidAPS Users Facebook group.</string>
     <string name="troubleshooting_wiki">You should read (and re-read) the AndroidAPS documentation.</string>
-    <string name="troubleshooting_gitter">You can ask for advice and log technical problems or issues in the AndroidAPS Gitter room.</string>
+    <string name="troubleshooting_gitter">You can ask for advice and log technical problems or issues in the AndroidAPS Discord.</string>
     <string name="troubleshooting_yourendo">You should ask your diabetes clinic/endocrinologist.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulin Plugins</string>
     <string name="insulin_ultrarapid">Which insulin should you use with the Ultra-Rapid Oref plugin?</string>
     <string name="insulin_fiasp">Fiasp®</string>


### PR DESCRIPTION
Fixes #1415 

I left the name of the translation string `troubleshooting_gitter` for now.
If i should change that too let me know.