### PR TITLE
Increase max ISF to 1000, previous value was too low for babies

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/HardLimits.kt
@@ -53,7 +53,7 @@ class HardLimits @Inject constructor(
         val MIN_IC = doubleArrayOf(2.0, 2.0, 2.0, 2.0, 0.3)
         val MAX_IC = doubleArrayOf(100.0, 100.0, 100.0, 100.0, 100.0)
         const val MIN_ISF = 2.0 // mgdl
-        const val MAX_ISF = 720.0 // mgdl
+        const val MAX_ISF = 1000.0 // mgdl
         val MAX_IOB_AMA = doubleArrayOf(3.0, 5.0, 7.0, 12.0, 25.0)
         val MAX_IOB_SMB = doubleArrayOf(7.0, 13.0, 22.0, 30.0, 70.0)
         val MAX_BASAL = doubleArrayOf(2.0, 5.0, 10.0, 12.0, 25.0)


### PR DESCRIPTION
ISF=720 can be dangerously low for babies, even in profile helper I was able to find setups with ISF=900+