### PR TITLE
Theme switcher preparation: gac for overview and historybrowser

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
@@ -196,7 +196,7 @@ class HistoryBrowseActivity : NoSplashAppCompatActivity() {
 
 
         axisWidth = if (dm.densityDpi <= 120) 3 else if (dm.densityDpi <= 160) 10 else if (dm.densityDpi <= 320) 35 else if (dm.densityDpi <= 420) 50 else if (dm.densityDpi <= 560) 70 else 80
-        binding.bgGraph.gridLabelRenderer?.gridColor = rh.gc(R.color.graphgrid)
+        binding.bgGraph.gridLabelRenderer?.gridColor = rh.gac(this,  R.attr.graphgrid)
         binding.bgGraph.gridLabelRenderer?.reloadStyles()
         binding.bgGraph.gridLabelRenderer?.labelVerticalWidth = axisWidth
 
@@ -280,12 +280,12 @@ class HistoryBrowseActivity : NoSplashAppCompatActivity() {
 
                 val graph = GraphView(this)
                 graph.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, rh.dpToPx(100)).also { it.setMargins(0, rh.dpToPx(15), 0, rh.dpToPx(10)) }
-                graph.gridLabelRenderer?.gridColor = rh.gc(R.color.graphgrid)
+                graph.gridLabelRenderer?.gridColor = rh.gac( R.attr.graphgrid)
                 graph.gridLabelRenderer?.reloadStyles()
                 graph.gridLabelRenderer?.isHorizontalLabelsVisible = false
                 graph.gridLabelRenderer?.labelVerticalWidth = axisWidth
                 graph.gridLabelRenderer?.numVerticalLabels = 3
-                graph.viewport.backgroundColor = Color.argb(20, 255, 255, 255) // 8% of gray
+                graph.viewport.backgroundColor =rh.gac(this , R.attr.viewPortbackgroundColor)
                 relativeLayout.addView(graph)
 
                 val label = TextView(this)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview
 
+import android.content.Context
 import android.graphics.DashPathEffect
 import android.graphics.Paint
 import com.jjoe64.graphview.series.BarGraphSeries
@@ -138,12 +139,13 @@ class OverviewData @Inject constructor(
             lastBg.valueToUnits(profileFunction.getUnits()) > defaultValueHelper.determineHighLine()
         } ?: false
 
-    val lastBgColor: Int
-        get() = when {
-            isLow  -> rh.gc(R.color.low)
-            isHigh -> rh.gc(R.color.high)
-            else   -> rh.gc(R.color.inrange)
+    fun lastBgColor(context: Context?): Int {
+        return when {
+            isLow  -> rh.gac(context, R.attr.bgLow)
+            isHigh -> rh.gac(context, R.attr.bgHigh)
+            else   -> rh.gac(context, R.attr.bgInRange)
         }
+    }
 
     val lastBgDescription: String
         get() = when {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -173,7 +173,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         binding.notifications.setHasFixedSize(false)
         binding.notifications.layoutManager = LinearLayoutManager(view.context)
         axisWidth = if (dm.densityDpi <= 120) 3 else if (dm.densityDpi <= 160) 10 else if (dm.densityDpi <= 320) 35 else if (dm.densityDpi <= 420) 50 else if (dm.densityDpi <= 560) 70 else 80
-        binding.graphsLayout.bgGraph.gridLabelRenderer?.gridColor = rh.gc(R.color.graphgrid)
+        binding.graphsLayout.bgGraph.gridLabelRenderer?.gridColor = rh.gac(context , R.attr.graphgrid)
         binding.graphsLayout.bgGraph.gridLabelRenderer?.reloadStyles()
         binding.graphsLayout.bgGraph.gridLabelRenderer?.labelVerticalWidth = axisWidth
         binding.graphsLayout.bgGraph.layoutParams?.height = rh.dpToPx(skinProvider.activeSkin().mainGraphHeight)
@@ -559,10 +559,10 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         binding.buttonsLayout.calibrationButton.visibility = (xDripIsBgSource && actualBG != null && sp.getBoolean(R.string.key_show_calibration_button, true)).toVisibility()
         if (dexcomIsSource) {
             binding.buttonsLayout.cgmButton.setCompoundDrawablesWithIntrinsicBounds(null, rh.gd(R.drawable.ic_byoda), null, null)
-            binding.buttonsLayout.cgmButton.setTextColor(rh.gc(R.color.colorLightGray))
+            binding.buttonsLayout.cgmButton.setTextColor(rh.gac(context, R.attr.cgmdexColor))
         } else if (xDripIsBgSource) {
             binding.buttonsLayout.cgmButton.setCompoundDrawablesWithIntrinsicBounds(null, rh.gd(R.drawable.ic_xdrip), null, null)
-            binding.buttonsLayout.cgmButton.setTextColor(rh.gc(R.color.colorCalibrationButton))
+            binding.buttonsLayout.cgmButton.setTextColor(rh.gac(context, R.attr.cgmxdripColor))
         }
         binding.buttonsLayout.cgmButton.visibility = (sp.getBoolean(R.string.key_show_cgm_button, false) && (xDripIsBgSource || dexcomIsSource)).toVisibility()
 
@@ -574,7 +574,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 if (event.isEnabled && event.trigger.shouldRun())
                     context?.let { context ->
                         SingleClickButton(context).also {
-                            it.setTextColor(rh.gc(R.color.colorTreatmentButton))
+                            it.setTextColor(rh.gac(context, R.attr.treatmentButton))
                             it.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10f)
                             it.layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0.5f).also { l ->
                                 l.setMargins(0, 0, rh.dpToPx(-4), 0)
@@ -722,12 +722,12 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 val graph = GraphView(context)
                 graph.layoutParams =
                     LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, rh.dpToPx(skinProvider.activeSkin().secondaryGraphHeight)).also { it.setMargins(0, rh.dpToPx(15), 0, rh.dpToPx(10)) }
-                graph.gridLabelRenderer?.gridColor = rh.gc(R.color.graphgrid)
+                graph.gridLabelRenderer?.gridColor = rh.gac(context , R.attr.graphgrid)
                 graph.gridLabelRenderer?.reloadStyles()
                 graph.gridLabelRenderer?.isHorizontalLabelsVisible = false
                 graph.gridLabelRenderer?.labelVerticalWidth = axisWidth
                 graph.gridLabelRenderer?.numVerticalLabels = 3
-                graph.viewport.backgroundColor = Color.argb(20, 255, 255, 255) // 8% of gray
+                graph.viewport.backgroundColor = rh.gac(context , R.attr.viewPortbackgroundColor)
                 relativeLayout.addView(graph)
 
                 val label = TextView(context)
@@ -765,15 +765,15 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         val units = profileFunction.getUnits()
         binding.infoLayout.bg.text = overviewData.lastBg?.valueToUnitsString(units)
             ?: rh.gs(R.string.notavailable)
-        binding.infoLayout.bg.setTextColor(overviewData.lastBgColor)
+        binding.infoLayout.bg.setTextColor(overviewData.lastBgColor(context))
         binding.infoLayout.arrow.setImageResource(trendCalculator.getTrendArrow(overviewData.lastBg).directionToIcon())
-        binding.infoLayout.arrow.setColorFilter(overviewData.lastBgColor)
+        binding.infoLayout.arrow.setColorFilter(overviewData.lastBgColor(context))
         binding.infoLayout.arrow.contentDescription = overviewData.lastBgDescription + " " + rh.gs(R.string.and) + " " + trendCalculator.getTrendDescription(overviewData.lastBg)
 
         val glucoseStatus = glucoseStatusProvider.glucoseStatusData
         if (glucoseStatus != null) {
             binding.infoLayout.deltaLarge.text = Profile.toSignedUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units)
-            binding.infoLayout.deltaLarge.setTextColor(overviewData.lastBgColor)
+            binding.infoLayout.deltaLarge.setTextColor(overviewData.lastBgColor(context))
             binding.infoLayout.delta.text = Profile.toSignedUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units)
             binding.infoLayout.avgDelta.text = Profile.toSignedUnitsString(glucoseStatus.shortAvgDelta, glucoseStatus.shortAvgDelta * Constants.MGDL_TO_MMOLL, units)
             binding.infoLayout.longAvgDelta.text = Profile.toSignedUnitsString(glucoseStatus.longAvgDelta, glucoseStatus.longAvgDelta * Constants.MGDL_TO_MMOLL, units)
@@ -816,27 +816,27 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             profileFunction.getProfile()?.let {
                 if (it is ProfileSealed.EPS) {
                     if (it.value.originalPercentage != 100 || it.value.originalTimeshift != 0L || it.value.originalDuration != 0L)
-                        rh.gc(R.color.ribbonWarning)
-                    else rh.gc(R.color.ribbonDefault)
+                        rh.gac(context, R.attr.ribbonWarningColor)
+                    else   rh.gac(context, R.attr.ribbonDefaultColor)
                 } else if (it is ProfileSealed.PS) {
-                    rh.gc(R.color.ribbonDefault)
+                    rh.gac(context, R.attr.ribbonDefaultColor)
                 } else {
-                    rh.gc(R.color.ribbonDefault)
+                    rh.gac(context, R.attr.ribbonDefaultColor)
                 }
-            } ?: rh.gc(R.color.ribbonCritical)
+            } ?:  rh.gac(context, R.attr.ribbonCriticalColor)
 
         val profileTextColor =
             profileFunction.getProfile()?.let {
                 if (it is ProfileSealed.EPS) {
                     if (it.value.originalPercentage != 100 || it.value.originalTimeshift != 0L || it.value.originalDuration != 0L)
-                        rh.gc(R.color.ribbonTextWarning)
-                    else rh.gc(R.color.ribbonTextDefault)
+                        rh.gac(context, R.attr.ribbonTextWarningColor)
+                    else rh.gac(context, R.attr.ribbonTextDefaultColor)
                 } else if (it is ProfileSealed.PS) {
-                    rh.gc(R.color.ribbonTextDefault)
+                    rh.gac(context, R.attr.ribbonTextDefaultColor)
                 } else {
-                    rh.gc(R.color.ribbonTextDefault)
+                    rh.gac(context, R.attr.ribbonTextDefaultColor)
                 }
-            } ?: rh.gc(R.color.ribbonTextDefault)
+            } ?:  rh.gac(context, R.attr.ribbonTextDefaultColor)
 
         binding.activeProfile.text = profileFunction.getProfileNameWithRemainingTime()
         binding.activeProfile.setBackgroundColor(profileBackgroundColor)
@@ -929,8 +929,8 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         if (overviewData.temporaryTarget?.isInProgress(dateUtil) == false) overviewData.temporaryTarget = null
         val tempTarget = overviewData.temporaryTarget
         if (tempTarget != null) {
-            binding.tempTarget.setTextColor(rh.gc(R.color.ribbonTextWarning))
-            binding.tempTarget.setBackgroundColor(rh.gc(R.color.ribbonWarning))
+            binding.tempTarget.setTextColor(rh.gac(context, R.attr.ribbonTextWarningColor))
+            binding.tempTarget.setBackgroundColor(rh.gac(context, R.attr.ribbonWarningColor))
             binding.tempTarget.text = Profile.toTargetRangeString(tempTarget.lowTarget, tempTarget.highTarget, GlucoseUnit.MGDL, units) + " " + dateUtil.untilString(tempTarget.end, rh)
         } else {
             // If the target is not the same as set in the profile then oref has overridden it
@@ -940,11 +940,11 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 if (targetUsed != 0.0 && abs(profile.getTargetMgdl() - targetUsed) > 0.01) {
                     aapsLogger.debug("Adjusted target. Profile: ${profile.getTargetMgdl()} APS: $targetUsed")
                     binding.tempTarget.text = Profile.toTargetRangeString(targetUsed, targetUsed, GlucoseUnit.MGDL, units)
-                    binding.tempTarget.setTextColor(rh.gc(R.color.ribbonTextWarning))
-                    binding.tempTarget.setBackgroundColor(rh.gc(R.color.tempTargetBackground))
+                    binding.tempTarget.setTextColor(rh.gac(context, R.attr.ribbonTextWarningColor))
+                    binding.tempTarget.setBackgroundColor(rh.gac(context, R.attr.tempTargetBackgroundColor))
                 } else {
-                    binding.tempTarget.setTextColor(rh.gc(R.color.ribbonTextDefault))
-                    binding.tempTarget.setBackgroundColor(rh.gc(R.color.ribbonDefault))
+                    binding.tempTarget.setTextColor(rh.gac(context, R.attr.ribbonTextDefaultColor))
+                    binding.tempTarget.setBackgroundColor(rh.gac(context, R.attr.ribbonDefaultColor))
                     binding.tempTarget.text = Profile.toTargetRangeString(profile.getTargetLowMgdl(), profile.getTargetHighMgdl(), GlucoseUnit.MGDL, units)
                 }
             }

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelper.kt
@@ -32,5 +32,5 @@ interface ResourceHelper {
     /**
      * Get Attribute Color based on theme style for specified context
      */
-    @ColorInt fun gac(context: Context, @AttrRes attributeId: Int): Int
+    @ColorInt fun gac(context: Context?, @AttrRes attributeId: Int): Int
 }

--- a/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/resources/ResourceHelperImplementation.kt
@@ -85,8 +85,8 @@ class ResourceHelperImplementation @Inject constructor(private val context: Cont
 
     override fun shortTextMode(): Boolean = !gb(R.bool.isTablet)
 
-    override fun gac(context: Context, attributeId: Int): Int =
-        context.getThemeColor(attributeId)
+    override fun gac(context: Context?, attributeId: Int): Int =
+        (context ?: ContextThemeWrapper(this.context, R.style.AppTheme)).getThemeColor(attributeId)
 
     override fun gac(attributeId: Int): Int =
         ContextThemeWrapper(this.context, R.style.AppTheme).getThemeColor(attributeId)

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -92,6 +92,10 @@
         <item name="activity_title_backgroundColor">@color/activity_title_background</item>
         <!---Automation  -->
         <item name="ribbonDefaultColor">@color/ribbonDefault</item>
+        <item name="ribbonWarningColor">@color/ribbonWarning</item>
+        <item name="ribbonCriticalColor">@color/ribbonCritical</item>
+        <item name="ribbonTextDefaultColor">@color/ribbonTextDefault</item>
+        <item name="ribbonTextWarningColor">@color/ribbonTextWarning</item>
         <!---Main Activity Tab  -->
         <item name="tabSelectedTextColor">@color/tabSelectedText</item>
         <item name="tabTextColor">@color/tabText</item>
@@ -115,6 +119,17 @@
         <item name="android:windowBackground">@color/black</item>
         <!---Dialogfragment Background Color  -->
         <item name="android:dialogCornerRadius">12dp</item>
+        <!---Overview and Historybrowser  -->
+        <item name="graphgrid">@color/graphgrid</item>
+        <item name="viewPortbackgroundColor">@color/white_alpha_20</item>
+        <item name="tempTargetBackgroundColor">@color/tempTargetBackground</item>
+        <!---CGM source-->
+        <item name="cgmdexColor">@color/colorLightGray</item>
+        <item name="cgmxdripColor">@color/colorCalibrationButton</item>
+        <!---BG color-->
+        <item name="bgLow">@color/low</item>
+        <item name="bgHigh">@color/high</item>
+        <item name="bgInRange">@color/inrange</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -60,6 +60,10 @@
     <attr name="activity_title_backgroundColor" format="reference|color" />
     <!---Automation  -->
     <attr name="ribbonDefaultColor" format="reference|color" />
+    <attr name="ribbonWarningColor" format="reference|color" />
+    <attr name="ribbonCriticalColor" format="reference|color" />
+    <attr name="ribbonTextDefaultColor" format="reference|color" />
+    <attr name="ribbonTextWarningColor" format="reference|color" />
     <!---Main Activity Tab  -->
     <attr name="tabSelectedTextColor" format="reference|color" />
     <attr name="tabTextColor" format="reference|color" />
@@ -86,5 +90,15 @@
     <attr name="splashBackgroundColor" format="reference|color" />
     <!---Disabled Text Color  -->
     <attr name="disabledTextColor" format="reference|color" />
-
+    <!---Overview and Historybrowser  -->
+    <attr name="graphgrid" format="reference|color" />
+    <attr name="viewPortbackgroundColor" format="reference|color" />
+    <attr name="tempTargetBackgroundColor" format="reference|color" />
+    <!---CGM source-->
+    <attr name="cgmdexColor" format="reference|color" />
+    <attr name="cgmxdripColor" format="reference|color" />
+    <!---BG color-->
+    <attr name="bgLow" format="reference|color" />
+    <attr name="bgHigh" format="reference|color" />
+    <attr name="bgInRange" format="reference|color" />
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -150,7 +150,7 @@
 
     <color name="ribbonWarning">#f4d700</color>
     <color name="ribbonCritical">#ff0400</color>
-    <color name="ribbonTextDefault">#FFFFFF</color>
+    <color name="ribbonTextDefault">#000000</color>
     <color name="ribbonTextWarning">#303030</color>
     <color name="tempTargetConfirmation">#77dd77</color>
 

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -91,6 +91,10 @@
         <item name="activity_title_backgroundColor">@color/activity_title_background</item>
         <!---Automation  -->
         <item name="ribbonDefaultColor">@color/ribbonDefault</item>
+        <item name="ribbonWarningColor">@color/ribbonWarning</item>
+        <item name="ribbonCriticalColor">@color/ribbonCritical</item>
+        <item name="ribbonTextDefaultColor">@color/ribbonTextDefault</item>
+        <item name="ribbonTextWarningColor">@color/ribbonTextWarning</item>
         <!---Main Activity Tab  -->
         <item name="tabSelectedTextColor">@color/tabSelectedText</item>
         <item name="tabTextColor">@color/tabText</item>
@@ -114,6 +118,17 @@
         <item name="android:windowBackground">@color/white</item>
         <!---Dialogfragment Background Color  -->
         <item name="android:dialogCornerRadius">12dp</item>
+        <!---Overview and Historybrowser  -->
+        <item name="graphgrid">@color/graphgrid</item>
+        <item name="viewPortbackgroundColor">@color/white_alpha_20</item>
+        <item name="tempTargetBackgroundColor">@color/tempTargetBackground</item>
+        <!---CGM source-->
+        <item name="cgmdexColor">@color/colorLightGray</item>
+        <item name="cgmxdripColor">@color/colorCalibrationButton</item>
+        <!---BG color-->
+        <item name="bgLow">@color/low</item>
+        <item name="bgHigh">@color/high</item>
+        <item name="bgInRange">@color/inrange</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>


### PR DESCRIPTION
Next steps for enabling the themeswitcher for dark and light mode is to change hardcoded colors in
coding with the new gac function.
All colors in fragments and in code shall be set with attributes.

Optical Changes: None . 

Refactoring of code files will be divided in little portions to avoid failures and to simplify the review