### PR TITLE
style event date time to material input

### DIFF
--- a/core/src/main/res/drawable-hdpi/background_darkgray.xml
+++ b/core/src/main/res/drawable-hdpi/background_darkgray.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-
-    <solid android:color="#505050"/>
-    <stroke android:width="1dp" android:color="@color/colorLightGray"/>
-    <corners android:radius="4dp" />
-</shape>

--- a/core/src/main/res/drawable-hdpi/background_input_border.xml
+++ b/core/src/main/res/drawable-hdpi/background_input_border.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/mtrl_textinput_default_box_stroke_color" />
+    <corners android:radius="4dp" />
+
+</shape>

--- a/core/src/main/res/layout/datetime.xml
+++ b/core/src/main/res/layout/datetime.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingTop="2dp"
     android:orientation="horizontal">
 
     <TextView
@@ -21,6 +22,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/background_input_border"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
         android:padding="10dp"
         android:text="2017/05/05" />
 
@@ -29,6 +34,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:background="@drawable/background_input_border"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
         android:padding="10dp"
         android:text="08:20pm" />
 


### PR DESCRIPTION
In the dialogs the Event time inputs are text views to set date and time, giving the materiel input bordered appearance, makes the users aware they are editable.
- Add border stroke
- Add click ripple effect

![image](https://user-images.githubusercontent.com/6724749/162634285-7f4c30e0-4a2c-4fa0-9b99-60242df8f484.png)
