### PR TITLE
Communication moved from Gitter to Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,5 @@ Hints
 * Start small, it is easier to review smaller changes that affect fewer parts of code 
 * Take a look into Issues list (https://github.com/nightscout/AndroidAPS/issues) - maybe there is something you can fix or implement
 * For new features, make sure there is Issue to track progress and have on-topic discussion
-* Reach out to community, discuss idea on Gitter (https://gitter.im/MilosKozak/AndroidAPS)
+* Reach out to community, discuss idea on Discord (https://discord.gg/4fQUWHZ4Mw)
 * Speak with other developers to minimise merge conflicts. Find out who worked, working or plan to work on speciffic issue or part of app

--- a/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective2.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/constraints/objectives/objectives/Objective2.kt
@@ -153,7 +153,7 @@ class Objective2(injector: HasAndroidInjector) : Objective(injector, "exam", R.s
         tasks.add(ExamTask(this, R.string.troubleshooting_label, R.string.troubleshooting_wheretoask, "troubleshooting")
             .option(Option(R.string.troubleshooting_fb, true))
             .option(Option(R.string.troubleshooting_wiki, true))
-            .option(Option(R.string.troubleshooting_gitter, true))
+            .option(Option(R.string.troubleshooting_discord, true))
             .option(Option(R.string.troubleshooting_yourendo, false))
             .hint(Hint(R.string.troubleshooting_hint1))
             .hint(Hint(R.string.troubleshooting_hint2))

--- a/app/src/main/res/values-bg-rBG/exam.xml
+++ b/app/src/main/res/values-bg-rBG/exam.xml
@@ -37,7 +37,7 @@
     <string name="update_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#update-to-a-new-version-or-branch</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_hint1">https://androidaps.readthedocs.io/en/latest/EN/Configuration/Config-Builder.html#insulin</string>
     <string name="sensitivity_which">Отбележете всички правилни отговори.</string>

--- a/app/src/main/res/values-ca-rES/exam.xml
+++ b/app/src/main/res/values-ca-rES/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">A on es pot cercar ajuda relacionada amb AndroidAPS?</string>
     <string name="troubleshooting_fb">Demanant consell al grup de Facebook d\'usuaris d\'AndroidAPS.</string>
     <string name="troubleshooting_wiki">Llegint (i rellegint) la documentació d\'AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Demanant consell i enregistrant problemes tècnics o errors de funcionament a la sala AndroidAPS de Gitter.</string>
+    <string name="troubleshooting_discord">Demanant consell i enregistrant problemes tècnics o errors de funcionament a la sala AndroidAPS de Discord.</string>
     <string name="troubleshooting_yourendo">Preguntant a la clínica on us porten la diabetis o a la vostra endocrinòloga.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugins d\'insulina</string>
     <string name="insulin_ultrarapid">Quina insulina s\'ha de fer servir amb el plugin Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-cs-rCZ/exam.xml
+++ b/app/src/main/res/values-cs-rCZ/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Kde můžete hledat pomoc s AndroidAPS?</string>
     <string name="troubleshooting_fb">Můžete požádat o radu v Facebookové skupině uživatelů AndroidAPS.</string>
     <string name="troubleshooting_wiki">Měli byste si přečíst (a znovu přečíst) dokumentaci AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Můžete požádat o radu a nahlásit technické problémy nebo potíže na Gitteru.</string>
+    <string name="troubleshooting_discord">Můžete požádat o radu a nahlásit technické problémy nebo potíže na Discordu.</string>
     <string name="troubleshooting_yourendo">Měli byste se zeptat svého lékaře/endokrinologa.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/cs/index.html#poradce-pri-potizich</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Pluginy Inzulín</string>
     <string name="insulin_ultrarapid">Který inzulin byste měli používat s pluginem Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-da-rDK/exam.xml
+++ b/app/src/main/res/values-da-rDK/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Hvor kan du søge efter hjælp til AndroidAPS?</string>
     <string name="troubleshooting_fb">Du kan bede om råd i \"AndroidAPS-users\" Facebook-gruppen.</string>
     <string name="troubleshooting_wiki">Du bør læse (og genlæse) AndroidAPS dokumentation.</string>
-    <string name="troubleshooting_gitter">Du kan bede om råd og notere tekniske problemer eller problemer i AndroidAPS Gitter-rummet.</string>
+    <string name="troubleshooting_discord">Du kan bede om råd og notere tekniske problemer eller problemer i AndroidAPS Discord-rummet.</string>
     <string name="troubleshooting_yourendo">Du bør spørge din diabetessygeplejerske/endokrinolog.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulin Plugins</string>
     <string name="insulin_ultrarapid">Hvilken insulin skal du bruge sammen med Ultra-Rapid Oref-pluginnet?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-de-rDE/exam.xml
+++ b/app/src/main/res/values-de-rDE/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Wo kannst Du nach Hilfe für AndroidAPS suchen?</string>
     <string name="troubleshooting_fb">Du kannst in der AndroidAPS-Facebook-Gruppe um Rat bitten.</string>
     <string name="troubleshooting_wiki">Du solltest die AndroidAPS-Dokumentation lesen (und wiederholt lesen).</string>
-    <string name="troubleshooting_gitter">Du kannst im AndroidAPS Gitter-Raum nach Rat fragen und technische Probleme dort erfassen und posten.</string>
+    <string name="troubleshooting_discord">Du kannst im AndroidAPS Discord-Raum nach Rat fragen und technische Probleme dort erfassen und posten.</string>
     <string name="troubleshooting_yourendo">Du solltest Deine Diabetesklinik / Deinen Diabetologen fragen.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/de/Installing-AndroidAPS/Update-to-new-version.html#problembehandlung</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/loopedDE/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulin-Plugins</string>
     <string name="insulin_ultrarapid">Welches Insulin kann mit dem Ultra-Rapid-Oref-Plugin verwendet werden?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-el-rGR/exam.xml
+++ b/app/src/main/res/values-el-rGR/exam.xml
@@ -31,7 +31,7 @@
     <string name="update_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#update-to-a-new-version-or-branch</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_humalog">Humalog®</string>
     <string name="insulin_hint1">https://androidaps.readthedocs.io/en/latest/EN/Configuration/Config-Builder.html#insulin</string>

--- a/app/src/main/res/values-es-rES/exam.xml
+++ b/app/src/main/res/values-es-rES/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">¿Dónde se puede pedir ayuda relacionada con AndroidAPS?</string>
     <string name="troubleshooting_fb">Puedes pedir ayuda en el grupo de Facebook AndroidAPS Users.</string>
     <string name="troubleshooting_wiki">Debes leer (y después releer) la documentación oficial de AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Puedes pedir ayuda y registrar problemas técnicos en la llamada AndroidAPS Gitter room.</string>
+    <string name="troubleshooting_discord">Puedes pedir ayuda y registrar problemas técnicos en la llamada AndroidAPS Discord room.</string>
     <string name="troubleshooting_yourendo">Debes preguntar a tu endocrino o educador diabetológico.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugins de insulina</string>
     <string name="insulin_ultrarapid">¿Qué insulina debes usar con el plugin Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-fr-rFR/exam.xml
+++ b/app/src/main/res/values-fr-rFR/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Où pouvez-vous chercher de l\'aide avec AndroidAPS ?</string>
     <string name="troubleshooting_fb">Vous pouvez demander des conseils dans le groupe Facebook des utilisateurs AndroidAPS.</string>
     <string name="troubleshooting_wiki">Vous devez lire (et relire) la documentation AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Vous pouvez demander des conseils et signaler des problèmes techniques ou des défauts dans forum Gitter AndroidAPS.</string>
+    <string name="troubleshooting_discord">Vous pouvez demander des conseils et signaler des problèmes techniques ou des défauts dans forum Discord AndroidAPS.</string>
     <string name="troubleshooting_yourendo">Vous devez demander à votre diabétologue/professionnels de santés.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/fr/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugins Insuline</string>
     <string name="insulin_ultrarapid">Quelle insuline devez-vous utiliser avec le plugin Ultra-Rapid-Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-it-rIT/exam.xml
+++ b/app/src/main/res/values-it-rIT/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Dove puoi cercare aiuto con AndroidAPS?</string>
     <string name="troubleshooting_fb">Puoi chiedere consiglio nel gruppo Facebook degli utenti AndroidAPS.</string>
     <string name="troubleshooting_wiki">Dovresti leggere (e rileggere) la documentazione di AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Puoi chiedere consigli e segnalare problemi tecnici nella stanza Gitter di AndroidAPS.</string>
+    <string name="troubleshooting_discord">Puoi chiedere consigli e segnalare problemi tecnici nella stanza Discord di AndroidAPS.</string>
     <string name="troubleshooting_yourendo">Dovresti chiedere al tuo endocrinologo/centro diabetologico.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/aapsitalia/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugin insulina</string>
     <string name="insulin_ultrarapid">Quale insulina dovresti usare con il plugin Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-iw-rIL/exam.xml
+++ b/app/src/main/res/values-iw-rIL/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">איפה אפשר לחפש עזרה עם AndroidAPS?</string>
     <string name="troubleshooting_fb">אפשר לבקש עצות בקבוצת הפייסבוק \"AndroidAPS Users\" (אנגלית).</string>
     <string name="troubleshooting_wiki">צריך לקרוא (ולקרוא מחדש) את מסמכי AndroidAPS.</string>
-    <string name="troubleshooting_gitter">תוכלו לבקש עצות ולרשום בעיות טכניות או בעיות בחדר ה-Gitter של AndroidAPS.</string>
+    <string name="troubleshooting_discord">תוכלו לבקש עצות ולרשום בעיות טכניות או בעיות בחדר ה-Discord של AndroidAPS.</string>
     <string name="troubleshooting_yourendo">עליכם לשאול את המרפאה\\הרופא האנדוקרינולוג שלכם.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">תוספי אינסולין</string>
     <string name="insulin_ultrarapid">באיזה אינסולין להשתמש עם תוסף האולטרה מהיר?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-ko-rKR/exam.xml
+++ b/app/src/main/res/values-ko-rKR/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">어디에서 AndroidAPS에 대한 도움을 받을 수 있을까요?</string>
     <string name="troubleshooting_fb">Facebook의 AndrioidAPS 사용자 그룹에 조언을 요청할 수 있습니다.</string>
     <string name="troubleshooting_wiki">AndroidAPS 문서를 읽어야 (그리고 다시 읽어야) 합니다.</string>
-    <string name="troubleshooting_gitter">AndroidAPS Gitter room에 기술적 문제들을 기록하고, 조언을 요청할 수 있습니다.</string>
+    <string name="troubleshooting_discord">AndroidAPS Discord room에 기술적 문제들을 기록하고, 조언을 요청할 수 있습니다.</string>
     <string name="troubleshooting_yourendo">당뇨병 클리닉/내분비내과의사에게 문의해야 합니다.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/ko/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">인슐린 플러그인</string>
     <string name="insulin_ultrarapid">어떤 인슐린에서 초-초속효성의 Oref 플러그인을 사용해야 할까요?</string>
     <string name="insulin_fiasp">피아스프(Fiasp®)</string>

--- a/app/src/main/res/values-lt-rLT/exam.xml
+++ b/app/src/main/res/values-lt-rLT/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Kur galima ieškoti pagalbos su AndroidAPS?</string>
     <string name="troubleshooting_fb">Galite kreiptis patarimo AndroidAPS Users Facebook grupėje.</string>
     <string name="troubleshooting_wiki">Jūs turėtumėte skaityti (ir pakartotinai skaityti) AndroidAPS dokumentaciją.</string>
-    <string name="troubleshooting_gitter">AndroidAPS Gitter kambaryje galite paprašyti patarimo ir užregistruoti technines problemas ar klausimus.</string>
+    <string name="troubleshooting_discord">AndroidAPS Discord kambaryje galite paprašyti patarimo ir užregistruoti technines problemas ar klausimus.</string>
     <string name="troubleshooting_yourendo">Turėtumėte kreiptis į savo diabeto kliniką/endokrinologą.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulino įskiepiai</string>
     <string name="insulin_ultrarapid">Kurį insuliną reikėtų naudoti su Ultra-Rapid Oref įskiepiu?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-nl-rNL/exam.xml
+++ b/app/src/main/res/values-nl-rNL/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Waar kan je hulp zoeken voor AndroidAPS?</string>
     <string name="troubleshooting_fb">Je kunt om advies vragen in de AndroidAPS Users Facebookgroep.</string>
     <string name="troubleshooting_wiki">Je moet de AndroidAPS documentatie lezen (en opnieuw lezen).</string>
-    <string name="troubleshooting_gitter">Je kunt om advies vragen en technische problemen bespreken in de AndroidAPS Gitter-room.</string>
+    <string name="troubleshooting_discord">Je kunt om advies vragen en technische problemen bespreken in de AndroidAPS Discord-room.</string>
     <string name="troubleshooting_yourendo">Je moet hulp vragen aan je behandelteam.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/nl/Installing-AndroidAPS/Update-to-new-version.html#problemen-oplossen</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insuline-plugins</string>
     <string name="insulin_ultrarapid">Welke insuline gebruik je met de Ultra-Rapid Oref plugin?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-no-rNO/exam.xml
+++ b/app/src/main/res/values-no-rNO/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Hvor kan du søke etter hjelp for AndroidAPS?</string>
     <string name="troubleshooting_fb">Du kan be om råd i Facebookgruppen AndroidAPS Users.</string>
     <string name="troubleshooting_wiki">Du bør lese (og lese om igjen) AndroidAPS dokumentasjonen.</string>
-    <string name="troubleshooting_gitter">Du kan be om råd og logge tekniske problemer eller hendelser i AndroidAPS Gitter.</string>
+    <string name="troubleshooting_discord">Du kan be om råd og logge tekniske problemer eller hendelser i AndroidAPS Discord.</string>
     <string name="troubleshooting_yourendo">Du bør spørre din diabetesklinikk/endokrinolog.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulin plugin modul</string>
     <string name="insulin_ultrarapid">Hvilken insulin skal du bruke sammens med Ultra-Rapid Oref modulen?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-pl-rPL/exam.xml
+++ b/app/src/main/res/values-pl-rPL/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Gdzie możesz szukać pomocy z AndroidAPS?</string>
     <string name="troubleshooting_fb">Możesz poprosić o poradę w grupie użytkowników AndroidAPS na Facebooku.</string>
     <string name="troubleshooting_wiki">Należy przeczytać (i ponownie przeczytać) dokumentację AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Możesz poprosić o poradę i zarejestrować problemy techniczne w pokoju AndroidAPS Gitter.</string>
+    <string name="troubleshooting_discord">Możesz poprosić o poradę i zarejestrować problemy techniczne w pokoju AndroidAPS Discord.</string>
     <string name="troubleshooting_yourendo">Należy zwrócić się do diabetologa lub lekarza endokrynologa.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Wtyczki insuliny</string>
     <string name="insulin_ultrarapid">Która insulina powinna być używana z wtyczką Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-pt-rPT/exam.xml
+++ b/app/src/main/res/values-pt-rPT/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Onde pode procurar ajuda com o AndroidAPS?</string>
     <string name="troubleshooting_fb">Pedir conselhos no grupo de Facebook AndroidAPS Users.</string>
     <string name="troubleshooting_wiki">Deve ler (e reler) a documentação do AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Pode solicitar aconselhamento e registar problemas técnicos ou problemas na sala Gitter do AndroidAPS.</string>
+    <string name="troubleshooting_discord">Pode solicitar aconselhamento e registar problemas técnicos ou problemas na sala Discord do AndroidAPS.</string>
     <string name="troubleshooting_yourendo">Deveria pedir à sua clínica de diabetes/endocrinologista.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugins de Insulina</string>
     <string name="insulin_ultrarapid">Que insulina deve utilizar com o plugin Oref Ultra-Rápida ?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-ro-rRO/exam.xml
+++ b/app/src/main/res/values-ro-rRO/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Unde puteți căuta ajutor pentru AndroidAPS?</string>
     <string name="troubleshooting_fb">Puteti cere sfaturi in grupul AndroidAPS Users Facebook.</string>
     <string name="troubleshooting_wiki">Ar trebui să citiți (și să re-citiți) documentația AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Puteți solicita sfaturi și să înregistrați probleme tehnice în camera AndroidAPS Gitter.</string>
+    <string name="troubleshooting_discord">Puteți solicita sfaturi și să înregistrați probleme tehnice în camera AndroidAPS Discord.</string>
     <string name="troubleshooting_yourendo">Ar trebui să întrebați medicul diabetolog.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Plugin-uri insulină</string>
     <string name="insulin_ultrarapid">Ce insulină trebuie să utilizaţi cu plugin-ul Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-ru-rRU/exam.xml
+++ b/app/src/main/res/values-ru-rRU/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Где искать помощь с AndroidAPS?</string>
     <string name="troubleshooting_fb">Вы можете попросить совета в группе AndroidAPS Users Facebook.</string>
     <string name="troubleshooting_wiki">Вам следует прочитать (и перечитать) документацию AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Можно консультироваться и пересылать логи технических проблем и неполадок в чате Gitter по AndroidAPS.</string>
+    <string name="troubleshooting_discord">Можно консультироваться и пересылать логи технических проблем и неполадок в чате Discord по AndroidAPS.</string>
     <string name="troubleshooting_yourendo">Вы должны спросить в диабетической клинике / у вашего врача-эндокринолога.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw
  
 Context | Edit Context</string>
     <string name="insulin_label">Модули для инсулинов</string>

--- a/app/src/main/res/values-sk-rSK/exam.xml
+++ b/app/src/main/res/values-sk-rSK/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Kde môžete hľadať pomoc s AndroidAPS?</string>
     <string name="troubleshooting_fb">Môžete požiadať o radu vo Facebookovej skupine používateľov AndroidAPS.</string>
     <string name="troubleshooting_wiki">Mali by ste si prečítať (a znovu prečítať) dokumentáciu k AndroidAPS.</string>
-    <string name="troubleshooting_gitter">Môžete požiadať o radu a nahlásiť technické problémy, alebo chyby na Gitteri.</string>
+    <string name="troubleshooting_discord">Môžete požiadať o radu a nahlásiť technické problémy, alebo chyby na Discordi.</string>
     <string name="troubleshooting_yourendo">Mali by ste se spýtať svojho lekára/endokrinológa.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/CROWDIN/cs/index.html#poradce-pri-potizich</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Pluginy Inzulín</string>
     <string name="insulin_ultrarapid">Ktorý inzulín by ste mali používať s pluginom Ultra-rýchly Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-sv-rSE/exam.xml
+++ b/app/src/main/res/values-sv-rSE/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Var kan du leta efter hjälp med AndroidAPS?</string>
     <string name="troubleshooting_fb">Du kan be om råd i Facebookgruppen AndroidAPS Users.</string>
     <string name="troubleshooting_wiki">Du bör läsa (och läsa om) AndroidAPS dokumentation.</string>
-    <string name="troubleshooting_gitter">Du kan be om råd och logga tekniska problem eller problem i AndroidAPS Gitter-rum.</string>
+    <string name="troubleshooting_discord">Du kan be om råd och logga tekniska problem eller problem i AndroidAPS Discord-rum.</string>
     <string name="troubleshooting_yourendo">Du bör fråga din diabetesklinik/endokrinolog.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulininställningar</string>
     <string name="insulin_ultrarapid">Vilket insulin ska du använda med insticksprogrammet Ultra-Rapid Oref?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values-tr-rTR/exam.xml
+++ b/app/src/main/res/values-tr-rTR/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">AndroidAPS ile ilgili nereden yardım alabilirsiniz?</string>
     <string name="troubleshooting_fb">AndroidAPS Kullanıcıları Facebook grubundan tavsiye isteyebilirsiniz.</string>
     <string name="troubleshooting_wiki">AndroidAPS belgelerini okumalısınız (ve yeniden okumalısınız).</string>
-    <string name="troubleshooting_gitter">AndroidAPS Gitter odasından tavsiye isteyebilir ve teknik problemleri veya sorunları not edebilirsiniz.</string>
+    <string name="troubleshooting_discord">AndroidAPS Discord odasından tavsiye isteyebilir ve teknik problemleri veya sorunları not edebilirsiniz.</string>
     <string name="troubleshooting_yourendo">Diyabet kliniğinize/endokrinoloğunuza sormalısınız.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">İnsülin Eklentileri</string>
     <string name="insulin_ultrarapid">Ultra-Hızlı Oref eklentisi ile hangi insülini kullanmalısınız?</string>
     <string name="insulin_fiasp">Fiasp®</string>

--- a/app/src/main/res/values/exam.xml
+++ b/app/src/main/res/values/exam.xml
@@ -104,11 +104,11 @@
     <string name="troubleshooting_wheretoask">Where can you look for help with AndroidAPS?</string>
     <string name="troubleshooting_fb">You can ask for advice in the AndroidAPS Users Facebook group.</string>
     <string name="troubleshooting_wiki">You should read (and re-read) the AndroidAPS documentation.</string>
-    <string name="troubleshooting_gitter">You can ask for advice and log technical problems or issues in the AndroidAPS Gitter room.</string>
+    <string name="troubleshooting_discord">You can ask for advice and log technical problems or issues in the AndroidAPS Discord room.</string>
     <string name="troubleshooting_yourendo">You should ask your diabetes clinic/endocrinologist.</string>
     <string name="troubleshooting_hint1">https://androidaps.readthedocs.io/en/latest/EN/Installing-AndroidAPS/Update-to-new-version.html#troubleshooting</string>
     <string name="troubleshooting_hint2">https://www.facebook.com/groups/AndroidAPSUsers/</string>
-    <string name="troubleshooting_hint3">https://gitter.im/MilosKozak/AndroidAPS</string>
+    <string name="troubleshooting_hint3">https://discord.gg/4fQUWHZ4Mw</string>
     <string name="insulin_label">Insulin Plugins</string>
     <string name="insulin_ultrarapid">Which insulin should you use with the Ultra-Rapid Oref plugin?</string>
     <string name="insulin_fiasp">Fiasp®</string>


### PR DESCRIPTION
As of last comment in Gitter-Channel communication moved to Discord, but in CONTRIBUTING and in the exams the Gitter-Channel is still referenced.