### PR TITLE
Chore: fix layout lint warning

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/activities/QuickWizardListActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/activities/QuickWizardListActivity.kt
@@ -76,6 +76,10 @@ class QuickWizardListActivity : DaggerAppCompatActivityWithResult(), OnStartDrag
                         else                          -> R.drawable.ic_smartphone
                     }
                 )
+                holder.binding.device.contentDescription = when (quickWizard[position].device()) {
+                    QuickWizardEntry.DEVICE_WATCH -> rh.gs(R.string.a11y_only_on_watch)
+                    else                          -> rh.gs(R.string.a11y_only_on_phone)
+                }
             }
             holder.binding.root.setOnClickListener {
                 if (actionHelper.isNoAction) {

--- a/app/src/main/res/layout/activity_historybrowse.xml
+++ b/app/src/main/res/layout/activity_historybrowse.xml
@@ -59,7 +59,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="24" />
+                tools:text="24" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_setupwizard.xml
+++ b/app/src/main/res/layout/activity_setupwizard.xml
@@ -20,6 +20,7 @@
             android:layout_marginTop="16dp"
             android:layout_weight="1"
             android:background="@android:color/transparent"
+            android:importantForAccessibility="no"
             android:onClick="exitPressed"
             app:srcCompat="@drawable/ic_exit_to_app" />
 

--- a/app/src/main/res/layout/activity_smscommunicator_otp.xml
+++ b/app/src/main/res/layout/activity_smscommunicator_otp.xml
@@ -35,6 +35,7 @@
                 android:id="@+id/otp_provisioning"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/a11y_otp_qr_code"
                 android:layout_marginTop="10dp"
                 android:scaleType="center" />
 
@@ -72,6 +73,7 @@
                     android:layout_width="140sp"
                     android:layout_height="wrap_content"
                     android:hint="@string/smscommunicator_code_verify_hint"
+                    android:importantForAutofill="no"
                     android:inputType="number"
                     android:maxLength="12"
                     android:textAlignment="center"

--- a/app/src/main/res/layout/bgsource_item.xml
+++ b/app/src/main/res/layout/bgsource_item.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/tools"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.MaterialComponents.CardView"
     android:id="@+id/bg_card"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/configbuilder_single_category.xml
+++ b/app/src/main/res/layout/configbuilder_single_category.xml
@@ -36,8 +36,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="4dp"
-            app:tint="?android:attr/colorAccent"
-            app:srcCompat="@drawable/ic_visibility" />
+            android:importantForAccessibility="no"
+            app:srcCompat="@drawable/ic_visibility"
+            app:tint="?android:attr/colorAccent" />
+
     </LinearLayout>
 
     <LinearLayout
@@ -45,4 +47,5 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/configbuilder_single_plugin.xml
+++ b/app/src/main/res/layout/configbuilder_single_plugin.xml
@@ -38,7 +38,8 @@
                 android:layout_width="36dp"
                 android:layout_height="36dp"
                 android:layout_gravity="center_vertical"
-                android:layout_marginEnd="8dp" />
+                android:layout_marginEnd="8dp"
+                android:importantForAccessibility="no" />
 
             <ImageView
                 android:id="@+id/plugin_icon2"
@@ -46,6 +47,7 @@
                 android:layout_height="36dp"
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="8dp"
+                android:importantForAccessibility="no"
                 tools:visibility="gone" />
 
         </LinearLayout>
@@ -70,6 +72,7 @@
                 android:layout_height="wrap_content"
                 android:textSize="12sp"
                 tools:text="A super exquisite plugin description" />
+
         </LinearLayout>
 
     </LinearLayout>
@@ -80,6 +83,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
+        android:contentDescription="@string/a11y_open_settings"
         android:background="?attr/selectableItemBackgroundBorderless"
         app:srcCompat="@drawable/ic_settings" />
 
@@ -88,4 +92,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:saveEnabled="false" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_carbs.xml
+++ b/app/src/main/res/layout/dialog_carbs.xml
@@ -75,6 +75,7 @@
         <TableLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingStart="0dp"
             android:paddingEnd="5dp">
 
             <TableRow
@@ -91,7 +92,7 @@
 
                     <TextView
                         android:id="@+id/time_label"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:width="120dp"
@@ -267,6 +268,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:importantForAccessibility="no"
                 android:src="@drawable/ic_access_alarm_24dp" />
 
             <CheckBox
@@ -276,6 +278,7 @@
                 android:layout_gravity="center_vertical"
                 android:checked="false"
                 android:padding="2dp" />
+
         </LinearLayout>
 
         <include

--- a/app/src/main/res/layout/dialog_insulin.xml
+++ b/app/src/main/res/layout/dialog_insulin.xml
@@ -145,29 +145,28 @@
             android:padding="5dp">
 
             <com.google.android.material.button.MaterialButton
-                style="@style/GrayButton"
                 android:id="@+id/plus05"
+                style="@style/GrayButton"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:contentDescription="Increment insulin with 0.5"
-                android:text="+0.5" />
+                tools:text="+0.5" />
 
             <com.google.android.material.button.MaterialButton
-                style="@style/GrayButton"
                 android:id="@+id/plus10"
+                style="@style/GrayButton"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="+1.0" />
+                tools:text="+1.0" />
 
             <com.google.android.material.button.MaterialButton
-                style="@style/GrayButton"
                 android:id="@+id/plus20"
+                style="@style/GrayButton"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="+2.0" />
+                tools:text="+2.0" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_loop.xml
+++ b/app/src/main/res/layout/dialog_loop.xml
@@ -182,7 +182,7 @@
                 android:id="@+id/overview_resume"
                 style="?android:attr/buttonStyle"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="0dp"
                 android:layout_gravity="center"
                 android:layout_marginEnd="-4dp"
                 android:layout_weight="0.5"
@@ -291,7 +291,7 @@
                 android:id="@+id/overview_reconnect"
                 style="?android:attr/buttonStyle"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:layout_gravity="center"
                 android:layout_marginEnd="-4dp"
                 android:layout_weight="0.5"
@@ -396,7 +396,7 @@
             android:id="@+id/cancel"
             style="@style/OkCancelButton.Text"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginEnd="8dp"
             android:layout_weight="1"
             android:text="@string/cancel"
@@ -404,4 +404,5 @@
             android:textAlignment="textEnd" />
 
     </LinearLayout>
+
 </ScrollView>

--- a/app/src/main/res/layout/dialog_profileswitch.xml
+++ b/app/src/main/res/layout/dialog_profileswitch.xml
@@ -151,7 +151,8 @@
                 android:paddingStart="5dp"
                 android:paddingEnd="5dp"
                 android:text="%"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:ignore="HardcodedText" />
 
         </LinearLayout>
 
@@ -210,7 +211,7 @@
 
             <CheckBox
                 android:id="@+id/tt"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_weight="1"

--- a/app/src/main/res/layout/dialog_tempbasal.xml
+++ b/app/src/main/res/layout/dialog_tempbasal.xml
@@ -77,7 +77,8 @@
                 android:paddingStart="5dp"
                 android:paddingEnd="5dp"
                 android:text="%"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:ignore="HardcodedText" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_wizard.xml
+++ b/app/src/main/res/layout/dialog_wizard.xml
@@ -48,8 +48,8 @@
         <TableLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingEnd="5dp"
-            tools:ignore="RtlSymmetry">
+            android:paddingStart="0dp"
+            android:paddingEnd="5dp">
 
             <TableRow
                 android:layout_width="match_parent"
@@ -149,7 +149,8 @@
                         android:padding="2dp"
                         android:text="%"
                         android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                        android:textStyle="bold" />
+                        android:textStyle="bold"
+                        tools:ignore="HardcodedText" />
 
                 </LinearLayout>
 
@@ -347,7 +348,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:checked="false"
-                    android:contentDescription="set carb timer alarm"
+                    android:contentDescription="@string/a11y_set_carb_timer"
                     android:drawableEnd="@drawable/ic_access_alarm_24dp"
                     android:layoutDirection="rtl"
                     android:padding="2dp" />
@@ -384,7 +385,8 @@
                     android:layout_marginEnd="5dp"
                     android:layout_weight="0.5"
                     android:hint="@string/profile"
-                    android:paddingStart="7dp">
+                    android:paddingStart="7dp"
+                    android:paddingEnd="0dp">
 
                     <com.google.android.material.textfield.MaterialAutoCompleteTextView
                         android:id="@+id/profileList"

--- a/app/src/main/res/layout/objectives_exam_fragment.xml
+++ b/app/src/main/res/layout/objectives_exam_fragment.xml
@@ -50,7 +50,7 @@
                 android:text="@string/reset" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="" />
@@ -76,10 +76,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="Question"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/exam_name" />
+            app:layout_constraintTop_toBottomOf="@id/exam_name"
+            tools:text="Question" />
 
         <TextView
             android:id="@+id/exam_hint"
@@ -94,22 +94,22 @@
             android:id="@+id/exam_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Name"
             android:textAppearance="@style/TextAppearance.AppCompat.Large"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Name" />
 
         <TextView
             android:id="@+id/exam_disabledto"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="Disabled until:"
             android:textColor="?attr/objectivesDisabledTextColor"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/exam_hints" />
+            app:layout_constraintTop_toBottomOf="@+id/exam_hints"
+            tools:text="Disabled until:" />
 
         <LinearLayout
             android:id="@+id/navigation"
@@ -130,7 +130,7 @@
                 android:text="@string/previous_button" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="" />

--- a/app/src/main/res/layout/objectives_item.xml
+++ b/app/src/main/res/layout/objectives_item.xml
@@ -95,7 +95,7 @@
             android:id="@+id/requestcode"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Request code: XXXXX" />
+            tools:text="Request code: XXXXX" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -108,8 +108,9 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:ems="10"
-                android:hint="XXXXXXXXXX"
-                android:inputType="text" />
+                android:inputType="text"
+                tools:hint="XXXXXXXXXX"
+                android:importantForAutofill="no" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/enterbutton"

--- a/app/src/main/res/layout/overview_editquickwizard_dialog.xml
+++ b/app/src/main/res/layout/overview_editquickwizard_dialog.xml
@@ -85,15 +85,16 @@
                 android:layout_gravity="center"
                 android:gravity="center_horizontal|center_vertical"
                 android:padding="10dp"
-                android:text="08:20pm"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                tools:text="08:20pm" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
                 android:text="-"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/to"
@@ -102,8 +103,8 @@
                 android:layout_gravity="center"
                 android:gravity="center_horizontal|center_vertical"
                 android:padding="10dp"
-                android:text="08:20pm"
-                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                tools:text="08:20pm" />
 
         </LinearLayout>
 
@@ -123,17 +124,17 @@
             <RadioButton
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="All" />
+                android:text="@string/device_all" />
 
             <RadioButton
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Phone" />
+                android:text="@string/device_phone" />
 
             <RadioButton
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Watch" />
+                android:text="@string/device_watch" />
 
         </RadioGroup>
 
@@ -366,9 +367,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ems="10"
+            android:importantForAutofill="no"
             android:inputType="number"
-            android:maxLength="3"
-            android:paddingStart="10dp" />
+            android:maxLength="3"/>
 
         <include
             android:id="@+id/okcancel"

--- a/app/src/main/res/layout/overview_graphs_layout.xml
+++ b/app/src/main/res/layout/overview_graphs_layout.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/app/src/main/res/layout/overview_quickwizardlist_item.xml
+++ b/app/src/main/res/layout/overview_quickwizardlist_item.xml
@@ -2,7 +2,6 @@
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:card_view="http://schemas.android.com/tools"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.MaterialComponents.CardView"
     android:id="@+id/card"
@@ -30,6 +29,7 @@
                 android:layout_height="wrap_content"
                 android:adjustViewBounds="false"
                 android:cropToPadding="false"
+                android:importantForAccessibility="no"
                 android:scaleType="fitStart"
                 app:srcCompat="@drawable/ic_quick_wizard" />
 
@@ -81,14 +81,15 @@
                         android:adjustViewBounds="false"
                         android:cropToPadding="false"
                         android:scaleType="fitStart"
-                        app:srcCompat="@drawable/ic_smartphone"
-                        tools:ignore="RtlSymmetry" />
+                        android:contentDescription="@string/a11y_only_on_phone"
+                        app:srcCompat="@drawable/ic_smartphone" />
 
                     <ImageView
                         android:id="@+id/sortHandle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:adjustViewBounds="false"
+                        android:contentDescription="@string/a11y_drag_and_drop_handle"
                         android:cropToPadding="false"
                         android:scaleType="fitStart"
                         app:srcCompat="@drawable/ic_reorder_gray_24dp" />

--- a/app/src/main/res/layout/overview_statuslights_layout.xml
+++ b/app/src/main/res/layout/overview_statuslights_layout.xml
@@ -9,14 +9,16 @@
     android:layout_marginBottom="3dp"
     android:orientation="horizontal"
     android:paddingTop="4dp"
-    android:paddingBottom="4dp">
+    android:paddingBottom="4dp"
+    android:baselineAligned="false">
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:focusable="true"
-        android:gravity="center_horizontal">
+        android:gravity="center_horizontal"
+        tools:ignore="UseCompoundDrawables">
 
         <ImageView
             android:id="@+id/cannula_or_patch"
@@ -64,6 +66,7 @@
             android:layout_height="wrap_content"
             android:lines="1"
             android:paddingStart="2dp"
+            android:paddingEnd="0dp"
             tools:text="50+U" />
 
     </LinearLayout>
@@ -73,7 +76,8 @@
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:focusable="true"
-        android:gravity="center_horizontal">
+        android:gravity="center_horizontal"
+        tools:ignore="UseCompoundDrawables">
 
         <ImageView
             android:layout_width="28dp"
@@ -121,6 +125,7 @@
             android:layout_height="fill_parent"
             android:lines="1"
             android:paddingStart="2dp"
+            android:paddingEnd="0dp"
             tools:text="100%" />
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1212,4 +1212,13 @@
     <string name="show_hide_records">Hide loop records</string>
     <string name="widget_description">AndroidAPS widget</string>
     <string name="configure">Configure opacity</string>
+    <string name="a11y_otp_qr_code">QR Code for setup one time password</string>
+    <string name="a11y_open_settings">open settings</string>
+    <string name="a11y_set_carb_timer">set carb timer alarm</string>
+    <string name="device_all">All</string>
+    <string name="device_phone">Phone</string>
+    <string name="device_watch">Watch</string>
+    <string name="a11y_only_on_watch">only on watch</string>
+    <string name="a11y_only_on_phone">only on phone</string>
+    <string name="a11y_drag_and_drop_handle">drag and drop handle</string>
 </resources>


### PR DESCRIPTION
Remove various lint warnings in the layouts:
- Left To Right Symmetry
- Hardcode Text
- Accessibility content description
- etc.