### PR TITLE
Chore use safe resource helper get string

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -438,10 +438,10 @@ class WizardDialog : DaggerDialogFragment() {
         )
 
         wizard?.let { wizard ->
-            binding.bg.text = String.format(rh.gs(R.string.format_bg_isf), valueToUnitsToString(Profile.toMgdl(bg, profileFunction.getUnits()), profileFunction.getUnits().asText), wizard.sens)
+            binding.bg.text = rh.gs(R.string.format_bg_isf, valueToUnitsToString(Profile.toMgdl(bg, profileFunction.getUnits()), profileFunction.getUnits().asText), wizard.sens)
             binding.bgInsulin.text = rh.gs(R.string.formatinsulinunits, wizard.insulinFromBG)
 
-            binding.carbs.text = String.format(rh.gs(R.string.format_carbs_ic), carbs.toDouble(), wizard.ic)
+            binding.carbs.text = rh.gs(R.string.format_carbs_ic, carbs.toDouble(), wizard.ic)
             binding.carbsInsulin.text = rh.gs(R.string.formatinsulinunits, wizard.insulinFromCarbs)
 
             binding.iobInsulin.text = rh.gs(R.string.formatinsulinunits, wizard.insulinFromBolusIOB + wizard.insulinFromBasalIOB)
@@ -464,7 +464,7 @@ class WizardDialog : DaggerDialogFragment() {
 
             // COB
             if (binding.cobCheckbox.isChecked) {
-                binding.cob.text = String.format(rh.gs(R.string.format_cob_ic), cob, wizard.ic)
+                binding.cob.text = rh.gs(R.string.format_cob_ic, cob, wizard.ic)
                 binding.cobInsulin.text = rh.gs(R.string.formatinsulinunits, wizard.insulinFromCOB)
             } else {
                 binding.cob.text = ""

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/safety/SafetyPlugin.kt
@@ -109,29 +109,29 @@ class SafetyPlugin @Inject constructor(
     }
 
     override fun applyBasalConstraints(absoluteRate: Constraint<Double>, profile: Profile): Constraint<Double> {
-        absoluteRate.setIfGreater(aapsLogger, 0.0, String.format(rh.gs(R.string.limitingbasalratio), 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
+        absoluteRate.setIfGreater(aapsLogger, 0.0, rh.gs(R.string.limitingbasalratio, 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
         if (config.APS) {
             var maxBasal = sp.getDouble(R.string.key_openapsma_max_basal, 1.0)
             if (maxBasal < profile.getMaxDailyBasal()) {
                 maxBasal = profile.getMaxDailyBasal()
                 absoluteRate.addReason(rh.gs(R.string.increasingmaxbasal), this)
             }
-            absoluteRate.setIfSmaller(aapsLogger, maxBasal, String.format(rh.gs(R.string.limitingbasalratio), maxBasal, rh.gs(R.string.maxvalueinpreferences)), this)
+            absoluteRate.setIfSmaller(aapsLogger, maxBasal,rh.gs(R.string.limitingbasalratio, maxBasal, rh.gs(R.string.maxvalueinpreferences)), this)
 
             // Check percentRate but absolute rate too, because we know real current basal in pump
             val maxBasalMultiplier = sp.getDouble(R.string.key_openapsama_current_basal_safety_multiplier, 4.0)
             val maxFromBasalMultiplier = floor(maxBasalMultiplier * profile.getBasal() * 100) / 100
-            absoluteRate.setIfSmaller(aapsLogger, maxFromBasalMultiplier, String.format(rh.gs(R.string.limitingbasalratio), maxFromBasalMultiplier, rh.gs(R.string.maxbasalmultiplier)), this)
+            absoluteRate.setIfSmaller(aapsLogger, maxFromBasalMultiplier, rh.gs(R.string.limitingbasalratio, maxFromBasalMultiplier, rh.gs(R.string.maxbasalmultiplier)), this)
             val maxBasalFromDaily = sp.getDouble(R.string.key_openapsama_max_daily_safety_multiplier, 3.0)
             val maxFromDaily = floor(profile.getMaxDailyBasal() * maxBasalFromDaily * 100) / 100
-            absoluteRate.setIfSmaller(aapsLogger, maxFromDaily, String.format(rh.gs(R.string.limitingbasalratio), maxFromDaily, rh.gs(R.string.maxdailybasalmultiplier)), this)
+            absoluteRate.setIfSmaller(aapsLogger, maxFromDaily,rh.gs(R.string.limitingbasalratio, maxFromDaily, rh.gs(R.string.maxdailybasalmultiplier)), this)
         }
-        absoluteRate.setIfSmaller(aapsLogger, hardLimits.maxBasal(), String.format(rh.gs(R.string.limitingbasalratio), hardLimits.maxBasal(), rh.gs(R.string.hardlimit)), this)
+        absoluteRate.setIfSmaller(aapsLogger, hardLimits.maxBasal(),rh.gs(R.string.limitingbasalratio, hardLimits.maxBasal(), rh.gs(R.string.hardlimit)), this)
         val pump = activePlugin.activePump
         // check for pump max
         if (pump.pumpDescription.tempBasalStyle == PumpDescription.ABSOLUTE) {
             val pumpLimit = pump.pumpDescription.pumpType.tbrSettings?.maxDose ?: 0.0
-            absoluteRate.setIfSmaller(aapsLogger, pumpLimit, String.format(rh.gs(R.string.limitingbasalratio), pumpLimit, rh.gs(R.string.pumplimit)), this)
+            absoluteRate.setIfSmaller(aapsLogger, pumpLimit, rh.gs(R.string.limitingbasalratio, pumpLimit, rh.gs(R.string.pumplimit)), this)
         }
 
         // do rounding
@@ -151,19 +151,19 @@ class SafetyPlugin @Inject constructor(
         val pump = activePlugin.activePump
         var percentRateAfterConst = java.lang.Double.valueOf(absoluteConstraint.value() / currentBasal * 100).toInt()
         percentRateAfterConst = if (percentRateAfterConst < 100) Round.ceilTo(percentRateAfterConst.toDouble(), pump.pumpDescription.tempPercentStep.toDouble()).toInt() else Round.floorTo(percentRateAfterConst.toDouble(), pump.pumpDescription.tempPercentStep.toDouble()).toInt()
-        percentRate.set(aapsLogger, percentRateAfterConst, String.format(rh.gs(R.string.limitingpercentrate), percentRateAfterConst, rh.gs(R.string.pumplimit)), this)
+        percentRate.set(aapsLogger, percentRateAfterConst, rh.gs(R.string.limitingpercentrate, percentRateAfterConst, rh.gs(R.string.pumplimit)), this)
         if (pump.pumpDescription.tempBasalStyle == PumpDescription.PERCENT) {
             val pumpLimit = pump.pumpDescription.pumpType.tbrSettings?.maxDose ?: 0.0
-            percentRate.setIfSmaller(aapsLogger, pumpLimit.toInt(), String.format(rh.gs(R.string.limitingbasalratio), pumpLimit, rh.gs(R.string.pumplimit)), this)
+            percentRate.setIfSmaller(aapsLogger, pumpLimit.toInt(), rh.gs(R.string.limitingbasalratio, pumpLimit, rh.gs(R.string.pumplimit)), this)
         }
         return percentRate
     }
 
     override fun applyBolusConstraints(insulin: Constraint<Double>): Constraint<Double> {
-        insulin.setIfGreater(aapsLogger, 0.0, String.format(rh.gs(R.string.limitingbolus), 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
+        insulin.setIfGreater(aapsLogger, 0.0, rh.gs(R.string.limitingbolus, 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
         val maxBolus = sp.getDouble(R.string.key_treatmentssafety_maxbolus, 3.0)
-        insulin.setIfSmaller(aapsLogger, maxBolus, String.format(rh.gs(R.string.limitingbolus), maxBolus, rh.gs(R.string.maxvalueinpreferences)), this)
-        insulin.setIfSmaller(aapsLogger, hardLimits.maxBolus(), String.format(rh.gs(R.string.limitingbolus), hardLimits.maxBolus(), rh.gs(R.string.hardlimit)), this)
+        insulin.setIfSmaller(aapsLogger, maxBolus, rh.gs(R.string.limitingbolus, maxBolus, rh.gs(R.string.maxvalueinpreferences)), this)
+        insulin.setIfSmaller(aapsLogger, hardLimits.maxBolus(), rh.gs(R.string.limitingbolus, hardLimits.maxBolus(), rh.gs(R.string.hardlimit)), this)
         val pump = activePlugin.activePump
         val rounded = pump.pumpDescription.pumpType.determineCorrectBolusSize(insulin.value())
         insulin.setIfDifferent(aapsLogger, rounded, rh.gs(R.string.pumplimit), this)
@@ -171,10 +171,10 @@ class SafetyPlugin @Inject constructor(
     }
 
     override fun applyExtendedBolusConstraints(insulin: Constraint<Double>): Constraint<Double> {
-        insulin.setIfGreater(aapsLogger, 0.0, String.format(rh.gs(R.string.limitingextendedbolus), 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
+        insulin.setIfGreater(aapsLogger, 0.0, rh.gs(R.string.limitingextendedbolus, 0.0, rh.gs(R.string.itmustbepositivevalue)), this)
         val maxBolus = sp.getDouble(R.string.key_treatmentssafety_maxbolus, 3.0)
-        insulin.setIfSmaller(aapsLogger, maxBolus, String.format(rh.gs(R.string.limitingextendedbolus), maxBolus, rh.gs(R.string.maxvalueinpreferences)), this)
-        insulin.setIfSmaller(aapsLogger, hardLimits.maxBolus(), String.format(rh.gs(R.string.limitingextendedbolus), hardLimits.maxBolus(), rh.gs(R.string.hardlimit)), this)
+        insulin.setIfSmaller(aapsLogger, maxBolus, rh.gs(R.string.limitingextendedbolus, maxBolus, rh.gs(R.string.maxvalueinpreferences)), this)
+        insulin.setIfSmaller(aapsLogger, hardLimits.maxBolus(), rh.gs(R.string.limitingextendedbolus, hardLimits.maxBolus(), rh.gs(R.string.hardlimit)), this)
         val pump = activePlugin.activePump
         val rounded = pump.pumpDescription.pumpType.determineCorrectExtendedBolusSize(insulin.value())
         insulin.setIfDifferent(aapsLogger, rounded, rh.gs(R.string.pumplimit), this)
@@ -182,9 +182,9 @@ class SafetyPlugin @Inject constructor(
     }
 
     override fun applyCarbsConstraints(carbs: Constraint<Int>): Constraint<Int> {
-        carbs.setIfGreater(aapsLogger, 0, String.format(rh.gs(R.string.limitingcarbs), 0, rh.gs(R.string.itmustbepositivevalue)), this)
+        carbs.setIfGreater(aapsLogger, 0, rh.gs(R.string.limitingcarbs, 0, rh.gs(R.string.itmustbepositivevalue)), this)
         val maxCarbs = sp.getInt(R.string.key_treatmentssafety_maxcarbs, 48)
-        carbs.setIfSmaller(aapsLogger, maxCarbs, String.format(rh.gs(R.string.limitingcarbs), maxCarbs, rh.gs(R.string.maxvalueinpreferences)), this)
+        carbs.setIfSmaller(aapsLogger, maxCarbs, rh.gs(R.string.limitingcarbs, maxCarbs, rh.gs(R.string.maxvalueinpreferences)), this)
         return carbs
     }
 
@@ -192,11 +192,11 @@ class SafetyPlugin @Inject constructor(
         val apsMode = sp.getString(R.string.key_aps_mode, "open")
         val maxIobPref: Double = if (openAPSSMBPlugin.isEnabled() || OpenAPSSMBDynamicISFPlugin.isEnabled()) sp.getDouble(R.string.key_openapssmb_max_iob, 3.0) else sp.getDouble(R.string
         .key_openapsma_max_iob, 1.5)
-        maxIob.setIfSmaller(aapsLogger, maxIobPref, String.format(rh.gs(R.string.limitingiob), maxIobPref, rh.gs(R.string.maxvalueinpreferences)), this)
-        if (openAPSAMAPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobAMA(), String.format(rh.gs(R.string.limitingiob), hardLimits.maxIobAMA(), rh.gs(R.string.hardlimit)), this)
-        if (openAPSSMBPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobSMB(), String.format(rh.gs(R.string.limitingiob), hardLimits.maxIobSMB(), rh.gs(R.string.hardlimit)), this)
-        if (OpenAPSSMBDynamicISFPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobSMB(), String.format(rh.gs(R.string.limitingiob), hardLimits.maxIobSMB(), rh.gs(R.string.hardlimit)), this)
-        if (apsMode == "lgs") maxIob.setIfSmaller(aapsLogger, HardLimits.MAX_IOB_LGS, String.format(rh.gs(R.string.limitingiob), HardLimits.MAX_IOB_LGS, rh.gs(R.string.lowglucosesuspend)), this)
+        maxIob.setIfSmaller(aapsLogger, maxIobPref, rh.gs(R.string.limitingiob, maxIobPref, rh.gs(R.string.maxvalueinpreferences)), this)
+        if (openAPSAMAPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobAMA(), rh.gs(R.string.limitingiob, hardLimits.maxIobAMA(), rh.gs(R.string.hardlimit)), this)
+        if (openAPSSMBPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobSMB(), rh.gs(R.string.limitingiob, hardLimits.maxIobSMB(), rh.gs(R.string.hardlimit)), this)
+        if (OpenAPSSMBDynamicISFPlugin.isEnabled()) maxIob.setIfSmaller(aapsLogger, hardLimits.maxIobSMB(), rh.gs(R.string.limitingiob, hardLimits.maxIobSMB(), rh.gs(R.string.hardlimit)), this)
+        if (apsMode == "lgs") maxIob.setIfSmaller(aapsLogger, HardLimits.MAX_IOB_LGS, rh.gs(R.string.limitingiob, HardLimits.MAX_IOB_LGS, rh.gs(R.string.lowglucosesuspend)), this)
         return maxIob
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -328,7 +328,7 @@ class SmsCommunicatorPlugin @Inject constructor(
         } else if (lastBG != null) {
             val agoMilliseconds = dateUtil.now() - lastBG.timestamp
             val agoMin = (agoMilliseconds / 60.0 / 1000.0).toInt()
-            reply = rh.gs(R.string.sms_lastbg) + " " + lastBG.valueToUnitsString(units) + " " + String.format(rh.gs(R.string.sms_minago), agoMin) + ", "
+            reply = rh.gs(R.string.sms_lastbg) + " " + lastBG.valueToUnitsString(units) + " " + rh.gs(R.string.sms_minago, agoMin) + ", "
         }
         val glucoseStatus = glucoseStatusProvider.glucoseStatusData
         if (glucoseStatus != null) reply += rh.gs(R.string.sms_delta) + " " + Profile.toUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units) + " " + units + ", "
@@ -348,7 +348,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             "DISABLE", "STOP" -> {
                 if (loop.enabled) {
                     val passCode = generatePassCode()
-                    val reply = String.format(rh.gs(R.string.smscommunicator_loopdisablereplywithcode), passCode)
+                    val reply = rh.gs(R.string.smscommunicator_loopdisablereplywithcode, passCode)
                     receivedSms.processed = true
                     messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                         override fun run() {
@@ -372,7 +372,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             "ENABLE", "START" -> {
                 if (!loop.enabled) {
                     val passCode = generatePassCode()
-                    val reply = String.format(rh.gs(R.string.smscommunicator_loopenablereplywithcode), passCode)
+                    val reply = rh.gs(R.string.smscommunicator_loopenablereplywithcode, passCode)
                     receivedSms.processed = true
                     messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                         override fun run() {
@@ -389,7 +389,7 @@ class SmsCommunicatorPlugin @Inject constructor(
 
             "STATUS"          -> {
                 val reply = if (loop.enabled) {
-                    if (loop.isSuspended) String.format(rh.gs(R.string.loopsuspendedfor), loop.minutesToEndOfSuspend())
+                    if (loop.isSuspended) rh.gs(R.string.loopsuspendedfor, loop.minutesToEndOfSuspend())
                     else rh.gs(R.string.smscommunicator_loopisenabled)
                 } else
                     rh.gs(R.string.loopisdisabled)
@@ -399,7 +399,7 @@ class SmsCommunicatorPlugin @Inject constructor(
 
             "RESUME"          -> {
                 val passCode = generatePassCode()
-                val reply = String.format(rh.gs(R.string.smscommunicator_loopresumereplywithcode), passCode)
+                val reply = rh.gs(R.string.smscommunicator_loopresumereplywithcode, passCode)
                 receivedSms.processed = true
                 messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true) {
                     override fun run() {
@@ -436,7 +436,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                     return
                 } else {
                     val passCode = generatePassCode()
-                    val reply = String.format(rh.gs(R.string.smscommunicator_suspendreplywithcode), duration, passCode)
+                    val reply = rh.gs(R.string.smscommunicator_suspendreplywithcode, duration, passCode)
                     receivedSms.processed = true
                     messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, duration) {
                         override fun run() {
@@ -515,7 +515,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             receivedSms.processed = true
         } else if ((divided.size == 2) && (divided[1].equals("CONNECT", ignoreCase = true))) {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_pumpconnectwithcode), passCode)
+            val reply = rh.gs(R.string.smscommunicator_pumpconnectwithcode, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true) {
                 override fun run() {
@@ -548,7 +548,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                 return
             } else {
                 val passCode = generatePassCode()
-                val reply = String.format(rh.gs(R.string.smscommunicator_pumpdisconnectwithcode), duration, passCode)
+                val reply = rh.gs(R.string.smscommunicator_pumpdisconnectwithcode, duration, passCode)
                 receivedSms.processed = true
                 messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true) {
                     override fun run() {
@@ -601,7 +601,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                 if (profile == null) sendSMS(Sms(receivedSms.phoneNumber, rh.gs(R.string.noprofile)))
                 else {
                     val passCode = generatePassCode()
-                    val reply = String.format(rh.gs(R.string.smscommunicator_profilereplywithcode), list[pIndex - 1], percentage, passCode)
+                    val reply = rh.gs(R.string.smscommunicator_profilereplywithcode, list[pIndex - 1], percentage, passCode)
                     receivedSms.processed = true
                     val finalPercentage = percentage
                     messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, list[pIndex - 1] as String, finalPercentage) {
@@ -627,7 +627,7 @@ class SmsCommunicatorPlugin @Inject constructor(
     private fun processBASAL(divided: Array<String>, receivedSms: Sms) {
         if (divided[1].uppercase(Locale.getDefault()) == "CANCEL" || divided[1].uppercase(Locale.getDefault()) == "STOP") {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_basalstopreplywithcode), passCode)
+            val reply = rh.gs(R.string.smscommunicator_basalstopreplywithcode, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true) {
                 override fun run() {
@@ -662,14 +662,14 @@ class SmsCommunicatorPlugin @Inject constructor(
             else {
                 tempBasalPct = constraintChecker.applyBasalPercentConstraints(Constraint(tempBasalPct), profile).value()
                 val passCode = generatePassCode()
-                val reply = String.format(rh.gs(R.string.smscommunicator_basalpctreplywithcode), tempBasalPct, duration, passCode)
+                val reply = rh.gs(R.string.smscommunicator_basalpctreplywithcode, tempBasalPct, duration, passCode)
                 receivedSms.processed = true
                 messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, tempBasalPct, duration) {
                     override fun run() {
                         commandQueue.tempBasalPercent(anInteger(), secondInteger(), true, profile, PumpSync.TemporaryBasalType.NORMAL, object : Callback() {
                             override fun run() {
                                 if (result.success) {
-                                    var replyText = if (result.isPercent) String.format(rh.gs(R.string.smscommunicator_tempbasalset_percent), result.percent, result.duration) else String.format(rh.gs(R.string.smscommunicator_tempbasalset), result.absolute, result.duration)
+                                    var replyText = if (result.isPercent) rh.gs(R.string.smscommunicator_tempbasalset_percent, result.percent, result.duration) else rh.gs(R.string.smscommunicator_tempbasalset, result.absolute, result.duration)
                                     replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                                     if (result.isPercent)
@@ -706,15 +706,15 @@ class SmsCommunicatorPlugin @Inject constructor(
             else {
                 tempBasal = constraintChecker.applyBasalConstraints(Constraint(tempBasal), profile).value()
                 val passCode = generatePassCode()
-                val reply = String.format(rh.gs(R.string.smscommunicator_basalreplywithcode), tempBasal, duration, passCode)
+                val reply = rh.gs(R.string.smscommunicator_basalreplywithcode, tempBasal, duration, passCode)
                 receivedSms.processed = true
                 messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, tempBasal, duration) {
                     override fun run() {
                         commandQueue.tempBasalAbsolute(aDouble(), secondInteger(), true, profile, PumpSync.TemporaryBasalType.NORMAL, object : Callback() {
                             override fun run() {
                                 if (result.success) {
-                                    var replyText = if (result.isPercent) String.format(rh.gs(R.string.smscommunicator_tempbasalset_percent), result.percent, result.duration)
-                                    else String.format(rh.gs(R.string.smscommunicator_tempbasalset), result.absolute, result.duration)
+                                    var replyText = if (result.isPercent) rh.gs(R.string.smscommunicator_tempbasalset_percent, result.percent, result.duration)
+                                    else rh.gs(R.string.smscommunicator_tempbasalset, result.absolute, result.duration)
                                     replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                                     if (result.isPercent)
@@ -743,7 +743,7 @@ class SmsCommunicatorPlugin @Inject constructor(
     private fun processEXTENDED(divided: Array<String>, receivedSms: Sms) {
         if (divided[1].uppercase(Locale.getDefault()) == "CANCEL" || divided[1].uppercase(Locale.getDefault()) == "STOP") {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_extendedstopreplywithcode), passCode)
+            val reply = rh.gs(R.string.smscommunicator_extendedstopreplywithcode, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true) {
                 override fun run() {
@@ -773,14 +773,14 @@ class SmsCommunicatorPlugin @Inject constructor(
             if (extended == 0.0 || duration == 0) sendSMS(Sms(receivedSms.phoneNumber, rh.gs(R.string.wrongformat)))
             else {
                 val passCode = generatePassCode()
-                val reply = String.format(rh.gs(R.string.smscommunicator_extendedreplywithcode), extended, duration, passCode)
+                val reply = rh.gs(R.string.smscommunicator_extendedreplywithcode, extended, duration, passCode)
                 receivedSms.processed = true
                 messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, extended, duration) {
                     override fun run() {
                         commandQueue.extendedBolus(aDouble(), secondInteger(), object : Callback() {
                             override fun run() {
                                 if (result.success) {
-                                    var replyText = String.format(rh.gs(R.string.smscommunicator_extendedset), aDouble, duration)
+                                    var replyText = rh.gs(R.string.smscommunicator_extendedset, aDouble, duration)
                                     if (config.APS) replyText += "\n" + rh.gs(R.string.loopsuspended)
                                     replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
@@ -817,9 +817,9 @@ class SmsCommunicatorPlugin @Inject constructor(
         } else if (bolus > 0.0) {
             val passCode = generatePassCode()
             val reply = if (isMeal)
-                String.format(rh.gs(R.string.smscommunicator_mealbolusreplywithcode), bolus, passCode)
+                rh.gs(R.string.smscommunicator_mealbolusreplywithcode, bolus, passCode)
             else
-                String.format(rh.gs(R.string.smscommunicator_bolusreplywithcode), bolus, passCode)
+                rh.gs(R.string.smscommunicator_bolusreplywithcode, bolus, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, bolus) {
                 override fun run() {
@@ -833,9 +833,9 @@ class SmsCommunicatorPlugin @Inject constructor(
                                 override fun run() {
                                     if (resultSuccess) {
                                         var replyText = if (isMeal)
-                                            String.format(rh.gs(R.string.smscommunicator_mealbolusdelivered), resultBolusDelivered)
+                                            rh.gs(R.string.smscommunicator_mealbolusdelivered, resultBolusDelivered)
                                         else
-                                            String.format(rh.gs(R.string.smscommunicator_bolusdelivered), resultBolusDelivered)
+                                            rh.gs(R.string.smscommunicator_bolusdelivered, resultBolusDelivered)
                                         replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                         lastRemoteBolusTime = dateUtil.now()
                                         if (isMeal) {
@@ -866,7 +866,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                                                 val tt = if (currentProfile.units == GlucoseUnit.MMOL) {
                                                     DecimalFormatter.to1Decimal(eatingSoonTT)
                                                 } else DecimalFormatter.to0Decimal(eatingSoonTT)
-                                                replyText += "\n" + String.format(rh.gs(R.string.smscommunicator_mealbolusdelivered_tt), tt, eatingSoonTTDuration)
+                                                replyText += "\n" + rh.gs(R.string.smscommunicator_mealbolusdelivered_tt, tt, eatingSoonTTDuration)
                                             }
                                         }
                                         sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
@@ -920,7 +920,7 @@ class SmsCommunicatorPlugin @Inject constructor(
         if (grams == 0) sendSMS(Sms(receivedSms.phoneNumber, rh.gs(R.string.wrongformat)))
         else {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_carbsreplywithcode), grams, dateUtil.timeString(time), passCode)
+            val reply = rh.gs(R.string.smscommunicator_carbsreplywithcode, grams, dateUtil.timeString(time), passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = true, grams, time) {
                 override fun run() {
@@ -930,7 +930,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                     commandQueue.bolus(detailedBolusInfo, object : Callback() {
                         override fun run() {
                             if (result.success) {
-                                var replyText = String.format(rh.gs(R.string.smscommunicator_carbsset), anInteger)
+                                var replyText = rh.gs(R.string.smscommunicator_carbsset, anInteger)
                                 replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                 sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                                 uel.log(Action.CARBS, Sources.SMS, activePlugin.activePump.shortStatus(true) + ": " + rh.gs(R.string.smscommunicator_carbsset, anInteger),
@@ -956,7 +956,7 @@ class SmsCommunicatorPlugin @Inject constructor(
         val isStop = divided[1].equals("STOP", ignoreCase = true) || divided[1].equals("CANCEL", ignoreCase = true)
         if (isMeal || isActivity || isHypo) {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_temptargetwithcode), divided[1].uppercase(Locale.getDefault()), passCode)
+            val reply = rh.gs(R.string.smscommunicator_temptargetwithcode, divided[1].uppercase(Locale.getDefault()), passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                 override fun run() {
@@ -1009,7 +1009,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                         aapsLogger.error(LTag.DATABASE, "Error while saving temporary target", it)
                     })
                     val ttString = if (units == GlucoseUnit.MMOL) DecimalFormatter.to1Decimal(tt) else DecimalFormatter.to0Decimal(tt)
-                    val replyText = String.format(rh.gs(R.string.smscommunicator_tt_set), ttString, ttDuration)
+                    val replyText = rh.gs(R.string.smscommunicator_tt_set, ttString, ttDuration)
                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                     uel.log(Action.TT, Sources.SMS,
                         ValueWithUnit.fromGlucoseUnit(tt, units.asText),
@@ -1018,7 +1018,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             })
         } else if (isStop) {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_temptargetcancel), passCode)
+            val reply = rh.gs(R.string.smscommunicator_temptargetcancel, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                 override fun run() {
@@ -1028,7 +1028,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                         }, {
                             aapsLogger.error(LTag.DATABASE, "Error while saving temporary target", it)
                         })
-                    val replyText = String.format(rh.gs(R.string.smscommunicator_tt_canceled))
+                    val replyText = rh.gs(R.string.smscommunicator_tt_canceled)
                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                     uel.log(Action.CANCEL_TT, Sources.SMS, rh.gs(R.string.smscommunicator_tt_canceled),
                             ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_tt_canceled)))
@@ -1043,12 +1043,12 @@ class SmsCommunicatorPlugin @Inject constructor(
             || divided[1].equals("DISABLE", ignoreCase = true))
         if (isStop) {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_stopsmswithcode), passCode)
+            val reply = rh.gs(R.string.smscommunicator_stopsmswithcode, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                 override fun run() {
                     sp.putBoolean(R.string.key_smscommunicator_remotecommandsallowed, false)
-                    val replyText = String.format(rh.gs(R.string.smscommunicator_stoppedsms))
+                    val replyText = rh.gs(R.string.smscommunicator_stoppedsms)
                     sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
                     uel.log(Action.STOP_SMS, Sources.SMS, rh.gs(R.string.smscommunicator_stoppedsms),
                             ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_stoppedsms)))
@@ -1061,7 +1061,7 @@ class SmsCommunicatorPlugin @Inject constructor(
         val cal = SafeParse.stringToDouble(divided[1])
         if (cal > 0.0) {
             val passCode = generatePassCode()
-            val reply = String.format(rh.gs(R.string.smscommunicator_calibrationreplywithcode), cal, passCode)
+            val reply = rh.gs(R.string.smscommunicator_calibrationreplywithcode, cal, passCode)
             receivedSms.processed = true
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false, cal) {
                 override fun run() {
@@ -1127,7 +1127,7 @@ class SmsCommunicatorPlugin @Inject constructor(
     }
 
     private fun generatePassCode(): String =
-        String.format(rh.gs(R.string.smscommunicator_code_from_authenticator_for), otp.name())
+        rh.gs(R.string.smscommunicator_code_from_authenticator_for, otp.name())
 
     private fun stripAccents(str: String): String {
         var s = str

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/ActionStringHandler.kt
@@ -111,7 +111,7 @@ class ActionStringHandler @Inject constructor(
     @Synchronized
     private fun handleInitiate(actionString: String) {
         //TODO: i18n
-        Log.i("ActionStringHandler", "handleInitiate actionString=" + actionString)
+        Log.i("ActionStringHandler", "handleInitiate actionString=$actionString")
         if (!sp.getBoolean(R.string.key_wear_control, false)) return
         lastBolusWizard = null
         var rTitle = rh.gs(R.string.confirm).uppercase()
@@ -640,10 +640,10 @@ class ActionStringHandler @Inject constructor(
         var msg = ""
         //check for validity
         if (percentage < Constants.CPP_MIN_PERCENTAGE || percentage > Constants.CPP_MAX_PERCENTAGE) {
-            msg += String.format(rh.gs(R.string.valueoutofrange), "Profile-Percentage") + "\n"
+            msg += rh.gs(R.string.valueoutofrange, "Profile-Percentage") + "\n"
         }
         if (timeshift < 0 || timeshift > 23) {
-            msg += String.format(rh.gs(R.string.valueoutofrange), "Profile-Timeshift") + "\n"
+            msg += rh.gs(R.string.valueoutofrange, "Profile-Timeshift") + "\n"
         }
         val profile = profileFunction.getProfile()
         if (profile == null) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/WearPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/WearPlugin.kt
@@ -95,7 +95,7 @@ class WearPlugin @Inject constructor(
             .toObservable(EventBolusRequested::class.java)
             .observeOn(aapsSchedulers.io)
             .subscribe({ event: EventBolusRequested ->
-                val status = String.format(rh.gs(R.string.bolusrequested), event.amount)
+                val status = rh.gs(R.string.bolusrequested, event.amount)
                 val intent = Intent(ctx, WatchUpdaterService::class.java).setAction(WatchUpdaterService.ACTION_SEND_BOLUSPROGRESS)
                 intent.putExtra("progresspercent", 0)
                 intent.putExtra("progressstatus", status)

--- a/app/src/main/java/info/nightscout/androidaps/utils/AndroidPermission.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/AndroidPermission.kt
@@ -113,7 +113,7 @@ class AndroidPermission @Inject constructor(
     @Synchronized
     fun notifyForBatteryOptimizationPermission(activity: FragmentActivity) {
         if (permissionNotGranted(activity, Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)) {
-            val notification = NotificationWithAction(injector, Notification.PERMISSION_BATTERY, String.format(rh.gs(R.string.needwhitelisting), rh.gs(R.string.app_name)), Notification.URGENT)
+            val notification = NotificationWithAction(injector, Notification.PERMISSION_BATTERY, rh.gs(R.string.needwhitelisting, rh.gs(R.string.app_name)), Notification.URGENT)
             notification.action(R.string.request) { askForPermission(activity, arrayOf(Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)) }
             rxBus.send(EventNewNotification(notification))
         } else rxBus.send(EventDismissNotification(Notification.PERMISSION_BATTERY))

--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ComboPlugin.java
@@ -1415,7 +1415,7 @@ public class ComboPlugin extends PumpPluginBase implements Pump, Constraints {
     @NonNull @Override
     public Constraint<Double> applyMaxIOBConstraints(@NonNull Constraint<Double> maxIob) {
         if (lowSuspendOnlyLoopEnforcedUntil > System.currentTimeMillis())
-            maxIob.setIfSmaller(getAapsLogger(), 0d, String.format(getRh().gs(R.string.limitingmaxiob), 0d, getRh().gs(R.string.unsafeusage)), this);
+            maxIob.setIfSmaller(getAapsLogger(), 0d, getRh().gs(R.string.limitingmaxiob, 0d, getRh().gs(R.string.unsafeusage)), this);
         return maxIob;
     }
 

--- a/core/src/main/java/info/nightscout/androidaps/events/EventPumpStatusChanged.kt
+++ b/core/src/main/java/info/nightscout/androidaps/events/EventPumpStatusChanged.kt
@@ -47,7 +47,7 @@ class EventPumpStatusChanged : EventStatus {
     // status for startup wizard
     override fun getStatus(rh: ResourceHelper): String {
         return when (status) {
-            Status.CONNECTING                -> String.format(rh.gs(R.string.connectingfor), secondsElapsed)
+            Status.CONNECTING                -> rh.gs(R.string.connectingfor, secondsElapsed)
             Status.HANDSHAKING               -> rh.gs(R.string.handshaking)
             Status.CONNECTED                 -> rh.gs(R.string.connected)
             Status.PERFORMING                -> performingAction

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
@@ -97,7 +97,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
     }
 
     val carbsRequiredText: String
-        get() = String.format(rh.gs(R.string.carbsreq), carbsReq, carbsReqWithin)
+        get() = rh.gs(R.string.carbsreq, carbsReq, carbsReqWithin)
 
     override fun toString(): String {
         val pump = activePlugin.activePump

--- a/core/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
@@ -94,9 +94,9 @@ class HardLimits @Inject constructor(
         if (newValue < lowLimit || newValue > highLimit) {
             newValue = max(newValue, lowLimit)
             newValue = min(newValue, highLimit)
-            var msg = String.format(rh.gs(R.string.valueoutofrange), rh.gs(valueName))
+            var msg = rh.gs(R.string.valueoutofrange, rh.gs(valueName))
             msg += ".\n"
-            msg += String.format(rh.gs(R.string.valuelimitedto), value, newValue)
+            msg += rh.gs(R.string.valuelimitedto, value, newValue)
             aapsLogger.error(msg)
             disposable += repository.runTransaction(InsertTherapyEventAnnouncementTransaction(msg)).subscribe()
             ToastUtils.showToastInUiThread(context, rxBus, msg, R.raw.error)

--- a/danar/src/main/java/info/nightscout/androidaps/danar/AbstractDanaRPlugin.java
+++ b/danar/src/main/java/info/nightscout/androidaps/danar/AbstractDanaRPlugin.java
@@ -456,21 +456,21 @@ public abstract class AbstractDanaRPlugin extends PumpPluginBase implements Pump
 
     @NonNull @Override
     public Constraint<Double> applyBasalConstraints(Constraint<Double> absoluteRate, @NonNull Profile profile) {
-        absoluteRate.setIfSmaller(getAapsLogger(), danaPump.getMaxBasal(), String.format(getRh().gs(R.string.limitingbasalratio), danaPump.getMaxBasal(), getRh().gs(R.string.pumplimit)), this);
+        absoluteRate.setIfSmaller(getAapsLogger(), danaPump.getMaxBasal(), getRh().gs(R.string.limitingbasalratio, danaPump.getMaxBasal(), getRh().gs(R.string.pumplimit)), this);
         return absoluteRate;
     }
 
     @NonNull @Override
     public Constraint<Integer> applyBasalPercentConstraints(Constraint<Integer> percentRate, @NonNull Profile profile) {
-        percentRate.setIfGreater(getAapsLogger(), 0, String.format(getRh().gs(R.string.limitingpercentrate), 0, getRh().gs(R.string.itmustbepositivevalue)), this);
-        percentRate.setIfSmaller(getAapsLogger(), getPumpDescription().getMaxTempPercent(), String.format(getRh().gs(R.string.limitingpercentrate), getPumpDescription().getMaxTempPercent(), getRh().gs(R.string.pumplimit)), this);
+        percentRate.setIfGreater(getAapsLogger(), 0, getRh().gs(R.string.limitingpercentrate, 0, getRh().gs(R.string.itmustbepositivevalue)), this);
+        percentRate.setIfSmaller(getAapsLogger(), getPumpDescription().getMaxTempPercent(), getRh().gs(R.string.limitingpercentrate, getPumpDescription().getMaxTempPercent(), getRh().gs(R.string.pumplimit)), this);
 
         return percentRate;
     }
 
     @NonNull @Override
     public Constraint<Double> applyBolusConstraints(Constraint<Double> insulin) {
-        insulin.setIfSmaller(getAapsLogger(), danaPump.getMaxBolus(), String.format(getRh().gs(R.string.limitingbolus), danaPump.getMaxBolus(), getRh().gs(R.string.pumplimit)), this);
+        insulin.setIfSmaller(getAapsLogger(), danaPump.getMaxBolus(), getRh().gs(R.string.limitingbolus, danaPump.getMaxBolus(), getRh().gs(R.string.pumplimit)), this);
         return insulin;
     }
 

--- a/danars/src/main/java/info/nightscout/androidaps/danars/DanaRSPlugin.kt
+++ b/danars/src/main/java/info/nightscout/androidaps/danars/DanaRSPlugin.kt
@@ -302,7 +302,7 @@ class DanaRSPlugin @Inject constructor(
                     0x40 -> error = rh.gs(R.string.speederror)
                     0x80 -> error = rh.gs(R.string.insulinlimitviolation)
                 }
-                result.comment = String.format(rh.gs(R.string.boluserrorcode), detailedBolusInfo.insulin, t.insulin, error)
+                result.comment = rh.gs(R.string.boluserrorcode, detailedBolusInfo.insulin, t.insulin, error)
             } else result.comment = rh.gs(R.string.ok)
             aapsLogger.debug(LTag.PUMP, "deliverTreatment: OK. Asked: " + detailedBolusInfo.insulin + " Delivered: " + result.bolusDelivered)
             result

--- a/danars/src/main/java/info/nightscout/androidaps/danars/services/DanaRSService.kt
+++ b/danars/src/main/java/info/nightscout/androidaps/danars/services/DanaRSService.kt
@@ -306,7 +306,7 @@ class DanaRSService : DaggerService() {
         val expectedEnd = bolusStart + bolusDurationInMSec + 2000
         while (System.currentTimeMillis() < expectedEnd) {
             val waitTime = expectedEnd - System.currentTimeMillis()
-            bolusingEvent.status = String.format(rh.gs(R.string.waitingforestimatedbolusend), waitTime / 1000)
+            bolusingEvent.status = rh.gs(R.string.waitingforestimatedbolusend, waitTime / 1000)
             rxBus.send(bolusingEvent)
             SystemClock.sleep(1000)
         }

--- a/diaconn/src/main/java/info/nightscout/androidaps/diaconn/service/DiaconnG8Service.kt
+++ b/diaconn/src/main/java/info/nightscout/androidaps/diaconn/service/DiaconnG8Service.kt
@@ -406,7 +406,7 @@ class DiaconnG8Service : DaggerService() {
         val totalwaitTime = (expectedEnd - System.currentTimeMillis()) / 1000
         while (!diaconnG8Pump.bolusDone) {
             val waitTime = (expectedEnd - System.currentTimeMillis()) / 1000
-            bolusingEvent.status = String.format(rh.gs(R.string.waitingforestimatedbolusend), if (waitTime < 0) 0 else waitTime)
+            bolusingEvent.status = rh.gs(R.string.waitingforestimatedbolusend, if (waitTime < 0) 0 else waitTime)
             var progressPecent = 0
             if (totalwaitTime > waitTime) {
                 progressPecent = ((totalwaitTime - waitTime) * 100 / totalwaitTime).toInt()

--- a/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
+++ b/insight/src/main/java/info/nightscout/androidaps/plugins/pump/insight/LocalInsightPlugin.java
@@ -1583,22 +1583,22 @@ public class LocalInsightPlugin extends PumpPluginBase implements Pump, Constrai
 
     @NonNull @Override
     public Constraint<Integer> applyBasalPercentConstraints(Constraint<Integer> percentRate, @NonNull Profile profile) {
-        percentRate.setIfGreater(getAapsLogger(), 0, String.format(rh.gs(R.string.limitingpercentrate), 0, rh.gs(R.string.itmustbepositivevalue)), this);
-        percentRate.setIfSmaller(getAapsLogger(), getPumpDescription().getMaxTempPercent(), String.format(rh.gs(R.string.limitingpercentrate), getPumpDescription().getMaxTempPercent(), rh.gs(R.string.pumplimit)), this);
+        percentRate.setIfGreater(getAapsLogger(), 0, rh.gs(R.string.limitingpercentrate, 0, rh.gs(R.string.itmustbepositivevalue)), this);
+        percentRate.setIfSmaller(getAapsLogger(), getPumpDescription().getMaxTempPercent(), rh.gs(R.string.limitingpercentrate, getPumpDescription().getMaxTempPercent(), rh.gs(R.string.pumplimit)), this);
         return percentRate;
     }
 
     @NonNull @Override
     public Constraint<Double> applyBolusConstraints(@NonNull Constraint<Double> insulin) {
         if (!limitsFetched) return insulin;
-        insulin.setIfSmaller(getAapsLogger(), maximumBolusAmount, String.format(rh.gs(R.string.limitingbolus), maximumBolusAmount, rh.gs(R.string.pumplimit)), this);
+        insulin.setIfSmaller(getAapsLogger(), maximumBolusAmount, rh.gs(R.string.limitingbolus, maximumBolusAmount, rh.gs(R.string.pumplimit)), this);
         if (insulin.value() < minimumBolusAmount) {
 
             //TODO: Add function to Constraints or use different approach
             // This only works if the interface of the InsightPlugin is called last.
             // If not, another constraint could theoretically set the value between 0 and minimumBolusAmount
 
-            insulin.set(getAapsLogger(), 0d, String.format(rh.gs(R.string.limitingbolus), minimumBolusAmount, rh.gs(R.string.pumplimit)), this);
+            insulin.set(getAapsLogger(), 0d, rh.gs(R.string.limitingbolus, minimumBolusAmount, rh.gs(R.string.pumplimit)), this);
         }
         return insulin;
     }


### PR DESCRIPTION
Using `String.format` can cause crashes when a string is translated incorrectly. With PR #1329 get string became crash-safe and will fall back if English when possible.
This PR removes `String.format`, and passes the args to the `rh.gs` which can do the formatting.
