### PR TITLE
Feature statuslight opens caredialogs

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -207,6 +207,10 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         binding.infoLayout.apsMode.setOnClickListener(this)
         binding.infoLayout.apsMode.setOnLongClickListener(this)
         binding.activeProfile.setOnLongClickListener(this)
+        binding.statusLightsLayout.cannulaOrPatchLayout.setOnClickListener(this)
+        binding.statusLightsLayout.insulinLayout.setOnClickListener(this)
+        binding.statusLightsLayout.sensorLayout.setOnClickListener(this)
+        binding.statusLightsLayout.batteryLayout.setOnClickListener(this)
     }
 
     @Synchronized
@@ -333,6 +337,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         // https://stackoverflow.com/questions/14860239/checking-if-state-is-saved-before-committing-a-fragmenttransaction
         if (childFragmentManager.isStateSaved) return
         activity?.let { activity ->
+            val pump = activePlugin.activePump
             when (v.id) {
                 R.id.treatment_button    -> protectionCheck.queryProtection(
                     activity,
@@ -424,6 +429,28 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                             dialog.arguments = Bundle().also { it.putInt("showOkCancel", 1) }
                         }.show(childFragmentManager, "Overview")
                     })
+                }
+
+                R.id.cannula_or_patch_layout -> {
+                    if (pump.pumpDescription.isRefillingCapable && pump.isInitialized() && !pump.isSuspended()){
+                        activity.let { protectionCheck.queryProtection(activity, ProtectionCheck.Protection.BOLUS, UIRunnable { FillDialog().show(childFragmentManager, "FillDialog") }) }
+                    }
+                }
+
+                R.id.insulin_layout -> {
+                    if (pump.pumpDescription.isRefillingCapable && pump.isInitialized() && !pump.isSuspended()){
+                        activity.let { protectionCheck.queryProtection(activity, ProtectionCheck.Protection.BOLUS, UIRunnable { FillDialog().show(childFragmentManager, "FillDialog") }) }
+                    }
+                }
+
+                R.id.sensor_layout -> {
+                    CareDialog().setOptions(CareDialog.EventType.SENSOR_INSERT, R.string.careportal_cgmsensorinsert).show(childFragmentManager, "Actions")
+                }
+
+                R.id.battery_layout -> {
+                    if (pump.pumpDescription.isBatteryReplaceable || pump.isBatteryChangeLoggingEnabled()){
+                        CareDialog().setOptions(CareDialog.EventType.BATTERY_CHANGE, R.string.careportal_pumpbatterychange).show(childFragmentManager, "Actions")
+                    }
                 }
             }
         }

--- a/app/src/main/res/layout/overview_statuslights_layout.xml
+++ b/app/src/main/res/layout/overview_statuslights_layout.xml
@@ -13,10 +13,12 @@
     android:paddingBottom="4dp">
 
     <LinearLayout
+        android:id="@+id/cannula_or_patch_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
         android:gravity="center_horizontal">
 
         <ImageView
@@ -38,10 +40,12 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/insulin_layout"
         android:layout_width="wrap_content"
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
         android:gravity="center_horizontal">
 
         <ImageView
@@ -70,10 +74,12 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/sensor_layout"
         android:layout_width="wrap_content"
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
         android:gravity="center_horizontal">
 
         <ImageView
@@ -99,6 +105,7 @@
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
         android:gravity="center_horizontal">
 
         <ImageView


### PR DESCRIPTION
As a new feature to make the handling better the care dialogs for:
prime fill, sensor change, battery change can also be opened in overviewfragment.
So for normal operations only overview fragment is necessary.
The click behavior is the same as for the textfields top open the date/timepicker dialogs.

![prime-fill](https://user-images.githubusercontent.com/25795894/163353806-8f6c3e52-4a42-4b66-8c19-e56585b38d34.PNG)

![statuslight_click](https://user-images.githubusercontent.com/25795894/163362894-ed2db67e-071c-4282-a4b6-4e9e8e702333.PNG)

