### PR TITLE
chore: implement view binding adapter number picker

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/ProfileHelperActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/ProfileHelperActivity.kt
@@ -241,10 +241,10 @@ class ProfileHelperActivity : NoSplashAppCompatActivity() {
             }
             ToastUtils.showToastInUiThread(this, R.string.invalidinput)
         }
-        binding.age.editText?.id?.let { binding.ageLabel.labelFor = it }
-        binding.tdd.editText?.id?.let { binding.tddLabel.labelFor = it }
-        binding.weight.editText?.id?.let { binding.weightLabel.labelFor = it }
-        binding.basalPctFromTdd.editText?.id?.let { binding.basalPctFromTddLabel.labelFor = it }
+        binding.ageLabel.labelFor = binding.age.editTextId
+        binding.tddLabel.labelFor = binding.tdd.editTextId
+        binding.weightLabel.labelFor = binding.weight.editTextId
+        binding.basalPctFromTddLabel.labelFor = binding.basalPctFromTdd.editTextId
 
         switchTab(0, typeSelected[0], false)
     }

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CalibrationDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CalibrationDialog.kt
@@ -64,7 +64,7 @@ class CalibrationDialog : DialogFragmentWithDate() {
             binding.bg.setParams(savedInstanceState?.getDouble("bg")
                 ?: bg, 36.0, 500.0, 1.0, DecimalFormat("0"), false, binding.okcancel.ok)
         binding.units.text = if (units == GlucoseUnit.MMOL) rh.gs(R.string.mmol) else rh.gs(R.string.mgdl)
-        binding.bg.editText?.id?.let { binding.bgLabel.labelFor = it }
+        binding.bgLabel.labelFor = binding.bg.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CarbsDialog.kt
@@ -199,9 +199,9 @@ class CarbsDialog : DialogFragmentWithDate() {
             binding.hypoTt.isChecked = false
             binding.activityTt.isChecked = false
         }
-        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
-        binding.time.editText?.id?.let { binding.timeLabel.labelFor = it }
-        binding.carbs.editText?.id?.let { binding.carbsLabel.labelFor = it }
+        binding.durationLabel.labelFor = binding.duration.editTextId
+        binding.timeLabel.labelFor = binding.time.editTextId
+        binding.carbsLabel.labelFor = binding.carbs.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/CareDialog.kt
@@ -165,8 +165,8 @@ class CareDialog : DialogFragmentWithDate() {
             ?: 0.0, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, binding.okcancel.ok)
         if (options == EventType.NOTE || options == EventType.QUESTION || options == EventType.ANNOUNCEMENT || options == EventType.EXERCISE)
             binding.notesLayout.root.visibility = View.VISIBLE // independent to preferences
-        binding.bg.editText?.id?.let { binding.bgLabel.labelFor = it }
-        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+        binding.bgLabel.labelFor = binding.bg.editTextId
+        binding.durationLabel.labelFor = binding.duration.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ExtendedBolusDialog.kt
@@ -75,8 +75,8 @@ class ExtendedBolusDialog : DialogFragmentWithDate() {
         val extendedMaxDuration = pumpDescription.extendedBolusMaxDuration
         binding.duration.setParams(savedInstanceState?.getDouble("duration")
             ?: extendedDurationStep, extendedDurationStep, extendedMaxDuration, extendedDurationStep, DecimalFormat("0"), false, binding.okcancel.ok)
-        binding.insulin.editText?.id?.let { binding.insulinLabel.labelFor = it }
-        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+        binding.insulinLabel.labelFor = binding.insulin.editTextId
+        binding.durationLabel.labelFor = binding.duration.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/FillDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/FillDialog.kt
@@ -99,7 +99,7 @@ class FillDialog : DialogFragmentWithDate() {
         } else {
             binding.fillPresetButton3.visibility = View.GONE
         }
-        binding.fillInsulinamount.editText?.id?.let { binding.fillLabel.labelFor = it }
+        binding.fillLabel.labelFor = binding.fillInsulinamount.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/InsulinDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/InsulinDialog.kt
@@ -150,8 +150,8 @@ class InsulinDialog : DialogFragmentWithDate() {
         binding.recordOnly.setOnCheckedChangeListener { _, isChecked: Boolean ->
             binding.timeLayout.visibility = isChecked.toVisibility()
         }
-        binding.amount.editText?.id?.let { binding.insulinLabel.labelFor = it }
-        binding.time.editText?.id?.let { binding.timeLabel.labelFor = it }
+        binding.insulinLabel.labelFor = binding.amount.editTextId
+        binding.timeLabel.labelFor = binding.time.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/ProfileSwitchDialog.kt
@@ -152,9 +152,9 @@ class ProfileSwitchDialog : DialogFragmentWithDate() {
                 }
         }
         binding.ttLayout.visibility = View.GONE
-        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
-        binding.percentage.editText?.id?.let { binding.percentageLabel.labelFor = it }
-        binding.timeshift.editText?.id?.let { binding.timeshiftLabel.labelFor = it }
+        binding.durationLabel.labelFor = binding.duration.editTextId
+        binding.percentageLabel.labelFor = binding.percentage.editTextId
+        binding.timeshiftLabel.labelFor = binding.timeshift.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TempBasalDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TempBasalDialog.kt
@@ -89,9 +89,9 @@ class TempBasalDialog : DialogFragmentWithDate() {
             binding.percentLayout.visibility = View.GONE
             binding.absoluteLayout.visibility = View.VISIBLE
         }
-        binding.basalPercentInput.editText?.id?.let { binding.basalPercentLabel.labelFor = it }
-        binding.basalAbsoluteInput.editText?.id?.let { binding.basalAbsoluteLabel.labelFor = it }
-        binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
+        binding.basalPercentLabel.labelFor = binding.basalPercentInput.editTextId
+        binding.basalAbsoluteLabel.labelFor = binding.basalAbsoluteInput.editTextId
+        binding.durationLabel.labelFor = binding.duration.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TempTargetDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TempTargetDialog.kt
@@ -123,8 +123,8 @@ class TempTargetDialog : DialogFragmentWithDate() {
                 longClick(it)
                 return@setOnLongClickListener true
             }
-            binding.duration.editText?.id?.let { binding.durationLabel.labelFor = it }
-            binding.temptarget.editText?.id?.let { binding.temptargetLabel.labelFor = it }
+            binding.durationLabel.labelFor = binding.duration.editTextId
+            binding.temptargetLabel.labelFor = binding.temptarget.editTextId
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/TreatmentDialog.kt
@@ -108,8 +108,8 @@ class TreatmentDialog : DialogFragmentWithDate() {
         binding.insulin.setParams(savedInstanceState?.getDouble("insulin")
             ?: 0.0, 0.0, maxInsulin, pumpDescription.bolusStep, DecimalFormatter.pumpSupportedBolusFormat(activePlugin.activePump), false, binding.okcancel.ok, textWatcher)
         binding.recordOnlyLayout.visibility = View.GONE
-        binding.insulin.editText?.id?.let { binding.insulinLabel.labelFor = it }
-        binding.carbs.editText?.id?.let { binding.carbsLabel.labelFor = it }
+        binding.insulinLabel.labelFor = binding.insulin.editTextId
+        binding.carbsLabel.labelFor = binding.carbs.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -248,10 +248,10 @@ class WizardDialog : DaggerDialogFragment() {
     }
 
     private fun setA11yLabels() {
-        binding.bgInput.editText?.id?.let { binding.bgInputLabel.labelFor = it }
-        binding.carbsInput.editText?.id?.let { binding.carbsInputLabel.labelFor = it }
-        binding.correctionInput.editText?.id?.let { binding.correctionInputLabel.labelFor = it }
-        binding.carbTimeInput.editText?.id?.let { binding.carbTimeInputLabel.labelFor = it }
+        binding.bgInputLabel.labelFor = binding.bgInput.editTextId
+        binding.carbsInputLabel.labelFor = binding.carbsInput.editTextId
+        binding.correctionInputLabel.labelFor = binding.correctionInput.editTextId
+        binding.carbTimeInputLabel.labelFor = binding.carbTimeInput.editTextId
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/profile/local/LocalProfileFragment.kt
@@ -115,9 +115,7 @@ class LocalProfileFragment : DaggerFragment() {
             override fun onTabUnselected(tab: TabLayout.Tab) {}
             override fun onTabReselected(tab: TabLayout.Tab) {}
         })
-
-        binding.dia.editText?.id?.let { binding.diaLabel.labelFor = it }
-
+        binding.diaLabel.labelFor = binding.dia.editTextId
         binding.unlock.setOnClickListener { queryProtection() }
     }
 

--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/MinutesNumberPicker.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/MinutesNumberPicker.kt
@@ -13,16 +13,16 @@ class MinutesNumberPicker constructor(context: Context, attrs: AttributeSet? = n
     }
 
     override fun updateEditText() {
-        if (currentValue == 0.0 && !allowZero) editText?.setText("")
+        if (currentValue == 0.0 && !allowZero) binding.editText.setText("")
         else {
-            if (focused) editText?.setText(DecimalFormat("0").format(currentValue))
+            if (focused) binding.editText.setText(DecimalFormat("0").format(currentValue))
             else {
                 val hours = (currentValue / 60).toInt()
                 val minutes = (currentValue - hours * 60).toInt()
                 val formatted =
                     if (hours != 0) String.format(context.getString(R.string.format_hour_minute), hours, minutes)
                     else DecimalFormat("0").format(currentValue)
-                editText?.setText(formatted)
+                binding.editText.setText(formatted)
             }
         }
     }

--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPickerVertical.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPickerVertical.kt
@@ -3,11 +3,13 @@ package info.nightscout.androidaps.utils.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import info.nightscout.androidaps.R
+import info.nightscout.androidaps.core.databinding.NumberPickerLayoutVerticalBinding
 
 class NumberPickerVertical(context: Context, attrs: AttributeSet? = null) : NumberPicker(context, attrs) {
 
     override fun inflate(context: Context) {
-        LayoutInflater.from(context).inflate(R.layout.number_picker_layout_vertical, this, true)
+        val inflater = LayoutInflater.from(context)
+        val bindLayout = NumberPickerLayoutVerticalBinding.inflate(inflater, this, true)
+        binding = NumberPickerViewAdapter(null, bindLayout)
     }
 }

--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPickerViewAdapter.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/NumberPickerViewAdapter.kt
@@ -1,0 +1,36 @@
+package info.nightscout.androidaps.utils.ui
+
+import info.nightscout.androidaps.core.databinding.NumberPickerLayoutBinding
+import info.nightscout.androidaps.core.databinding.NumberPickerLayoutVerticalBinding
+
+/**
+ * NumberPickerViewAdapter binds both NumberPickerLayoutBinding and NumberPickerLayoutVerticalBinding shared attributes to one common view adapter.
+ * Requires at least one of the ViewBinding as a parameter. Recommended to use the factory object to create the binding.
+ */
+class NumberPickerViewAdapter(
+    val nH: NumberPickerLayoutBinding?,
+    val nV: NumberPickerLayoutVerticalBinding?,
+) {
+
+    init {
+        if (nH == null && nV == null) {
+            throw IllegalArgumentException("Require at least on Binding parameter")
+        }
+    }
+
+    val editText = nH?.display ?: nV?.display ?: throw IllegalArgumentException("Missing require View Binding parameter display")
+    val minusButton = nH?.decrement ?: nV?.decrement ?: throw IllegalArgumentException("require at least on Binding parameter decrement")
+    val plusButton = nH?.increment ?: nV?.increment ?: throw IllegalArgumentException("require at least on Binding parameter increment")
+    var textInputLayout = nH?.textInputLayout ?: nV?.textInputLayout ?: throw IllegalArgumentException("require at least on Binding parameter textInputLayout")
+
+    companion object {
+
+        fun getBinding(bindLayout: NumberPickerLayoutBinding): NumberPickerViewAdapter {
+            return NumberPickerViewAdapter(bindLayout, null)
+        }
+
+        fun getBinding(bindLayout: NumberPickerLayoutVerticalBinding): NumberPickerViewAdapter {
+            return NumberPickerViewAdapter(null, bindLayout)
+        }
+    }
+}

--- a/core/src/main/res/layout/number_picker_layout.xml
+++ b/core/src/main/res/layout/number_picker_layout.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="130dp"
-    android:layout_height="40dp">
+    android:layout_height="40dp"
+    tools:context="info.nightscout.androidaps.utils.ui.NumberPicker">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/textInputLayout"

--- a/core/src/main/res/layout/number_picker_layout_vertical.xml
+++ b/core/src/main/res/layout/number_picker_layout_vertical.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="60dp"
-    android:layout_height="100dp">
+    android:layout_height="100dp"
+    tools:context="info.nightscout.androidaps.utils.ui.NumberPickerVertical">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/textInputLayout"


### PR DESCRIPTION
We are not using view binding when an implementation has multiple layouts; a possible solution is suggested in https://stackoverflow.com/questions/66214318/view-binding-with-2-possible-layouts-assign-binding-variable-to-2-generated-bin to create an adapter uniting the attributes.

With this principle, we united the layouts on the NumberPicker and NumberPickerVertical, with a bit of boilerplate code, making it type and null and safe. 

This pattern also provides a strategy to solve #259 too.