### PR TITLE
change notes edit textfield to material style

### DIFF
--- a/core/src/main/res/layout/notes.xml
+++ b/core/src/main/res/layout/notes.xml
@@ -1,25 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/notes_layout"
+xmlns:app="http://schemas.android.com/apk/res-auto"
+android:id="@+id/notes_layout"
+android:layout_width="match_parent"
+android:layout_height="wrap_content"
+android:orientation="horizontal">
+
+<com.google.android.material.textfield.TextInputLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+    android:hint="@string/notes_label"
+    app:boxStrokeColor="@color/mtrl_textinput_default_box_stroke_color"
+    android:textColorHint="?attr/colorOnPrimary"
+    app:hintTextColor="?attr/colorOnPrimary"
+    app:endIconMode="clear_text">
 
-    <TextView
-        android:labelFor="@+id/notes"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:width="120dp"
-        android:padding="10dp"
-        android:text="@string/notes_label"
-        android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textStyle="bold" />
-
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/notes"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_gravity="center_vertical"
+        android:layout_weight="1"
+        android:autofillHints="@string/notes_label"
+        android:gravity="start"
+        android:textStyle="bold"
         android:width="180dp"
-        android:inputType="text" />
+        android:inputType="text|textCapSentences" />
+
+</com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default theme color -->
     <!-- This section describes the main theme colors -->
     <color name="colorPrimary">#212121</color>
@@ -244,6 +244,8 @@
 
     <!-- Button icons - general -->
     <color name="pod_icon_outline">#9E9E9E</color>
+
+    <color name="mtrl_textinput_default_box_stroke_color" tools:override="true" >#9E9E9E</color>
 
     <!-- Omnipod Wizard -->
     <color name="omnipod_wizard_progress_bar">#0099CC</color>

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -96,7 +96,7 @@
         <!---Toast  -->
         <item name="toastBaseTextColor">@color/toastBase</item>
         <!---Input  -->
-        <item name="boxStrokeColor">@color/white</item>
+        <item name="boxStrokeColor">@color/white_alpha_20</item>
         <!---Profile Helper  -->
         <item name="tabBgColorSelected">@color/tabBgColorSelected</item>
         <!---Dialog Helper  -->

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default theme color -->
     <!-- This section describes the main theme colors -->
     <color name="colorPrimary">#FBF9FF</color>
@@ -248,6 +248,8 @@
 
     <!-- Button icons - general -->
     <color name="pod_icon_outline">#9E9E9E</color>
+
+    <color name="mtrl_textinput_default_box_stroke_color" tools:override="true" >#9E9E9E</color>
 
     <!-- Omnipod Wizard -->
     <color name="omnipod_wizard_progress_bar">#0099CC</color>


### PR DESCRIPTION
change the notes textfield layout to material for dark and light theme
![material_textfield_dark_01](https://user-images.githubusercontent.com/25795894/161777159-d0ee7fef-ed72-411b-bcfd-cf37ed7003e4.PNG)
![material_textfield_dark_02](https://user-images.githubusercontent.com/25795894/161777161-326ee96e-15a1-4a4d-8895-e057f8d13097.PNG)
![material_textfield_dark_03](https://user-images.githubusercontent.com/25795894/161777162-b0c37a14-30d4-44e4-bb1d-8a967b97e211.PNG)
![material_textfield_light_01](https://user-images.githubusercontent.com/25795894/161777166-42eb97f7-e197-4bfe-84d8-531db416b59f.PNG)
![material_textfield_light_02](https://user-images.githubusercontent.com/25795894/161777168-01e04595-0296-4a3b-ab8c-d3cf95e84af8.PNG)
![material_textfield_light_03](https://user-images.githubusercontent.com/25795894/161777169-9fe1aaf7-0b0b-4b44-a09f-4fed66797564.PNG)

