### PR TITLE
chore: convert to material alert dialogs

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/PrefImportSummaryDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/PrefImportSummaryDialog.kt
@@ -16,6 +16,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.appcompat.view.ContextThemeWrapper
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import info.nightscout.androidaps.R
 import info.nightscout.androidaps.extensions.runOnUiThread
 import info.nightscout.androidaps.plugins.general.maintenance.formats.Prefs
@@ -48,7 +49,6 @@ object PrefImportSummaryDialog {
 
         var idx = 0
         val details = LinkedList<String>()
-
 
         for ((metaKey, metaEntry) in prefs.metadata) {
             val rowLayout = LayoutInflater.from(themedCtx).inflate(R.layout.import_summary_item, null)
@@ -92,7 +92,7 @@ object PrefImportSummaryDialog {
                 webView.setBackgroundColor(Color.TRANSPARENT)
                 webView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null)
 
-                AlertDialogHelper.Builder(context, R.style.DialogTheme)
+                MaterialAlertDialogBuilder(context, R.style.DialogTheme)
                     .setCustomTitle(
                         AlertDialogHelper.buildCustomTitle(
                             context,
@@ -109,11 +109,10 @@ object PrefImportSummaryDialog {
             }
         }
 
-        val builder = AlertDialogHelper.Builder(context, theme)
+        val builder = MaterialAlertDialogBuilder(context, theme)
             .setMessage(context.getString(messageRes))
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, context.getString(R.string.nav_import), headerIcon, theme))
             .setView(innerLayout)
-
             .setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _: Int ->
                 dialog.dismiss()
                 SystemClock.sleep(100)

--- a/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/TwoMessagesAlertDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/alertDialogs/TwoMessagesAlertDialog.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.DrawableRes
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import info.nightscout.androidaps.R
 import info.nightscout.androidaps.extensions.runOnUiThread
 
@@ -19,7 +20,7 @@ object TwoMessagesAlertDialog {
         val secondMessageLayout = LayoutInflater.from(context).inflate(R.layout.dialog_alert_two_messages, null)
         (secondMessageLayout.findViewById<View>(R.id.password_prompt_title) as TextView).text = secondMessage
 
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(
                 AlertDialogHelper.buildCustomTitle(
@@ -32,7 +33,6 @@ object TwoMessagesAlertDialog {
                 dialog.dismiss()
                 SystemClock.sleep(100)
                 if (ok != null) runOnUiThread { ok() }
-
             }
             .setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _: Int ->
                 dialog.dismiss()

--- a/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/OKDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/OKDialog.kt
@@ -6,6 +6,7 @@ import android.content.DialogInterface
 import android.os.SystemClock
 import android.text.Spanned
 import androidx.fragment.app.FragmentActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.extensions.runOnUiThread
 
@@ -17,7 +18,7 @@ object OKDialog {
         var notEmptyTitle = title
         if (notEmptyTitle.isEmpty()) notEmptyTitle = context.getString(R.string.message)
 
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, notEmptyTitle))
             .setMessage(message)
             .setPositiveButton(context.getString(R.string.ok)) { dialog: DialogInterface, _: Int ->
@@ -39,7 +40,7 @@ object OKDialog {
         var notEmptyTitle = title
         if (notEmptyTitle.isEmpty()) notEmptyTitle = activity.getString(R.string.message)
 
-        AlertDialogHelper.Builder(activity, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(activity, R.style.DialogTheme)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(activity, notEmptyTitle))
             .setMessage(message)
             .setPositiveButton(activity.getString(R.string.ok)) { dialog: DialogInterface, _: Int ->
@@ -66,7 +67,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showConfirmation(activity: FragmentActivity, title: String, message: Spanned, ok: Runnable?, cancel: Runnable? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(activity, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(activity, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(activity, title))
             .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _: Int ->
@@ -94,7 +95,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showConfirmation(activity: FragmentActivity, title: String, message: String, ok: Runnable?, cancel: Runnable? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(activity, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(activity, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(activity, title))
             .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _: Int ->
@@ -126,7 +127,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showConfirmation(context: Context, title: String, message: Spanned, ok: Runnable?, cancel: Runnable? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, title))
             .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _: Int ->
@@ -158,7 +159,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showConfirmation(context: Context, title: String, message: String, ok: Runnable?, cancel: Runnable? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, title))
             .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _: Int ->
@@ -186,7 +187,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showConfirmation(context: Context, title: String, message: String, ok: DialogInterface.OnClickListener?, cancel: DialogInterface.OnClickListener? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, title))
             .setPositiveButton(android.R.string.ok) { dialog: DialogInterface, which: Int ->
@@ -214,7 +215,7 @@ object OKDialog {
     @SuppressLint("InflateParams")
     fun showYesNoCancel(context: Context, title: String, message: String, yes: Runnable?, no: Runnable? = null) {
         var okClicked = false
-        AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        MaterialAlertDialogBuilder(context, R.style.DialogTheme)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, title))
             .setPositiveButton(R.string.yes) { dialog: DialogInterface, _: Int ->

--- a/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/WarningDialog.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/alertDialogs/WarningDialog.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.os.SystemClock
 import androidx.annotation.StringRes
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.extensions.runOnUiThread
 
@@ -15,7 +16,7 @@ object WarningDialog {
     @SuppressLint("InflateParams")
     fun showWarning(context: Context, title: String, message: String, @StringRes positiveButton: Int = -1, ok: (() -> Unit)? = null, cancel: (() -> Unit)? = null) {
         var okClicked = false
-        val builder = AlertDialogHelper.Builder(context, R.style.AppThemeWarningDialog)
+        val builder = MaterialAlertDialogBuilder(context, R.style.AppThemeWarningDialog)
             .setMessage(message)
             .setCustomTitle(AlertDialogHelper.buildCustomTitle(context, title, R.drawable.ic_header_warning, R.style.AppThemeWarningDialog))
             .setNegativeButton(R.string.dismiss) { dialog: DialogInterface, _: Int ->

--- a/core/src/main/java/info/nightscout/androidaps/utils/protection/PasswordCheck.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/protection/PasswordCheck.kt
@@ -11,6 +11,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.StringRes
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.interfaces.ActivePlugin
 import info.nightscout.androidaps.plugins.general.maintenance.PrefFileListProvider
@@ -44,7 +45,7 @@ class PasswordCheck @Inject constructor(
             return
         }
         val promptsView = LayoutInflater.from(context).inflate(R.layout.passwordprompt, null)
-        val alertDialogBuilder = AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        val alertDialogBuilder = MaterialAlertDialogBuilder(context, R.style.DialogTheme)
         alertDialogBuilder.setView(promptsView)
 
         val userInput = promptsView.findViewById<View>(R.id.password_prompt_pass) as EditText
@@ -101,7 +102,7 @@ class PasswordCheck @Inject constructor(
     @SuppressLint("InflateParams")
     fun setPassword(context: Context, @StringRes labelId: Int, @StringRes preference: Int, ok: ((String) -> Unit)? = null, cancel: (() -> Unit)? = null, clear: (() -> Unit)? = null, pinInput: Boolean = false) {
         val promptsView = LayoutInflater.from(context).inflate(R.layout.passwordprompt, null)
-        val alertDialogBuilder = AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        val alertDialogBuilder = MaterialAlertDialogBuilder(context, R.style.DialogTheme)
         alertDialogBuilder.setView(promptsView)
 
         val userInput = promptsView.findViewById<View>(R.id.password_prompt_pass) as EditText
@@ -165,7 +166,7 @@ class PasswordCheck @Inject constructor(
                          @StringRes passwordWarning: Int?, ok: ((String) -> Unit)?, cancel: (() -> Unit)? = null) {
 
         val promptsView = LayoutInflater.from(context).inflate(R.layout.passwordprompt, null)
-        val alertDialogBuilder = AlertDialogHelper.Builder(context, R.style.DialogTheme)
+        val alertDialogBuilder = MaterialAlertDialogBuilder(context, R.style.DialogTheme)
         alertDialogBuilder.setView(promptsView)
         passwordExplanation?.let { alertDialogBuilder.setMessage(it) }
 


### PR DESCRIPTION
Convert to material components. Should not have any effect on styling. In preparation for the Material 3 upgrade