### PR TITLE
color and theme cleaning

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -183,7 +183,7 @@ class OverviewData @Inject constructor(
         } ?: R.drawable.ic_cp_basal_no_tbr
 
     fun temporaryBasalColor(context: Context?, iobCobCalculator: IobCobCalculator): Int = iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { rh.gac(context , R.attr.basal) }
-            ?: rh.gac(context, R.attr.textAppearancemediumColor)
+            ?: rh.gac(context, R.attr.defaultTextColor)
 
     /*
      * EXTENDED BOLUS

--- a/app/src/main/res/layout/actions_fragment.xml
+++ b/app/src/main/res/layout/actions_fragment.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/fragmentbackground"
     tools:context=".plugins.general.actions.ActionsFragment">
 
     <LinearLayout

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -5,7 +5,6 @@
     <color name="colorPrimary">#96CAF2</color>
     <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#40bbaa</color>
-    <color name="mdtp_white">#ffffff</color>
     <color name="mdtp_line_dark">#808080</color>
     <color name="colorLightGray">#d8d8d8</color>
     <color name="cardColorBackground">#212121</color>
@@ -166,7 +165,6 @@
     <color name="devslopepos">#FFFFFF00</color>
     <color name="devslopeneg">#FFFF00FF</color>
     <color name="actionsConfirm">#FFFF00</color>
-    <color name="tabBgColorSelected">#FF666666</color>
     <color name="deviations">#FF0000</color>
     <color name="cobAlert">#7484E2</color>
     <color name="inrangebackground">#2800FF00</color>

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -4,25 +4,30 @@
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/secondaryColorDefault</item>
+        <item name="colorAccent">@color/aaps_theme_dark_secondary</item>
         <item name="dialogTitleBackground">@color/dialog_title_background</item>
         <item name="dialogTitleColor">@color/dialog_title_color</item>
         <item name="dialogTitleIconTint">@color/dialog_title_icon_tint</item>
         <!-- New MaterialComponents attributes. -->
-        <item name="colorSecondary">@color/secondaryColorDefault</item>
+        <item name="colorSecondary">@color/aaps_theme_dark_secondary</item>
         <item name="colorPrimaryVariant">@color/primaryLightColorDefault</item>
         <item name="colorSecondaryVariant">@color/secondaryLightColorDefault</item>
         <item name="colorOnPrimary">@color/primaryTextColorDefault</item>
-        <item name="colorSurface">@color/black</item>
+        <item name="colorSurface">@color/aaps_theme_dark_surface</item>
         <item name="colorOnSurface">@color/white</item>
         <item name="colorOnSecondary">@color/white</item>
         <item name="colorOnBackground">@color/white</item>
         <item name="colorOnError">@color/black</item>
         <item name="scrimBackground">@color/mtrl_scrim_color</item>
-        <item name="popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu</item>
-        <item name="actionOverflowMenuStyle">@style/Widget.MaterialComponents.PopupMenu.Overflow</item>
-        <!-- Fragment background for some themes default transparent  -->
-        <item name="fragmentbackground">@color/transparent</item>
+        <!---Splash Background  -->
+        <item name="splashBackgroundColor">@color/splashBackground</item>
+        <!---Application Background Color  -->
+        <item name="android:windowBackground">@color/black</item>
+        <!---Text Colors -->
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:textColor">@color/white</item>
+        <!---TextColor -->
+        <item name="defaultTextColor">@color/white</item>
         <!---Notification -->
         <item name="notificationUrgent">@color/notificationUrgent</item>
         <item name="notificationNormal">@color/notificationNormal</item>
@@ -94,18 +99,12 @@
         <item name="toastBaseTextColor">@color/toastBase</item>
         <!---Input  -->
         <item name="boxStrokeColor">@color/white_alpha_20</item>
-        <!---Profile Helper  -->
-        <item name="tabBgColorSelected">@color/tabBgColorSelected</item>
         <!---Dialog Helper  -->
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="alertDialogTheme">@style/DialogTheme</item>
         <!---Disabled Text Color  -->
         <item name="disabledTextColor">@color/sandGray</item>
-        <!---Splash Background  -->
-        <item name="splashBackgroundColor">@color/splashBackground</item>
-        <!---Application Background Color  -->
-        <item name="android:windowBackground">@color/black</item>
         <!---Dialogfragment Background Color  -->
         <item name="android:dialogCornerRadius">12dp</item>
         <!---Overview and Historybrowser  -->
@@ -127,8 +126,6 @@
         <item name="errorBackgroundColor">@color/error_background</item>
         <!---Warning  -->
         <item name="warningColor">@color/warning</item>
-        <!---TextColor -->
-        <item name="defaultTextColor">@color/white</item>
         <!---TempBasal -->
         <item name="tempBasalColor">@color/tempbasal</item>
         <item name="infoColor">@color/info</item>
@@ -229,7 +226,6 @@
 
     <style name="Aaps_ActionBarStyle" parent="@style/Widget.AppCompat.ActionBar">
         <item name="android:titleTextStyle">@style/Theme.Aaps.ActionBar.TitleTextStyle</item>
-        <item name="backgroundColor">?attr/backgroundColor</item>
     </style>
 
     <style name="Theme.Aaps.ActionBar.TitleTextStyle"

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -70,10 +70,6 @@
     <attr name="toastBaseTextColor" format="reference|color" />
     <!---Input  -->
     <attr name="boxStrokeColor" format="reference|color" />
-    <!---Profile Helper  -->
-    <attr name="tabBgColorSelected" format="reference|color" />
-    <!-- Fragment background for some themes default transparent  -->
-    <attr name="fragmentbackground" format="reference|color" />
     <declare-styleable name="NumberPicker">
         <attr name="customContentDescription" format="string" />
     </declare-styleable>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -5,7 +5,6 @@
     <color name="colorPrimary">#3378C5</color>
     <color name="colorPrimaryDark">#676767</color>
     <color name="colorAccent">#40bbaa</color>
-    <color name="mdtp_white">#ffffff</color>
     <color name="mdtp_line_dark">#808080</color>
     <color name="colorLightGray">#d8d8d8</color>
     <color name="cardColorBackground">#CBCBCB</color>
@@ -76,7 +75,7 @@
     <!--    Loop     -->
     <color name="loopDisconnected">#939393</color>
     <color name="loopClosed">#00C03E</color>
-    <color name="loopSuspended">#FFFF13</color>
+    <color name="loopSuspended">#F6CE22</color>
     <color name="loopOpened">#4983D7</color>
     <color name="loopDisabled">#FF1313</color>
 
@@ -97,7 +96,7 @@
     <color name="red">#FF0000</color>
     <color name="blue">#0000FF</color>
 
-    <color name="ribbonDefault">#5a595b</color>
+    <color name="ribbonDefault">#8C8C8C</color>
     <color name="daySelected">#D000FF00</color>
     <color name="weekdayOutline">#1ea3e5</color>
     <color name="weekendOutline">#1e88e5</color>
@@ -169,7 +168,6 @@
     <color name="devslopepos">#FFFFFF00</color>
     <color name="devslopeneg">#FFFF00FF</color>
     <color name="actionsConfirm">#FFFF00</color>
-    <color name="tabBgColorSelected">#FF666666</color>
     <color name="deviations">#FF0000</color>
     <color name="cobAlert">#7484E2</color>
     <color name="inrangebackground">#2800FF00</color>
@@ -190,7 +188,7 @@
     <color name="cardObjectiveText">#779ECB</color>
 
     <color name="colorAcceptTempButton">#E19701</color>
-    <color name="colorTreatmentButton">#429BF5</color>
+    <color name="colorTreatmentButton">#006493</color>
     <color name="colorInsulinButton">#67dfe8</color>
     <color name="colorCarbsButton">#E19701</color>
     <color name="colorCalibrationButton">#e93057</color>
@@ -298,18 +296,66 @@
     <color name="ic_pod_management_rl_stats">@color/rl_board_shape</color>
     <color name="ic_pod_management_rl_stats_outline">@color/rl_icon_outline</color>
 
-    <!---Example light theme colors -->
-    <color name="aaps_theme_light_primary">#1D5FA5</color>
+    <!---Example light theme colors for testing
+         build with material 3 theme builder
+         colors can be used also if we change to material 3
+         !!! In the moment only tested in light theme !!! -->
+    <color name="aaps_theme_light_primary">#006493</color>
     <color name="aaps_theme_light_onPrimary">#FFFFFF</color>
-    <color name="aaps_theme_light_secondary">#5954A8</color>
+    <color name="aaps_theme_light_primaryContainer">#C7E6FF</color>
+    <color name="aaps_theme_light_onPrimaryContainer">#001E30</color>
+    <color name="aaps_theme_light_secondary">#006A5F</color>
     <color name="aaps_theme_light_onSecondary">#FFFFFF</color>
+    <color name="aaps_theme_light_secondaryContainer">#4FFBE6</color>
+    <color name="aaps_theme_light_onSecondaryContainer">#00201C</color>
+    <color name="aaps_theme_light_tertiary">#7D5260</color>
+    <color name="aaps_theme_light_onTertiary">#FFFFFF</color>
+    <color name="aaps_theme_light_tertiaryContainer">#FFD8E4</color>
+    <color name="aaps_theme_light_onTertiaryContainer">#31111D</color>
     <color name="aaps_theme_light_error">#B3261E</color>
+    <color name="aaps_theme_light_errorContainer">#F9DEDC</color>
     <color name="aaps_theme_light_onError">#FFFFFF</color>
-    <color name="aaps_theme_light_background">#FFFBFE</color>
-    <color name="aaps_theme_light_onBackground">#1C1B1F</color>
-    <color name="aaps_theme_light_surface">#FAF9F8</color>
-    <color name="aaps_theme_light_onSurface">#1C1B1F</color>
-    <color name="aaps_theme_light_surfaceVariant">#E2E0DF</color>
+    <color name="aaps_theme_light_onErrorContainer">#410E0B</color>
+    <color name="aaps_theme_light_background">#FFFBFC</color>
+    <color name="aaps_theme_light_onBackground">#1D1B1E</color>
+    <color name="aaps_theme_light_surface">#FFFBFC</color>
+    <color name="aaps_theme_light_onSurface">#1D1B1E</color>
+    <color name="aaps_theme_light_surfaceVariant">#E7E0EC</color>
+    <color name="aaps_theme_light_onSurfaceVariant">#49454F</color>
+    <color name="aaps_theme_light_outline">#79747E</color>
+    <color name="aaps_theme_light_inverseOnSurface">#F5EFF3</color>
+    <color name="aaps_theme_light_inverseSurface">#322F33</color>
+    <color name="aaps_theme_light_inversePrimary">#88CEFF</color>
+    <color name="aaps_theme_light_shadow">#000000</color>
+    <color name="aaps_theme_light_primaryInverse">#88CEFF</color>
+    <color name="aaps_theme_dark_primary">#88CEFF</color>
+    <color name="aaps_theme_dark_onPrimary">#00344F</color>
+    <color name="aaps_theme_dark_primaryContainer">#004B6F</color>
+    <color name="aaps_theme_dark_onPrimaryContainer">#C7E6FF</color>
+    <color name="aaps_theme_dark_secondary">#17DECA</color>
+    <color name="aaps_theme_dark_onSecondary">#003730</color>
+    <color name="aaps_theme_dark_secondaryContainer">#005047</color>
+    <color name="aaps_theme_dark_onSecondaryContainer">#4FFBE6</color>
+    <color name="aaps_theme_dark_tertiary">#EFB8C8</color>
+    <color name="aaps_theme_dark_onTertiary">#492532</color>
+    <color name="aaps_theme_dark_tertiaryContainer">#633B48</color>
+    <color name="aaps_theme_dark_onTertiaryContainer">#FFD8E4</color>
+    <color name="aaps_theme_dark_error">#F2B8B5</color>
+    <color name="aaps_theme_dark_errorContainer">#8C1D18</color>
+    <color name="aaps_theme_dark_onError">#601410</color>
+    <color name="aaps_theme_dark_onErrorContainer">#F9DEDC</color>
+    <color name="aaps_theme_dark_background">#1D1B1E</color>
+    <color name="aaps_theme_dark_onBackground">#E7E1E5</color>
+    <color name="aaps_theme_dark_surface">#1D1B1E</color>
+    <color name="aaps_theme_dark_onSurface">#E7E1E5</color>
+    <color name="aaps_theme_dark_surfaceVariant">#49454F</color>
+    <color name="aaps_theme_dark_onSurfaceVariant">#CAC4D0</color>
+    <color name="aaps_theme_dark_outline">#938F99</color>
+    <color name="aaps_theme_dark_inverseOnSurface">#1D1B1E</color>
+    <color name="aaps_theme_dark_inverseSurface">#E7E1E5</color>
+    <color name="aaps_theme_dark_inversePrimary">#006493</color>
+    <color name="aaps_theme_dark_shadow">#000000</color>
+    <color name="aaps_theme_dark_primaryInverse">#006493</color>
 
 
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -4,39 +4,41 @@
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!---Example light theme colors -->
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorOnPrimary">@color/aaps_theme_light_onPrimary</item>
         <item name="colorSecondary">@color/aaps_theme_light_secondary</item>
         <item name="colorOnSecondary">@color/aaps_theme_light_onSecondary</item>
         <item name="colorError">@color/aaps_theme_light_error</item>
         <item name="colorOnError">@color/aaps_theme_light_onError</item>
         <item name="android:colorBackground">@color/aaps_theme_light_background</item>
         <item name="colorOnBackground">@color/aaps_theme_light_onBackground</item>
-        <item name="colorSurface">@color/aaps_theme_light_surfaceVariant</item>
+        <item name="colorSurface">@color/aaps_theme_light_surface</item>
         <item name="colorOnSurface">@color/aaps_theme_light_onSurface</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorPrimaryDark">@color/aaps_theme_light_primary</item>
         <item name="colorAccent">@color/aaps_theme_light_secondary</item>
         <item name="dialogTitleBackground">@color/dialog_title_background</item>
         <item name="dialogTitleColor">@color/dialog_title_color</item>
         <item name="dialogTitleIconTint">@color/dialog_title_icon_tint</item>
-        <!-- Actionbar -->
-        <item name="actionBarTheme">@style/ThemeOverlay.MaterialComponents.ActionBar</item>
         <!-- New MaterialComponents attributes. -->
         <item name="colorPrimaryVariant">@color/primaryLightColorDefault</item>
         <item name="colorSecondaryVariant">@color/secondaryLightColorDefault</item>
-        <item name="scrimBackground">@color/aaps_theme_light_background</item>
-        <item name="popupMenuStyle">@style/Widget.MaterialComponents.PopupMenu</item>
-        <item name="actionOverflowMenuStyle">@style/Widget.MaterialComponents.PopupMenu.Overflow</item>
+        <item name="scrimBackground">@color/mtrl_scrim_color</item>
+        <!---Splash Background  -->
+        <item name="splashBackgroundColor">@color/aaps_theme_light_background</item>
+        <!---Application Background Color  -->
+        <item name="android:windowBackground">@color/aaps_theme_light_background</item>
         <!---Text Colors -->
         <item name="android:textColorPrimary">@color/black</item>
         <item name="android:textColor">@color/black</item>
+        <!---TextColor -->
+        <item name="defaultTextColor">@color/black</item>
+        <!---Disabled Text Color  -->
+        <item name="disabledTextColor">@color/sandGray</item>
         <!---Notification -->
         <item name="notificationUrgent">@color/notificationUrgent</item>
         <item name="notificationNormal">@color/notificationNormal</item>
         <item name="notificationLow">@color/notificationLow</item>
         <item name="notificationInfo">@color/notificationInfo</item>
         <item name="notificationAnnouncement">@color/notificationAnnouncement</item>
-        <!-- Fragment background for some themes default transparent  -->
-        <item name="fragmentbackground">@color/transparent</item>
         <item name="actionModeCloseDrawable">@drawable/ic_close</item>
         <!---bolus color -->
         <item name="bolusColor">@color/bolus</item>
@@ -102,18 +104,10 @@
         <item name="toastBaseTextColor">@color/toastBase</item>
         <!---Input  -->
         <item name="boxStrokeColor">@color/white</item>
-        <!---Profile Helper  -->
-        <item name="tabBgColorSelected">@color/tabBgColorSelected</item>
         <!---Dialog Helper  -->
         <item name="materialAlertDialogTheme">@style/DialogTheme</item>
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="alertDialogTheme">@style/DialogTheme</item>
-        <!---Disabled Text Color  -->
-        <item name="disabledTextColor">@color/sandGray</item>
-        <!---Splash Background  -->
-        <item name="splashBackgroundColor">@color/splashBackground</item>
-        <!---Application Background Color  -->
-        <item name="android:windowBackground">@color/white</item>
         <!---Dialogfragment Background Color  -->
         <item name="android:dialogCornerRadius">12dp</item>
         <!---Overview and Historybrowser  -->
@@ -135,8 +129,6 @@
         <item name="errorBackgroundColor">@color/error_background</item>
         <!---Warning  -->
         <item name="warningColor">@color/warning</item>
-        <!---TextColor -->
-        <item name="defaultTextColor">@color/black</item>
         <!---TempBasal -->
         <item name="tempBasalColor">@color/tempbasal</item>
         <item name="infoColor">@color/info</item>
@@ -226,7 +218,7 @@
         <item name="devslopeposColor">@color/devslopepos</item>
         <item name="predictionColor">@color/prediction</item>
         <item name="bgiColor">@color/bgi</item>
-        <item name="ratioColor">@color/ratio</item>
+        <item name="ratioColor">@color/lightSandGray</item>
         <item name="activityColor">@color/activity</item>
         <!-- CardView specific colors  -->
         <item name="strokeColor">@color/plastic_grey</item>
@@ -237,7 +229,6 @@
 
     <style name="Aaps_ActionBarStyle" parent="@style/Widget.AppCompat.ActionBar">
         <item name="android:titleTextStyle">@style/Theme.Aaps.ActionBar.TitleTextStyle</item>
-        <item name="backgroundColor">?attr/backgroundColor</item>
     </style>
 
     <style name="Theme.Aaps.ActionBar.TitleTextStyle"


### PR DESCRIPTION
- Begin with cleaning attributes , styles and colors not really needed. Not ready yet , will be continued.
- In addition fix again the gray text colors in overview info section ( now white colors again, because they are better readable )
- Working on light theme colors , build with the new material theme builder 

Open for  wishes or propsals for better coloring
@MilosKozak : I think we can start open theme switching and testing under developers

![AAPS_Dark](https://user-images.githubusercontent.com/25795894/162567912-35e21c57-618d-4654-ae3b-3c526faf3d0f.PNG)
![AAPS_light](https://user-images.githubusercontent.com/25795894/162567913-2b2ad12c-a1cc-42d4-b015-d79e47a9dbff.PNG)

 