### PR TITLE
remove light workaround for linktext

### DIFF
--- a/app/src/main/res/layout/objectives_exam_fragment.xml
+++ b/app/src/main/res/layout/objectives_exam_fragment.xml
@@ -28,7 +28,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="10dp"
-            android:background="?attr/objectivesBackgroundColor"
             android:orientation="vertical"
             app:layout_constraintTop_toBottomOf="@+id/exam_options"
             tools:layout_editor_absoluteX="3dp" />


### PR DESCRIPTION
With one of the last PR's linked text is now in standard secondary color.
So we can remove the former workaround for objectives dialog.

![objective_dark](https://user-images.githubusercontent.com/25795894/163674368-beb25ec3-89d5-4d64-8d2c-b9d777cac953.PNG)
![objective_light](https://user-images.githubusercontent.com/25795894/163674369-a5aa98be-eb7f-48d7-a533-696ee5410916.PNG)
![objective_Workaround_dark](https://user-images.githubusercontent.com/25795894/163674370-b8456265-cd12-4211-aba2-5f12ce2a1574.PNG)
![objective_Workaround_light](https://user-images.githubusercontent.com/25795894/163674371-40f085a6-f485-45ae-8585-c1bb704accc9.PNG)

