### PR TITLE
Dash: update default insulin level

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -99,6 +99,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
         private const val BOLUS_RETRY_INTERVAL_MS = 2000.toLong()
         private const val BOLUS_RETRIES = 5 // number of retries for cancel/get bolus status
         private const val STATUS_CHECK_INTERVAL_MS = (60L * 1000)
+        private const val RESERVOIR_OVER_50_UNITS_DEFAULT = 75.0
 
         private val pluginDescription = PluginDescription()
             .mainType(PluginType.PUMP)
@@ -537,7 +538,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
             // Omnipod only reports reservoir level when there's < 1023 pulses left
             return podStateManager.pulsesRemaining?.let {
                 it * PodConstants.POD_PULSE_BOLUS_UNITS
-            } ?: 50.0
+            } ?: RESERVOIR_OVER_50_UNITS_DEFAULT
         }
 
     override val batteryLevel: Int


### PR DESCRIPTION
If we use 50 here, then it will be displayed as "50(yellow)".
When the insulin level is > 50, we want it to be displayed as: "50+(white)".
I remember that nsclient might not display this correctly, let's fix nsclient in this case!