### PR TITLE
Fix Autotune Crashes

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
@@ -312,7 +312,8 @@ class AutotuneFragment : DaggerFragment() {
                 binding.autotuneCompare.visibility = View.VISIBLE
             }
             else                              -> {
-                binding.autotuneRun.visibility = View.VISIBLE
+                if (profile.isValid)
+                    binding.autotuneRun.visibility = View.VISIBLE
                 binding.autotuneCheckInputProfile.visibility = View.VISIBLE
             }
         }
@@ -337,7 +338,8 @@ class AutotuneFragment : DaggerFragment() {
             warning = rh.gs(R.string.profileswitch_ismissing)
                 return warning
         }
-        profileFunction.getProfile()?.let {
+        profileFunction.getProfile()?.let { currentProfile ->
+            profile = ATProfile(profileStore.getSpecificProfile(profileName)?.let { ProfileSealed.Pure(it) } ?:currentProfile, LocalInsulin(""), injector)
             if (!profile.isValid) return rh.gs(R.string.autotune_profile_invalid)
             if (profile.icSize > 1) {
                 warning += nl + rh.gs(R.string.autotune_ic_warning, profile.icSize, profile.ic)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/data/ATProfile.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/data/ATProfile.kt
@@ -235,11 +235,15 @@ class ATProfile(profile: Profile, var localInsulin: LocalInsulin, val injector: 
         isValid = profile.isValid
         if (isValid) {
             //initialize tuned value with current profile values
+            var minBasal = 1.0
             for (h in 0..23) {
                 basal[h] = Round.roundTo(profile.basalBlocks.blockValueBySeconds(T.hours(h.toLong()).secs().toInt(), 1.0, 0), 0.001)
+                minBasal = Math.min(minBasal, basal[h])
             }
             ic = avgIC
             isf = avgISF
+            if (ic * isf * minBasal == 0.0)     // Additional validity check to avoid error later in AutotunePrep
+                isValid = false
             pumpProfile = profile
             pumpProfileAvgIC = avgIC
             pumpProfileAvgISF = avgISF


### PR DESCRIPTION
AutotuneFragment.kt:341 : very strange to have `profile` not initialized here because onResume should be after onViewCreated (I added additional initialisation of `profile` before to avoid this crash)
AutotunePrep.kt:437 : The only way to have a NaN value in `Round.roundTo(mealCOB)` is if `sens` value (`tunedprofile.isf`) equals to zero. I included an additionnal validity check in `ATProfile.kt` (not sure if necessary), and I hide Run Autotune button to avoid autotune calculation with a profile not valid... (I didn't find any other possible NaN values in line 437 of AutotunePrep...)

=> the 2 crashes should be fixed with these modifications...