### PR TITLE
add group to option menu for static entries

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -296,6 +296,7 @@ class MainActivity : NoSplashAppCompatActivity() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menu.setGroupDividerEnabled(true)
         this.menu = menu
         menuInflater.inflate(R.menu.menu_main, menu)
         pluginPreferencesMenuItem = menu.findItem(R.id.nav_plugin_preferences)

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -44,6 +44,7 @@
         android:orderInCategory="1"
         app:showAsAction="never"
         android:title="@string/nav_profilehelper" />
+    <group android:id="@+id/about_exit">
     <item
         android:id="@+id/nav_about"
         android:orderInCategory="1"
@@ -54,5 +55,5 @@
         android:orderInCategory="1"
         app:showAsAction="never"
         android:title="@string/nav_exit" />
-
+    </group>
 </menu>


### PR DESCRIPTION
Add group and group separator for the last entries that are static ( about and exit), so we have a logical and optical separation.
 
Now:

![option_menu_after](https://user-images.githubusercontent.com/25795894/165123322-312bc9e8-0044-44be-8e4f-679dbd1708d3.PNG)
![option_menu_after_loop](https://user-images.githubusercontent.com/25795894/165123330-60693b1e-4a25-4ff7-aa3e-8703dc3ae0e7.PNG)

Before:
![option_menu_before](https://user-images.githubusercontent.com/25795894/165123332-6f199183-1a1c-48e9-ad7f-699c7a5caa79.PNG)
)