### PR TITLE
Fix: dialog alert crash

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -115,6 +115,7 @@
     <style name="DialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
         <item name="buttonBarNegativeButtonStyle">@style/DialogOkCancelButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/DialogOkCancelButtonStyle</item>
+        <item name="dialogTitleBackground">@color/dialog_title_background</item>
         <item name="buttonBarNeutralButtonStyle">@style/DialogOkCancelButtonStyle</item>
     </style>
 


### PR DESCRIPTION
Looks like the crashes in the dialog are caused by a missing style
https://console.firebase.google.com/project/androidaps-c34f8/crashlytics/app/android:info.nightscout.androidaps/issues/da332ca14cfb0c1bd61b1cb699b1435a?time=last-seven-days&versions=3.0.0.1-dev-f%20(1500)&sessionEventKey=623011CA023400010995FE565650560F_1653620440511928382

