### PR TITLE
fix: remove tint light theme action icons

### DIFF
--- a/app/src/main/res/drawable/ic_sort.xml
+++ b/app/src/main/res/drawable/ic_sort.xml
@@ -2,7 +2,6 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="#FFFFFF"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/core/src/main/res/drawable/ic_close.xml
+++ b/core/src/main/res/drawable/ic_close.xml
@@ -1,10 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#FFFFFF"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="?attr/colorControlNormal"
         android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
 </vector>

--- a/core/src/main/res/drawable/ic_sort.xml
+++ b/core/src/main/res/drawable/ic_sort.xml
@@ -2,7 +2,6 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="#FFFFFF"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path


### PR DESCRIPTION
Icon fixes for light theme:
- Close icon in the delete action bar is now visible
- The sort icon in the automation action bar is now visible

![image](https://user-images.githubusercontent.com/6724749/177175961-4279d334-6e09-42c7-b5e7-e4852cd3b95c.png)
