### PR TITLE
Fix protection default timeout

### DIFF
--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -87,9 +87,9 @@
                 android:key="@string/key_protection_timeout"
                 android:title="@string/protection_timeout_title"
                 android:summary="@string/protection_timeout_summary"
-                app:defaultValue="0"
+                app:defaultValue="1"
                 validate:maxNumber="180"
-                validate:minNumber="0"
+                validate:minNumber="1"
                 validate:testType="numeric" />
 
         </PreferenceCategory>

--- a/core/src/main/java/info/nightscout/androidaps/utils/protection/ProtectionCheck.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/protection/ProtectionCheck.kt
@@ -16,7 +16,6 @@ class ProtectionCheck @Inject constructor(
 ) {
 
     private var lastAuthorization = mutableListOf(0L, 0L, 0L)
-    private val timeout = TimeUnit.SECONDS.toMillis(sp.getInt(R.string.key_protection_timeout, 0).toLong())
 
     enum class Protection {
         PREFERENCES,
@@ -75,6 +74,9 @@ class ProtectionCheck @Inject constructor(
     }
 
     private fun activeSession(protection: Protection): Boolean {
+        var timeout = TimeUnit.SECONDS.toMillis(sp.getInt(R.string.key_protection_timeout, 0).toLong())
+        // Default timeout to pass the resume check at start of an activity
+        timeout = if (timeout < 1000) 1000 else timeout
         val last = lastAuthorization[protection.ordinal]
         val diff = dateUtil.now() - last
         return diff < timeout


### PR DESCRIPTION
- Default 1 second to pass the resume check at the start of an activity, to prevent asking two times
- Support protection timeout changes without restarting the app