### PR TITLE
Fix bolus wizard layout

### DIFF
--- a/app/src/main/res/layout/dialog_wizard.xml
+++ b/app/src/main/res/layout/dialog_wizard.xml
@@ -242,77 +242,67 @@
         </LinearLayout>
 
         <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center|center_vertical"
-            android:layout_marginTop="10dp"
-            android:background="@android:color/transparent"
-            android:orientation="horizontal"
-            android:padding="0dp">
+            android:layout_width="match_parent"
+            android:layout_height="45dp"
+            android:paddingHorizontal="10dp">
 
-            <CheckBox
+            <ToggleButton
                 android:id="@+id/bg_checkbox_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:button="@android:color/transparent"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/treatments_wizard_bg_label"
-                android:drawableStart="@drawable/checkbox_bg_icon"
+                android:drawableTop="@drawable/checkbox_bg_icon"
                 android:scaleX="1.4"
                 android:scaleY="1.4" />
 
-            <CheckBox
+            <ToggleButton
                 android:id="@+id/tt_checkbox_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:button="@android:color/transparent"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/treatments_wizard_tt_label"
-                android:drawableStart="@drawable/checkbox_tt_icon"
+                android:drawableTop="@drawable/checkbox_tt_icon"
                 android:scaleX="1.6"
-                android:scaleY="1.6"
-                android:visibility="gone" />
+                android:scaleY="1.6" />
 
-            <CheckBox
+            <ToggleButton
                 android:id="@+id/trend_checkbox_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:button="@android:color/transparent"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/bg_trend_label"
-                android:drawableStart="@drawable/checkbox_trend_icon"
+                android:drawableTop="@drawable/checkbox_trend_icon"
                 android:scaleX="1.4"
                 android:scaleY="1.4" />
 
-            <CheckBox
+            <ToggleButton
                 android:id="@+id/iob_checkbox_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:button="@android:color/transparent"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/iob"
-                android:drawableStart="@drawable/checkbox_iob_icon"
+                android:drawableTop="@drawable/checkbox_iob_icon"
                 android:scaleX="1.4"
                 android:scaleY="1.4" />
 
-            <CheckBox
+            <ToggleButton
                 android:id="@+id/cob_checkbox_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:button="@android:color/transparent"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/treatments_wizard_cob_label"
-                android:drawableStart="@drawable/checkbox_cob_icon"
+                android:drawableTop="@drawable/checkbox_cob_icon"
                 android:scaleX="1.6"
                 android:scaleY="1.6" />
 


### PR DESCRIPTION
Improve bolus wizard UI with icon alignment, increase touch area and add button ripple effect by replacing the checkboxes with toggle buttons.
 
![image](https://user-images.githubusercontent.com/6724749/157646214-d64df76c-8dc2-4378-b021-b87b2bb9778a.png)

Alternative for PR #1422 