### PR TITLE
fix styling , corners of progressbar and progress now in full material style

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/dialogs/BolusProgressDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/BolusProgressDialog.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.dialogs
 
+import android.content.res.Resources
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.LayoutInflater
@@ -82,6 +83,9 @@ class BolusProgressDialog : DaggerDialogFragment() {
         dialog?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
         isCancelable = false
         dialog?.setCanceledOnTouchOutside(false)
+
+        val theme: Resources.Theme? = context?.theme
+        theme?.applyStyle(R.style.AppTheme,  true)
 
         _binding = DialogBolusprogressBinding.inflate(inflater, container, false)
         return binding.root

--- a/core/src/main/res/drawable/ic_trending_flat_white_48dp.xml
+++ b/core/src/main/res/drawable/ic_trending_flat_white_48dp.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48dp"
     android:height="48dp"
-    android:tint="#FFFFFF"
+    android:tint="?attr/defaultTextColor"
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="?attr/colorControlNormal"
+        android:fillColor="?attr/defaultTextColor"
         android:pathData="M22,12l-4,-4v3H3v2h15v3z" />
 </vector>

--- a/core/src/main/res/layout/dialog_bolusprogress.xml
+++ b/core/src/main/res/layout/dialog_bolusprogress.xml
@@ -62,7 +62,7 @@
 
     <ProgressBar
         android:id="@+id/progressbar"
-        style="@android:style/Widget.ProgressBar.Horizontal"
+        style="@android:style/Widget.Material.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="20dp"
         android:layout_marginLeft="5dp"


### PR DESCRIPTION
The progress is now identical to the new progress in overview fragment.
![progress_dark](https://user-images.githubusercontent.com/25795894/161432978-5ca89c9f-bd62-48e7-a61d-0af0a791619c.PNG)
![progress_light](https://user-images.githubusercontent.com/25795894/161432979-94742991-97ac-4388-9b46-ad519103adb1.PNG)

