### PR TITLE
fix: remove override textColor without state

### DIFF
--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -8,7 +8,7 @@
         <item name="dialogTitleBackground">@color/dialog_title_background</item>
         <item name="dialogTitleColor">@color/dialog_title_color</item>
         <item name="dialogTitleIconTint">@color/dialog_title_icon_tint</item>
-        <!-- New MaterialComponents attributes. -->dialogTitleBackground
+        <!-- New MaterialComponents attributes. -->
         <item name="colorSecondary">@color/secondaryColorDefault</item>
         <item name="colorPrimaryVariant">@color/primaryLightColorDefault</item>
         <item name="colorSecondaryVariant">@color/secondaryLightColorDefault</item>
@@ -19,9 +19,6 @@
         <item name="colorOnBackground">@color/white</item>
         <item name="colorOnError">@color/black</item>
         <item name="scrimBackground">@color/mtrl_scrim_color</item>
-        <item name="android:textColorSecondary">@color/white</item>
-        <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColor">@color/white</item>
         <item name="popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/Widget.MaterialComponents.PopupMenu.Overflow</item>
         <!-- Fragment background for some themes default transparent  -->

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -19,9 +19,6 @@
         <item name="colorOnBackground">@color/white</item>
         <item name="colorOnError">@color/black</item>
         <item name="scrimBackground">@color/white</item>
-        <item name="android:textColorSecondary">@color/black</item>
-        <item name="android:textColorPrimary">@color/black</item>
-        <item name="android:textColor">@color/black</item>
         <item name="popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/Widget.MaterialComponents.PopupMenu.Overflow</item>
         <!---Notification -->

--- a/omnipod-dash/src/main/res/layout/omnipod_dash_pod_management.xml
+++ b/omnipod-dash/src/main/res/layout/omnipod_dash_pod_management.xml
@@ -19,7 +19,6 @@
             android:layout_marginLeft="10dp"
             android:layout_marginTop="20dp"
             android:layout_marginRight="10dp"
-
             android:gravity="center"
             android:text="@string/omnipod_common_pod_management_title"
             android:textAlignment="center"
@@ -35,7 +34,6 @@
             android:text="@string/omnipod_common_pod_management_heading_actions" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-
             android:id="@+id/Actions_Row_1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -49,7 +47,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_activate_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_activate_pod"
@@ -70,7 +67,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_deactivate_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_deactivate_pod"
@@ -99,7 +95,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_play_test_beep"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_play_test_beep"
@@ -111,9 +106,8 @@
                 app:layout_constraintRight_toLeftOf="@+id/Actions_Col_1_Row_2_vertical_guideline"
                 app:layout_constraintTop_toTopOf="parent" />
 
-           <info.nightscout.androidaps.utils.ui.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_pod_history"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_pod_history"
@@ -132,9 +126,8 @@
                 android:orientation="vertical"
                 app:layout_constraintGuide_percent="0.5" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_discard_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_discard_pod"
@@ -148,5 +141,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
+
 </ScrollView>

--- a/omnipod-eros/src/main/res/layout/omnipod_eros_pod_management.xml
+++ b/omnipod-eros/src/main/res/layout/omnipod_eros_pod_management.xml
@@ -19,7 +19,6 @@
             android:layout_marginLeft="10dp"
             android:layout_marginTop="20dp"
             android:layout_marginRight="10dp"
-
             android:gravity="center"
             android:text="@string/omnipod_common_pod_management_title"
             android:textAlignment="center"
@@ -51,6 +50,7 @@
                 android:text="@string/omnipod_eros_pod_management_waiting_for_riley_link_connection"
                 android:textAlignment="center"
                 android:textSize="8pt" />
+
         </LinearLayout>
 
         <TextView
@@ -62,7 +62,6 @@
             android:text="@string/omnipod_common_pod_management_heading_actions" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-
             android:id="@+id/Actions_Row_1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -76,7 +75,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_activate_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_activate_pod"
@@ -97,7 +95,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_deactivate_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_deactivate_pod"
@@ -124,9 +121,8 @@
                 android:orientation="horizontal"
                 app:layout_constraintGuide_percent="0" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_play_test_beep"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_play_test_beep"
@@ -147,7 +143,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_discard_pod"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_discard_pod"
@@ -161,7 +156,6 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
 
         <TextView
             android:layout_width="match_parent"
@@ -186,7 +180,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_reset_rileylink_config"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_activity_reset_rileylink_config"
@@ -207,7 +200,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_pod_history"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_pod_history"
@@ -222,7 +214,6 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-
             android:id="@+id/Tools_Row_2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -236,7 +227,6 @@
 
             <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_rileylink_stats"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_rl_stats"
@@ -255,9 +245,8 @@
                 android:orientation="vertical"
                 app:layout_constraintGuide_percent="0.5" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/button_pulse_log"
-                style="?android:attr/buttonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:drawableTop="@drawable/ic_pod_management_pulse_log"
@@ -270,5 +259,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
+
 </ScrollView>


### PR DESCRIPTION
Text color default from material theme are sufficient.
- Remove styling for text color  without state colors
- Removed superfluous styling on buttons pod management layouts
- Converted AppCompatButton to Single Click in pod management layouts
 
Fixes #1500 
Fixes #1473