### PR TITLE
Fix regression in medtronic cannula change detection

### DIFF
--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
@@ -397,7 +397,7 @@ class MedtronicHistoryData @Inject constructor(
                 continue
             }
             if (primeRecord.atechDateTime > maxAllowedTimeInPast) {
-                if (lastPrimeRecordTime != 0L && lastPrimeRecordTime < primeRecord.atechDateTime) {
+                if (lastPrimeRecordTime < primeRecord.atechDateTime) {
                     lastPrimeRecordTime = primeRecord.atechDateTime
                     lastPrimeRecord = primeRecord
                 }


### PR DESCRIPTION
It seems an erroneous `lastPrimeRecordTime!=0L && ` was added during the kotlin refactorings of this:
https://github.com/nightscout/AndroidAPS/commit/59a3bf88834a8433676a78e893ee5694166f0949#diff-b3c8866292a4a902f69ba7dc1b82892bae6fc93a2dce97749c34f1fcf9f1f751R400
(you'll likely have to scroll down to `MedtronicHistoryData.kt` and expand it to see the linked change due to github collapsing large diffs)

This PR just reverts that line, which restores the previously-working functionality of automatic cannula change detection in medtronic pumps.