### PR TITLE
Fix widget color

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/widget/Widget.kt
+++ b/app/src/main/java/info/nightscout/androidaps/widget/Widget.kt
@@ -105,17 +105,17 @@ class Widget : AppWidgetProvider() {
         views.setTextViewText(R.id.bg, overviewData.lastBg?.valueToUnitsString(units) ?: rh.gs(R.string.notavailable))
         views.setTextColor(
             R.id.bg, when {
-                overviewData.isLow  -> rh.gc(R.color.low)
-                overviewData.isHigh -> rh.gc(R.color.high)
-                else                -> rh.gc(R.color.inrange)
+                overviewData.isLow  -> rh.gc(R.color.widget_low)
+                overviewData.isHigh -> rh.gc(R.color.widget_high)
+                else                -> rh.gc(R.color.widget_inrange)
             }
         )
         views.setImageViewResource(R.id.arrow, trendCalculator.getTrendArrow(overviewData.lastBg).directionToIcon())
         views.setInt(
             R.id.arrow, "setColorFilter", when {
-                overviewData.isLow  -> rh.gc(R.color.low)
-                overviewData.isHigh -> rh.gc(R.color.high)
-                else                -> rh.gc(R.color.inrange)
+                overviewData.isLow  -> rh.gc(R.color.widget_low)
+                overviewData.isHigh -> rh.gc(R.color.widget_high)
+                else                -> rh.gc(R.color.widget_inrange)
             }
         )
 
@@ -140,7 +140,7 @@ class Widget : AppWidgetProvider() {
 
     private fun updateTemporaryBasal(views: RemoteViews) {
         views.setTextViewText(R.id.base_basal, overviewData.temporaryBasalText(iobCobCalculator))
-        views.setTextColor(R.id.base_basal, iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { rh.gc(R.color.basal) }
+        views.setTextColor(R.id.base_basal, iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { rh.gc(R.color.widget_basal) }
             ?: rh.gc(R.color.white))
         views.setImageViewResource(R.id.base_basal_icon, overviewData.temporaryBasalIcon(iobCobCalculator))
     }
@@ -176,7 +176,7 @@ class Widget : AppWidgetProvider() {
             // this is crashing, use background as text for now
             //views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonTextWarning))
             //views.setInt(R.id.temp_target, "setBackgroundColor", rh.gc(R.color.ribbonWarning))
-            views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonWarning))
+            views.setTextColor(R.id.temp_target, rh.gc(R.color.widget_ribbonWarning))
             views.setTextViewText(R.id.temp_target, Profile.toTargetRangeString(tempTarget.lowTarget, tempTarget.highTarget, GlucoseUnit.MGDL, units) + " " + dateUtil.untilString(tempTarget.end, rh))
         } else {
             // If the target is not the same as set in the profile then oref has overridden it
@@ -189,12 +189,12 @@ class Widget : AppWidgetProvider() {
                     // this is crashing, use background as text for now
                     //views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonTextWarning))
                     //views.setInt(R.id.temp_target, "setBackgroundResource", rh.gc(R.color.tempTargetBackground))
-                    views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonWarning))
+                    views.setTextColor(R.id.temp_target, rh.gc(R.color.widget_ribbonWarning))
                 } else {
                     // this is crashing, use background as text for now
                     //views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonTextDefault))
                     //views.setInt(R.id.temp_target, "setBackgroundColor", rh.gc(R.color.ribbonDefault))
-                    views.setTextColor(R.id.temp_target, rh.gc(R.color.ribbonTextDefault))
+                    views.setTextColor(R.id.temp_target, rh.gc(R.color.widget_ribbonTextDefault))
                     views.setTextViewText(R.id.temp_target, Profile.toTargetRangeString(profile.getTargetLowMgdl(), profile.getTargetHighMgdl(), GlucoseUnit.MGDL, units))
                 }
             }
@@ -206,14 +206,14 @@ class Widget : AppWidgetProvider() {
             profileFunction.getProfile()?.let {
                 if (it is ProfileSealed.EPS) {
                     if (it.value.originalPercentage != 100 || it.value.originalTimeshift != 0L || it.value.originalDuration != 0L)
-                        rh.gc(R.color.ribbonWarning)
-                    else rh.gc(R.color.ribbonTextDefault)
+                        rh.gc(R.color.widget_ribbonWarning)
+                    else rh.gc(R.color.widget_ribbonTextDefault)
                 } else if (it is ProfileSealed.PS) {
-                    rh.gc(R.color.ribbonTextDefault)
+                    rh.gc(R.color.widget_ribbonTextDefault)
                 } else {
-                    rh.gc(R.color.ribbonTextDefault)
+                    rh.gc(R.color.widget_ribbonTextDefault)
                 }
-            } ?: rh.gc(R.color.ribbonCritical)
+            } ?: rh.gc(R.color.widget_ribbonCritical)
 
         views.setTextViewText(R.id.active_profile, profileFunction.getProfileNameWithRemainingTime())
         // this is crashing, use background as text for now

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -357,5 +357,17 @@
     <color name="aaps_theme_dark_shadow">#000000</color>
     <color name="aaps_theme_dark_primaryInverse">#006493</color>
 
+    <!-- widget theme color -->
+    <!-- This section describes the widget theme colors
+     Because the implementation of google has no idea of a light/dark mode until now
+     we generate extra colornames only used for the widget
+     Colors for the widget are always taken from the default color.xml-->
+    <color name="widget_inrange">#00FF00</color>
+    <color name="widget_low">#FF0000</color>
+    <color name="widget_high">#FFFF00</color>
+    <color name="widget_ribbonWarning">#f4d700</color>
+    <color name="widget_ribbonTextDefault">#FFFFFF</color>
+    <color name="widget_ribbonCritical">#ff0400</color>
+    <color name="widget_basal">#00ffff</color>
 
 </resources>


### PR DESCRIPTION
This solves the problem that widgets by google have no idea of light/dark mode.
Widgets color are taken always from the default color table, which is used for light mode in aaps.
So we create extra colors for the widget.

Solves issue: https://github.com/nightscout/AndroidAPS/issues/1604