### PR TITLE
Dash: remove automatic tz change

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -1296,30 +1296,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
     }
 
     override fun timezoneOrDSTChanged(timeChangeType: TimeChangeType) {
-        val eventHandlingEnabled = sp.getBoolean(R.string.key_omnipod_common_time_change_event_enabled, false)
-
-        aapsLogger.info(
-            LTag.PUMP,
-            "Time, Date and/or TimeZone changed. [timeChangeType=" + timeChangeType.name + ", eventHandlingEnabled=" + eventHandlingEnabled + "]"
-        )
-
-        when {
-            !eventHandlingEnabled -> {
-                aapsLogger.info(LTag.PUMP, "Ignoring time change because automatic time handling is disabled in configuration")
-                return
-            }
-            timeChangeType == TimeChangeType.TimeChanged -> {
-                aapsLogger.info(LTag.PUMP, "Ignoring time change because it is not a DST or TZ change")
-                return
-            }
-            !podStateManager.isPodRunning -> {
-                aapsLogger.info(LTag.PUMP, "Ignoring time change because no Pod is active")
-                return
-            }
-        }
-        aapsLogger.info(LTag.PUMP, "Handling time change")
-
-        commandQueue.customCommand(CommandHandleTimeChange(false), null)
+        aapsLogger.info(LTag.PUMP, "Ignoring time change because automatic time handling is not implemented. timeChangeType=${timeChangeType.name}")
     }
 
     private fun executeProgrammingCommand(

--- a/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -99,16 +99,4 @@
             android:title="@string/omnipod_common_preferences_notification_delivery_suspended_sound_enabled" />
 
     </PreferenceCategory>
-
-    <PreferenceCategory
-        android:key="@string/key_common_preferences_category_other_settings"
-        android:title="@string/omnipod_common_preferences_category_other"
-        app:initialExpandedChildrenCount="0">
-        
-        <SwitchPreference
-            android:defaultValue="true"
-            android:key="@string/key_omnipod_common_time_change_event_enabled"
-            android:title="@string/omnipod_common_preferences_time_change_enabled" />
-    </PreferenceCategory>
-
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Fixes https://github.com/nightscout/AndroidAPS/issues/1739

Remove automatic handling of TZ/DST change.b
There will still be a notification/we can update the time on pod after the press of a button, but no automatic profile update.

This change affects documentation!

