### PR TITLE
Fix Autotune Fragment Crash (#1764)

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
@@ -381,10 +381,9 @@ class AutotuneFragment : DaggerFragment() {
     }
 
     private fun showResults() {
-        _binding ?: return
-        Thread {
-            context?.let { context ->
-                runOnUiThread {
+        context?.let { context ->
+            runOnUiThread {
+                _binding?.let {
                     binding.autotuneResults.removeAllViews()
                     if (autotunePlugin.result.isNotBlank()) {
                         var toMgDl = 1.0
@@ -455,7 +454,7 @@ class AutotuneFragment : DaggerFragment() {
                     binding.autotuneResultsCard.visibility = if (autotunePlugin.calculationRunning && autotunePlugin.result.isEmpty()) View.GONE else View.VISIBLE
                 }
             }
-        }.start()
+        }
     }
 
     private fun toTableRowHeader(basal:Boolean = false): TableRow =


### PR DESCRIPTION
I already included `_binding ?: return` in the beginning of `updateGui()`but it was probably not enough...
I added a new one at the beginning of `showResults()` and check context before `runOnUiThread`
Fix #1764