### PR TITLE
Feature objective colors by attribute

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/ObjectivesFragment.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.plugins.constraints.objectives
 
+import android.annotation.SuppressLint
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
@@ -153,6 +154,7 @@ class ObjectivesFragment : DaggerFragment() {
             return ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.objectives_item, parent, false))
         }
 
+        @SuppressLint("SetTextI18n")
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val objective = objectivesPlugin.objectives[position]
             holder.binding.title.text = rh.gs(R.string.nth_objective, position + 1)
@@ -167,7 +169,7 @@ class ObjectivesFragment : DaggerFragment() {
             } else
                 holder.binding.gate.visibility = View.GONE
             if (!objective.isStarted) {
-                holder.binding.gate.setTextColor(-0x1)
+                holder.binding.gate.setTextColor(rh.gac(context, R.attr.defaultTextColor))
                 holder.binding.verify.visibility = View.GONE
                 holder.binding.progress.visibility = View.GONE
                 holder.binding.accomplished.visibility = View.GONE
@@ -178,7 +180,7 @@ class ObjectivesFragment : DaggerFragment() {
                 else
                     holder.binding.start.visibility = View.GONE
             } else if (objective.isAccomplished) {
-                holder.binding.gate.setTextColor(-0xb350b0)
+                holder.binding.gate.setTextColor(rh.gac(context, R.attr.isAccomplishedColor))
                 holder.binding.verify.visibility = View.GONE
                 holder.binding.progress.visibility = View.GONE
                 holder.binding.start.visibility = View.GONE
@@ -186,7 +188,7 @@ class ObjectivesFragment : DaggerFragment() {
                 holder.binding.unfinish.visibility = View.VISIBLE
                 holder.binding.unstart.visibility = View.GONE
             } else if (objective.isStarted) {
-                holder.binding.gate.setTextColor(-0x1)
+                holder.binding.gate.setTextColor(rh.gac(context,R.attr.defaultTextColor))
                 holder.binding.verify.visibility = View.VISIBLE
                 holder.binding.verify.isEnabled = objective.isCompleted || binding.fake.isChecked
                 holder.binding.start.visibility = View.GONE
@@ -200,7 +202,7 @@ class ObjectivesFragment : DaggerFragment() {
                     // name
                     val name = TextView(holder.binding.progress.context)
                     name.text = "${rh.gs(task.task)}:"
-                    name.setTextColor(-0x1)
+                    name.setTextColor(rh.gac(context,R.attr.defaultTextColor) )
                     holder.binding.progress.addView(name, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
                     // hint
                     task.hints.forEach { h ->
@@ -209,9 +211,9 @@ class ObjectivesFragment : DaggerFragment() {
                     }
                     // state
                     val state = TextView(holder.binding.progress.context)
-                    state.setTextColor(-0x1)
+                    state.setTextColor(rh.gac(context,R.attr.defaultTextColor))
                     val basicHTML = "<font color=\"%1\$s\"><b>%2\$s</b></font>"
-                    val formattedHTML = String.format(basicHTML, if (task.isCompleted()) "#4CAF50" else "#FF9800", task.progress)
+                    val formattedHTML = String.format(basicHTML, if (task.isCompleted()) rh.gac(context, R.attr.isCompletedColor) else rh.gac(context, R.attr.isNotCompletedColor), task.progress)
                     state.text = HtmlHelper.fromHtml(formattedHTML)
                     state.gravity = Gravity.END
                     holder.binding.progress.addView(state, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
@@ -228,7 +230,7 @@ class ObjectivesFragment : DaggerFragment() {
                     }
                     // horizontal line
                     val separator = View(holder.binding.progress.context)
-                    separator.setBackgroundColor(Color.DKGRAY)
+                    separator.setBackgroundColor(rh.gac(context, R.attr.seperatorColor))
                     holder.binding.progress.addView(separator, LinearLayout.LayoutParams.MATCH_PARENT, 2)
                 }
             }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective.kt
@@ -176,7 +176,7 @@ abstract class Objective(injector: HasAndroidInjector, spName: String, @StringRe
             textView.setText(hint)
             textView.autoLinkMask = Linkify.WEB_URLS
             textView.linksClickable = true
-            textView.setLinkTextColor(Color.YELLOW)
+            textView.setLinkTextColor(rh.gac(context, R.attr.colorSecondary))
             Linkify.addLinks(textView, Linkify.WEB_URLS)
             return textView
         }

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -183,8 +183,6 @@
     <color name="action">#ffffbb33</color>
     <color name="alarm">#ffff4444</color>
 
-    <color name="cardObjectiveText">#779ECB</color>
-
     <color name="colorAcceptTempButton">#f4d700</color>
     <color name="colorTreatmentButton">#67dfe8</color>
     <color name="colorInsulinButton">#67dfe8</color>
@@ -196,7 +194,11 @@
     <color name="colorSetExtendedButton">#FFDD7792</color>
     <color name="colorProfileSwitchButton">#ca77dd</color>
 
+    <color name="cardObjectiveText">#779ECB</color>
     <color name="colorObjectivesDisabledText">#FF5722</color>
+    <color name="isAccomplished">#67e86a</color>
+    <color name="isCompleted">#4CAF50</color>
+    <color name="isNotCompleted">#FF9800</color>
 
     <color name="colorScheduled">#de7550</color>
     <color name="colorActive">#25912e</color>

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -239,6 +239,11 @@
         <item name="textAppearancemediumColor">@color/textAppearancemediumDark</item>
         <!-- Actionbar  -->
         <item name="actionBarStyle">@style/Aaps_ActionBarStyle</item>
+        <!-- Objectives specific colors  -->
+        <item name="isAccomplishedColor">@color/isAccomplished</item>
+        <item name="seperatorColor">@color/sphere_plastic_grey</item>
+        <item name="isCompletedColor">@color/isCompleted</item>
+        <item name="isNotCompletedColor">@color/isNotCompleted</item>
     </style>
 
     <style name="Aaps_ActionBarStyle" parent="@style/Widget.AppCompat.ActionBar">

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -216,4 +216,9 @@
     <!-- CardView specific colors  -->
     <attr name="strokeColor" format="reference|color" />
     <attr name="textAppearancemediumColor" format="reference|color" />
+    <!-- Objectives specific colors  -->
+    <attr name="isAccomplishedColor" format="reference|color" />
+    <attr name="seperatorColor" format="reference|color" />
+    <attr name="isCompletedColor" format="reference|color" />
+    <attr name="isNotCompletedColor" format="reference|color" />
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -168,7 +168,7 @@
     <color name="bgi">#00EEEE</color>
     <color name="devslopepos">#FFFFFF00</color>
     <color name="devslopeneg">#FFFF00FF</color>
-    <color name="actionsConfirm">#FFFF00</color>
+    <color name="actionsConfirm">#F6CE22</color>
     <color name="deviations">#FF0000</color>
     <color name="cobAlert">#7484E2</color>
     <color name="inrangebackground">#2800FF00</color>
@@ -186,8 +186,6 @@
     <color name="action">#ffffbb33</color>
     <color name="alarm">#ffff4444</color>
 
-    <color name="cardObjectiveText">#779ECB</color>
-
     <color name="colorAcceptTempButton">#E19701</color>
     <color name="colorTreatmentButton">#006493</color>
     <color name="colorInsulinButton">#67dfe8</color>
@@ -199,7 +197,11 @@
     <color name="colorSetExtendedButton">#FFDD7792</color>
     <color name="colorProfileSwitchButton">#ca77dd</color>
 
+    <color name="cardObjectiveText">#779ECB</color>
     <color name="colorObjectivesDisabledText">#FF5722</color>
+    <color name="isAccomplished">#25912e</color>
+    <color name="isCompleted">#4CAF50</color>
+    <color name="isNotCompleted">#FF9800</color>
 
     <color name="colorScheduled">#de7550</color>
     <color name="colorActive">#25912e</color>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -242,6 +242,11 @@
         <item name="textAppearancemediumColor">@color/textAppearancemediumLight</item>
         <!-- Actionbar  -->
         <item name="actionBarStyle">@style/Aaps_ActionBarStyle</item>
+        <!-- Objectives specific colors  -->
+        <item name="isAccomplishedColor">@color/isAccomplished</item>
+        <item name="seperatorColor">@color/sphere_plastic_grey</item>
+        <item name="isCompletedColor">@color/isCompleted</item>
+        <item name="isNotCompletedColor">@color/isNotCompleted</item>
     </style>
 
     <style name="Aaps_ActionBarStyle" parent="@style/Widget.AppCompat.ActionBar">


### PR DESCRIPTION
Now all old styled colors in objectives are converted to attribute colors.
The URL link color follows now the standard of secondary color as you can see on nightscout client or 'about dialog' .


![objectives_dark](https://user-images.githubusercontent.com/25795894/163399719-3b9f60b7-628e-410b-9c4c-d3bf46cf74a2.PNG)
![objectives_light](https://user-images.githubusercontent.com/25795894/163399801-f8038f2c-3081-41da-ae04-c066269d68d1.PNG)

