### PR TITLE
Chore remove redundant style

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -130,7 +130,7 @@ class WizardDialog : DaggerDialogFragment() {
         val useSuperBolus = sp.getBoolean(R.string.key_usesuperbolus, false)
         binding.sbCheckbox.visibility = useSuperBolus.toVisibility()
         binding.superBolusRow.visibility = useSuperBolus.toVisibility()
-        binding.notesLayout.visibility = sp.getBoolean(R.string.key_show_notes_entry_dialogs, false).toVisibility()
+        binding.notesLayout.root.visibility = sp.getBoolean(R.string.key_show_notes_entry_dialogs, false).toVisibility()
 
         val maxCarbs = constraintChecker.getMaxCarbsAllowed().value()
         val maxCorrection = constraintChecker.getMaxBolusAllowed().value()
@@ -327,7 +327,7 @@ class WizardDialog : DaggerDialogFragment() {
             binding.carbsInput.value = carbsPassedIntoWizard
         }
         if (notesPassedIntoWizard.isNotBlank()) {
-            binding.notes.setText(notesPassedIntoWizard)
+            binding.notesLayout.notes.setText(notesPassedIntoWizard)
         }
         val profile = profileFunction.getProfile()
         val profileStore = activePlugin.activeProfileSource.profile
@@ -427,7 +427,7 @@ class WizardDialog : DaggerDialogFragment() {
             binding.ttCheckbox.isChecked,
             binding.bgTrendCheckbox.isChecked,
             binding.alarm.isChecked,
-            binding.notes.text.toString(),
+            binding.notesLayout.notes.text.toString(),
             carbTime,
             usePercentage = usePercentage,
             totalPercentage = percentageCorrection

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/filter"
-        android:textColorHint="?attr/colorOnPrimary"
         app:endIconMode="clear_text">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/layout/activity_profilehelper.xml
+++ b/app/src/main/res/layout/activity_profilehelper.xml
@@ -49,9 +49,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
-            android:hint="@string/profiletype"
-            android:textColorHint="?attr/tabBgColorSelected"
-            app:boxStrokeColor="?attr/tabBgColorSelected">
+            android:hint="@string/profiletype">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/profile_type"
@@ -213,8 +211,7 @@
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/selected_profile"
-                app:boxStrokeColor="?attr/boxStrokeColor">
+                android:hint="@string/selected_profile">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/available_profile_list"
@@ -241,8 +238,7 @@
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/careportal_profileswitch"
-                app:boxStrokeColor="?attr/boxStrokeColor">
+                android:hint="@string/careportal_profileswitch">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/profileswitch_list"

--- a/app/src/main/res/layout/dialog_wizard.xml
+++ b/app/src/main/res/layout/dialog_wizard.xml
@@ -211,34 +211,9 @@
 
         </LinearLayout>
 
-        <LinearLayout
+        <include
             android:id="@+id/notes_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:labelFor="@+id/notes"
-                android:padding="10dp"
-                android:text="@string/notes_label"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                android:textStyle="bold" />
-
-            <EditText
-                android:id="@+id/notes"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="1"
-                android:autofillHints="@string/notes_label"
-                android:gravity="start"
-                android:inputType="text|textCapSentences"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
-
-        </LinearLayout>
+            layout="@layout/notes" />
 
         <LinearLayout
             android:id="@+id/checkbox_row"

--- a/app/src/main/res/layout/food_fragment.xml
+++ b/app/src/main/res/layout/food_fragment.xml
@@ -21,10 +21,7 @@
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:boxStrokeColor="@color/mtrl_textinput_default_box_stroke_color"
             android:hint="@string/filter"
-            android:textColorHint="?attr/colorOnPrimary"
-            app:hintTextColor="?attr/colorOnPrimary"
             app:startIconDrawable="@android:drawable/ic_menu_search"
             app:endIconMode="clear_text">
 

--- a/core/src/main/res/layout/notes.xml
+++ b/core/src/main/res/layout/notes.xml
@@ -1,35 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-xmlns:app="http://schemas.android.com/apk/res-auto"
-android:id="@+id/notes_layout"
-android:layout_width="match_parent"
-android:layout_height="wrap_content"
-android:orientation="horizontal">
-
-<com.google.android.material.textfield.TextInputLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/notes_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-    android:hint="@string/notes_label"
-    app:boxStrokeColor="@color/mtrl_textinput_default_box_stroke_color"
-    android:textColorHint="?attr/colorOnPrimary"
-    app:hintTextColor="?attr/colorOnPrimary"
-    app:endIconMode="clear_text">
+    android:orientation="horizontal">
 
-    <com.google.android.material.textfield.TextInputEditText
-        android:id="@+id/notes"
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
-        android:layout_marginEnd="10dp"
-        android:layout_gravity="center_vertical"
-        android:layout_weight="1"
-        android:autofillHints="@string/notes_label"
-        android:gravity="start"
-        android:textStyle="bold"
-        android:width="180dp"
-        android:inputType="text|textCapSentences" />
+        android:hint="@string/notes_label"
+        app:endIconMode="clear_text">
 
-</com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/notes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
+            android:layout_weight="1"
+            android:width="180dp"
+            android:autofillHints="@string/notes_label"
+            android:gravity="start"
+            android:inputType="text|textCapSentences"
+            android:textStyle="bold" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>


### PR DESCRIPTION
After setting the new primary color the TextInputLayout border and hint can be removed
- reuse the notes layout in Wizard Dialog