### PR TITLE
Fix pump unreachable alarm loop

### DIFF
--- a/core/src/main/java/info/nightscout/androidaps/services/AlarmSoundService.kt
+++ b/core/src/main/java/info/nightscout/androidaps/services/AlarmSoundService.kt
@@ -74,7 +74,7 @@ class AlarmSoundService : DaggerService() {
         if (intent?.hasExtra(ErrorHelperActivity.SOUND_ID) == true) resourceId = intent.getIntExtra(ErrorHelperActivity.SOUND_ID, R.raw.error)
         player = MediaPlayer()
         try {
-            val afd = rh.openRawResourceFd(resourceId) ?: return START_STICKY
+            val afd = rh.openRawResourceFd(resourceId) ?: return START_NOT_STICKY
             player?.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
             afd.close()
             player?.isLooping = true
@@ -94,7 +94,7 @@ class AlarmSoundService : DaggerService() {
             aapsLogger.error("Unhandled exception", e)
         }
         aapsLogger.debug(LTag.CORE, "onStartCommand End")
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Description
If AAPS is stopped while an alarm is playing (such as the pump unreachable alarm), the alarm sound service will be started again by Android. There's no built-in way to stop the alarm sound service after this happens. This PR makes it so the alarm sound service won't be restarted by Android, thereby avoiding the aforementioned issue.

## Replication
1. Wait for a "pump unreachable" notification from AAPS' local alerts (not the identically-named notification from the Medtronic plugin)
2. The Nightscout chime sound ([`alarm.mp3`](https://github.com/nightscout/AndroidAPS/blob/master/core/src/main/res/raw/alarm.mp3)) should start playing, but do not dismiss the notification
3. Stop AAPS by either using the 3-dots menu and "Exit" or force kill through app info
4. Re-launch AAPS or wait for AAPS to re-launch itself
5. A blip sound ([`error.mp3`](https://github.com/nightscout/AndroidAPS/blob/master/core/src/main/res/raw/error.mp3)) will loop forever

You can stop the sound by clearing AAPS' cache in app info + force killing the app. 

## Cause
When an Android service is started explicitly, [the `onStartCommand()` function](https://developer.android.com/reference/android/app/Service#onStartCommand(android.content.Intent,%20int,%20int)) is called and the overriding function can set the started state. Some of these states can be `STICKY` which essentially tells Android that, if the service dies for any reason, the system can restart the service automatically. 

In AAPS, the alarm service is started explicitly and sets its state to [`START_STICKY`](https://developer.android.com/reference/android/app/Service#START_STICKY). The only place where this alarm service is stopped properly is via the NotificationStore [here](https://github.com/nightscout/AndroidAPS/blob/f8acbad759ccdc4dcdc58a7d150103dfe757ff94/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/notifications/NotificationStore.kt#L80) and [here](https://github.com/nightscout/AndroidAPS/blob/f8acbad759ccdc4dcdc58a7d150103dfe757ff94/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/notifications/NotificationStore.kt#L95), but these "stop service" calls are only executed when a notification with a sound resource was spawned during the app's uptime (thus added to the [in-memory notification store](https://github.com/nightscout/AndroidAPS/blob/f8acbad759ccdc4dcdc58a7d150103dfe757ff94/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/notifications/NotificationStore.kt#L44)) and the notification still exists to either be dismissed or marked as expired. 

After the app gets killed while an alarm service is active, Android will re-start the alarm service (without the intent data, which means the Nightscout chime sound for pump unreachables will turn into the blip sound) and get stuck playing the sound while the user has no recourse to stop the alarm besides clearing AAPS cache + force killing, or rebooting the phone.

An attempt was made to mitigate this issue [back in October 2021](https://github.com/nightscout/AndroidAPS/commit/c1290ce76649a8bed34574ac738b5b1b9a961980) but `onTerminate()` is [only called on Android emulator devices, not on production devices](https://developer.android.com/reference/android/app/Application#onTerminate()), so this only prevents the alarm loop issue for emulators.

## Fix
I just decided to make the service start as [non-sticky](https://developer.android.com/reference/android/app/Service#START_NOT_STICKY). The biggest reason I went with this approach is because there doesn't seem to be any logic to handle situations where the alarm service is started by Android without any known notifications or dialogs (such as ensuring the alarm is still valid and a way to dismiss the alarm exists). 

An alternative approach would be to duplicate [the line in `MainApp.onTerminate()` which stops the alarm service](https://github.com/nightscout/AndroidAPS/blob/f8acbad759ccdc4dcdc58a7d150103dfe757ff94/app/src/main/java/info/nightscout/androidaps/MainApp.kt#L252) and add it into the `onCreate()` function, but I felt this wasn't the best approach as there could be a race condition where Android restarts the alarm service before `alarmSoundServiceHelper.stopService()` is called in the `onCreate()`. [The docs do state that `onCreate()`](https://developer.android.com/reference/android/app/Application#onCreate()) is called `before any activity, [service], or receiver objects`, so this might not really be applicable. Nonetheless, the other reason in the previous paragraph still stands. 

This PR should (at least) partially fix #1792. The initial part mentioned in the issue (the pump unreachable alarm starting again on its own) doesn't seem like it would be fixed by this PR.. but this PR should fix the problem faced later on (the alarm sound would change to a blip after restarting and have no obvious way to stop it).