### PR TITLE
Feat: wear split carbs and extended carbs action

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -607,6 +607,10 @@
         <activity
             android:name=".interaction.actions.ECarbActivity"
             android:exported="true"
+            android:label="@string/action_ecarbs" />
+        <activity
+            android:name=".interaction.actions.CarbActivity"
+            android:exported="true"
             android:label="@string/action_carbs" />
         <activity
             android:name=".interaction.actions.TempTargetActivity"

--- a/wear/src/main/java/info/nightscout/androidaps/interaction/actions/CarbActivity.java
+++ b/wear/src/main/java/info/nightscout/androidaps/interaction/actions/CarbActivity.java
@@ -1,0 +1,92 @@
+package info.nightscout.androidaps.interaction.actions;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.wearable.view.GridPagerAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import java.text.DecimalFormat;
+
+import info.nightscout.androidaps.R;
+import info.nightscout.androidaps.data.ListenerService;
+import info.nightscout.androidaps.interaction.utils.PlusMinusEditText;
+import info.nightscout.shared.SafeParse;
+
+public class CarbActivity extends ViewSelectorActivity {
+
+    PlusMinusEditText editCarbs;
+    int maxCarbs;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setAdapter(new MyGridViewPagerAdapter());
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+        maxCarbs = sp.getInt(getString(R.string.key_treatmentssafety_maxcarbs), 48);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        finish();
+    }
+
+    private class MyGridViewPagerAdapter extends GridPagerAdapter {
+        @Override
+        public int getColumnCount(int arg0) {
+            return 2;
+        }
+
+        @Override
+        public int getRowCount() {
+            return 1;
+        }
+
+        @Override
+        public Object instantiateItem(ViewGroup container, int row, int col) {
+
+            if (col == 0) {
+                final View view = getInflatedPlusMinusView(container);
+                double def = 0;
+                if (editCarbs != null) {
+                    def = SafeParse.stringToDouble(editCarbs.editText.getText().toString());
+                }
+                editCarbs = new PlusMinusEditText(view, R.id.amountfield, R.id.plusbutton, R.id.minusbutton, def, 0d, (double)maxCarbs, 1d, new DecimalFormat("0"), true);
+                setLabelToPlusMinusView(view, getString(R.string.action_carbs));
+                container.addView(view);
+                view.requestFocus();
+                return view;
+            } else {
+                final View view = LayoutInflater.from(getApplicationContext()).inflate(R.layout.action_send_item, container, false);
+                final ImageView confirmbutton = view.findViewById(R.id.confirmbutton);
+                confirmbutton.setOnClickListener((View v) -> {
+                    // With start time 0 and duration 0
+                    String actionstring = "ecarbs " + SafeParse.stringToInt(editCarbs.editText.getText().toString()) + " 0 0";
+                    ListenerService.initiateAction(CarbActivity.this, actionstring);
+                    confirmAction(CarbActivity.this, R.string.action_ecarb_confirmation);
+                    finishAffinity();
+
+                });
+                container.addView(view);
+                return view;
+            }
+        }
+
+        @Override
+        public void destroyItem(ViewGroup container, int row, int col, Object view) {
+            // Handle this to get the data before the view is destroyed?
+            // Object should still be kept by this, just setup for reinit?
+            container.removeView((View) view);
+        }
+
+        @Override
+        public boolean isViewFromObject(View view, Object object) {
+            return view == object;
+        }
+
+    }
+}

--- a/wear/src/main/java/info/nightscout/androidaps/tile/ActionSource.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/tile/ActionSource.kt
@@ -2,11 +2,7 @@ package info.nightscout.androidaps.tile
 
 import android.content.res.Resources
 import info.nightscout.androidaps.R
-import info.nightscout.androidaps.interaction.actions.BolusActivity
-import info.nightscout.androidaps.interaction.actions.TreatmentActivity
-import info.nightscout.androidaps.interaction.actions.ECarbActivity
-import info.nightscout.androidaps.interaction.actions.TempTargetActivity
-import info.nightscout.androidaps.interaction.actions.WizardActivity
+import info.nightscout.androidaps.interaction.actions.*
 
 object ActionSource : StaticTileSource() {
 
@@ -36,6 +32,12 @@ object ActionSource : StaticTileSource() {
                 settingName = "carbs",
                 buttonText = resources.getString(R.string.action_carbs),
                 iconRes = R.drawable.ic_carbs_orange,
+                activityClass = CarbActivity::class.java.name,
+            ),
+            StaticAction(
+                settingName = "ecarbs",
+                buttonText = resources.getString(R.string.action_ecarbs),
+                iconRes = R.drawable.ic_carbs_orange,
                 activityClass = ECarbActivity::class.java.name,
             ),
             StaticAction(
@@ -55,7 +57,7 @@ object ActionSource : StaticTileSource() {
         return mapOf(
             "tile_action_1" to "wizard",
             "tile_action_2" to "treatment",
-            "tile_action_3" to "carbs",
+            "tile_action_3" to "ecarbs",
             "tile_action_4" to "temp_target"
         )
     }

--- a/wear/src/main/res/values/arrays.xml
+++ b/wear/src/main/res/values/arrays.xml
@@ -83,6 +83,7 @@
         <item>@string/menu_wizard</item>
         <item>@string/menu_treatment</item>
         <item>@string/menu_bolus</item>
+        <item>@string/menu_carb</item>
         <item>@string/menu_ecarb</item>
         <item>@string/menu_tempt</item>
         <item>@string/tile_none</item>
@@ -93,6 +94,7 @@
         <item>treatment</item>
         <item>bolus</item>
         <item>carbs</item>
+        <item>ecarbs</item>
         <item>temp_target</item>
         <item>none</item>
     </string-array>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -79,7 +79,8 @@
     <string name="menu_treatment">Treatment</string>
     <string name="menu_treatment_short">Treat</string>
     <string name="menu_bolus">Bolus</string>
-    <string name="menu_ecarb">Carbs</string>
+    <string name="menu_carb">Carbs</string>
+    <string name="menu_ecarb">eCarbs</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_status">Status</string>
     <string name="menu_resync">Re-Sync</string>
@@ -102,6 +103,7 @@
     <string name="action_low" comment="In temp target menu, lower value from range">Low</string>
     <string name="action_high" comment="In temp target menu, higher value from range">High</string>
     <string name="action_carbs">Carbs</string>
+    <string name="action_ecarbs">eCarbs</string>
     <string name="action_percentage">Percentage</string>
     <string name="action_start_min">Start [min]</string>
     <string name="action_duration_h">Duration [h]</string>


### PR DESCRIPTION
On the watch app it is possible to enter extended carbs, this has 3 inputs (carbs, start, duration), for most persons it would be sufficient to have just to enter the carbs. Just for the tiles, we keep eCarbs and add simplified Carbs action. Now the users can decide to use `Carbs` or `eCarbs` on `(AAPS) Action` Tile. The default on the Wear OS Menu (on click of watch face) will stay eCarbs