### PR TITLE
fix camelCase

### DIFF
--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -60,7 +60,7 @@
     <color name="errorAlertHeaderText">#FF000000</color>
     <color name="helperProfile">#C803A9F4</color>
     <color name="examinedProfile">#FFFF5555</color>
-    <color name="defaulttext">#666666</color>
+    <color name="defaultText">#666666</color>
 
     <!--    Datepicker-->
     <color name="dateTimePickerBackground">@color/white</color>


### PR DESCRIPTION
With the last refactoring of names one was lost.
As a result treatment userentry would crash.