### PR TITLE
card items and objectives now readable in light mode

### DIFF
--- a/app/src/main/res/layout/objectives_exam_fragment.xml
+++ b/app/src/main/res/layout/objectives_exam_fragment.xml
@@ -28,6 +28,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="10dp"
+            android:background="?attr/objectivesBackgroundColor"
             android:orientation="vertical"
             app:layout_constraintTop_toBottomOf="@+id/exam_options"
             tools:layout_editor_absoluteX="3dp" />

--- a/app/src/main/res/layout/objectives_item.xml
+++ b/app/src/main/res/layout/objectives_item.xml
@@ -8,8 +8,9 @@
     android:layout_marginLeft="16dp"
     android:layout_marginTop="16dp"
     android:layout_marginRight="16dp"
-    app:cardBackgroundColor="?attr/cardItemBackgroundColor"
+    app:cardBackgroundColor="?attr/objectivescardItemBackgroundColor"
     app:cardCornerRadius="2dp"
+    app:cardElevation="8dp"
     app:cardUseCompatPadding="true"
     app:contentPadding="16dp">
 

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -71,6 +71,7 @@
         <!-- Pump -->
         <item name="pumpStatusBackground">@color/pumpStatusBackground</item>
         <!-- Objectives -->
+        <item name="objectivescardItemBackgroundColor">?attr/cardItemBackgroundColor</item>
         <item name="objectivesBackgroundColor">@color/objectivesBackground</item>
         <item name="objectivesDisabledTextColor">@color/colorObjectivesDisabledText</item>
         <!---Import List -->

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -44,6 +44,7 @@
     <!-- Pump -->
     <attr name="pumpStatusBackground" format="reference|color" />
     <!-- Objectives -->
+    <attr name="objectivescardItemBackgroundColor" format="reference|color" />
     <attr name="objectivesBackgroundColor" format="reference|color" />
     <attr name="objectivesDisabledTextColor" format="reference|color" />
     <!---Import List -->

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -226,7 +226,7 @@
     <!-- Gray colors -->
     <color name="darkgray">#323232</color>
     <color name="darkgrayVariant">#424242</color>
-    <color name="objectivesBackground">#3C3C3C</color>
+    <color name="objectivesBackground">#8C8C8C</color>
     <color name="plastic_grey">#666666</color>
     <color name="byodagray">#777777</color>
     <color name="sphere_plastic_grey">#8c8c8c</color>
@@ -309,6 +309,7 @@
     <color name="aaps_theme_light_onBackground">#1C1B1F</color>
     <color name="aaps_theme_light_surface">#FAF9F8</color>
     <color name="aaps_theme_light_onSurface">#1C1B1F</color>
-    <color name="aaps_theme_light_surfaceVariant">#E7E0EC</color>
+    <color name="aaps_theme_light_surfaceVariant">#E2E0DF</color>
+
 
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
         <item name="colorOnError">@color/aaps_theme_light_onError</item>
         <item name="android:colorBackground">@color/aaps_theme_light_background</item>
         <item name="colorOnBackground">@color/aaps_theme_light_onBackground</item>
-        <item name="colorSurface">@color/aaps_theme_light_surface</item>
+        <item name="colorSurface">@color/aaps_theme_light_surfaceVariant</item>
         <item name="colorOnSurface">@color/aaps_theme_light_onSurface</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/aaps_theme_light_secondary</item>
@@ -79,6 +79,7 @@
         <!-- Pump -->
         <item name="pumpStatusBackground">@color/pumpStatusBackground</item>
         <!-- Objectives -->
+        <item name="objectivescardItemBackgroundColor">@color/midgray</item>
         <item name="objectivesBackgroundColor">@color/objectivesBackground</item>
         <item name="objectivesDisabledTextColor">@color/colorObjectivesDisabledText</item>
         <!---Import List -->


### PR DESCRIPTION
![objectives](https://user-images.githubusercontent.com/25795894/161993572-b553dd30-1edc-46d9-8592-b19ecb2c8216.PNG)
