### PR TITLE
fix: number picker - + icons

### DIFF
--- a/app/src/main/res/layout/number_picker_layout_vertical.xml
+++ b/app/src/main/res/layout/number_picker_layout_vertical.xml
@@ -6,14 +6,12 @@
     android:background="@drawable/background_total"
     android:orientation="vertical">
 
-    <Button
+    <ImageButton
         android:id="@+id/increment"
         android:layout_width="match_parent"
         android:layout_height="30dp"
         android:background="@color/transparent"
-        android:padding="0dp"
-        android:text="+"
-        android:textSize="20sp" />
+        android:src="@drawable/ic_minus" />
 
     <EditText
         android:id="@+id/display"
@@ -24,15 +22,13 @@
         android:imeOptions="actionDone"
         android:inputType="number"
         android:textColor="?attr/numPickerText"
-        android:text="1" />
+        tools:text="1" />
 
-    <Button
+    <ImageButton
         android:id="@+id/decrement"
         android:layout_width="match_parent"
         android:layout_height="30dp"
         android:background="@color/transparent"
-        android:padding="0dp"
-        android:text="—"
-        android:textStyle="bold" />
+        android:src="@drawable/ic_plus" />
 
 </LinearLayout>

--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPicker.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPicker.kt
@@ -20,6 +20,7 @@ import android.view.accessibility.AccessibilityManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.LinearLayout
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.utils.ToastUtils
@@ -39,8 +40,8 @@ open class NumberPicker(context: Context, attrs: AttributeSet? = null) : LinearL
     }
 
     var editText: EditText? = null
-    private var minusButton: Button? = null
-    private var plusButton: Button? = null
+    private var minusButton: ImageButton? = null
+    private var plusButton: ImageButton? = null
     var currentValue = 0.0
     var minValue = 0.0
     var maxValue = 1.0

--- a/core/src/main/res/drawable/ic_minus.xml
+++ b/core/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M 19 13 h -14 v -2 h 14 V 13 z" />
+</vector>

--- a/core/src/main/res/drawable/ic_plus.xml
+++ b/core/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/core/src/main/res/layout/number_picker_layout.xml
+++ b/core/src/main/res/layout/number_picker_layout.xml
@@ -3,40 +3,32 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="130dp"
     android:layout_height="40dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="horizontal"
-    android:background="@drawable/background_total">
+    android:background="@drawable/background_total"
+    android:orientation="horizontal">
 
-    <Button
+    <ImageButton
         android:id="@+id/decrement"
         android:layout_width="30dp"
         android:layout_height="match_parent"
-        android:padding="0dp"
-        android:background="@android:color/transparent"
-        app:backgroundTint="@android:color/transparent"
-        android:textStyle="bold"
-        android:text="-"
-        tools:ignore="HardcodedText" />
+        android:background="@color/transparent"
+        android:src="@drawable/ic_minus" />
 
     <EditText
         android:id="@+id/display"
         android:layout_width="70dp"
-        android:background="@drawable/border_gray"
         android:layout_height="match_parent"
-        android:text="1"
-        android:inputType="number"
+        android:background="@drawable/border_gray"
         android:gravity="center"
         android:imeOptions="actionDone"
+        android:inputType="number"
         android:textColor="?attr/numPickerText"
-        tools:ignore="HardcodedText" />
-    <Button
+        tools:text="1" />
+
+    <ImageButton
         android:id="@+id/increment"
         android:layout_width="30dp"
         android:layout_height="match_parent"
-        android:padding="0dp"
-        android:textSize="25sp"
-        android:background="@android:color/transparent"
-        app:backgroundTint="@android:color/transparent"
-        android:text="+"
-        tools:ignore="HardcodedText" />
+        android:background="@color/transparent"
+        android:src="@drawable/ic_plus" />
+
 </LinearLayout>


### PR DESCRIPTION
The number picker + and - the text does not well align described in #1425 

The buttons are replaced with Image Buttons with vector images

![image](https://user-images.githubusercontent.com/6724749/159238864-63f2789d-b087-4aee-ae9e-c62d40286a10.png)

