### PR TITLE
set darkmode background

### DIFF
--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -103,14 +103,16 @@
         <item name="boxStrokeColor">@color/white</item>
         <!---Profile Helper  -->
         <item name="tabBgColorSelected">@color/tabBgColorSelected</item>
-        <!---Splash Background  -->
-        <item name="splashBackgroundColor">@color/splashBackground</item>
         <!---Dialog Helper  -->
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="alertDialogTheme">@style/DialogTheme</item>
         <!---Disabled Text Color  -->
         <item name="disabledTextColor">@color/sandGray</item>
+        <!---Splash Background  -->
+        <item name="splashBackgroundColor">@color/splashBackground</item>
+        <!---Application Background Color  -->
+        <item name="android:windowBackground">@color/black</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -102,14 +102,16 @@
         <item name="boxStrokeColor">@color/white</item>
         <!---Profile Helper  -->
         <item name="tabBgColorSelected">@color/tabBgColorSelected</item>
-        <!---Splash Background  -->
-        <item name="splashBackgroundColor">@color/splashBackground</item>
         <!---Dialog Helper  -->
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="alertDialogTheme">@style/DialogTheme</item>
         <!---Disabled Text Color  -->
         <item name="disabledTextColor">@color/sandGray</item>
+        <!---Splash Background  -->
+        <item name="splashBackgroundColor">@color/splashBackground</item>
+        <!---Application Background Color  -->
+        <item name="android:windowBackground">@color/white</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>


### PR DESCRIPTION
Background in darkmode is set to real black . 

TODO: Set the dialogs background color , eg. Carbs Dialog , Wizard dialog, Insulin dialog , progress dialog etc.
            I make a proposal in the next days. 

@MilosKozak : The dialogs in the future , with or without rounded dialogs ? 
                         Latest in material 3 rounded dialogs are standard. I can make a proposal too. 

This will fix: https://github.com/nightscout/AndroidAPS/issues/1483