### PR TITLE
Autotune Crash during sort

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
@@ -39,7 +39,7 @@ open class AutotuneIob @Inject constructor(
     private val autotuneFS: AutotuneFS
 ) {
 
-    private val nsTreatments = ArrayList<NsTreatment>()
+    private var nsTreatments = ArrayList<NsTreatment>()
     private var dia: Double = Constants.defaultDIA
     var boluses: ArrayList<Bolus> = ArrayList()
     var meals = ArrayList<Carbs>()
@@ -59,11 +59,11 @@ open class AutotuneIob @Inject constructor(
         initializeTreatmentData(from - range(), to)
         initializeTempBasalData(from - range(), to, tunedProfile)
         initializeExtendedBolusData(from - range(), to, tunedProfile)
-        tempBasals.sortWith { o1: TemporaryBasal, o2: TemporaryBasal -> (o2.timestamp - o1.timestamp).toInt() }
+        tempBasals = ArrayList(tempBasals.toList().sortedWith { o1: TemporaryBasal, o2: TemporaryBasal -> (o2.timestamp - o1.timestamp).toInt() })
         // Without Neutral TBR, Autotune Web will ignore iob for periods without TBR running
         addNeutralTempBasal(from - range(), to, tunedProfile)
-        nsTreatments.sortWith { o1: NsTreatment, o2: NsTreatment -> (o2.date - o1.date).toInt() }
-        this.boluses.sortWith { o1: Bolus, o2: Bolus -> (o2.timestamp - o1.timestamp).toInt() }
+        nsTreatments = ArrayList(nsTreatments.toList().sortedWith { o1: NsTreatment, o2: NsTreatment -> (o2.date - o1.date).toInt() })
+        boluses = ArrayList(boluses.toList().sortedWith { o1: Bolus, o2: Bolus -> (o2.timestamp - o1.timestamp).toInt() })
         aapsLogger.debug(LTag.AUTOTUNE, "Nb Treatments: " + nsTreatments.size + " Nb meals: " + meals.size)
     }
 

--- a/core/src/main/java/info/nightscout/androidaps/interfaces/Autotune.kt
+++ b/core/src/main/java/info/nightscout/androidaps/interfaces/Autotune.kt
@@ -2,7 +2,7 @@ package info.nightscout.androidaps.interfaces
 
 interface Autotune {
 
-    fun aapsAutotune(daysBack: Int, autoSwitch: Boolean, profileToTune: String = ""): String
+    fun aapsAutotune(daysBack: Int, autoSwitch: Boolean, profileToTune: String = "")
     fun atLog(message: String)
 
     var lastRunSuccess: Boolean


### PR DESCRIPTION
I propose to use `@Synchronized` in main call (all crashs comes from automation call not secured if several rules run Autotune at the same time).
I noticed it's allways during `sortWith` that I get crash but I don't understand how an ArrayList of not nullable objects can raise a NullPointerException during sortWith ???
=> I tried to convert ArrayList to List only for sort execution (not sure it will work better...)