### PR TITLE
Fix lint layout warnings

### DIFF
--- a/app/src/main/res/layout/activity_profilehelper.xml
+++ b/app/src/main/res/layout/activity_profilehelper.xml
@@ -27,7 +27,7 @@
                 android:gravity="center"
                 android:paddingStart="5dp"
                 android:paddingEnd="5dp"
-                android:text="Profile 1" />
+                android:text="@string/profile1" />
 
             <TextView
                 android:id="@+id/menu2"
@@ -37,7 +37,7 @@
                 android:gravity="center"
                 android:paddingStart="5dp"
                 android:paddingEnd="5dp"
-                android:text="Profile 2" />
+                android:text="@string/profile2" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_smscommunicator_otp.xml
+++ b/app/src/main/res/layout/activity_smscommunicator_otp.xml
@@ -1,115 +1,111 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
     tools:context=".plugins.general.smsCommunicator.activities.SmsCommunicatorOtpActivity">
 
-    <ScrollView
+    <LinearLayout
+        android:id="@+id/otp_layout"
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-        <LinearLayout
-            android:id="@+id/otp_layout"
+        <TextView
+            style="@style/section_header_label"
+            android:text="@string/smscommunicator_otp_step1_install_header" />
+
+        <TextView
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_marginTop="5sp"
+            android:layout_marginBottom="5sp"
+            android:paddingStart="15sp"
+            android:paddingEnd="15sp"
+            android:text="@string/smscommunicator_otp_install_info" />
+
+        <TextView
+            style="@style/section_header_label"
+            android:text="@string/smscommunicator_otp_step2_provisioning_header" />
+
+        <ImageView
+            android:id="@+id/otp_provisioning"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:contentDescription="@string/a11y_otp_qr_code"
+            android:scaleType="center" />
+
+        <TextView
+            style="@style/warning_label"
+            android:text="" />
+
+        <TextView
+            style="@style/section_header_label"
+            android:text="@string/smscommunicator_otp_step3_test_header" />
+
+        <TextView
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5sp"
+            android:layout_marginBottom="5sp"
+            android:paddingStart="15sp"
+            android:paddingEnd="15sp"
+            android:text="@string/smscommunicator_code_verify_info" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
             <TextView
-                style="@style/section_header_label"
-                android:text="@string/smscommunicator_otp_step1_install_header" />
-
-            <TextView
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="5sp"
-                android:layout_marginBottom="5sp"
-                android:paddingStart="15sp"
-                android:paddingEnd="15sp"
-                android:text="@string/smscommunicator_otp_install_info" />
+                android:paddingStart="15dp"
+                android:paddingEnd="5dp"
+                android:text="@string/smscommunicator_code_verify_label" />
 
-            <TextView
-                style="@style/section_header_label"
-                android:text="@string/smscommunicator_otp_step2_provisioning_header" />
-
-            <ImageView
-                android:id="@+id/otp_provisioning"
-                android:layout_width="fill_parent"
+            <EditText
+                android:id="@+id/otp_verify_edit"
+                android:layout_width="140sp"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/a11y_otp_qr_code"
-                android:layout_marginTop="10dp"
-                android:scaleType="center" />
+                android:hint="@string/smscommunicator_code_verify_hint"
+                android:importantForAutofill="no"
+                android:inputType="number"
+                android:maxLength="12"
+                android:textAlignment="center"
+                android:textSize="19sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
-                style="@style/warning_label"
-                android:text="" />
-
-            <TextView
-                style="@style/section_header_label"
-                android:text="@string/smscommunicator_otp_step3_test_header" />
-
-            <TextView
-                android:layout_width="fill_parent"
+                android:id="@+id/otp_verify_label"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="5sp"
-                android:layout_marginBottom="5sp"
-                android:paddingStart="15sp"
-                android:paddingEnd="15sp"
-                android:text="@string/smscommunicator_code_verify_info" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingStart="15dp"
-                    android:paddingEnd="5dp"
-                    android:text="@string/smscommunicator_code_verify_label" />
-
-                <EditText
-                    android:id="@+id/otp_verify_edit"
-                    android:layout_width="140sp"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/smscommunicator_code_verify_hint"
-                    android:importantForAutofill="no"
-                    android:inputType="number"
-                    android:maxLength="12"
-                    android:textAlignment="center"
-                    android:textSize="19sp"
-                    tools:ignore="HardcodedText" />
-
-                <TextView
-                    android:id="@+id/otp_verify_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingStart="15dp"
-                    android:paddingEnd="5dp" />
-
-            </LinearLayout>
-
-            <TextView
-                style="@style/section_header_label"
-                android:text="@string/smscommunicator_otp_reset_header" />
-
-            <TextView
-                style="@style/warning_label"
-                android:text="@string/smscommunicator_otp_reset_warning" />
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/otp_reset"
-                style="@style/GrayButton"
-                android:layout_width="fill_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="10dp"
-                android:layout_marginTop="3dp"
-                android:layout_marginEnd="10dp"
-                android:layout_marginBottom="3dp"
-                android:text="@string/smscommunicator_otp_reset_btn"
-                android:textColor="?attr/treatmentButton" />
+                android:paddingStart="15dp"
+                android:paddingEnd="5dp" />
 
         </LinearLayout>
-    </ScrollView>
 
-</FrameLayout>
+        <TextView
+            style="@style/section_header_label"
+            android:text="@string/smscommunicator_otp_reset_header" />
+
+        <TextView
+            style="@style/warning_label"
+            android:text="@string/smscommunicator_otp_reset_warning" />
+
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
+            android:id="@+id/otp_reset"
+            style="@style/GrayButton"
+            android:layout_width="fill_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="3dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginBottom="3dp"
+            android:text="@string/smscommunicator_otp_reset_btn"
+            android:textColor="?attr/treatmentButton" />
+
+    </LinearLayout>
+
+</ScrollView>
+

--- a/app/src/main/res/layout/autotune_fragment.xml
+++ b/app/src/main/res/layout/autotune_fragment.xml
@@ -1,5 +1,4 @@
-<androidx.core.widget.NestedScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,87 +14,87 @@
             style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginStart="4dp"
-            android:layout_marginEnd="4dp"
             android:layout_marginTop="4dp"
+            android:layout_marginEnd="4dp"
             app:cardCornerRadius="4dp"
-            app:contentPadding="2dp"
             app:cardElevation="2dp"
             app:cardUseCompatPadding="false"
-            android:layout_gravity="center">
+            app:contentPadding="2dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_height="match_parent"
+                    android:orientation="horizontal">
 
-                    <LinearLayout
+                    <TextView
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="horizontal">
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal|center_vertical"
+                        android:layout_weight="2"
+                        android:gravity="end"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/autotune_profile"
+                        android:textSize="14sp" />
 
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_horizontal|center_vertical"
-                            android:layout_weight="2"
-                            android:gravity="end"
-                            android:paddingStart="5dp"
-                            android:paddingEnd="5dp"
-                            android:text="@string/autotune_profile"
-                            android:textSize="14sp" />
-
-                        <com.google.android.material.textfield.TextInputLayout
-                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:hint="@string/autotune_select_profile"
-                            android:paddingStart="5dp"
-                            android:paddingEnd="5dp">
-
-                            <com.google.android.material.textfield.MaterialAutoCompleteTextView
-                                android:id="@+id/profileList"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:inputType="none" />
-
-                        </com.google.android.material.textfield.TextInputLayout>
-
-                    </LinearLayout>
-
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="horizontal"
-                        android:paddingTop="5dp">
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/autotune_select_profile"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp">
 
-                        <TextView
+                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                            android:id="@+id/profileList"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center_horizontal|center_vertical"
-                            android:layout_weight="2"
-                            android:gravity="end"
-                            android:paddingStart="5dp"
-                            android:paddingEnd="5dp"
-                            android:text="@string/autotune_tune_days"
-                            android:textSize="14sp" />
+                            android:inputType="none" />
 
-
-                        <info.nightscout.androidaps.utils.ui.NumberPicker
-                            android:id="@+id/tune_days"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_horizontal"
-                            android:paddingStart="5dp"
-                            android:paddingEnd="5dp"
-                            android:layout_weight="1"
-                            android:layout_marginBottom="2dp"
-                            app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
-
-                    </LinearLayout>
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="horizontal"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal|center_vertical"
+                        android:layout_weight="2"
+                        android:gravity="end"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        android:text="@string/autotune_tune_days"
+                        android:textSize="14sp" />
+
+
+                    <info.nightscout.androidaps.utils.ui.NumberPicker
+                        android:id="@+id/tune_days"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginBottom="2dp"
+                        android:layout_weight="1"
+                        android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
+                        app:customContentDescription="@string/careportal_newnstreatment_duration_label" />
+
+                </LinearLayout>
+
+            </LinearLayout>
 
         </com.google.android.material.card.MaterialCardView>
 
@@ -103,14 +102,14 @@
             style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginStart="4dp"
-            android:layout_marginEnd="4dp"
             android:layout_marginTop="4dp"
+            android:layout_marginEnd="4dp"
             app:cardCornerRadius="4dp"
-            app:contentPadding="2dp"
             app:cardElevation="2dp"
             app:cardUseCompatPadding="false"
-            android:layout_gravity="center">
+            app:contentPadding="2dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -172,23 +171,23 @@
 
                 </LinearLayout>
 
-            </LinearLayout>>
+            </LinearLayout>
 
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
-            style="@style/Widget.MaterialComponents.CardView"
             android:id="@+id/autotune_results_card"
+            style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginStart="4dp"
-            android:layout_marginEnd="4dp"
             android:layout_marginTop="4dp"
+            android:layout_marginEnd="4dp"
             app:cardCornerRadius="4dp"
-            app:contentPadding="2dp"
             app:cardElevation="2dp"
             app:cardUseCompatPadding="false"
-            android:layout_gravity="center">
+            app:contentPadding="2dp">
 
 
             <LinearLayout

--- a/app/src/main/res/layout/bgsource_item.xml
+++ b/app/src/main/res/layout/bgsource_item.xml
@@ -45,6 +45,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
+                android:paddingEnd="0dp"
                 android:textStyle="bold"
                 tools:text="Name" />
 
@@ -60,17 +61,20 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
+                android:paddingEnd="0dp"
+                android:text="NS"
                 android:textAlignment="viewEnd"
                 android:textColor="?attr/setTempButton"
-                tools:text="NS" />
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/invalid"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:textColor="?attr/alarmColor"
-                tools:text="@string/invalid" />
+                android:paddingEnd="0dp"
+                android:text="@string/invalid"
+                android:textColor="?attr/alarmColor" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/bgsource_item.xml
+++ b/app/src/main/res/layout/bgsource_item.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:card_view="http://schemas.android.com/tools"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.MaterialComponents.CardView"
     android:id="@+id/bg_card"
+    style="@style/Widget.MaterialComponents.CardView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
     android:layout_marginStart="4dp"
     app:cardCornerRadius="4dp"
-    app:contentPadding="2dp"
     app:cardElevation="2dp"
-    android:layout_gravity="center">
+    app:contentPadding="2dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -25,8 +23,8 @@
             android:layout_height="wrap_content"
             android:background="?android:attr/dividerHorizontal"
             android:gravity="center"
-            android:text="1.1.2000"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            tools:text="1.1.2000" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -39,52 +37,52 @@
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="16:55"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                tools:text="16:55" />
 
             <TextView
                 android:id="@+id/value"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="Name"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                tools:text="Name" />
 
             <ImageView
                 android:id="@+id/direction"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_gravity="center_vertical"
-                card_view:srcCompat="@drawable/ic_flat" />
+                app:srcCompat="@drawable/ic_flat" />
 
             <TextView
                 android:id="@+id/ns"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="NS"
                 android:textAlignment="viewEnd"
-                android:textColor="?attr/setTempButton" />
+                android:textColor="?attr/setTempButton"
+                tools:text="NS" />
 
             <TextView
                 android:id="@+id/invalid"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingStart="10dp"
-                android:text="@string/invalid"
-                android:textColor="?attr/alarmColor" />
+                android:textColor="?attr/alarmColor"
+                tools:text="@string/invalid" />
 
         </LinearLayout>
 
         <CheckBox
             android:id="@+id/cb_remove"
             android:layout_width="wrap_content"
-            android:layout_gravity="end"
             android:layout_height="19dp"
+            android:layout_gravity="end"
+            android:layout_marginTop="-25dp"
             android:contentDescription="@string/select_for_removal"
             android:minWidth="0dp"
-            android:layout_marginTop="-25dp"
-            android:visibility="gone"/>
+            android:visibility="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_fill.xml
+++ b/app/src/main/res/layout/dialog_fill.xml
@@ -108,7 +108,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="0.3U" />
+                tools:text="0.3U" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/fill_preset_button2"
@@ -116,7 +116,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="0.7U" />
+                tools:text="0.7U" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/fill_preset_button3"
@@ -124,7 +124,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="1.2U" />
+                tools:text="1.2U" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/import_summary_item.xml
+++ b/app/src/main/res/layout/import_summary_item.xml
@@ -21,7 +21,7 @@
         android:layout_marginEnd="4dp"
         android:layout_marginBottom="4dp"
         app:srcCompat="@drawable/ic_meta_format"
-        android:tint="#ffffff" />
+        app:tint="?attr/colorControlNormal" />
 
     <TextView
         android:id="@+id/summary_text"

--- a/app/src/main/res/layout/loop_fragment.xml
+++ b/app/src/main/res/layout/loop_fragment.xml
@@ -1,519 +1,555 @@
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android = "http://schemas.android.com/apk/res/android"
-    xmlns:tools = "http://schemas.android.com/tools"
-    android:id = "@+id/swipeRefresh"
-    android:layout_width = "match_parent"
-    android:layout_height = "match_parent"
-    tools:context=".plugins.aps.loop.LoopFragment">
-
-<androidx.core.widget.NestedScrollView
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/swipeRefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="2dp">
+    tools:context=".plugins.aps.loop.LoopFragment">
 
-    <LinearLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="match_parent"
+        android:paddingTop="2dp">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <TextView
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_lastrun_label"
-                android:textSize="14sp" />
+                android:focusable="true"
+                android:orientation="horizontal">
 
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_lastrun_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
 
-            <TextView
-                android:id="@+id/lastrun"
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/lastrun"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="5/9/22 21:34" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
+                android:focusable="true"
+                android:orientation="horizontal"
+                android:screenReaderFocusable="true">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_aps_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/source"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="OpenAPS SMB" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_request_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/request"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="Rate: ..." />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_constraintsprocessed_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/constraintsprocessed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/constraints"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/constraints"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_tbrrequest_time_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/tbrrequest_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_tbrexecution_time_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/tbrexecution_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_tbrsetbypump_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/tbrsetbypump"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_smbrequest_time_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/smbrequest_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_smbexecution_time_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/smbexecution_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/loop_smbsetbypump_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/smbsetbypump"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
 
         </LinearLayout>
 
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal"
-            android:screenReaderFocusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_aps_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/source"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_request_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/request"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_constraintsprocessed_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/constraintsprocessed"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/constraints"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/constraints"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_tbrrequest_time_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/tbrrequest_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_tbrexecution_time_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/tbrexecution_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_tbrsetbypump_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/tbrsetbypump"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_smbrequest_time_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/smbrequest_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_smbexecution_time_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/smbexecution_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/loop_smbsetbypump_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/smbsetbypump"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-    </LinearLayout>
-
-</androidx.core.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/layout/objectives_fragment.xml
+++ b/app/src/main/res/layout/objectives_fragment.xml
@@ -11,8 +11,8 @@
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
         android:paddingTop="16dp"
+        android:paddingEnd="16dp"
         android:visibility="gone">
 
         <CheckBox
@@ -21,14 +21,17 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
             android:layout_weight="1"
-            android:text="Enable fake time and progress" />
+            android:text="Enable fake time and progress"
+            tools:ignore="HardcodedText" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/reset"
             style="@style/OkCancelButton.Text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Reset" />
+            android:text="Reset"
+            tools:ignore="HardcodedText" />
+
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
@@ -38,4 +41,5 @@
         android:layout_weight="1"
         android:clipToPadding="false"
         android:paddingBottom="16dp" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/openapsama_fragment.xml
+++ b/app/src/main/res/layout/openapsama_fragment.xml
@@ -1,576 +1,614 @@
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android = "http://schemas.android.com/apk/res/android"
-    xmlns:tools = "http://schemas.android.com/tools"
-    android:id = "@+id/swipeRefresh"
-    android:layout_width = "match_parent"
-    android:layout_height = "match_parent"
-    tools:context=".plugins.aps.openAPSAMA.OpenAPSAMAFragment">
-
-<androidx.core.widget.NestedScrollView
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/swipeRefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="2dp">
+    tools:context=".plugins.aps.openAPSAMA.OpenAPSAMAFragment">
 
-    <LinearLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="match_parent"
+        android:paddingTop="2dp">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:orientation="vertical">
 
-            <TextView
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_lastrun_label"
-                android:textSize="14sp" />
+                android:focusable="true"
+                android:orientation="horizontal">
 
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_lastrun_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
 
-            <TextView
-                android:id="@+id/lastrun"
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/lastrun"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="5/9/22 21:59" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_inputparameters_label"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/constraints"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/constraints"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="Safety: ...." />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_glucosestatus_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/glucosestatus"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="glucose: 159" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_currenttemp_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/currenttemp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_iobdata_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/iobdata"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_profile_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/profile"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_mealdata_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/mealdata"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_autosensdata_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/autosensdata"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/result"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="0dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_scriptdebugdata_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/scriptdebugdata"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/result"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/result"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/openapsma_request_label"
+                    android:textAlignment="viewEnd"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:text=":"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/request"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="2dip"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
+                android:background="?android:attr/dividerHorizontal" />
 
         </LinearLayout>
 
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="center_horizontal"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_inputparameters_label"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/constraints"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/constraints"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_glucosestatus_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/glucosestatus"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_currenttemp_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/currenttemp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_iobdata_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/iobdata"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_profile_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/profile"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_mealdata_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/mealdata"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_autosensdata_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/autosensdata"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="center_horizontal"
-                android:paddingEnd="5dp"
-                android:text="@string/result"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="0dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_scriptdebugdata_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/scriptdebugdata"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/result"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/result"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:gravity="end"
-                android:paddingEnd="5dp"
-                android:text="@string/openapsma_request_label"
-                android:textSize="14sp" />
-
-            <TextView
-                android:layout_width="5dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0"
-                android:gravity="center_horizontal"
-                android:paddingStart="2dp"
-                android:paddingEnd="2dp"
-                android:text=":"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/request"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="start"
-                android:paddingStart="5dp"
-                android:textSize="14sp" />
-
-        </LinearLayout>
-
-        <View
-            android:layout_width="fill_parent"
-            android:layout_height="2dip"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="5dp"
-            android:background="?android:attr/dividerHorizontal" />
-
-    </LinearLayout>
-
-</androidx.core.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/overview_buttons_layout.xml
+++ b/app/src/main/res/layout/overview_buttons_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/overview_buttons"
     android:layout_width="match_parent"
@@ -24,7 +23,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:paddingStart="0dp"
-        android:paddingEnd="5dp" >
+        android:paddingEnd="5dp">
 
     </LinearLayout>
 
@@ -34,7 +33,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:paddingStart="0dp"
-        android:paddingEnd="5dp" >
+        android:paddingEnd="5dp">
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/treatment_button"
@@ -44,12 +43,12 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/icon_insulin_carbs"
-            android:text="@string/overview_treatment_label"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
+            android:singleLine="true"
+            android:text="@string/overview_treatment_label"
             android:textColor="?attr/icTreatmentColor"
-            android:visibility="gone" />
+            android:visibility="gone"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/insulin_button"
@@ -59,11 +58,11 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_bolus"
-            android:text="@string/overview_insulin_label"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
-            android:textColor="?attr/icBolusColor" />
+            android:singleLine="true"
+            android:text="@string/overview_insulin_label"
+            android:textColor="?attr/icBolusColor"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/carbs_button"
@@ -73,11 +72,11 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_cp_bolus_carbs"
-            android:text="@string/treatments_wizard_carbs_label"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
-            android:textColor="?attr/icBolusCarbsColor" />
+            android:singleLine="true"
+            android:text="@string/treatments_wizard_carbs_label"
+            android:textColor="?attr/icBolusCarbsColor"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/wizard_button"
@@ -87,11 +86,11 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_calculator"
-            android:text="@string/overview_calculator_label"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
-            android:textColor="?attr/icCalculatorColor"/>
+            android:singleLine="true"
+            android:text="@string/overview_calculator_label"
+            android:textColor="?attr/icCalculatorColor"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/calibration_button"
@@ -101,12 +100,12 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_calibration"
-            android:text="@string/overview_calibration"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
+            android:singleLine="true"
+            android:text="@string/overview_calibration"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="gone" />
+            android:visibility="gone"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/cgm_button"
@@ -116,12 +115,12 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_xdrip"
-            android:text="@string/overview_cgm"
-            android:singleLine="true"
             android:ellipsize="end"
-            app:iconPadding="-4dp"
+            android:singleLine="true"
+            android:text="@string/overview_cgm"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="gone" />
+            android:visibility="gone"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/quick_wizard_button"
@@ -131,10 +130,10 @@
             android:layout_marginEnd="-2dp"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_quick_wizard"
-            android:text="@string/quickwizard"
             android:hint="@string/quickwizard"
-            app:iconPadding="-4dp"
-            android:textColor="?attr/icQuickWizardColor" />
+            android:text="@string/quickwizard"
+            android:textColor="?attr/icQuickWizardColor"
+            app:iconPadding="-4dp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/overview_quickwizardlist_item.xml
+++ b/app/src/main/res/layout/overview_quickwizardlist_item.xml
@@ -1,151 +1,143 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.MaterialComponents.CardView"
     android:id="@+id/card"
+    style="@style/Widget.MaterialComponents.CardView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
     android:layout_marginStart="4dp"
     app:cardCornerRadius="4dp"
-    app:contentPadding="2dp"
     app:cardElevation="2dp"
     app:cardUseCompatPadding="true"
-    android:layout_gravity="center">
+    app:contentPadding="2dp">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="false"
+            android:cropToPadding="false"
+            android:importantForAccessibility="no"
+            android:scaleType="fitStart"
+            app:srcCompat="@drawable/ic_quick_wizard" />
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:adjustViewBounds="false"
-                android:cropToPadding="false"
-                android:importantForAccessibility="no"
-                android:scaleType="fitStart"
-                app:srcCompat="@drawable/ic_quick_wizard" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:baselineAligned="true"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/buttonText"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="10dp"
+                        android:text="Sample button text"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                        android:textColor="?attr/cardObjectiveText"
+                        android:textStyle="normal|bold"
+                        tools:ignore="HardcodedText,RtlSymmetry" />
+
+                    <TextView
+                        android:id="@+id/carbs"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="10dp"
+                        android:text="36g"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                        android:textColor="?attr/cardObjectiveText"
+                        android:textStyle="normal|bold"
+                        tools:ignore="HardcodedText,RtlSymmetry" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/device"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="false"
+                    android:contentDescription="@string/a11y_only_on_phone"
+                    android:cropToPadding="false"
+                    android:scaleType="fitStart"
+                    app:srcCompat="@drawable/ic_smartphone" />
+
+                <ImageView
+                    android:id="@+id/sortHandle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="false"
+                    android:contentDescription="@string/a11y_drag_and_drop_handle"
+                    android:cropToPadding="false"
+                    android:scaleType="fitStart"
+                    app:srcCompat="@drawable/ic_reorder_gray_24dp" />
+
+                <CheckBox
+                    android:id="@+id/cb_remove"
+                    android:layout_width="wrap_content"
+                    android:layout_height="24dp"
+                    android:contentDescription="@string/select_for_removal"
+                    android:minWidth="0dp" />
+
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="horizontal">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:baselineAligned="true"
-                    android:orientation="horizontal">
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="horizontal">
-
-                        <TextView
-                            android:id="@+id/buttonText"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingStart="10dp"
-                            android:text="Sample button text"
-                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                            android:textColor="?attr/cardObjectiveText"
-                            android:textStyle="normal|bold"
-                            tools:ignore="HardcodedText,RtlSymmetry" />
-
-                        <TextView
-                            android:id="@+id/carbs"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:paddingStart="10dp"
-                            android:text="36g"
-                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                            android:textColor="?attr/cardObjectiveText"
-                            android:textStyle="normal|bold"
-                            tools:ignore="HardcodedText,RtlSymmetry" />
-
-                    </LinearLayout>
-
-                    <ImageView
-                        android:id="@+id/device"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:adjustViewBounds="false"
-                        android:cropToPadding="false"
-                        android:scaleType="fitStart"
-                        android:contentDescription="@string/a11y_only_on_phone"
-                        app:srcCompat="@drawable/ic_smartphone" />
-
-                    <ImageView
-                        android:id="@+id/sortHandle"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:adjustViewBounds="false"
-                        android:contentDescription="@string/a11y_drag_and_drop_handle"
-                        android:cropToPadding="false"
-                        android:scaleType="fitStart"
-                        app:srcCompat="@drawable/ic_reorder_gray_24dp" />
-
-                    <CheckBox
-                        android:id="@+id/cb_remove"
-                        android:layout_width="wrap_content"
-                        android:layout_height="24dp"
-                        android:contentDescription="@string/select_for_removal"
-                        android:minWidth="0dp"/>
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_gravity="top"
+                    android:paddingStart="10dp"
+                    android:paddingEnd="5dp"
+                    android:text="@string/overview_editquickwizard_valid"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="top"
-                        android:paddingStart="10dp"
-                        android:paddingEnd="5dp"
-                        android:text="@string/overview_editquickwizard_valid"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+                <TextView
+                    android:id="@+id/from"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:paddingEnd="10dp"
+                    android:text="07:45"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                    android:textStyle="normal|bold"
+                    tools:ignore="HardcodedText,RtlSymmetry" />
 
-                    <TextView
-                        android:id="@+id/from"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:paddingEnd="10dp"
-                        android:text="07:45"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                        android:textStyle="normal|bold"
-                        tools:ignore="HardcodedText,RtlSymmetry" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="-"
+                    tools:ignore="HardcodedText" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="-"
-                        tools:ignore="HardcodedText" />
-
-                    <TextView
-                        android:id="@+id/to"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:paddingStart="10dp"
-                        android:text="11:45"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                        android:textStyle="normal|bold"
-                        tools:ignore="HardcodedText,RtlSymmetry" />
-
-                </LinearLayout>
+                <TextView
+                    android:id="@+id/to"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:paddingStart="10dp"
+                    android:text="11:45"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                    android:textStyle="normal|bold"
+                    tools:ignore="HardcodedText,RtlSymmetry" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/tidepool_fragment.xml
+++ b/app/src/main/res/layout/tidepool_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -12,47 +13,48 @@
         android:layout_marginTop="32dp"
         android:text="-"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/login"
+        style="@style/GrayButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:text="Login"
+        android:text="@string/login"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/status" />
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/uploadnow"
+        style="@style/GrayButton"
         android:layout_width="113dp"
         android:layout_height="50dp"
         android:layout_marginTop="8dp"
-        android:text="Upload now"
+        android:text="@string/upload_now"
         app:layout_constraintStart_toEndOf="@+id/login"
         app:layout_constraintTop_toBottomOf="@+id/status" />
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/removeall"
+        style="@style/GrayButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
-        android:text="Remove all"
+        android:text="@string/remove_all"
         app:layout_constraintStart_toEndOf="@+id/uploadnow"
         app:layout_constraintTop_toBottomOf="@+id/status" />
 
     <com.google.android.material.button.MaterialButton
-        style="@style/GrayButton"
         android:id="@+id/resertstart"
+        style="@style/GrayButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
-        android:text="Reset start"
+        android:text="@string/reset_start"
         app:layout_constraintStart_toEndOf="@+id/removeall"
         app:layout_constraintTop_toBottomOf="@+id/status" />
 
@@ -72,7 +74,9 @@
             android:id="@+id/log"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="-- logs --" />
+            android:text="-- logs --"
+            tools:ignore="HardcodedText" />
+
     </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/virtualpump_fragment.xml
+++ b/app/src/main/res/layout/virtualpump_fragment.xml
@@ -1,383 +1,404 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".plugins.pump.virtual.VirtualPumpFragment">
 
-    <ScrollView
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="20dp"
+            android:text="@string/vitualpump_label"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="20dp"
-                android:text="@string/vitualpump_label"
-                android:textAppearance="?android:attr/textAppearanceLarge" />
-
-            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/basebasalrate_label"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/basebasalrate_label"
-                    android:textSize="14sp" />
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/basabasalrate"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
+            <TextView
+                android:id="@+id/basabasalrate"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/tempbasal_label"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/tempbasal"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/virtualpump_extendedbolus_label"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/extendedbolus"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/battery_label"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/battery"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <!-- Reservoir -->
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/reservoir_label"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/reservoir"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <!-- Pump Serial -->
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/serialnumber"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/serial_number"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <!-- Pump Type -->
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/virtualpump_type"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/type"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-
-            <!-- Pump Definition -->
-            <View
-                android:layout_width="fill_parent"
-                android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginTop="5dp"
-                android:background="?android:attr/dividerHorizontal" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingEnd="5dp"
-                    android:text="@string/virtualpump_definition"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="5dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0"
-                    android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
-                    android:paddingStart="2dp"
-                    android:text=":"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:id="@+id/type_def"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="start"
-                    android:paddingStart="5dp"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                tools:text="0.38 U/h" />
 
         </LinearLayout>
-    </ScrollView>
 
-</FrameLayout>
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/tempbasal_label"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/tempbasal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/virtualpump_extendedbolus_label"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/extendedbolus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/battery_label"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/battery"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                tools:text="50%" />
+
+        </LinearLayout>
+
+        <!-- Reservoir -->
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/reservoir_label"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/reservoir"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <!-- Pump Serial -->
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/serialnumber"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/serial_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <!-- Pump Type -->
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/virtualpump_type"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <!-- Pump Definition -->
+        <View
+            android:layout_width="fill_parent"
+            android:layout_height="2dip"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="5dp"
+            android:background="?android:attr/dividerHorizontal" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="0dp"
+                android:paddingEnd="5dp"
+                android:text="@string/virtualpump_definition"
+                android:textAlignment="viewEnd"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="5dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:gravity="center_horizontal"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text=":"
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/type_def"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="0dp"
+                android:textAlignment="viewStart"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1212,7 +1212,11 @@
     <string name="configure">Configure opacity</string>
     <string name="loop_status">Loop status</string>
     <string name="graph_scale">Graph scale</string>
-
+    <string name="profile1">Profile 1</string>
+    <string name="profile2">Profile 2</string>
+    <string name="login">Login</string>
+    <string name="remove_all">Remove all</string>
+    <string name="reset_start">Reset start</string>
     <string name="a11y_otp_qr_code">QR Code for setup one time password</string>
     <string name="a11y_open_settings">open settings</string>
     <string name="a11y_set_carb_timer">set carb timer alarm</string>
@@ -1227,5 +1231,6 @@
     <string name="aidex">GlucoRx Aidex</string>
     <string name="aidex_short">Aidex</string>
     <string name="description_source_aidex">Receive BG values from GlucoRx Aidex CGMS.</string>
+
 
 </resources>

--- a/combo/src/main/AndroidManifest.xml
+++ b/combo/src/main/AndroidManifest.xml
@@ -2,4 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="info.nightscout.androidaps.combo">
 
+    <application
+        android:supportsRtl="true">
+    </application>
+
 </manifest>

--- a/combo/src/main/res/layout/combopump_fragment.xml
+++ b/combo/src/main/res/layout/combopump_fragment.xml
@@ -1,13 +1,9 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingTop="5dp"
     tools:context="info.nightscout.androidaps.plugins.pump.combo.ComboFragment">
-
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
 
     <ScrollView
         android:id="@+id/scrollView"
@@ -22,16 +18,17 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/combo_pump_state_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -39,18 +36,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_state"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -58,25 +57,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/combo_pump_activity_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -84,18 +84,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <com.joanzapata.iconify.widget.IconTextView
                     android:id="@+id/combo_activity"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -103,25 +105,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/battery_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -129,45 +132,49 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <com.joanzapata.iconify.widget.IconTextView
                     android:id="@+id/combo_pumpstate_battery"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
                     android:text=""
-                    android:textSize="14sp" />
+                    android:textAlignment="viewStart"
+                    android:textSize="14sp"
+                    tools:text="30%" />
 
             </LinearLayout>
 
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/reservoir_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -175,18 +182,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_insulinstate"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -194,25 +203,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/lastconnection_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -220,18 +230,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_lastconnection"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -239,25 +251,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/lastbolus_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -265,18 +278,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_last_bolus"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -284,25 +299,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/basebasalrate_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -310,18 +326,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_base_basal_rate"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -329,25 +347,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/tempbasal_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -355,18 +374,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_temp_basal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -374,25 +395,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/combo_bolus_count"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -400,18 +422,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_bolus_count"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -419,25 +443,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/combo_tbr_count"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -445,18 +470,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_tbr_count"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -465,10 +492,10 @@
                 android:id="@+id/combo_connection_error_delimiter"
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
@@ -481,9 +508,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/pump_commerror_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -491,18 +519,20 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
 
                 <TextView
                     android:id="@+id/combo_connection_error_value"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -510,25 +540,26 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.5"
-                    android:gravity="end"
+                    android:paddingStart="0dp"
                     android:paddingEnd="5dp"
                     android:text="@string/serialnumber"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp" />
 
                 <TextView
@@ -536,18 +567,21 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText"
+                    tools:text="123123" />
 
                 <TextView
                     android:id="@+id/serial_number"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:paddingEnd="0dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp" />
 
             </LinearLayout>
@@ -555,10 +589,10 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <TextView
@@ -576,29 +610,21 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:paddingEnd="4dp"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:paddingEnd="4dp">
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
+            android:id="@+id/combo_refresh_button"
+            style="@style/GrayButton"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <info.nightscout.androidaps.utils.ui.SingleClickButton
-                android:id="@+id/combo_refresh_button"
-                style="@style/GrayButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.5"
-                android:layout_marginEnd="-4dp"
-                android:drawableTop="@drawable/ic_actions_refill"
-                android:paddingStart="0dp"
-                android:paddingEnd="0dp"
-                android:text="@string/refresh" />
-        </LinearLayout>
+            android:layout_marginEnd="-4dp"
+            android:layout_weight="0.5"
+            android:drawableTop="@drawable/ic_actions_refill"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            android:text="@string/refresh" />
 
     </LinearLayout>
 
-    </RelativeLayout>
-
-</FrameLayout>
+</RelativeLayout>

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
-    <application>
+    <application
+        android:supportsRtl="true">
         <activity android:name="info.nightscout.androidaps.activities.TDDStatsActivity" />
         <activity
             android:name="info.nightscout.androidaps.activities.BolusProgressHelperActivity"

--- a/core/src/main/res/layout/close.xml
+++ b/core/src/main/res/layout/close.xml
@@ -3,17 +3,18 @@
     android:id="@+id/done_background"
     android:layout_width="match_parent"
     android:layout_height="56dp"
-    android:orientation="horizontal"
+    android:layout_gravity="center_vertical"
     android:background="@android:color/transparent"
     android:gravity="end"
-    android:layout_gravity="center_vertical"
+    android:orientation="horizontal"
     android:paddingBottom="8dp">
 
     <Button
         android:id="@+id/close"
+        style="@style/OkCancelButton.Text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
-        style="@style/OkCancelButton.Text"
         android:text="@string/close" />
+
 </LinearLayout>

--- a/core/src/main/res/layout/dialog_profileviewer.xml
+++ b/core/src/main/res/layout/dialog_profileviewer.xml
@@ -82,8 +82,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/date"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -94,7 +94,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/date"
@@ -102,7 +103,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
+                android:textAlignment="viewStart"
                 android:textSize="14sp" />
 
         </LinearLayout>
@@ -119,16 +120,16 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/units_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -139,7 +140,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/units"
@@ -147,8 +149,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
-                android:textSize="14sp" />
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                tools:text="mmol" />
 
         </LinearLayout>
 
@@ -164,16 +167,16 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/dia_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -184,7 +187,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/dia"
@@ -192,8 +196,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
-                android:textSize="14sp" />
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                tools:text="6.50 h" />
 
         </LinearLayout>
 
@@ -209,16 +214,16 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/ic_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -229,7 +234,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/ic"
@@ -237,8 +243,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
-                android:textSize="14sp" />
+                android:textAlignment="viewStart"
+                android:textSize="14sp"
+                tools:text="00:00 13.8 g/U" />
 
         </LinearLayout>
 
@@ -263,13 +270,13 @@
             android:orientation="horizontal">
 
             <TextView
-                android:focusable="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
+                android:focusable="true"
                 android:text="@string/isf_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -280,7 +287,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/isf"
@@ -288,7 +296,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
+                android:textAlignment="viewStart"
                 android:textSize="14sp" />
 
         </LinearLayout>
@@ -311,16 +319,16 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/basal_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -331,7 +339,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/basal"
@@ -339,7 +348,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
+                android:textAlignment="viewStart"
                 android:textSize="14sp" />
 
         </LinearLayout>
@@ -354,8 +363,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text=""
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -374,7 +383,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="17dp"
                 android:layout_weight="1"
-                android:gravity="start"
+                android:textAlignment="viewStart"
                 android:textSize="14sp" />
 
         </LinearLayout>
@@ -397,16 +406,16 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:focusable="true"
+            android:orientation="horizontal">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
                 android:layout_weight="2"
-                android:gravity="end"
                 android:text="@string/target_label"
+                android:textAlignment="viewEnd"
                 android:textSize="14sp" />
 
             <TextView
@@ -417,7 +426,8 @@
                 android:layout_weight="0"
                 android:gravity="center_horizontal"
                 android:text=":"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                tools:ignore="HardcodedText" />
 
             <TextView
                 android:id="@+id/target"
@@ -425,7 +435,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:layout_weight="1"
-                android:gravity="start"
+                android:textAlignment="viewStart"
                 android:textSize="14sp" />
 
         </LinearLayout>

--- a/core/src/main/res/layout/maintenance_import_list_activity.xml
+++ b/core/src/main/res/layout/maintenance_import_list_activity.xml
@@ -2,23 +2,18 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginTop="4dp"
+    android:orientation="vertical"
     tools:context="info.nightscout.androidaps.plugins.general.maintenance.activities.PrefImportListActivity">
 
-    <LinearLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="4dp"
-        android:orientation="vertical">
+        android:fadeScrollbars="true"
+        android:scrollbarStyle="outsideOverlay"
+        android:scrollbars="vertical">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerview"
-            android:layout_width="match_parent"
-            android:scrollbars="vertical"
-            android:fadeScrollbars="true"
-            android:scrollbarStyle="outsideOverlay"
-            android:layout_height="match_parent">
-
-        </androidx.recyclerview.widget.RecyclerView>
-    </LinearLayout>
+    </androidx.recyclerview.widget.RecyclerView>
 
 </FrameLayout>

--- a/dana/src/main/AndroidManifest.xml
+++ b/dana/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="info.nightscout.androidaps.dana">
 
-    <application>
+    <application
+        android:supportsRtl="true">
         <activity
             android:name="info.nightscout.androidaps.dana.activities.DanaHistoryActivity"
             android:theme="@style/AppTheme" />

--- a/dana/src/main/res/layout/danar_fragment.xml
+++ b/dana/src/main/res/layout/danar_fragment.xml
@@ -1,17 +1,17 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context="info.nightscout.androidaps.dana.DanaFragment"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:context="info.nightscout.androidaps.dana.DanaFragment">
 
     <ScrollView
         android:id="@+id/scrollview"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:paddingTop="5dp"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        android:paddingTop="5dp">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -21,16 +21,16 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/serialnumber"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -39,8 +39,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -50,36 +50,37 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
-                    tools:ignore="RtlSymmetry" />
+                    tools:ignore="RtlSymmetry"
+                    tools:text="123123" />
 
             </LinearLayout>
 
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:id="@+id/bt_connection_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/danar_bluetooth_status"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -88,8 +89,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -99,9 +100,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
                     android:text="{fa-bluetooth-b}"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText,RtlSymmetry" />
 
@@ -110,25 +111,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/battery_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -137,8 +138,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -148,8 +149,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -158,25 +159,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/lastconnection_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -185,8 +186,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -196,8 +197,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -206,25 +207,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/lastbolus_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -233,8 +234,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -244,8 +245,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -254,25 +255,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/dailyunits"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -281,8 +282,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -292,8 +293,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -302,25 +303,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/basebasalrate_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlHardcoded,RtlSymmetry" />
 
@@ -329,8 +330,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -340,8 +341,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -350,25 +351,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/tempbasal_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -377,8 +378,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -388,8 +389,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -398,25 +399,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/virtualpump_extendedbolus_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -425,8 +426,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -436,8 +437,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -446,25 +447,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/reservoir_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -473,8 +474,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -484,8 +485,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -494,25 +495,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/basal_bolus_step"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -521,8 +522,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -532,8 +533,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -542,25 +543,25 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:focusable="true">
+                android:focusable="true"
+                android:orientation="horizontal">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="end"
                     android:paddingEnd="5dp"
                     android:text="@string/virtualpump_firmware_label"
+                    android:textAlignment="viewEnd"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -569,8 +570,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0"
                     android:gravity="center_horizontal"
-                    android:paddingEnd="2dp"
                     android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
                     android:text=":"
                     android:textSize="14sp"
                     tools:ignore="HardcodedText" />
@@ -580,8 +581,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:gravity="start"
                     android:paddingStart="5dp"
+                    android:textAlignment="viewStart"
                     android:textSize="14sp"
                     tools:ignore="RtlSymmetry" />
 
@@ -590,10 +591,10 @@
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dip"
-                android:layout_marginBottom="5dp"
                 android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="5dp"
                 android:background="?android:attr/dividerHorizontal" />
 
             <ImageView
@@ -601,9 +602,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:contentDescription="@string/pump_icon"
                 android:drawableTop="@drawable/ic_dana_rs"
-                android:paddingTop="10dp"
-                android:contentDescription="@string/pump_icon" />
+                android:paddingTop="10dp" />
 
         </LinearLayout>
 
@@ -622,12 +623,12 @@
             android:id="@+id/pump_status"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="6dp"
-            android:paddingBottom="6dp"
             android:layout_marginStart="5dp"
             android:layout_marginEnd="5dp"
             android:background="?attr/pumpStatusBackground"
             android:gravity="center_vertical|center_horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
             android:textAppearance="?android:attr/textAppearanceSmall" />
     </LinearLayout>
 
@@ -644,12 +645,12 @@
             android:id="@+id/queue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="6dp"
-            android:paddingBottom="6dp"
             android:layout_marginStart="5dp"
             android:layout_marginEnd="5dp"
             android:background="?attr/pumpStatusBackground"
             android:gravity="center_vertical|center_horizontal"
+            android:paddingTop="6dp"
+            android:paddingBottom="6dp"
             android:textAppearance="?android:attr/textAppearanceSmall" />
     </LinearLayout>
 
@@ -664,25 +665,25 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:layout_marginEnd="-2dp"
+            android:layout_weight="1"
             android:drawableTop="@drawable/ic_danarprofile"
-            android:text="@string/viewprofile"
-            android:maxLines="2"
             android:ellipsize="end"
-            app:iconPadding="-4dp"/>
+            android:maxLines="2"
+            android:text="@string/viewprofile"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/history"
             style="@style/ButtonSmallFontStyle"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:layout_marginEnd="-2dp"
+            android:layout_weight="1"
             android:drawableTop="@drawable/ic_pump_history"
-            android:text="@string/pumphistory"
-            android:maxLines="2"
             android:ellipsize="end"
+            android:maxLines="2"
+            android:text="@string/pumphistory"
             app:iconPadding="-4dp"
             tools:ignore="TooManyViews" />
 
@@ -691,26 +692,26 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:layout_marginEnd="-2dp"
+            android:layout_weight="1"
             android:drawableTop="@drawable/ic_danarstats"
-            android:text="@string/stats"
-            android:maxLines="2"
             android:ellipsize="end"
-            app:iconPadding="-4dp"/>
+            android:maxLines="2"
+            android:text="@string/stats"
+            app:iconPadding="-4dp" />
 
         <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/user_options"
             style="@style/ButtonSmallFontStyle"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:layout_marginEnd="-2dp"
+            android:layout_weight="1"
             android:drawableTop="@drawable/ic_danar_useropt"
-            android:text="@string/danar_useroptions"
-            android:maxLines="2"
             android:ellipsize="end"
-            app:iconPadding="-4dp"/>
+            android:maxLines="2"
+            android:text="@string/danar_useroptions"
+            app:iconPadding="-4dp" />
 
     </LinearLayout>
 

--- a/danar/src/main/AndroidManifest.xml
+++ b/danar/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
-    <application>
+    <application
+        android:supportsRtl="true">
         <service
             android:name="info.nightscout.androidaps.danar.services.DanaRExecutionService"
             android:enabled="true"


### PR DESCRIPTION
Fix various lint warning
- hardcoded text
- moved the test to the string file for translations
- Improve RTL in tables (loop, dana, combo etc.)
- removed extra nested layouts that were not required.
- Formatted the edited files

The change is easier to review in "spit" mode ignore whitespace
https://github.com/nightscout/AndroidAPS/pull/1753/files?diff=split&w=1