### PR TITLE
Fix: number picker error alignment

### DIFF
--- a/app/src/main/res/layout/number_picker_layout_vertical.xml
+++ b/app/src/main/res/layout/number_picker_layout_vertical.xml
@@ -25,6 +25,8 @@
             android:gravity="center"
             android:imeOptions="actionDone"
             android:inputType="number"
+            android:paddingStart="2dp"
+            android:paddingEnd="2dp"
             tools:text="1" />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/number_picker_layout_vertical.xml
+++ b/app/src/main/res/layout/number_picker_layout_vertical.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:errorEnabled="true"
+        app:errorIconDrawable="@null"
         app:hintEnabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/core/src/main/res/layout/number_picker_layout.xml
+++ b/core/src/main/res/layout/number_picker_layout.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:errorEnabled="true"
+        app:errorIconDrawable="@null"
         app:hintEnabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION
Follow up on #1589 Remove the error icon to keep the text aligned centre