### PR TITLE
Fix basal color and widget arrow color

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/Widget.kt
+++ b/app/src/main/java/info/nightscout/androidaps/Widget.kt
@@ -6,6 +6,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.graphics.Paint
 import android.view.View
 import android.widget.RemoteViews
@@ -105,7 +106,11 @@ class Widget : AppWidgetProvider() {
             }
         )
         views.setImageViewResource(R.id.arrow, trendCalculator.getTrendArrow(overviewData.lastBg).directionToIcon())
-        //binding.infoLayout.arrow.setColorFilter(overviewData.lastBgColor(context))
+        views.setInt(R.id.arrow, "setColorFilter", when {
+            overviewData.isLow  -> rh.gc(R.color.low)
+            overviewData.isHigh -> rh.gc(R.color.high)
+            else                -> rh.gc(R.color.inrange)
+        })
 
         val glucoseStatus = glucoseStatusProvider.glucoseStatusData
         if (glucoseStatus != null) {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -196,9 +196,13 @@ class OverviewData @Inject constructor(
                 }
             } ?: R.drawable.ic_cp_basal_no_tbr
 
+    // will be removed if a solution of getting the right color for widget is solved
     val temporaryBasalColor: Int
         get() = iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { rh.gc(R.color.basal) }
-            ?: rh.gc(R.color.defaulttextcolor)
+            ?: rh.gc(R.color.textAppearancemediumDark)
+
+    fun temporaryBasalColor(context: Context?): Int = iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { rh.gac(context , R.attr.basal) }
+            ?: rh.gac(context, R.attr.textAppearancemediumColor)
 
     /*
      * EXTENDED BOLUS

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -852,7 +852,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
     @Suppress("UNUSED_PARAMETER")
     fun updateTemporaryBasal(from: String) {
         binding.infoLayout.baseBasal.text = overviewData.temporaryBasalText
-        binding.infoLayout.baseBasal.setTextColor(overviewData.temporaryBasalColor)
+        binding.infoLayout.baseBasal.setTextColor(overviewData.temporaryBasalColor(context))
         binding.infoLayout.baseBasalIcon.setImageResource(overviewData.temporaryBasalIcon)
         binding.infoLayout.basalLayout.setOnClickListener {
             activity?.let { OKDialog.show(it, rh.gs(R.string.basal), overviewData.temporaryBasalDialogText) }

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -234,6 +234,9 @@
     <color name="mdtp_button_selected">#33969696</color>
     <color name="plastic">#EBEBEA</color>
 
+    <color name="textAppearancemediumLight">#000000</color>
+    <color name="textAppearancemediumDark">#B3FFFFFF</color>
+
     <!-- dash and eros colors -->
     <color name="omni_yellow">#FFFF00</color>
     <color name="omni_cyan">#00FFFF</color>

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -225,6 +225,7 @@
         <item name="activityColor">@color/activity</item>
         <!-- CardView specific colors  -->
         <item name="strokeColor">@color/plastic_grey</item>
+        <item name="textAppearancemediumColor">@color/textAppearancemediumDark</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -205,4 +205,5 @@
     <attr name="activityColor" format="reference|color" />
     <!-- CardView specific colors  -->
     <attr name="strokeColor" format="reference|color" />
+    <attr name="textAppearancemediumColor" format="reference|color" />
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -238,6 +238,9 @@
     <color name="mdtp_button_selected">#33969696</color>
     <color name="plastic">#EBEBEA</color>
 
+    <color name="textAppearancemediumLight">#000000</color>
+    <color name="textAppearancemediumDark">#B3FFFFFF</color>
+
     <!-- dash and eros colors -->
     <color name="omni_yellow">#FFFF00</color>
     <color name="omni_cyan">#00FFFF</color>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -53,7 +53,7 @@
         <!-- BG source temp button -->
         <item name="setTempButton">@color/colorSetTempButton</item>
         <!-- Card Item-->
-        <item name="cardItemBackgroundColor">@color/cardColorBackground</item>
+        <item name="cardItemBackgroundColor">?attr/colorSurface</item>
         <!-- Exercise -->
         <item name="exerciseColor">@color/exercise</item>
         <!-- BG low -->
@@ -233,6 +233,7 @@
         <item name="activityColor">@color/activity</item>
         <!-- CardView specific colors  -->
         <item name="strokeColor">@color/plastic_grey</item>
+        <item name="textAppearancemediumColor">@color/textAppearancemediumLight</item>
     </style>
 
     <style name="Theme.MaterialComponents.DayNight.DarkActionBar" parent="Theme.MaterialComponents.DayNight.Bridge"/>


### PR DESCRIPTION
This fix: https://github.com/nightscout/AndroidAPS/issues/1558

@MilosKozak  basal arrow color now ok. 
In addition i fixed the missing color in trend arrow on the widget.

In the moment the widget gets the color from the default colortable ( always the color table from the light theme ).
So they can be different from the dark mode colors.
I try to find a solution to get the right color in the widget in the future. 