### PR TITLE
Fix: a11y dropdown tempt

### DIFF
--- a/app/src/main/res/layout/dialog_temptarget.xml
+++ b/app/src/main/res/layout/dialog_temptarget.xml
@@ -123,16 +123,13 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="5dp"
             android:layout_marginEnd="5dp"
-            android:hint="@string/reason"
-            app:boxStrokeColor="@color/list_delimiter">
+            android:hint="@string/reason">
 
-            <androidx.appcompat.widget.AppCompatAutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/reasonList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:clickable="true"
-                android:enabled="false"
-                tools:ignore="KeyboardInaccessibleWidget" />
+                android:inputType="none" />
 
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default theme color -->
     <!-- This section describes the main theme colors -->
-    <color name="colorPrimary">#212121</color>
+    <color name="colorPrimary">#3378c5</color>
     <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#40bbaa</color>
     <color name="mdtp_white">#ffffff</color>


### PR DESCRIPTION
The dropdown is now enabled, making it accessible for screenreaders. With the bonus that the whole input can be clicked to open the menu.
To use the correct colours for focus and high lighting, the primary color should be contrasting to the background and can no longer be black or grey. When agreeing on the color we can use it generically throughout all inputs to show the focus

The primary color was incorrectly used in the toolbar, which will be fixed in the pr #1570 #1569  
![dropdown_fix](https://user-images.githubusercontent.com/6724749/161919396-c5f597c3-112f-4953-91e8-90396b617d88.gif)

After this PR got merged, we can change the other auto-completes components too


