### PR TITLE
Autotune remove Detailed log setting

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneFragment.kt
@@ -79,6 +79,7 @@ class AutotuneFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         sp.putBoolean(R.string.key_autotune_tune_insulin_curve, false)  // put to false tune insulin curve
+        sp.putBoolean(R.string.key_autotune_additional_log, false)      // put to false additional log
         autotunePlugin.lastRun = sp.getLong(R.string.key_autotune_last_run, 0)
         if (autotunePlugin.lastNbDays.isEmpty())
             autotunePlugin.lastNbDays = sp.getInt(R.string.key_autotune_default_tune_days, 5).toString()

--- a/app/src/main/res/xml/pref_autotune.xml
+++ b/app/src/main/res/xml/pref_autotune.xml
@@ -36,11 +36,12 @@
             android:key="@string/key_autotune_circadian_ic_isf"
             android:summary="@string/autotune_circadian_ic_isf_summary"
             android:title="@string/autotune_circadian_ic_isf_title" />
-
+        <!--  Hide autotune_additional_log option
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/key_autotune_additional_log"
             android:summary="@string/autotune_additional_log_summary"
             android:title="@string/autotune_additional_log_title" />
+        -->
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
I added this setting to be able to compare detailed IOB calculation.
I no more needed to use it recently, and can generate issue on slow machines...