### PR TITLE
Fix style date time dialog

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
@@ -169,7 +169,7 @@ class HistoryBrowseActivity : NoSplashAppCompatActivity() {
             val cal = Calendar.getInstance()
             cal.timeInMillis = overviewData.fromTime
             DatePickerDialog(
-                this, R.style.MaterialPickerTheme,
+                this,
                 dateSetListener,
                 cal.get(Calendar.YEAR),
                 cal.get(Calendar.MONTH),

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/dialogs/EditQuickWizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/dialogs/EditQuickWizardDialog.kt
@@ -105,7 +105,7 @@ class EditQuickWizardDialog : DaggerDialogFragment(), View.OnClickListener {
         binding.from.setOnClickListener {
             context?.let {
                 TimePickerDialog(
-                    it, R.style.MaterialPickerTheme,
+                    it,
                     fromTimeSetListener,
                     T.secs(fromSeconds.toLong()).hours().toInt(),
                     T.secs((fromSeconds % 3600).toLong()).mins().toInt(),
@@ -124,7 +124,7 @@ class EditQuickWizardDialog : DaggerDialogFragment(), View.OnClickListener {
         binding.to.setOnClickListener {
             context?.let {
                 TimePickerDialog(
-                    it, R.style.MaterialPickerTheme,
+                    it,
                     toTimeSetListener,
                     T.secs(toSeconds.toLong()).hours().toInt(),
                     T.secs((toSeconds % 3600).toLong()).mins().toInt(),

--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputDateTime.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputDateTime.kt
@@ -36,7 +36,7 @@ class InputDateTime(private val rh: ResourceHelper, private val dateUtil: DateUt
                                 val cal = Calendar.getInstance()
                                 cal.timeInMillis = value
                                 DatePickerDialog(
-                                    it, R.style.MaterialPickerTheme,
+                                    it,
                                     { _, year, monthOfYear, dayOfMonth ->
                                         value = Calendar.getInstance().apply {
                                             timeInMillis = value
@@ -62,7 +62,7 @@ class InputDateTime(private val rh: ResourceHelper, private val dateUtil: DateUt
                                 val cal = Calendar.getInstance()
                                 cal.timeInMillis = value
                                 TimePickerDialog(
-                                    it, R.style.MaterialPickerTheme,
+                                    it,
                                     { _, hour, minute ->
                                         value = Calendar.getInstance().apply {
                                             timeInMillis = value

--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputTime.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputTime.kt
@@ -38,7 +38,7 @@ class InputTime(private val rh: ResourceHelper, private val dateUtil: DateUtil) 
                                 val cal = Calendar.getInstance()
                                 cal.timeInMillis = toMills(value)
                                 TimePickerDialog(
-                                    it, R.style.MaterialPickerTheme,
+                                    it,
                                     { _, hour, minute ->
                                         value = 60 * hour + minute
                                         text = dateUtil.timeString(toMills(value))

--- a/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputTimeRange.kt
+++ b/automation/src/main/java/info/nightscout/androidaps/plugins/general/automation/elements/InputTimeRange.kt
@@ -42,7 +42,7 @@ class InputTimeRange(private val rh: ResourceHelper, private val dateUtil: DateU
                                 val cal = Calendar.getInstance()
                                 cal.timeInMillis = toMills(start)
                                 TimePickerDialog(
-                                    it, R.style.MaterialPickerTheme,
+                                    it,
                                     { _, hour, minute ->
                                         start = 60 * hour + minute
                                         text = dateUtil.timeString(toMills(start))
@@ -63,7 +63,7 @@ class InputTimeRange(private val rh: ResourceHelper, private val dateUtil: DateU
                             val cal = Calendar.getInstance()
                             cal.timeInMillis = toMills(end)
                             TimePickerDialog(
-                                it, R.style.MaterialPickerTheme,
+                                it,
                                 { _, hour, minute ->
                                     end = 60 * hour + minute
                                     text = dateUtil.timeString(toMills(end))

--- a/core/src/main/java/info/nightscout/androidaps/dialogs/DialogFragmentWithDate.kt
+++ b/core/src/main/java/info/nightscout/androidaps/dialogs/DialogFragmentWithDate.kt
@@ -105,7 +105,7 @@ abstract class DialogFragmentWithDate : DaggerDialogFragment() {
                 val cal = Calendar.getInstance()
                 cal.timeInMillis = eventTime
                 DatePickerDialog(
-                    it, R.style.MaterialPickerTheme,
+                    it,
                     dateSetListener,
                     cal.get(Calendar.YEAR),
                     cal.get(Calendar.MONTH),
@@ -134,7 +134,7 @@ abstract class DialogFragmentWithDate : DaggerDialogFragment() {
                 val cal = Calendar.getInstance()
                 cal.timeInMillis = eventTime
                 TimePickerDialog(
-                    it, R.style.MaterialPickerTheme,
+                    it,
                     timeSetListener,
                     cal.get(Calendar.HOUR_OF_DAY),
                     cal.get(Calendar.MINUTE),

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -279,39 +279,6 @@
         <item name="android:textAllCaps">true</item>
     </style>
 
-
-    <style name="MaterialPickerTheme" parent="android:Theme.Material.Dialog.Alert">
-        <item name="android:datePickerStyle">@style/MaterialDatePickerStyle</item>
-        <item name="android:timePickerStyle">@style/MaterialTimePickerStyle</item>
-        <item name="android:buttonBarPositiveButtonStyle">@style/PickerTextButton</item>
-        <item name="android:buttonBarNegativeButtonStyle">@style/PickerTextButton</item>
-        <item name="colorAccent">@color/dialog_title_background</item>
-        <item name="colorSecondary">@color/dialog_title_background</item>
-        <item name="android:textColorSecondary">@color/defaulttextcolor</item>
-        <item name="android:textColorPrimary">@color/defaulttextcolor</item>
-        <item name="android:textColor">@color/defaulttextcolor</item>
-        <item name="backgroundColor">@color/dateTimePickerBackground</item>
-        <item name="android:dialogCornerRadius">12dp</item>
-    </style>
-
-    <style name="MaterialDatePickerStyle" parent="Widget.MaterialComponents.MaterialCalendar">
-        <item name="android:calendarTextColor">@color/defaulttextcolor</item>
-        <item name="android:datePickerMode">calendar</item>
-        <item name="colorSecondary">@color/dialog_title_background</item>
-        <item name="android:background">@color/dateTimePickerBackground</item>
-        <item name="android:headerBackground">@color/dialog_title_background</item>
-    </style>
-
-    <style name="MaterialTimePickerStyle" parent="Widget.MaterialComponents.TimePicker">
-        <item name="android:numbersTextColor">@color/defaulttextcolor</item>
-        <item name="android:numbersSelectorColor">@color/white_alpha_40</item>
-        <item name="android:numbersBackgroundColor">@color/dialog_title_background</item>
-        <item name="android:background">@color/dateTimePickerBackground</item>
-        <item name="android:headerBackground">@color/dialog_title_background</item>
-        <item name="android:headerTimeTextAppearance">@color/defaulttextcolor</item>
-        <item name="android:timePickerMode">clock</item>
-    </style>
-
     <style name="PickerTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
         <item name="android:textColor">@color/okButtonText</item>
     </style>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -295,35 +295,6 @@
         <item name="android:textAllCaps">true</item>
     </style>
 
-    <style name="MaterialPickerTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
-        <item name="android:datePickerStyle">@style/MaterialDatePickerStyle</item>
-        <item name="android:timePickerStyle">@style/MaterialTimePickerStyle</item>
-        <item name="android:buttonBarPositiveButtonStyle">@style/PickerTextButton</item>
-        <item name="android:buttonBarNegativeButtonStyle">@style/PickerTextButton</item>
-        <item name="colorAccent">@color/dialog_title_background</item>
-        <item name="android:textColorSecondary">@color/defaulttextcolor</item>
-        <item name="android:textColorPrimary">@color/defaulttextcolor</item>
-        <item name="android:textColor">@color/defaulttextcolor</item>
-        <item name="android:dialogCornerRadius">12dp</item>
-    </style>
-
-    <style name="MaterialDatePickerStyle" parent="Widget.MaterialComponents.MaterialCalendar">
-        <item name="android:calendarTextColor">@color/defaulttextcolor</item>
-        <item name="android:datePickerMode">calendar</item>
-        <item name="android:background">@color/dateTimePickerBackground</item>
-        <item name="android:headerBackground">@color/dialog_title_background</item>
-    </style>
-
-    <style name="MaterialTimePickerStyle" parent="Widget.MaterialComponents.TimePicker">
-        <item name="android:numbersTextColor">@color/defaulttextcolor</item>
-        <item name="android:numbersSelectorColor">@color/white_alpha_40</item>
-        <item name="android:numbersBackgroundColor">@color/dialog_title_background</item>
-        <item name="android:background">@color/dateTimePickerBackground</item>
-        <item name="android:headerBackground">@color/dialog_title_background</item>
-        <item name="android:headerTimeTextAppearance">@color/defaulttextcolor</item>
-        <item name="android:timePickerMode">clock</item>
-    </style>
-
     <style name="PickerTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
         <item name="android:textColor">@color/okButtonText</item>
     </style>


### PR DESCRIPTION
Styling Date and Time picker theme does not needed to be overwritten when using proper DayNight Time and correct colors.

Before, the theme of the dialog was not the day/night theme. (Implemented manually)

It fixes the wrong color of the time picker mentioned in https://github.com/nightscout/AndroidAPS/pull/1600#issuecomment-1094360416

Before, 
after

![image](https://user-images.githubusercontent.com/6724749/162768654-f0d6c7d0-db8e-4186-a632-6734309978a7.png)

@osodebailar What is your perspective on this change? (Are we ok, with the accentColor in the light theme as header, as default from Android?)
The other question should the Date and Time ticker be converted to the Material TimePicker https://material.io/components/time-pickers/android#using-time-pickers


