### PR TITLE
Fix cardview in overview small displays

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -165,7 +165,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         val landscape = screenHeight < screenWidth
 
         skinProvider.activeSkin().preProcessLandscapeOverviewLayout(dm, binding, landscape, rh.gb(R.bool.isTablet), smallHeight)
-        binding.nsclientLayout.visibility = config.NSCLIENT.toVisibility()
+        binding.nsclientCard.visibility = config.NSCLIENT.toVisibility()
 
         binding.notifications.setHasFixedSize(false)
         binding.notifications.layoutManager = LinearLayoutManager(view.context)

--- a/app/src/main/java/info/nightscout/androidaps/skins/SkinLowRes.kt
+++ b/app/src/main/java/info/nightscout/androidaps/skins/SkinLowRes.kt
@@ -2,6 +2,8 @@ package info.nightscout.androidaps.skins
 
 import android.util.DisplayMetrics
 import android.view.View.GONE
+import android.view.ViewGroup
+import androidx.core.view.marginStart
 import info.nightscout.androidaps.interfaces.Config
 import info.nightscout.androidaps.R
 import info.nightscout.androidaps.databinding.ActionsFragmentBinding
@@ -38,6 +40,45 @@ class SkinLowRes @Inject constructor(private val config: Config) : SkinInterface
 
     override fun preProcessLandscapeOverviewLayout(dm: DisplayMetrics, binding: OverviewFragmentBinding, isLandscape: Boolean, isTablet: Boolean, isSmallHeight: Boolean) {
         if (!config.NSCLIENT && isLandscape) moveButtonsLayout(binding.root)
+
+        binding.apply {
+            loopCard.elevation = 0F
+            loopCard.radius = 0F
+            val param = (loopCard.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                setMargins(0,0,0,0)
+            }
+            loopCard.layoutParams = param
+
+            infoCard.elevation = 0F
+            infoCard.radius = 0F
+            val paramInfo = (infoCard.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                setMargins(0,0,0,0)
+            }
+            infoCard.layoutParams = paramInfo
+
+            statusCard.elevation = 0F
+            statusCard.radius = 0F
+            statusCard.strokeWidth = 1
+            val paramStatus = (statusCard.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                setMargins(0,0,0,0)
+            }
+            statusCard.layoutParams = paramStatus
+
+            nsclientCard.elevation = 0F
+            nsclientCard.radius = 0F
+            val paramNsClient = (nsclientCard.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                setMargins(0,0,0,0)
+            }
+            nsclientCard.layoutParams = paramNsClient
+
+            graphCard.elevation = 0F
+            graphCard.radius = 0F
+            val paramGraph = (graphCard.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                setMargins(0,0,0,0)
+            }
+            graphCard.layoutParams = paramGraph
+        }
+
     }
 
 }

--- a/app/src/main/res/layout/overview_fragment.xml
+++ b/app/src/main/res/layout/overview_fragment.xml
@@ -25,7 +25,7 @@
                 android:layout_height="wrap_content" />
 
             <com.google.android.material.card.MaterialCardView
-                android:id="@+id/loop"
+                android:id="@+id/loopCard"
                 style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -78,7 +78,7 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.card.MaterialCardView
-                android:id="@+id/info"
+                android:id="@+id/infoCard"
                 style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -98,7 +98,7 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.card.MaterialCardView
-                android:id="@+id/status"
+                android:id="@+id/statusCard"
                 style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -118,7 +118,7 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.card.MaterialCardView
-                android:id="@+id/nsclient_layout"
+                android:id="@+id/nsclientCard"
                 style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -178,7 +178,7 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.card.MaterialCardView
-                android:id="@+id/graph"
+                android:id="@+id/graphCard"
                 style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
For small displays the cardviews in overview fragment are not good usable.
So they are 'removed' by setting the margin , elevation and corner radius to 0.
To separate status bar stroke is added.
![overview_cards-smalldisplay](https://user-images.githubusercontent.com/25795894/164185456-8e5aeb6d-2bd0-4f2e-9cad-40f63155b33c.PNG)

