### PR TITLE
Fix #1619 by removing unnecessarily chatty ruffy logging.

### DIFF
--- a/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ruffyscripter/RuffyScripter.java
+++ b/combo/src/main/java/info/nightscout/androidaps/plugins/pump/combo/ruffyscripter/RuffyScripter.java
@@ -70,7 +70,14 @@ public class RuffyScripter implements RuffyCommands {
     private final IRTHandler mHandler = new IRTHandler.Stub() {
         @Override
         public void log(String message) {
-            aapsLogger.debug(LTag.PUMP, "Ruffy says: " + message);
+            // Ruffy is very verbose at this level, but the data provided isn't too helpful for
+            // debugging. For debugging Ruffy, it makes more sense to check logcat, where other
+            // possibly relevant (BT) events are also logged.
+            // Due to the amount of calls, logging this causes timing issues as reported in
+            // https://github.com/nightscout/AndroidAPS/issues/1619#issuecomment-1115811485
+            // This was caused by changing the log level from trace to debug so these messages
+            // where logged by default.
+            //aapsLogger.debug(LTag.PUMP, "Ruffy says: " + message);
         }
 
         @Override


### PR DESCRIPTION
The refactoring done via https://github.com/nightscout/AndroidAPS/commit/ad8c2297a01a9165f1e9babc29f63bb9bf46e8f4 changed ruffy trace messages to be logged on debug level, thus enabling them by default.
This caused timing issues as reported in https://github.com/nightscout/AndroidAPS/issues/1619.
This commit disables those log messages, which aren't really useful.