### PR TITLE
Tidepool Plug-in back on.

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/di/PluginsModule.kt
+++ b/app/src/main/java/info/nightscout/androidaps/di/PluginsModule.kt
@@ -35,6 +35,7 @@ import info.nightscout.androidaps.plugins.general.smsCommunicator.SmsCommunicato
 import info.nightscout.androidaps.plugins.general.themes.ThemeSwitcherPlugin
 import info.nightscout.androidaps.plugins.general.wear.WearPlugin
 import info.nightscout.androidaps.plugins.general.xdripStatusline.StatusLinePlugin
+import info.nightscout.androidaps.plugins.general.tidepool.TidepoolPlugin
 import info.nightscout.androidaps.plugins.insulin.InsulinLyumjevPlugin
 import info.nightscout.androidaps.plugins.insulin.InsulinOrefFreePeakPlugin
 import info.nightscout.androidaps.plugins.insulin.InsulinOrefRapidActingPlugin
@@ -393,6 +394,12 @@ abstract class PluginsModule {
     @IntoMap
     @IntKey(500)
     abstract fun bindThemeSwitcherPlugin(plugin: ThemeSwitcherPlugin): PluginBase
+
+    @Binds
+    @NotNSClient
+    @IntoMap
+    @IntKey(510)
+    abstract fun bindTidepoolPlugin(plugin: TidepoolPlugin): PluginBase
 
     @Qualifier
     annotation class AllConfigs

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/comm/TidepoolUploader.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/comm/TidepoolUploader.kt
@@ -48,7 +48,7 @@ class TidepoolUploader @Inject constructor(
         private const val INTEGRATION_BASE_URL = "https://int-api.tidepool.org"
         private const val PRODUCTION_BASE_URL = "https://api.tidepool.org"
         internal const val VERSION = "0.0.1"
-        const val PUMP_TYPE = "Tandem"
+        const val PUMP_TYPE = "Insulet"
     }
 
     private var retrofit: Retrofit? = null

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/comm/UploadChunk.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/comm/UploadChunk.kt
@@ -112,7 +112,7 @@ class UploadChunk @Inject constructor(
         val result = LinkedList<BaseElement>()
         repository.getBolusesDataFromTimeToTime(start, end, true)
             .blockingGet()
-            .forEach { bolus ->
+            .forEach {  bolus ->
                 result.add(BolusElement(bolus, dateUtil))
             }
         repository.getCarbsDataFromTimeToTimeExpanded(start, end, true)
@@ -144,7 +144,7 @@ class UploadChunk @Inject constructor(
     private fun fromTemporaryBasals(tbrList: List<TemporaryBasal>, start: Long, end: Long): List<BasalElement> {
         val results = LinkedList<BasalElement>()
         for (tbr in tbrList) {
-            if (tbr.timestamp in start..end)
+            if (tbr.timestamp in start..end && !tbr.isInProgress)
                 profileFunction.getProfile(tbr.timestamp)?.let {
                     results.add(BasalElement(tbr, it, dateUtil))
                 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/elements/BasalElement.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/tidepool/elements/BasalElement.kt
@@ -30,10 +30,14 @@ class BasalElement(tbr: TemporaryBasal, private val profile: Profile, dateUtil: 
     @Expose
     internal var conversionOffset: Long = 0
 
+    @Expose
+    internal var InProgress: Boolean = false
+
     init {
         type = "basal"
         timestamp = tbr.timestamp
         rate = tbr.convertedToAbsolute(tbr.timestamp, profile)
         duration = tbr.duration
+        InProgress = tbr.isInProgress
     }
 }

--- a/app/src/main/res/xml/pref_tidepool.xml
+++ b/app/src/main/res/xml/pref_tidepool.xml
@@ -51,7 +51,7 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
-            android:enabled="false"
+            android:enabled="true"
             android:key="@string/key_tidepool_dev_servers"
             android:summary="@string/summary_tidepool_dev_servers"
             android:title="@string/title_tidepool_dev_servers" />


### PR DESCRIPTION
Compared to the original version of the plugin, the main change is only uploaded finished TBR to avoid overlapping Temp basals in the Tidepool website. 
One recommendation is only to activate and upload once a day. (Simulate the Tidepool uploader behavior of one dump of data instead of continuous stream information)