### PR TITLE
Fix nightscout client big time text

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/skins/SkinInterface.kt
+++ b/app/src/main/java/info/nightscout/androidaps/skins/SkinInterface.kt
@@ -48,8 +48,10 @@ interface SkinInterface {
 
             if (isTablet) {
                 binding.infoLayout.apply {
-                    val texts = listOf(bg, time, timeAgoShort, iob, cob, baseBasal, extendedBolus, sensitivity)
+                    val texts = listOf(bg, iob, cob, baseBasal, extendedBolus, sensitivity)
                     for (v in texts) v.setTextSize(COMPLEX_UNIT_PX, v.textSize * 1.5f)
+                    val textsTime = listOf(time, timeAgoShort)
+                    for (v in textsTime) v.setTextSize(COMPLEX_UNIT_PX, v.textSize * 2.25f)
                 }
                 binding.apply {
                     val texts = listOf(pump, openaps, uploader)

--- a/app/src/main/res/layout/overview_info_layout.xml
+++ b/app/src/main/res/layout/overview_info_layout.xml
@@ -226,10 +226,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="-10dp"
-            android:layout_marginBottom="-10dp"
+            android:layout_marginTop="-5dp"
             android:text="8:00 PM"
-            android:textSize="40sp"
+            android:textSize="25sp"
             android:textStyle="bold"
             tools:ignore="HardcodedText" />
 
@@ -238,11 +237,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="-5dp"
-            android:layout_marginBottom="-5dp"
+            android:layout_marginTop="-10dp"
             android:gravity="center_vertical"
             android:text="(-5)"
-            android:textSize="30sp"
+            android:textSize="20sp"
             android:textStyle="bold"
             tools:ignore="HardcodedText" />
 

--- a/app/src/main/res/layout/overview_info_layout.xml
+++ b/app/src/main/res/layout/overview_info_layout.xml
@@ -240,7 +240,7 @@
             android:layout_marginTop="-10dp"
             android:gravity="center_vertical"
             android:text="(-5)"
-            android:textSize="20sp"
+            android:textSize="19sp"
             android:textStyle="bold"
             tools:ignore="HardcodedText" />
 


### PR DESCRIPTION
When running the nightscout client, the time is shown, this was too big and made part of the UI unusable
With the PR the font size is made smaller.

![image](https://user-images.githubusercontent.com/6724749/158032170-8dfa5da9-4d9d-4df3-9cda-ab072845b102.png)

Fixes #1308

