### PR TITLE
Feature add swipe refresh for loop and APS fragments

### DIFF
--- a/app/src/main/res/layout/loop_fragment.xml
+++ b/app/src/main/res/layout/loop_fragment.xml
@@ -1,21 +1,19 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android = "http://schemas.android.com/apk/res/android"
+    xmlns:tools = "http://schemas.android.com/tools"
+    android:id = "@+id/swipeRefresh"
+    android:layout_width = "match_parent"
+    android:layout_height = "match_parent"
+    tools:context=".plugins.aps.loop.LoopFragment">
+
+<androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="2dp"
-    tools:context=".plugins.aps.loop.LoopFragment">
+    android:paddingTop="2dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-
-        <com.google.android.material.button.MaterialButton
-            style="@style/GrayButton"
-            android:id="@+id/run"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/openapsma_run" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -515,4 +513,7 @@
 
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+

--- a/app/src/main/res/layout/openapsama_fragment.xml
+++ b/app/src/main/res/layout/openapsama_fragment.xml
@@ -1,28 +1,19 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android = "http://schemas.android.com/apk/res/android"
+    xmlns:tools = "http://schemas.android.com/tools"
+    android:id = "@+id/swipeRefresh"
+    android:layout_width = "match_parent"
+    android:layout_height = "match_parent"
+    tools:context=".plugins.aps.openAPSAMA.OpenAPSAMAFragment">
+
+<androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="2dp"
-    tools:context=".plugins.aps.openAPSAMA.OpenAPSAMAFragment">
+    android:paddingTop="2dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal">
-
-            <com.google.android.material.button.MaterialButton
-                style="@style/GrayButton"
-                android:id="@+id/run"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/openapsma_run" />
-
-        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -580,4 +571,6 @@
 
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
To save space and to have a better look on the loop and all APS Fragments buttons
to re run calculation are removed and a swipefrefreshlayout was added.
You can see the swipefresh also in apps like google drive.

For users that have not the ability to swipe additional an option menu entry is created.
Text entry is the same as in fromer button

see also:
https://developer.android.com/training/swipe/add-swipe-interface
![APS_ISF](https://user-images.githubusercontent.com/25795894/164979881-234850b0-2e2e-4fc7-8814-971ff826bc86.PNG)
![APS_ISF_menu](https://user-images.githubusercontent.com/25795894/164979883-e250bad6-eed5-43f8-8d42-77a3ee5ae0e9.PNG)
![APS_ISF_swipe](https://user-images.githubusercontent.com/25795894/164979885-5aa7dec2-2df3-4cef-8454-129d46e31dc7.PNG)

