### PR TITLE
cardview for actions and overview and minor optical improvements

### DIFF
--- a/app/src/main/res/layout/actions_fragment.xml
+++ b/app/src/main/res/layout/actions_fragment.xml
@@ -1,4 +1,5 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,301 +12,369 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/actions"
+            style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:paddingStart="15dp"
-            android:paddingEnd="15dp"
-            android:text="@string/actions" />
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginTop="4dp"
+            app:cardCornerRadius="4dp"
+            app:contentPadding="2dp"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false"
+            android:layout_gravity="center">
 
-        <androidx.gridlayout.widget.GridLayout
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="15dp"
+                android:paddingEnd="15dp"
+                android:layout_marginBottom="10dp"
+                android:text="@string/actions" />
+
+            <androidx.gridlayout.widget.GridLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:padding="10dip"
+                app:columnCount="2">
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/profile_switch"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_actions_profileswitch"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_profileswitch"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="0" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/temp_target"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_temptarget_high"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_temporarytarget"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="0" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/set_temp_basal"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_actions_starttempbasal"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/overview_tempbasal_button"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="1" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/cancel_temp_basal"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_cancelbasal"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/canceltemp"
+                    android:textSize="11sp"
+                    android:visibility="gone"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="1" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/extended_bolus"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_actions_startextbolus"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/overview_extendedbolus_button"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="1" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/extended_bolus_cancel"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_actions_cancelextbolus"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/overview_extendedbolus_cancel_button"
+                    android:textSize="11sp"
+                    android:visibility="gone"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="1" />
+
+            </androidx.gridlayout.widget.GridLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/careportal_statuslight"
+            style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="10dip"
-            app:columnCount="2">
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginTop="4dp"
+            app:cardCornerRadius="4dp"
+            app:contentPadding="2dp"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false"
+            android:layout_gravity="center">
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/profile_switch"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
+            <include
+                android:id="@+id/status"
+                layout="@layout/careportal_stats_fragment"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_actions_profileswitch"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_profileswitch"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="0" />
+                android:layout_marginTop="10dp" />
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/temp_target"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_temptarget_high"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_temporarytarget"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="0" />
+        </com.google.android.material.card.MaterialCardView>
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/set_temp_basal"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_actions_starttempbasal"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/overview_tempbasal_button"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="1" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/cancel_temp_basal"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_cancelbasal"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/canceltemp"
-                android:textSize="11sp"
-                android:visibility="gone"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="1" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/extended_bolus"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_actions_startextbolus"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/overview_extendedbolus_button"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="1" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/extended_bolus_cancel"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_actions_cancelextbolus"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/overview_extendedbolus_cancel_button"
-                android:textSize="11sp"
-                android:visibility="gone"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="1" />
-
-        </androidx.gridlayout.widget.GridLayout>
-
-        <TextView
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/careportal_statuslightbutton"
+            style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingStart="15dp"
-            android:paddingEnd="15dp"
-            android:text="@string/careportal" />
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginTop="4dp"
+            app:cardCornerRadius="4dp"
+            app:contentPadding="2dp"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false"
+            android:layout_gravity="center">
 
-        <include
-            android:id="@+id/status"
-            layout="@layout/careportal_stats_fragment"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="15dp"
+                android:paddingEnd="15dp"
+                android:text="@string/careportal" />
 
-        <androidx.gridlayout.widget.GridLayout
+            <androidx.gridlayout.widget.GridLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:padding="10dip"
+                app:columnCount="2">
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/bg_check"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_bgcheck"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_bgcheck"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="2" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/fill"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_cp_pump_canula"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/primefill"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="2" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/cgm_sensor_insert"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_cgm_insert"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_cgmsensorinsert"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="3" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/pump_battery_change"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_pump_battery"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_pumpbatterychange"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="3" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/note"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_note"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_note"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="4" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/exercise"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_exercise"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_exercise"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="4" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/announcement"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_announcement"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_announcement"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="5" />
+
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/question"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:drawableTop="@drawable/ic_cp_question"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/careportal_question"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="5" />
+
+            </androidx.gridlayout.widget.GridLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/careportal_tools"
+            style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="10dip"
-            app:columnCount="2">
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp"
+            app:cardCornerRadius="4dp"
+            app:contentPadding="2dp"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false"
+            android:layout_gravity="center">
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/bg_check"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_bgcheck"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_bgcheck"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="2" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/fill"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
+            <TextView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_cp_pump_canula"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/primefill"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="2" />
+                android:paddingStart="15dp"
+                android:paddingEnd="15dp"
+                android:text="@string/tools" />
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/cgm_sensor_insert"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_cgm_insert"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_cgmsensorinsert"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="3" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/pump_battery_change"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_pump_battery"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_pumpbatterychange"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="3" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/note"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_note"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_note"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="4" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/exercise"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_exercise"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_exercise"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="4" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/announcement"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_announcement"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_announcement"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="5" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/question"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:drawableTop="@drawable/ic_cp_question"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/careportal_question"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="5" />
-
-        </androidx.gridlayout.widget.GridLayout>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="15dp"
-            android:paddingEnd="15dp"
-            android:text="@string/tools" />
-
-        <androidx.gridlayout.widget.GridLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="10dip"
-            app:columnCount="2">
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/history_browser"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
+            <androidx.gridlayout.widget.GridLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_pump_history"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/nav_historybrowser"
-                android:textSize="11sp"
-                app:layout_column="0"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="6" />
+                android:layout_marginTop="10dp"
+                android:padding="10dip"
+                app:columnCount="2">
 
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/tdd_stats"
-                style="?android:attr/buttonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:drawableTop="@drawable/ic_cp_stats"
-                android:paddingLeft="0dp"
-                android:paddingRight="0dp"
-                android:text="@string/tdd"
-                android:textSize="11sp"
-                app:layout_column="1"
-                app:layout_columnWeight="1"
-                app:layout_gravity="fill"
-                app:layout_row="6" />
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/history_browser"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_pump_history"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/nav_historybrowser"
+                    android:textSize="11sp"
+                    app:layout_column="0"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="6" />
 
-        </androidx.gridlayout.widget.GridLayout>
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
+                    android:id="@+id/tdd_stats"
+                    style="?android:attr/buttonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_cp_stats"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/tdd"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="6" />
+
+            </androidx.gridlayout.widget.GridLayout>
+
+        </com.google.android.material.card.MaterialCardView>
 
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/overview_fragment.xml
+++ b/app/src/main/res/layout/overview_fragment.xml
@@ -3,10 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context=".plugins.general.overview.OverviewFragment">
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/top_part_scrollbar"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
@@ -23,104 +24,184 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <LinearLayout
-                android:id="@+id/loop_layout"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/loop"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                app:cardCornerRadius="4dp"
+                app:contentPadding="2dp"
+                app:cardElevation="4dp"
+                app:cardUseCompatPadding="false"
+                android:layout_gravity="center">
 
-                <TextView
-                    android:id="@+id/active_profile"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:id="@+id/loop_layout"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_marginEnd="5dp"
-                    android:layout_weight="1"
-                    android:gravity="center_vertical|center_horizontal"
-                    android:paddingTop="6dp"
-                    android:paddingBottom="6dp"
-                    android:hint="active profile"
-                    android:text="Profile"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    tools:ignore="HardcodedText" />
+                    android:orientation="horizontal" >
 
-                <TextView
-                    android:id="@+id/temp_target"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_weight="1"
-                    android:gravity="center_vertical|center_horizontal"
-                    android:paddingTop="6dp"
-                    android:paddingBottom="6dp"
-                    android:hint="temp target"
-                    android:text="@string/notavailable"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    tools:ignore="HardcodedText" />
+                    <TextView
+                        android:id="@+id/active_profile"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_marginEnd="5dp"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical|center_horizontal"
+                        android:paddingTop="6dp"
+                        android:paddingBottom="6dp"
+                        android:hint="active profile"
+                        android:text="Profile"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        tools:ignore="HardcodedText" />
 
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/temp_target"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical|center_horizontal"
+                        android:paddingTop="6dp"
+                        android:paddingBottom="6dp"
+                        android:hint="temp target"
+                        android:text="@string/notavailable"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        tools:ignore="HardcodedText" />
 
+                </LinearLayout>
 
-            <include
-                android:id="@+id/info_layout"
-                layout="@layout/overview_info_layout" />
+            </com.google.android.material.card.MaterialCardView>
 
-            <include
-                android:id="@+id/status_lights_layout"
-                layout="@layout/overview_statuslights_layout" />
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/info"
+                style="@style/Widget.MaterialComponents.CardView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                app:cardCornerRadius="4dp"
+                app:contentPadding="2dp"
+                app:cardElevation="4dp"
+                app:cardUseCompatPadding="false"
+                android:layout_gravity="center">
 
-            <com.google.android.flexbox.FlexboxLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+                <include
+                    android:id="@+id/info_layout"
+                    layout="@layout/overview_info_layout" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/status"
+                style="@style/Widget.MaterialComponents.CardView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                app:cardCornerRadius="4dp"
+                app:contentPadding="2dp"
+                app:cardElevation="4dp"
+                app:cardUseCompatPadding="false"
+                android:layout_gravity="center">
+
+                <include
+                    android:id="@+id/status_lights_layout"
+                    layout="@layout/overview_statuslights_layout" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/nsclient_layout"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="?attr/colorControlHighlight"
-                app:alignContent="stretch"
-                app:alignItems="stretch"
-                app:flexDirection="row"
-                app:flexWrap="wrap"
-                app:justifyContent="center">
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                app:cardCornerRadius="4dp"
+                app:contentPadding="2dp"
+                app:cardElevation="4dp"
+                app:cardUseCompatPadding="false"
+                android:layout_gravity="center">
 
-                <TextView
-                    android:id="@+id/pump"
-                    android:layout_width="wrap_content"
+                <com.google.android.flexbox.FlexboxLayout
+                    android:id="@+id/nsclient"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingStart="4sp"
-                    android:paddingEnd="4sp"
-                    android:text="Pump: running"
-                    android:textSize="16sp"
-                    tools:ignore="HardcodedText" />
+                    android:background="?attr/colorControlHighlight"
+                    app:alignContent="stretch"
+                    app:alignItems="stretch"
+                    app:flexDirection="row"
+                    app:flexWrap="wrap"
+                    app:justifyContent="center">
 
-                <TextView
-                    android:id="@+id/openaps"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="4sp"
-                    android:paddingEnd="4sp"
-                    android:text="OpenAPS: 3 min ago"
-                    android:textSize="16sp"
-                    tools:ignore="HardcodedText" />
+                    <TextView
+                        android:id="@+id/pump"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="4sp"
+                        android:paddingEnd="4sp"
+                        android:text="Pump: running"
+                        android:textSize="16sp"
+                        tools:ignore="HardcodedText" />
 
-                <TextView
-                    android:id="@+id/uploader"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:paddingStart="4sp"
-                    android:paddingEnd="4sp"
-                    android:text="Uploader: 84%"
-                    android:textSize="16sp"
-                    tools:ignore="HardcodedText" />
+                    <TextView
+                        android:id="@+id/openaps"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="4sp"
+                        android:paddingEnd="4sp"
+                        android:text="OpenAPS: 3 min ago"
+                        android:textSize="16sp"
+                        tools:ignore="HardcodedText" />
 
-            </com.google.android.flexbox.FlexboxLayout>
+                    <TextView
+                        android:id="@+id/uploader"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="4sp"
+                        android:paddingEnd="4sp"
+                        android:text="Uploader: 84%"
+                        android:textSize="16sp"
+                        tools:ignore="HardcodedText" />
 
-            <include
-                android:id="@+id/graphs_layout"
-                layout="@layout/overview_graphs_layout" />
+                </com.google.android.flexbox.FlexboxLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/graph"
+                style="@style/Widget.MaterialComponents.CardView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                app:cardCornerRadius="4dp"
+                app:contentPadding="2dp"
+                app:cardElevation="4dp"
+                app:cardUseCompatPadding="false"
+                android:layout_gravity="center">
+
+                <include
+                    android:id="@+id/graphs_layout"
+                    layout="@layout/overview_graphs_layout" />
+
+            </com.google.android.material.card.MaterialCardView>
 
         </LinearLayout>
 
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
     <LinearLayout
         android:id="@+id/pump_status_layout"

--- a/app/src/main/res/layout/overview_statuslights_layout.xml
+++ b/app/src/main/res/layout/overview_statuslights_layout.xml
@@ -7,7 +7,6 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="3dp"
     android:layout_marginBottom="3dp"
-    android:background="?attr/colorControlHighlight"
     android:orientation="horizontal"
     android:paddingTop="4dp"
     android:paddingBottom="4dp">

--- a/core/src/main/res/values-night/styles.xml
+++ b/core/src/main/res/values-night/styles.xml
@@ -110,7 +110,7 @@
         <item name="android:dialogCornerRadius">12dp</item>
         <!---Overview and Historybrowser  -->
         <item name="graphgrid">@color/graphgrid</item>
-        <item name="viewPortbackgroundColor">@color/white_alpha_20</item>
+        <item name="viewPortbackgroundColor">@color/transparent</item>
         <item name="tempTargetBackgroundColor">@color/tempTargetBackground</item>
         <!---CGM source-->
         <item name="cgmdexColor">@color/byodagray</item>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -113,7 +113,7 @@
         <item name="android:dialogCornerRadius">12dp</item>
         <!---Overview and Historybrowser  -->
         <item name="graphgrid">@color/graphgrid</item>
-        <item name="viewPortbackgroundColor">@color/black_alpha_20</item>
+        <item name="viewPortbackgroundColor">@color/transparent</item>
         <item name="tempTargetBackgroundColor">@color/tempTargetBackground</item>
         <!---CGM source-->
         <item name="cgmdexColor">@color/byodagray</item>


### PR DESCRIPTION
To follow the google design guide to structure things in their logical components,
I make a proposal and minor optical improvements for actions and overview fragment.
Now we can dispense the gray background color for status lights for example and the whole design
seems more consistent and professional.
Thanks @Andries-Smit for your idea of this.

Open here for discussion or merge it you like it.

![cardview_actions](https://user-images.githubusercontent.com/25795894/163672906-6df6291b-1c5e-47a9-9138-9e459c142fc4.PNG)
![cardview_actions_light](https://user-images.githubusercontent.com/25795894/163672907-089071bb-181f-4c40-8cf1-68fcf095aa30.PNG)
![cardview_overview](https://user-images.githubusercontent.com/25795894/163672909-451aa86e-426d-4e5d-bb8b-ae73d677cb72.PNG)
![cardview_overview_light](https://user-images.githubusercontent.com/25795894/163672910-5f29990a-f29d-404b-a8ec-de6aaafaab14.PNG)

