### PR TITLE
Theme switcher preparation:  graphdata treatmentdata by attribut and final preperations

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
@@ -205,7 +205,7 @@ class HistoryBrowseActivity : NoSplashAppCompatActivity() {
         binding.bgGraph.gridLabelRenderer?.reloadStyles()
         binding.bgGraph.gridLabelRenderer?.labelVerticalWidth = axisWidth
 
-        overviewMenus.setupChartMenu(binding.chartMenuButton)
+        overviewMenus.setupChartMenu(context, binding.chartMenuButton)
         prepareGraphsIfNeeded(overviewMenus.setting.size)
         savedInstanceState?.let { bundle ->
             rangeToDisplay = bundle.getInt("rangeToDisplay", 0)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -548,7 +548,7 @@ class OverviewData @Inject constructor(
 
         // ProfileSwitch
         repository.getEffectiveProfileSwitchDataFromTimeToTime(fromTime, endTime, true).blockingGet()
-            .map { EffectiveProfileSwitchDataPoint(it) }
+            .map { EffectiveProfileSwitchDataPoint(it,rh) }
             .forEach(filteredTreatments::add)
 
         // OfflineEvent
@@ -566,7 +566,7 @@ class OverviewData @Inject constructor(
         // Extended bolus
         if (!activePlugin.activePump.isFakingTempsByExtendedBoluses) {
             repository.getExtendedBolusDataFromTimeToTime(fromTime, endTime, true).blockingGet()
-                .map { ExtendedBolusDataPoint(it) }
+                .map { ExtendedBolusDataPoint(it, rh) }
                 .filter { it.duration != 0L }
                 .forEach {
                     it.y = getNearestBg(it.x.toLong())

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -197,7 +197,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             false
         }
         prepareGraphsIfNeeded(overviewMenus.setting.size)
-        overviewMenus.setupChartMenu(binding.graphsLayout.chartMenuButton)
+        context?.let { overviewMenus.setupChartMenu(it, binding.graphsLayout.chartMenuButton) }
 
         binding.activeProfile.setOnClickListener(this)
         binding.activeProfile.setOnLongClickListener(this)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
@@ -1,10 +1,13 @@
 package info.nightscout.androidaps.plugins.general.overview
 
+import android.content.Context
 import android.text.SpannableString
+import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
 import android.view.Menu
 import android.view.View
 import android.widget.ImageButton
+import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.PopupMenu
@@ -31,18 +34,17 @@ class OverviewMenus @Inject constructor(
     private val loop: Loop,
     private val config: Config
 ) {
-
-    enum class CharType(@StringRes val nameId: Int, @ColorRes val colorId: Int, val primary: Boolean, val secondary: Boolean, @StringRes val shortnameId: Int) {
-        PRE(R.string.overview_show_predictions, R.color.prediction, primary = true, secondary = false, shortnameId = R.string.prediction_shortname),
-        BAS(R.string.overview_show_basals, R.color.basal, primary = true, secondary = false, shortnameId = R.string.basal_shortname),
-        ABS(R.string.overview_show_absinsulin, R.color.iob, primary = false, secondary = true, shortnameId = R.string.abs_insulin_shortname),
-        IOB(R.string.overview_show_iob, R.color.iob, primary = false, secondary = true, shortnameId = R.string.iob),
-        COB(R.string.overview_show_cob, R.color.cob, primary = false, secondary = true, shortnameId = R.string.cob),
-        DEV(R.string.overview_show_deviations, R.color.bgi, primary = false, secondary = true, shortnameId = R.string.deviation_shortname),
-        BGI(R.string.overview_show_bgi, R.color.bgi, primary = false, secondary = true, shortnameId = R.string.bgi_shortname),
-        SEN(R.string.overview_show_sensitivity, R.color.ratio, primary = false, secondary = true, shortnameId = R.string.sensitivity_shortname),
-        ACT(R.string.overview_show_activity, R.color.activity, primary = true, secondary = false, shortnameId = R.string.activity_shortname),
-        DEVSLOPE(R.string.overview_show_deviationslope, R.color.devslopepos, primary = false, secondary = true, shortnameId = R.string.devslope_shortname)
+    enum class CharType(@StringRes val nameId: Int, @AttrRes val attrId: Int, val primary: Boolean, val secondary: Boolean, @StringRes val shortnameId: Int) {
+        PRE(R.string.overview_show_predictions, R.attr.predictionColor, primary = true, secondary = false, shortnameId = R.string.prediction_shortname),
+        BAS(R.string.overview_show_basals, R.attr.basal, primary = true, secondary = false,shortnameId = R.string.basal_shortname),
+        ABS(R.string.overview_show_absinsulin, R.attr.iobColor, primary = false, secondary = true,shortnameId = R.string.abs_insulin_shortname),
+        IOB(R.string.overview_show_iob, R.attr.iobColor, primary = false, secondary = true,shortnameId = R.string.iob),
+        COB(R.string.overview_show_cob, R.attr.cobColor, primary = false, secondary = true,shortnameId = R.string.cob),
+        DEV(R.string.overview_show_deviations, R.attr.bgiColor, primary = false, secondary = true,shortnameId = R.string.deviation_shortname),
+        BGI(R.string.overview_show_bgi, R.attr.bgiColor, primary = false, secondary = true,shortnameId = R.string.bgi_shortname),
+        SEN(R.string.overview_show_sensitivity, R.attr.ratioColor, primary = false, secondary = true,shortnameId = R.string.sensitivity_shortname),
+        ACT(R.string.overview_show_activity, R.attr.activityColor, primary = true, secondary = false,shortnameId = R.string.activity_shortname),
+        DEVSLOPE(R.string.overview_show_deviationslope, R.attr.devslopeposColor, primary = false, secondary = true,shortnameId = R.string.devslope_shortname)
     }
 
     companion object {
@@ -86,7 +88,7 @@ class OverviewMenus @Inject constructor(
         }
     }
 
-    fun setupChartMenu(chartButton: ImageButton) {
+    fun setupChartMenu(context: Context, chartButton: ImageButton) {
         val settingsCopy = setting
         val numOfGraphs = settingsCopy.size // 1 main + x secondary
 
@@ -120,7 +122,8 @@ class OverviewMenus @Inject constructor(
                         val item = popup.menu.add(Menu.NONE, m.ordinal + 100 * (g + 1), Menu.NONE, rh.gs(m.nameId))
                         val title = item.title
                         val s = SpannableString(title)
-                        s.setSpan(ForegroundColorSpan(rh.gc(m.colorId)), 0, s.length, 0)
+                        s.setSpan(ForegroundColorSpan(rh.gc(R.color.black)), 0, s.length, 0)
+                        s.setSpan(BackgroundColorSpan(rh.gac(context, m.attrId)), 0, s.length, 0)
                         item.title = s
                         item.isCheckable = true
                         item.isChecked = settingsCopy[g][m.ordinal]
@@ -152,7 +155,7 @@ class OverviewMenus @Inject constructor(
                     }
                 }
                 storeGraphConfig()
-                setupChartMenu(chartButton)
+                setupChartMenu(context, chartButton)
                 rxBus.send(EventRefreshOverview("OnMenuItemClickListener", now = true))
                 return@setOnMenuItemClickListener true
             }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
@@ -66,7 +66,7 @@ class GraphData(
         addSeries(AreaGraphSeries(inRangeAreaDataPoints).also {
             it.color = 0
             it.isDrawBackground = true
-            it.backgroundColor = rh.gc(R.color.inrangebackground)
+            it.backgroundColor = rh.gac(graph.context,R.attr.inrangeBackground)
         })
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/BolusDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/BolusDataPoint.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import android.graphics.Color
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.Bolus
@@ -28,13 +29,11 @@ class BolusDataPoint @Inject constructor(
     override val shape
         get() = if (data.type == Bolus.Type.SMB) PointsWithLabelGraphSeries.Shape.SMB else PointsWithLabelGraphSeries.Shape.BOLUS
 
-    override val color
-        get() =
-            when {
-                data.type == Bolus.Type.SMB -> rh.gc(R.color.tempbasal)
-                data.isValid                -> Color.CYAN
-                else                        -> rh.gc(android.R.color.holo_red_light)
-            }
+    override fun color(context: Context?): Int =
+        if (data.type == Bolus.Type.SMB) rh.gac(context, R.attr.smbColor)
+        else if (data.isValid) rh.gac(context,  R.attr.bolusDataPointColor)
+        else rh.gac(context,  R.attr.alarmColor)
+
 
     override fun setY(y: Double) {
         yValue = y

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/CarbsDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/CarbsDataPoint.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.Carbs
 import info.nightscout.androidaps.utils.resources.ResourceHelper
@@ -18,7 +19,10 @@ class CarbsDataPoint @Inject constructor(
     override val duration = 0L
     override val size = 2f
     override val shape = PointsWithLabelGraphSeries.Shape.CARBS
-    override val color get() = if (data.isValid) rh.gc(R.color.carbs) else rh.gc(android.R.color.holo_red_light)
+
+    override fun color(context: Context?): Int {
+        return if (data.isValid) rh.gac(context, R.attr.cobColor) else rh.gac(context, R.attr.alarmColor)
+    }
 
     override fun setY(y: Double) {
         yValue = y

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/EffectiveProfileSwitchDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/EffectiveProfileSwitchDataPoint.kt
@@ -1,11 +1,15 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import android.graphics.Color
+import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.EffectiveProfileSwitch
+import info.nightscout.androidaps.utils.resources.ResourceHelper
 import javax.inject.Inject
 
 class EffectiveProfileSwitchDataPoint @Inject constructor(
-    val data: EffectiveProfileSwitch
+    val data: EffectiveProfileSwitch,
+    private val rh: ResourceHelper
 ) : DataPointWithLabelInterface {
 
     private var yValue = 0.0
@@ -21,5 +25,7 @@ class EffectiveProfileSwitchDataPoint @Inject constructor(
     override val duration = 0L
     override val shape = PointsWithLabelGraphSeries.Shape.PROFILE
     override val size = 10f
-    override val color = Color.CYAN
+    override fun color(context: Context?): Int {
+        return rh.gac(context, R.attr.profileSwitchColor)
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/ExtendedBolusDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/ExtendedBolusDataPoint.kt
@@ -1,12 +1,16 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import android.graphics.Color
+import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.ExtendedBolus
 import info.nightscout.androidaps.extensions.toStringTotal
+import info.nightscout.androidaps.utils.resources.ResourceHelper
 import javax.inject.Inject
 
 class ExtendedBolusDataPoint @Inject constructor(
-    val data: ExtendedBolus
+    val data: ExtendedBolus,
+    private val rh: ResourceHelper
 ) : DataPointWithLabelInterface {
 
     private var yValue = 0.0
@@ -17,7 +21,9 @@ class ExtendedBolusDataPoint @Inject constructor(
     override val duration get() = data.duration
     override val size = 10f
     override val shape = PointsWithLabelGraphSeries.Shape.EXTENDEDBOLUS
-    override val color = Color.CYAN
+    override fun color(context: Context?): Int {
+        return rh.gac(context, R.attr.extBolusColor)
+    }
 
     override fun setY(y: Double) {
         yValue = y

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.GlucoseValue
@@ -27,30 +28,28 @@ class GlucoseValueDataPoint @Inject constructor(
     override val duration = 0L
     override val shape get() = if (isPrediction) PointsWithLabelGraphSeries.Shape.PREDICTION else PointsWithLabelGraphSeries.Shape.BG
     override val size = 1f
-    override val color: Int
-        get() {
-            val units = profileFunction.getUnits()
-            val lowLine = defaultValueHelper.determineLowLine()
-            val highLine = defaultValueHelper.determineHighLine()
-            return when {
-                isPrediction                   -> predictionColor
-                valueToUnits(units) < lowLine  -> rh.gc(R.color.low)
-                valueToUnits(units) > highLine -> rh.gc(R.color.high)
-                else                           -> rh.gc(R.color.inrange)
-            }
+    override fun color(context: Context?): Int {
+        val units = profileFunction.getUnits()
+        val lowLine = defaultValueHelper.determineLowLine()
+        val highLine = defaultValueHelper.determineHighLine()
+        return when {
+            isPrediction                   -> predictionColor(context)
+            valueToUnits(units) < lowLine  -> rh.gac(context, R.attr.bgLow)
+            valueToUnits(units) > highLine -> rh.gac(context, R.attr.highColor)
+            else                           -> rh.gac(context, R.attr.bgInRange)
         }
+    }
 
-    val predictionColor: Int
-        get() {
+    private fun predictionColor (context: Context?): Int {
             return when (data.sourceSensor) {
-                GlucoseValue.SourceSensor.IOB_PREDICTION   -> rh.gc(R.color.iob)
-                GlucoseValue.SourceSensor.COB_PREDICTION   -> rh.gc(R.color.cob)
-                GlucoseValue.SourceSensor.A_COB_PREDICTION -> -0x7f000001 and rh.gc(R.color.cob)
-                GlucoseValue.SourceSensor.UAM_PREDICTION   -> rh.gc(R.color.uam)
-                GlucoseValue.SourceSensor.ZT_PREDICTION    -> rh.gc(R.color.zt)
-                else                                       -> R.color.white
+                GlucoseValue.SourceSensor.IOB_PREDICTION   -> rh.gac(context, R.attr.iobColor)
+                GlucoseValue.SourceSensor.COB_PREDICTION   -> rh.gac(context, R.attr.cobColor)
+                GlucoseValue.SourceSensor.A_COB_PREDICTION -> -0x7f000001 and rh.gac(context, R.attr.cobColor)
+                GlucoseValue.SourceSensor.UAM_PREDICTION   ->  rh.gac(context, R.attr.uamColor)
+                GlucoseValue.SourceSensor.ZT_PREDICTION    -> rh.gac(context, R.attr.ztColor)
+                else                                       -> rh.gac( context,R.attr.defaultTextColor)
             }
-        }
+    }
 
     private val isPrediction: Boolean
         get() = data.sourceSensor == GlucoseValue.SourceSensor.IOB_PREDICTION ||

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/InMemoryGlucoseValueDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/InMemoryGlucoseValueDataPoint.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.data.InMemoryGlucoseValue
@@ -24,5 +25,7 @@ class InMemoryGlucoseValueDataPoint @Inject constructor(
     override val duration = 0L
     override val shape = PointsWithLabelGraphSeries.Shape.BUCKETED_BG
     override val size = 0.3f
-    override val color get() = rh.gc(R.color.white)
+    override fun color(context: Context?): Int {
+        return rh.gac(context, R.attr.inMemoryColor)
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/TherapyEventDataPoint.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/TherapyEventDataPoint.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import android.graphics.Color
 import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.core.R
@@ -59,14 +60,14 @@ class TherapyEventDataPoint @Inject constructor(
             }
 
     override val size get() = if (rh.gb(R.bool.isTablet)) 12.0f else 10.0f
-    override val color
-        get() =
-            when (data.type) {
-                TherapyEvent.Type.ANNOUNCEMENT          -> rh.gc(R.color.notificationAnnouncement)
-                TherapyEvent.Type.NS_MBG                -> Color.RED
-                TherapyEvent.Type.FINGER_STICK_BG_VALUE -> Color.RED
-                TherapyEvent.Type.EXERCISE              -> Color.BLUE
-                TherapyEvent.Type.APS_OFFLINE           -> Color.GRAY and -0x7f000001
-                else                                    -> Color.GRAY
-            }
+    override fun color(context: Context?): Int {
+        return when (data.type) {
+            TherapyEvent.Type.ANNOUNCEMENT          -> rh.gac(context, R.attr.notificationAnnouncement)
+            TherapyEvent.Type.NS_MBG                -> rh.gac(context, R.attr.therapyEvent_NS_MBG)
+            TherapyEvent.Type.FINGER_STICK_BG_VALUE -> rh.gac(context, R.attr.therapyEvent_FINGER_STICK_BG_VALUE)
+            TherapyEvent.Type.EXERCISE              -> rh.gac(context, R.attr.therapyEvent_EXERCISE)
+            TherapyEvent.Type.APS_OFFLINE           -> rh.gac(context, R.attr.therapyEvent_APS_OFFLINE) and -0x7f000001
+            else                                    -> rh.gac(context, R.attr.therapyEvent_Default)
+        }
+    }
 }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/WatchUpdaterService.java
@@ -529,7 +529,8 @@ public class WatchUpdaterService extends WearableListenerService implements Goog
             if (!predArray.isEmpty()) {
                 for (GlucoseValueDataPoint bg : predArray) {
                     if (bg.getData().getValue() < 40) continue;
-                    predictions.add(predictionMap(bg.getData().getTimestamp(), bg.getData().getValue(), bg.getPredictionColor()));
+                    predictions.add(predictionMap(bg.getData().getTimestamp(),
+                            bg.getData().getValue(), bg.color(null)));
                 }
             }
         }

--- a/core/src/main/java/info/nightscout/androidaps/data/IobTotal.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/IobTotal.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.data
 
+import android.content.Context
 import info.nightscout.androidaps.plugins.general.overview.graphExtensions.DataPointWithLabelInterface
 import info.nightscout.androidaps.plugins.general.overview.graphExtensions.PointsWithLabelGraphSeries
 import info.nightscout.androidaps.utils.DateUtil
@@ -104,7 +105,7 @@ class IobTotal(val time: Long) : DataPointWithLabelInterface {
     }
 
     // DataPoint interface
-    override var color = 0
+    private var color = 0
     override fun getX(): Double = time.toDouble()
     override fun getY(): Double = iob
     override fun setY(y: Double) {}
@@ -112,6 +113,11 @@ class IobTotal(val time: Long) : DataPointWithLabelInterface {
     override val duration = 0L
     override val shape = PointsWithLabelGraphSeries.Shape.IOBPREDICTION
     override val size = 0.5f
+
+    override fun color(context: Context?): Int {
+        return color
+    }
+
 
     fun setColor(color: Int): IobTotal {
         this.color = color

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/DataPointWithLabelInterface.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/DataPointWithLabelInterface.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.general.overview.graphExtensions
 
+import android.content.Context
 import com.jjoe64.graphview.series.DataPointInterface
 
 interface DataPointWithLabelInterface : DataPointInterface {
@@ -12,5 +13,5 @@ interface DataPointWithLabelInterface : DataPointInterface {
     val duration: Long
     val shape: PointsWithLabelGraphSeries.Shape?
     val size: Float
-    val color: Int
+    fun color(context: Context?): Int
 }

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/PointsWithLabelGraphSeries.java
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/PointsWithLabelGraphSeries.java
@@ -152,7 +152,7 @@ public class PointsWithLabelGraphSeries<E extends DataPointWithLabelInterface> e
         while (values.hasNext()) {
             E value = values.next();
 
-            mPaint.setColor(value.getColor());
+            mPaint.setColor(value.color(graphView.getContext()));
 
             double valY = value.getY() - minY;
             double ratY = valY / diffY;
@@ -200,12 +200,12 @@ public class PointsWithLabelGraphSeries<E extends DataPointWithLabelInterface> e
                     mPaint.setStrokeWidth(0);
                     canvas.drawCircle(endX, endY, value.getSize() * scaledPxSize, mPaint);
                 } else if (value.getShape() == Shape.BG || value.getShape() == Shape.IOBPREDICTION || value.getShape() == Shape.BUCKETED_BG) {
-                    mPaint.setColor(value.getColor());
+                    mPaint.setColor(value.color(graphView.getContext()));
                     mPaint.setStyle(Paint.Style.FILL);
                     mPaint.setStrokeWidth(0);
                     canvas.drawCircle(endX, endY, value.getSize() * scaledPxSize, mPaint);
                 } else if (value.getShape() == Shape.PREDICTION) {
-                    mPaint.setColor(value.getColor());
+                    mPaint.setColor(value.color(graphView.getContext()));
                     mPaint.setStyle(Paint.Style.FILL);
                     mPaint.setStrokeWidth(0);
                     canvas.drawCircle(endX, endY, scaledPxSize, mPaint);

--- a/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/data/AutosensData.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/data/AutosensData.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.iob.iobCobCalculator.data
 
+import android.content.Context
 import dagger.android.HasAndroidInjector
 import info.nightscout.androidaps.Constants
 import info.nightscout.androidaps.core.R
@@ -162,7 +163,9 @@ class AutosensData(injector: HasAndroidInjector) : DataPointWithLabelInterface {
     override val duration = 0L
     override val shape = PointsWithLabelGraphSeries.Shape.COBFAILOVER
     override val size = 0.5f
-    override val color get() = rh.gc(R.color.cob)
+    override fun color(context: Context?): Int {
+        return rh.gac(context,R.attr.cobColor)
+    }
 
     init {
         injector.androidInjector().inject(this)

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -217,7 +217,12 @@
         <item name="therapyEvent_APS_OFFLINE">@color/mdtp_line_dark</item>
         <item name="therapyEvent_Default">@color/mdtp_line_dark</item>
         <!-- Graph specific colors  -->
-        <item name="inrangeBackground">@color/inrangebackground</item>
+        <item name="inrangeBackground">@color/black_alpha_20</item>
+        <item name="devslopeposColor">@color/devslopepos</item>
+        <item name="predictionColor">@color/prediction</item>
+        <item name="bgiColor">@color/bgi</item>
+        <item name="ratioColor">@color/ratio</item>
+        <item name="activityColor">@color/activity</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>
@@ -268,14 +273,37 @@
 
 
     <style name="MaterialPickerTheme" parent="android:Theme.Material.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/MaterialDatePickerStyle</item>
+        <item name="android:timePickerStyle">@style/MaterialTimePickerStyle</item>
         <item name="android:buttonBarPositiveButtonStyle">@style/PickerTextButton</item>
         <item name="android:buttonBarNegativeButtonStyle">@style/PickerTextButton</item>
-        <item name="android:textColorPrimary">@color/okButtonText</item>
-        <item name="android:colorPrimary">@color/okButtonText</item>
-        <item name="android:calendarTextColor">@color/okButtonText</item>
-        <item name="android:colorAccent">@color/okButtonText</item>
+        <item name="colorAccent">@color/dialog_title_background</item>
+        <item name="colorSecondary">@color/dialog_title_background</item>
+        <item name="android:textColorSecondary">@color/defaulttextcolor</item>
+        <item name="android:textColorPrimary">@color/defaulttextcolor</item>
+        <item name="android:textColor">@color/defaulttextcolor</item>
+        <item name="backgroundColor">@color/dateTimePickerBackground</item>
         <item name="android:dialogCornerRadius">12dp</item>
     </style>
+
+    <style name="MaterialDatePickerStyle" parent="Widget.MaterialComponents.MaterialCalendar">
+        <item name="android:calendarTextColor">@color/defaulttextcolor</item>
+        <item name="android:datePickerMode">calendar</item>
+        <item name="colorSecondary">@color/dialog_title_background</item>
+        <item name="android:background">@color/dateTimePickerBackground</item>
+        <item name="android:headerBackground">@color/dialog_title_background</item>
+    </style>
+
+    <style name="MaterialTimePickerStyle" parent="Widget.MaterialComponents.TimePicker">
+        <item name="android:numbersTextColor">@color/defaulttextcolor</item>
+        <item name="android:numbersSelectorColor">@color/white_alpha_40</item>
+        <item name="android:numbersBackgroundColor">@color/dialog_title_background</item>
+        <item name="android:background">@color/dateTimePickerBackground</item>
+        <item name="android:headerBackground">@color/dialog_title_background</item>
+        <item name="android:headerTimeTextAppearance">@color/defaulttextcolor</item>
+        <item name="android:timePickerMode">clock</item>
+    </style>
+
     <style name="PickerTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
         <item name="android:textColor">@color/okButtonText</item>
     </style>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -198,4 +198,9 @@
     <attr name="graphVerticalLabelText" format="reference|color" />
     <attr name="inrangeBackground" format="reference|color" />
     <attr name="graphGrid" format="reference|color" />
+    <attr name="devslopeposColor" format="reference|color" />
+    <attr name="predictionColor" format="reference|color" />
+    <attr name="bgiColor" format="reference|color" />
+    <attr name="ratioColor" format="reference|color" />
+    <attr name="activityColor" format="reference|color" />
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -226,6 +226,11 @@
         <item name="therapyEvent_Default">@color/mdtp_line_dark</item>
         <!-- Graph specific colors  -->
         <item name="inrangeBackground">@color/black_alpha_20</item>
+        <item name="devslopeposColor">@color/devslopepos</item>
+        <item name="predictionColor">@color/prediction</item>
+        <item name="bgiColor">@color/bgi</item>
+        <item name="ratioColor">@color/ratio</item>
+        <item name="activityColor">@color/activity</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>
@@ -287,16 +292,33 @@
         <item name="android:textAllCaps">true</item>
     </style>
 
-
     <style name="MaterialPickerTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/MaterialDatePickerStyle</item>
+        <item name="android:timePickerStyle">@style/MaterialTimePickerStyle</item>
         <item name="android:buttonBarPositiveButtonStyle">@style/PickerTextButton</item>
         <item name="android:buttonBarNegativeButtonStyle">@style/PickerTextButton</item>
-        <item name="android:textColorPrimary">@color/black</item>
-        <item name="android:colorPrimary">@color/colorPrimary</item>
-        <item name="android:calendarTextColor">@color/black</item>
-        <item name="android:colorAccent">@color/dialog_title_background</item>
-        <item name="colorSecondary">@color/dialog_title_background</item>
+        <item name="colorAccent">@color/dialog_title_background</item>
+        <item name="android:textColorSecondary">@color/defaulttextcolor</item>
+        <item name="android:textColorPrimary">@color/defaulttextcolor</item>
+        <item name="android:textColor">@color/defaulttextcolor</item>
         <item name="android:dialogCornerRadius">12dp</item>
+    </style>
+
+    <style name="MaterialDatePickerStyle" parent="Widget.MaterialComponents.MaterialCalendar">
+        <item name="android:calendarTextColor">@color/defaulttextcolor</item>
+        <item name="android:datePickerMode">calendar</item>
+        <item name="android:background">@color/dateTimePickerBackground</item>
+        <item name="android:headerBackground">@color/dialog_title_background</item>
+    </style>
+
+    <style name="MaterialTimePickerStyle" parent="Widget.MaterialComponents.TimePicker">
+        <item name="android:numbersTextColor">@color/defaulttextcolor</item>
+        <item name="android:numbersSelectorColor">@color/white_alpha_40</item>
+        <item name="android:numbersBackgroundColor">@color/dialog_title_background</item>
+        <item name="android:background">@color/dateTimePickerBackground</item>
+        <item name="android:headerBackground">@color/dialog_title_background</item>
+        <item name="android:headerTimeTextAppearance">@color/defaulttextcolor</item>
+        <item name="android:timePickerMode">clock</item>
     </style>
 
     <style name="PickerTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">


### PR DESCRIPTION
@MilosKozak : This is the last main pull request.
I will further work on minor things in the fragments and dialogs for coloring.
Its up to you that we can start a wider test for the main developers by open the theme switching in preferences.

Graphdata and treatmentdata colors now accessed by attribute
Nearly all Fragments and dialogs can now be used in light theme !

TODOS:
- Testing, testing, testing.
- Working on colors to establish a very well looking light theme. 
- After this work is finished: cleaning the colortable, remove duplicates and discuss naming of colors.The main meaning is given
 by the attribut-name
- establish theme switching in pref_general

Colors in objectives @MilosKozak : Color handling here is a little bit strange hardcoded. Maybe someone can help