### PR TITLE
Theme switcher preparation: gac for carbs extbolus boluswizard profileviewer

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
@@ -234,8 +234,9 @@ class CarbsDialog : DialogFragmentWithDate() {
         if (activitySelected)
             actions.add(
                 rh.gs(R.string.temptargetshort) + ": " + (DecimalFormatter.to1Decimal(activityTT) + " " + unitLabel + " (" + rh.gs(R.string.format_mins, activityTTDuration) + ")").formatColor(
+                    context,
                     rh,
-                    R.color.tempTargetConfirmation
+                    R.attr.tempTargetConfirmation
                 )
             )
         val eatingSoonSelected = binding.eatingSoonTt.isChecked
@@ -244,27 +245,27 @@ class CarbsDialog : DialogFragmentWithDate() {
                 rh.gs(R.string.temptargetshort) + ": " + (DecimalFormatter.to1Decimal(eatingSoonTT) + " " + unitLabel + " (" + rh.gs(
                     R.string.format_mins,
                     eatingSoonTTDuration
-                ) + ")").formatColor(rh, R.color.tempTargetConfirmation)
+                ) + ")").formatColor(context, rh, R.attr.tempTargetConfirmation)
             )
         val hypoSelected = binding.hypoTt.isChecked
         if (hypoSelected)
             actions.add(
-                rh.gs(R.string.temptargetshort) + ": " + (DecimalFormatter.to1Decimal(hypoTT) + " " + unitLabel + " (" + rh.gs(R.string.format_mins, hypoTTDuration) + ")").formatColor(
+                rh.gs(R.string.temptargetshort) + ": " + (DecimalFormatter.to1Decimal(hypoTT) + " " + unitLabel + " (" + rh.gs(R.string.format_mins, hypoTTDuration) + ")").formatColor( context,
                     rh,
-                    R.color.tempTargetConfirmation
+                    R.attr.tempTargetConfirmation
                 )
             )
 
         val timeOffset = binding.time.value.toInt()
         if (useAlarm && carbs > 0 && timeOffset > 0)
-            actions.add(rh.gs(R.string.alarminxmin, timeOffset).formatColor(rh, R.color.info))
+            actions.add(rh.gs(R.string.alarminxmin, timeOffset).formatColor(context , rh, R.attr.infoColor))
         val duration = binding.duration.value.toInt()
         if (duration > 0)
             actions.add(rh.gs(R.string.duration) + ": " + duration + rh.gs(R.string.shorthour))
         if (carbsAfterConstraints > 0) {
-            actions.add(rh.gs(R.string.carbs) + ": " + "<font color='" + rh.gc(R.color.carbs) + "'>" + rh.gs(R.string.format_carbs, carbsAfterConstraints) + "</font>")
+            actions.add(rh.gs(R.string.carbs) + ": " + "<font color='" + rh.gac(context, R.attr.carbsColor) + "'>" + rh.gs(R.string.format_carbs, carbsAfterConstraints) + "</font>")
             if (carbsAfterConstraints != carbs)
-                actions.add("<font color='" + rh.gc(R.color.warning) + "'>" + rh.gs(R.string.carbsconstraintapplied) + "</font>")
+                actions.add("<font color='" + rh.gac(context, R.attr.warningColor) + "'>" + rh.gs(R.string.carbsconstraintapplied) + "</font>")
         }
         val notes = binding.notesLayout.notes.text.toString()
         if (notes.isNotEmpty())

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
@@ -93,7 +93,7 @@ class ExtendedBolusDialog : DialogFragmentWithDate() {
         actions.add(rh.gs(R.string.formatinsulinunits, insulinAfterConstraint))
         actions.add(rh.gs(R.string.duration) + ": " + rh.gs(R.string.format_mins, durationInMinutes))
         if (abs(insulinAfterConstraint - insulin) > 0.01)
-            actions.add(rh.gs(R.string.constraintapllied).formatColor(rh, R.color.warning))
+            actions.add(rh.gs(R.string.constraintapllied).formatColor(context, rh, R.attr.warningColor))
 
         activity?.let { activity ->
             OKDialog.showConfirmation(activity, rh.gs(R.string.extended_bolus), HtmlHelper.fromHtml(Joiner.on("<br/>").join(actions)), {

--- a/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/wizard/BolusWizard.kt
@@ -300,12 +300,12 @@ class BolusWizard @Inject constructor(
         )
     }
 
-    private fun confirmMessageAfterConstraints(advisor: Boolean): Spanned {
+    private fun confirmMessageAfterConstraints(context: Context, advisor: Boolean): Spanned {
 
         val actions: LinkedList<String> = LinkedList()
         if (insulinAfterConstraints > 0) {
             val pct = if (percentageCorrection != 100) " ($percentageCorrection%)" else ""
-            actions.add(rh.gs(R.string.bolus) + ": " + rh.gs(R.string.formatinsulinunits, insulinAfterConstraints).formatColor(rh, R.color.bolus) + pct)
+            actions.add(rh.gs(R.string.bolus) + ": " + rh.gs(R.string.formatinsulinunits, insulinAfterConstraints).formatColor(context, rh, R.attr.bolusColor) + pct)
         }
         if (carbs > 0 && !advisor) {
             var timeShift = ""
@@ -314,24 +314,25 @@ class BolusWizard @Inject constructor(
             } else if (carbTime < 0) {
                 timeShift += " (" + rh.gs(R.string.mins, carbTime) + ")"
             }
-            actions.add(rh.gs(R.string.carbs) + ": " + rh.gs(R.string.format_carbs, carbs).formatColor(rh, R.color.carbs) + timeShift)
+            actions.add(rh.gs(R.string.carbs) + ": " + rh.gs(R.string.format_carbs, carbs).formatColor(context, rh, R.attr.carbsColor) + timeShift)
         }
         if (insulinFromCOB > 0) {
             actions.add(
-                rh.gs(R.string.cobvsiob) + ": " + rh.gs(R.string.formatsignedinsulinunits, insulinFromBolusIOB + insulinFromBasalIOB + insulinFromCOB + insulinFromBG).formatColor(rh, R.color.cobAlert)
+                rh.gs(R.string.cobvsiob) + ": " + rh.gs(R.string.formatsignedinsulinunits, insulinFromBolusIOB + insulinFromBasalIOB + insulinFromCOB + insulinFromBG).formatColor(context, rh, R.attr
+                    .cobAlertColor)
             )
             val absorptionRate = iobCobCalculator.ads.slowAbsorptionPercentage(60)
             if (absorptionRate > .25)
-                actions.add(rh.gs(R.string.slowabsorptiondetected, rh.gc(R.color.cobAlert), (absorptionRate * 100).toInt()))
+                actions.add(rh.gs(R.string.slowabsorptiondetected, rh.gac(context, R.attr.cobAlertColor), (absorptionRate * 100).toInt()))
         }
         if (abs(insulinAfterConstraints - calculatedTotalInsulin) > activePlugin.activePump.pumpDescription.pumpType.determineCorrectBolusStepSize(insulinAfterConstraints))
-            actions.add(rh.gs(R.string.bolusconstraintappliedwarn, calculatedTotalInsulin, insulinAfterConstraints).formatColor(rh, R.color.warning))
+            actions.add(rh.gs(R.string.bolusconstraintappliedwarn, calculatedTotalInsulin, insulinAfterConstraints).formatColor(context, rh, R.attr.warningColor))
         if (config.NSCLIENT && insulinAfterConstraints > 0)
-            actions.add(rh.gs(R.string.bolusrecordedonly).formatColor(rh, R.color.warning))
+            actions.add(rh.gs(R.string.bolusrecordedonly).formatColor(context, rh, R.attr.warningColor))
         if (useAlarm && !advisor && carbs > 0 && carbTime > 0)
-            actions.add(rh.gs(R.string.alarminxmin, carbTime).formatColor(rh, R.color.info))
+            actions.add(rh.gs(R.string.alarminxmin, carbTime).formatColor(context, rh, R.attr.infoColor))
         if (advisor)
-            actions.add(rh.gs(R.string.advisoralarm).formatColor(rh, R.color.info))
+            actions.add(rh.gs(R.string.advisoralarm).formatColor(context, rh, R.attr.infoColor))
 
         return HtmlHelper.fromHtml(Joiner.on("<br/>").join(actions))
     }
@@ -360,7 +361,7 @@ class BolusWizard @Inject constructor(
     }
 
     private fun bolusAdvisorProcessing(ctx: Context) {
-        val confirmMessage = confirmMessageAfterConstraints(advisor = true)
+        val confirmMessage = confirmMessageAfterConstraints(ctx, advisor = true)
         OKDialog.showConfirmation(ctx, rh.gs(R.string.boluswizard), confirmMessage, {
             DetailedBolusInfo().apply {
                 eventType = DetailedBolusInfo.EventType.CORRECTION_BOLUS
@@ -417,7 +418,7 @@ class BolusWizard @Inject constructor(
         val profile = profileFunction.getProfile() ?: return
         val pump = activePlugin.activePump
 
-        val confirmMessage = confirmMessageAfterConstraints(advisor = false)
+        val confirmMessage = confirmMessageAfterConstraints(ctx, advisor = false)
         OKDialog.showConfirmation(ctx, rh.gs(R.string.boluswizard), confirmMessage, {
             if (insulinAfterConstraints > 0 || carbs > 0) {
                 if (useSuperBolus) {

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/ProfileViewerDialog.kt
@@ -206,20 +206,20 @@ class ProfileViewerDialog : DaggerDialogFragment() {
     }
 
     private fun formatColors(label: String, text1: String, text2: String, units: String): String {
-        var s = "<font color='${rh.gc(R.color.white)}'>$label</font>"
+        var s = "<font color='${rh.gac(context, R.attr.defaultTextColor)}'>$label</font>"
         s += "    "
-        s += "<font color='${rh.gc(R.color.tempbasal)}'>$text1</font>"
+        s += "<font color='${rh.gac(context, R.attr.tempBasalColor)}'>$text1</font>"
         s += "    "
-        s += "<font color='${rh.gc(R.color.examinedProfile)}'>$text2</font>"
+        s += "<font color='${rh.gac(context, R.attr.examinedProfileColor)}'>$text2</font>"
         s += "    "
-        s += "<font color='${rh.gc(R.color.white)}'>$units</font>"
+        s += "<font color='${rh.gac(context, R.attr.defaultTextColor)}'>$units</font>"
         return s
     }
 
     private fun formatColors(text1: String, text2: String): String {
-        var s = "<font color='${rh.gc(R.color.tempbasal)}'>$text1</font>"
+        var s = "<font color='${rh.gac(context, R.attr.tempBasalColor)}'>$text1</font>"
         s += "<BR/>"
-        s += "<font color='${rh.gc(R.color.examinedProfile)}'>$text2</font>"
+        s += "<font color='${rh.gac(context, R.attr.examinedProfileColor)}'>$text2</font>"
         return s
     }
 

--- a/core/src/main/java/info/nightscout/androidaps/extensions/HtmlString.kt
+++ b/core/src/main/java/info/nightscout/androidaps/extensions/HtmlString.kt
@@ -1,5 +1,7 @@
 package info.nightscout.androidaps.extensions
 
+import android.content.Context
+import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import info.nightscout.androidaps.utils.resources.ResourceHelper
 
@@ -8,4 +10,7 @@ fun String.formatBold(): String =
 
 fun String.formatColor(rh: ResourceHelper, @ColorRes colorId: Int): String =
     "<font color='" + rh.gc(colorId) + "'>" + this + "</font>"
+
+fun String.formatColor(context: Context?, rh: ResourceHelper, @AttrRes attributeId: Int): String =
+    "<font color='" + rh.gac(context, attributeId) + "'>" + this + "</font>"
 

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -133,6 +133,15 @@
         <!---Local profile -->
         <item name="okBackgroundColor">@color/ok_background</item>
         <item name="errorBackgroundColor">@color/error_background</item>
+        <!---Warning  -->
+        <item name="warningColor">@color/warning</item>
+        <!---TextColor -->
+        <item name="defaultTextColor">@color/white</item>
+        <!---TempBasal -->
+        <item name="tempBasalColor">@color/tempbasal</item>
+        <item name="infoColor">@color/info</item>
+        <!---Bolus wizard -->
+        <item name="cobAlertColor">@color/cobAlert</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -107,4 +107,13 @@
     <!---Local profile -->
     <attr name="okBackgroundColor" format="reference|color" />
     <attr name="errorBackgroundColor" format="reference|color" />
+    <!---Warning  -->
+    <attr name="warningColor" format="reference|color" />
+    <!---TextColor -->
+    <attr name="defaultTextColor" format="reference|color" />
+    <!---Profile viewer TempBasal -->
+    <attr name="tempBasalColor" format="reference|color" />
+    <attr name="infoColor" format="reference|color" />
+    <!---Bolus wizard -->
+    <attr name="cobAlertColor" format="reference|color" />
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -132,6 +132,15 @@
         <!---Local profile -->
         <item name="okBackgroundColor">@color/ok_background</item>
         <item name="errorBackgroundColor">@color/error_background</item>
+        <!---Warning  -->
+        <item name="warningColor">@color/warning</item>
+        <!---TextColor -->
+        <item name="defaultTextColor">@color/black</item>
+        <!---TempBasal -->
+        <item name="tempBasalColor">@color/tempbasal</item>
+        <item name="infoColor">@color/info</item>
+        <!---Bolus wizard -->
+        <item name="cobAlertColor">@color/cobAlert</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>


### PR DESCRIPTION
Next steps for enabling the themeswitcher for dark and light mode is to change hardcoded colors in
coding with the new gac function.
All colors in fragments and in code shall be set with attributes.

Minor changes and preparations. Treatments now full visible in light mode.

Refactoring of code files will be divided in little portions to avoid failures and to simplify the review