### PR TITLE
Feat treatment empty list view

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsBolusCarbsFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsBolusCarbsFragment.kt
@@ -14,6 +14,7 @@ import info.nightscout.androidaps.database.AppRepository
 import info.nightscout.androidaps.database.entities.Bolus
 import info.nightscout.androidaps.database.entities.BolusCalculatorResult
 import info.nightscout.androidaps.database.entities.Carbs
+import info.nightscout.androidaps.database.entities.UserEntry
 import info.nightscout.androidaps.database.entities.UserEntry.Action
 import info.nightscout.androidaps.database.entities.UserEntry.Sources
 import info.nightscout.androidaps.database.entities.ValueWithUnit
@@ -82,8 +83,6 @@ class TreatmentsBolusCarbsFragment : DaggerFragment() {
     private val disposable = CompositeDisposable()
     private lateinit var actionHelper: ActionModeHelper<MealLink>
     private val millsToThePast = T.days(30).msecs()
-
-    // private var selectedItems: SparseArray<MealLink> = SparseArray()
     private var showInvalidated = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
@@ -98,6 +97,8 @@ class TreatmentsBolusCarbsFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun bolusMealLinksWithInvalid(now: Long) = repository
@@ -126,7 +127,7 @@ class TreatmentsBolusCarbsFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
-
+        binding.recyclerview.isLoading = true
         disposable +=
             if (showInvalidated)
                 carbsMealLinksWithInvalid(now)

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsCareportalFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsCareportalFragment.kt
@@ -73,6 +73,8 @@ class TreatmentsCareportalFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun refreshFromNightscout() {
@@ -105,6 +107,7 @@ class TreatmentsCareportalFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
+        binding.recyclerview.isLoading = true
         disposable +=
             if (showInvalidated)
                 repository

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsExtendedBolusesFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsExtendedBolusesFragment.kt
@@ -79,10 +79,13 @@ class TreatmentsExtendedBolusesFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
+        binding.recyclerview.isLoading = true
         disposable += if (showInvalidated)
             repository
                 .getExtendedBolusDataIncludingInvalidFromTime(now - millsToThePast, false)

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsProfileSwitchFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsProfileSwitchFragment.kt
@@ -84,6 +84,8 @@ class TreatmentsProfileSwitchFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun refreshFromNightscout() {
@@ -128,7 +130,7 @@ class TreatmentsProfileSwitchFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
-
+        binding.recyclerview.isLoading = true
         disposable +=
             if (showInvalidated)
                 profileSwitchWithInvalid(now)

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsTempTargetFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsTempTargetFragment.kt
@@ -83,6 +83,8 @@ class TreatmentsTempTargetFragment : DaggerFragment() {
         actionHelper.setOnRemoveHandler { removeSelected(it) }
         setHasOptionsMenu(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun refreshFromNightscout() {
@@ -111,6 +113,7 @@ class TreatmentsTempTargetFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
+        binding.recyclerview.isLoading = true
         disposable +=
             if (showInvalidated)
                 repository

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsTemporaryBasalsFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsTemporaryBasalsFragment.kt
@@ -84,6 +84,8 @@ class TreatmentsTemporaryBasalsFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun tempBasalsWithInvalid(now: Long) = repository
@@ -102,6 +104,7 @@ class TreatmentsTemporaryBasalsFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
+        binding.recyclerview.isLoading = true
         disposable +=
             if (activePlugin.activePump.isFakingTempsByExtendedBoluses) {
                 if (showInvalidated)

--- a/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsUserEntryFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/fragments/TreatmentsUserEntryFragment.kt
@@ -63,6 +63,8 @@ class TreatmentsUserEntryFragment : DaggerFragment() {
         setHasOptionsMenu(true)
         binding.recyclerview.setHasFixedSize(true)
         binding.recyclerview.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerview.emptyView = binding.noRecordsText
+        binding.recyclerview.loadingView = binding.progressBar
     }
 
     private fun exportUserEntries() {
@@ -76,6 +78,7 @@ class TreatmentsUserEntryFragment : DaggerFragment() {
 
     fun swapAdapter() {
         val now = System.currentTimeMillis()
+        binding.recyclerview.isLoading = true
         disposable +=
             if (showLoop)
                 repository

--- a/app/src/main/res/layout/treatments_bolus_carbs_fragment.xml
+++ b/app/src/main/res/layout/treatments_bolus_carbs_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsBolusCarbsFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_bolus_carbs_item.xml
+++ b/app/src/main/res/layout/treatments_bolus_carbs_item.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardElevation="0dp"
-    card_view:cardBackgroundColor="?attr/cardItemBackgroundColor">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -23,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:id="@+id/metadata_layout"
@@ -40,16 +38,16 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="5dp"
                 android:gravity="center"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/calc_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="11:45"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="11:45" />
 
             <TextView
                 android:layout_width="0dp"
@@ -82,16 +80,16 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="5dp"
                 android:gravity="center"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/bolus_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="11:45"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="11:45" />
 
             <TextView
                 android:id="@+id/insulin"
@@ -99,9 +97,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="10dp"
-                android:text="1.00 U"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                tools:text="1.00 U" />
 
             <TextView
                 android:id="@+id/iob_label"
@@ -117,9 +114,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:text="0.45U"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                tools:text="0.45U" />
 
             <TextView
                 android:layout_width="0dp"
@@ -132,27 +128,24 @@
                 android:id="@+id/meal_or_correction"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Meal"
                 android:textAlignment="textEnd"
-                tools:ignore="HardcodedText" />
+                tools:text="Meal" />
 
             <TextView
                 android:id="@+id/bolus_ns"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
             <TextView
                 android:id="@+id/bolus_pump"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="PH"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="PH" />
 
             <TextView
                 android:id="@+id/bolus_invalid"
@@ -189,16 +182,16 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="5dp"
                 android:gravity="center"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/carbs_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="11:45"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="11:45" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -234,18 +227,16 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
             <TextView
                 android:id="@+id/carbs_pump"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="PH"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="PH" />
 
             <TextView
                 android:id="@+id/carbs_invalid"

--- a/app/src/main/res/layout/treatments_careportal_fragment.xml
+++ b/app/src/main/res/layout/treatments_careportal_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsCareportalFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_careportal_item.xml
+++ b/app/src/main/res/layout/treatments_careportal_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardBackgroundColor="?android:colorBackground">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,17 +38,16 @@
                 android:gravity="center_vertical|end"
                 android:paddingStart="10dp"
                 android:paddingEnd="5dp"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText" />
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingEnd="10dp"
-                android:text="18:00"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="18:00" />
 
             <TextView
                 android:id="@+id/type"
@@ -73,9 +71,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
             <TextView
                 android:id="@+id/invalid"
@@ -109,8 +106,8 @@
                 android:layout_gravity="center_vertical"
                 android:layout_weight="1"
                 android:paddingEnd="10dp"
-                android:text="Activity"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="Activity" />
 
             <CheckBox
                 android:id="@+id/cb_remove"

--- a/app/src/main/res/layout/treatments_extendedbolus_fragment.xml
+++ b/app/src/main/res/layout/treatments_extendedbolus_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsExtendedBolusesFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_extendedbolus_item.xml
+++ b/app/src/main/res/layout/treatments_extendedbolus_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardBackgroundColor="?android:colorBackground">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,37 +38,35 @@
                 android:gravity="center_vertical"
                 android:paddingStart="10dp"
                 android:paddingEnd="5dp"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText" />
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="18:00"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText" />
+                tools:text="18:00" />
 
             <TextView
                 android:id="@+id/insulin"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="150%"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="150%" />
 
             <TextView
                 android:id="@+id/duration"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="30 min"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="30 min" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
                 android:layout_weight="1"
@@ -80,18 +77,16 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
-                android:text="PH"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="PH" />
 
             <TextView
                 android:id="@+id/ns"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
         </LinearLayout>
 
@@ -104,7 +99,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="top"
-                android:paddingLeft="10dp"
+                android:paddingStart="10dp"
                 android:paddingEnd="5dp"
                 android:text="@string/tempbasals_netratio_label_string"
                 android:textAppearance="?android:attr/textAppearanceSmall"
@@ -116,17 +111,18 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:paddingEnd="10dp"
-                android:text="0.05 U/h"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="0.05 U/h" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="top"
-                android:paddingRight="10dp"
+                android:paddingEnd="10dp"
                 android:text="@string/tempbasals_iob_label_string"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:ignore="RtlSymmetry" />
 
             <TextView
                 android:id="@+id/iob"
@@ -134,12 +130,11 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="30dp"
-                android:text="0.12 U"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                tools:text="0.12 U" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
                 android:layout_weight="1"
@@ -173,10 +168,10 @@
             android:id="@+id/delimiter"
             android:layout_width="fill_parent"
             android:layout_height="2dip"
-            android:layout_marginBottom="5dp"
             android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
             android:layout_marginTop="5dp"
+            android:layout_marginRight="5dp"
+            android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/treatments_profileswitch_fragment.xml
+++ b/app/src/main/res/layout/treatments_profileswitch_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsProfileSwitchFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_profileswitch_item.xml
+++ b/app/src/main/res/layout/treatments_profileswitch_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardBackgroundColor="?android:colorBackground">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,17 +38,16 @@
                 android:gravity="center_vertical|end"
                 android:paddingStart="10dp"
                 android:paddingEnd="5dp"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText" />
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="18:00"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="18:00" />
 
             <TextView
                 android:id="@+id/name"
@@ -57,28 +55,28 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:paddingStart="10dp"
-                android:text="Name"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="Name" />
 
             <TextView
                 android:id="@+id/ph"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingEnd="10dp"
-                android:text="PH"
                 android:textAlignment="viewEnd"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="PH" />
 
             <TextView
                 android:id="@+id/ns"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingEnd="10dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="NS" />
 
         </LinearLayout>
 
@@ -93,9 +91,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="60 min"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="60 min" />
 
             <TextView
                 android:id="@+id/spacer"

--- a/app/src/main/res/layout/treatments_tempbasals_fragment.xml
+++ b/app/src/main/res/layout/treatments_tempbasals_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsTemporaryBasalsFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_tempbasals_item.xml
+++ b/app/src/main/res/layout/treatments_tempbasals_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardBackgroundColor="?android:colorBackground">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,34 +38,32 @@
                 android:gravity="center"
                 android:paddingStart="10dp"
                 android:paddingEnd="5dp"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText" />
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="18:00"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText" />
+                tools:text="18:00" />
 
             <TextView
                 android:id="@+id/rate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="150%"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="150%" />
 
             <TextView
                 android:id="@+id/duration"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="30 min"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="30 min" />
 
             <TextView
                 android:layout_width="0dp"
@@ -78,54 +75,52 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="E"
                 android:textColor="?attr/setExtendedButtonColor"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="E" />
 
             <TextView
                 android:id="@+id/suspend_flag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="S"
                 android:textColor="?attr/setExtendedButtonColor"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="S" />
 
             <TextView
                 android:id="@+id/emulated_suspend_flag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="ES"
                 android:textColor="?attr/setExtendedButtonColor"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="ES" />
 
             <TextView
                 android:id="@+id/super_bolus_flag"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="SB"
                 android:textColor="?attr/setExtendedButtonColor"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="SB" />
 
             <TextView
                 android:id="@+id/ph"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="PH"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="PH" />
 
             <TextView
                 android:id="@+id/ns"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -155,9 +150,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="30dp"
-                android:text="0.12 U"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                tools:text="0.12 U" />
 
             <TextView
                 android:layout_width="0dp"

--- a/app/src/main/res/layout/treatments_temptarget_fragment.xml
+++ b/app/src/main/res/layout/treatments_temptarget_fragment.xml
@@ -1,13 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsTempTargetFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_temptarget_item.xml
+++ b/app/src/main/res/layout/treatments_temptarget_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
-    card_view:cardBackgroundColor="?android:colorBackground">
+    app:cardBackgroundColor="?attr/colorSurface">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,9 +22,8 @@
             android:layout_marginBottom="5dp"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            tools:ignore="HardcodedText" />
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,52 +38,51 @@
                 android:gravity="center"
                 android:paddingStart="10dp"
                 android:paddingEnd="5dp"
-                android:text="{fa-clock-o}"
-                tools:ignore="HardcodedText" />
+                tools:text="{fa-clock-o}" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="1.1.2000 18:00"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="1.1.2000 18:00" />
 
             <TextView
                 android:id="@+id/low"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="80"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="80" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="5dp"
-                android:text="-"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="-" />
 
             <TextView
                 android:id="@+id/high"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="5dp"
-                android:text="100"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="100" />
 
             <TextView
                 android:id="@+id/duration"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="30 min"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="30 min" />
 
             <TextView
                 android:layout_width="0dp"
@@ -98,9 +96,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
-                android:text="NS"
                 android:textColor="?attr/setTempButton"
-                tools:ignore="HardcodedText" />
+                tools:text="NS" />
 
         </LinearLayout>
 
@@ -134,9 +131,9 @@
                 android:layout_gravity="center_vertical"
                 android:layout_weight="1"
                 android:paddingEnd="10dp"
-                android:text="Activity"
                 android:textStyle="bold"
-                tools:ignore="HardcodedText,RtlSymmetry" />
+                tools:ignore="RtlSymmetry"
+                tools:text="Activity" />
 
             <TextView
                 android:id="@+id/invalid"

--- a/app/src/main/res/layout/treatments_user_entry_fragment.xml
+++ b/app/src/main/res/layout/treatments_user_entry_fragment.xml
@@ -1,14 +1,32 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="info.nightscout.androidaps.activities.fragments.TreatmentsUserEntryFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/no_records_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:paddingVertical="50dp"
+        android:text="@string/no_records_available"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:visibility="gone" />
+
+    <info.nightscout.androidaps.extensions.EmptyRecyclerView
         android:id="@+id/recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/treatments_user_entry_item.xml
+++ b/app/src/main/res/layout/treatments_user_entry_item.xml
@@ -17,11 +17,11 @@
         android:layout_marginBottom="5dp"
         android:background="?android:attr/dividerHorizontal"
         android:gravity="center"
-        android:text="1.1.2000"
         android:textAppearance="?android:attr/textAppearanceMedium"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="HardcodedText,RtlSymmetry" />
+        tools:ignore="RtlSymmetry"
+        tools:text="1.1.2000" />
 
     <TextView
         android:id="@+id/time"
@@ -29,12 +29,12 @@
         android:layout_height="wrap_content"
         android:paddingStart="10dp"
         android:paddingTop="3dp"
-        android:text="09:00"
         android:textAppearance="?android:attr/textAppearanceSmall"
         app:layout_constraintBottom_toBottomOf="@+id/iconSource"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/iconSource"
-        tools:ignore="HardcodedText,RtlSymmetry" />
+        tools:ignore="RtlSymmetry"
+        tools:text="09:00" />
 
     <TextView
         android:id="@+id/action"
@@ -42,11 +42,12 @@
         android:layout_height="wrap_content"
         android:paddingStart="10dp"
         android:paddingTop="3dp"
-        android:text="USER ENTRY"
         android:textAppearance="?android:attr/textAppearanceSmall"
         app:layout_constraintEnd_toStartOf="@+id/iconSource"
         app:layout_constraintStart_toEndOf="@id/time"
-        app:layout_constraintTop_toBottomOf="@id/date" />
+        app:layout_constraintTop_toBottomOf="@id/date"
+        tools:ignore="RtlSymmetry"
+        tools:text="USER ENTRY" />
 
     <ImageView
         android:id="@+id/iconSource"
@@ -57,7 +58,8 @@
         app:layout_constraintBottom_toBottomOf="@+id/action"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/action"
-        app:srcCompat="@drawable/ic_cp_bolus_carbs" />
+        app:srcCompat="@drawable/ic_cp_bolus_carbs"
+        tools:ignore="contentDescription" />
 
     <TextView
         android:id="@+id/values"
@@ -66,11 +68,11 @@
         android:layout_gravity="center_vertical"
         android:paddingStart="20dp"
         android:paddingEnd="10dp"
-        android:text="Values with units"
         android:textStyle="bold"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action" />
+        app:layout_constraintTop_toBottomOf="@id/action"
+        tools:text="Values with units" />
 
     <TextView
         android:id="@+id/notes"
@@ -78,12 +80,12 @@
         android:layout_height="wrap_content"
         android:paddingStart="20dp"
         android:paddingEnd="10dp"
-        android:text="Notes"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/values"
-        tools:ignore="HardcodedText,RtlSymmetry" />
+        tools:ignore="RtlSymmetry"
+        tools:text="Notes" />
 
     <View
         android:id="@+id/delimiter"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1198,6 +1198,7 @@
     <string name="tempt_targets">Temp Targets</string>
     <string name="carbs_and_bolus">Carbs and bolus</string>
     <string name="confirm_remove_multiple_items">Are you sure you want to remove %1$d items</string>
+    <string name="no_records_available">No records available</string>
     <string name="hide_loop">Hide loop</string>
     <string name="show_loop">Show loop</string>
     <string name="count_selected">%1$d selected</string>

--- a/core/src/main/java/info/nightscout/androidaps/extensions/EmptyRecyclerView.kt
+++ b/core/src/main/java/info/nightscout/androidaps/extensions/EmptyRecyclerView.kt
@@ -1,0 +1,89 @@
+package info.nightscout.androidaps.extensions
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class EmptyRecyclerView : RecyclerView {
+
+    private var mEmptyView: View? = null
+    private var mLoadingView: View? = null
+    private var mIsLoading = true
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+
+    private fun updateEmptyView() {
+        runOnUiThread {
+            val isEmpty = !mIsLoading && (adapter == null || adapter?.itemCount == 0)
+            visibility = isEmpty.not().toVisibility()
+            mEmptyView?.visibility = isEmpty.toVisibility()
+        }
+    }
+
+    private fun updateLoadingView() {
+        runOnUiThread {
+            mLoadingView?.visibility = mIsLoading.toVisibility()
+        }
+    }
+
+    private val observer: AdapterDataObserver = object : AdapterDataObserver() {
+        override fun onChanged() {
+            super.onChanged()
+            updateEmptyView()
+        }
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            super.onItemRangeInserted(positionStart, itemCount)
+            updateEmptyView()
+        }
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+            super.onItemRangeRemoved(positionStart, itemCount)
+            updateEmptyView()
+        }
+    }
+
+    override fun setAdapter(adapter: Adapter<*>?) {
+        val oldAdapter = getAdapter()
+        super.setAdapter(adapter)
+        update(oldAdapter, adapter)
+    }
+
+    override fun swapAdapter(adapter: Adapter<*>?, removeAndRecycleExistingViews: Boolean) {
+        val oldAdapter = getAdapter()
+        super.swapAdapter(adapter, removeAndRecycleExistingViews)
+        update(oldAdapter, adapter)
+    }
+
+    var emptyView: View?
+        get() = mEmptyView
+        set(view) {
+            mEmptyView = view
+            updateEmptyView()
+        }
+
+    var loadingView: View?
+        get() = mLoadingView
+        set(view) {
+            mLoadingView = view
+            updateLoadingView()
+        }
+
+    var isLoading: Boolean
+        get() = mIsLoading
+        set(loading) {
+            mIsLoading = loading
+            updateLoadingView()
+        }
+
+    private fun update(oldAdapter: Adapter<*>?, newAdapter: Adapter<*>?) {
+        oldAdapter?.unregisterAdapterDataObserver(observer)
+        newAdapter?.registerAdapterDataObserver(observer)
+        updateEmptyView()
+        isLoading = false
+        updateLoadingView()
+    }
+}


### PR DESCRIPTION
Treatment overview can be empty or slow loading. Showing the state to the user improves the user experience:
- Add a message when no records are available
- Show loading indicator when lists are loading and updating
- Change the background color to the surface color
- Clear up layout, using `tool:text` instead of text with `ignoreHardcode` annotation 

![treatment_loading_no_data](https://user-images.githubusercontent.com/6724749/162185148-aecea013-de40-41a5-b04e-086546b03c99.gif)

