### PR TITLE
Fix style button Omnipod disabled

### DIFF
--- a/core/src/main/res/color/mtrl_btn_bg_color_selector_grey.xml
+++ b/core/src/main/res/color/mtrl_btn_bg_color_selector_grey.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="@color/buttonBackground" android:state_enabled="true"/>
+  <item android:alpha="0.12" android:color="?attr/colorOnSurface"/>
+</selector>

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -320,8 +320,7 @@
     <dimen name="gray_material_button_margin_horizontal">5dp</dimen>
 
     <style name="GrayButton" parent="Widget.MaterialComponents.Button">
-        <item name="android:backgroundTint">@color/buttonBackground</item>
-        <item name="android:textColor">@color/buttonText</item>
+        <item name="android:backgroundTint">@color/mtrl_btn_bg_color_selector_grey</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center_vertical</item>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -332,8 +332,7 @@
     <dimen name="gray_material_button_margin_horizontal">5dp</dimen>
 
     <style name="GrayButton" parent="Widget.MaterialComponents.Button">
-        <item name="android:backgroundTint">@color/buttonBackground</item>
-        <item name="android:textColor">@color/buttonText</item>
+        <item name="android:backgroundTint">@color/mtrl_btn_bg_color_selector_grey</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center_vertical</item>

--- a/omnipod-common/src/main/res/layout/omnipod_common_wizard_nav_buttons.xml
+++ b/omnipod-common/src/main/res/layout/omnipod_common_wizard_nav_buttons.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/button_cancel"
+        style="@style/GrayButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:text="@string/omnipod_common_wizard_button_cancel" />
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/button_next"
+        style="@style/GrayButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="@string/omnipod_common_wizard_button_next" />
+        android:text="@string/omnipod_common_wizard_button_next"
+        tools:enabled="false" />
+
 </LinearLayout>


### PR DESCRIPTION
Set remove redundant style for button text color, and set button background based on disabled state. Fix #1594

![image](https://user-images.githubusercontent.com/6724749/162904042-c567a616-e715-494c-b466-fdccd9fcc448.png)
