### PR TITLE
Fix Autotune crashed

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
@@ -35,10 +35,8 @@ open class AutotuneIob @Inject constructor(
     private val profileFunction: ProfileFunction,
     private val sp: SP,
     private val dateUtil: DateUtil,
-    private val activePlugin: ActivePlugin,
     private val autotuneFS: AutotuneFS
 ) {
-
     private var nsTreatments = ArrayList<NsTreatment>()
     private var dia: Double = Constants.defaultDIA
     var boluses: ArrayList<Bolus> = ArrayList()
@@ -54,7 +52,11 @@ open class AutotuneIob @Inject constructor(
         startBG = from
         endBG = to
         nsTreatments.clear()
+        meals.clear()
+        boluses.clear()
         tempBasals = ArrayList<TemporaryBasal>()
+        if (profileFunction.getProfile(from - range()) == null)
+            return
         initializeBgreadings(from, to)
         initializeTreatmentData(from - range(), to)
         initializeTempBasalData(from - range(), to, tunedProfile)
@@ -91,8 +93,6 @@ open class AutotuneIob @Inject constructor(
         aapsLogger.debug(LTag.AUTOTUNE, "Check BG date: BG Size: " + glucose.size + " OldestBG: " + dateUtil.dateAndTimeAndSecondsString(oldestBgDate) + " to: " + dateUtil.dateAndTimeAndSecondsString(to))
         val tmpCarbs = repository.getCarbsDataFromTimeToTimeExpanded(from, to, false).blockingGet()
         aapsLogger.debug(LTag.AUTOTUNE, "Nb treatments after query: " + tmpCarbs.size)
-        meals.clear()
-        boluses.clear()
         var nbCarbs = 0
         for (i in tmpCarbs.indices) {
             val tp = tmpCarbs[i]

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotuneIob.kt
@@ -138,23 +138,17 @@ open class AutotuneIob @Inject constructor(
     //nsTreatment is used only for export data
     private fun initializeExtendedBolusData(from: Long, to: Long, tunedProfile: ATProfile) {
         val extendedBoluses = repository.getExtendedBolusDataFromTimeToTime(from, to, false).blockingGet()
-        val pumpInterface = activePlugin.activePump
-        if (pumpInterface.isFakingTempsByExtendedBoluses) {
-            for (i in extendedBoluses.indices) {
-                val eb = extendedBoluses[i]
-                if (eb.isValid)
+        for (i in extendedBoluses.indices) {
+            val eb = extendedBoluses[i]
+            if (eb.isValid)
+                if (eb.isEmulatingTempBasal) {
                     profileFunction.getProfile(eb.timestamp)?.let {
                         toSplittedTimestampTB(eb.toTemporaryBasal(it), tunedProfile)
                     }
-            }
-        } else {
-            for (i in extendedBoluses.indices) {
-                val eb = extendedBoluses[i]
-                if (eb.isValid) {
+                } else {
                     nsTreatments.add(NsTreatment(eb))
                     boluses.addAll(convertToBoluses(eb))
                 }
-            }
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotunePlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/autotune/AutotunePlugin.kt
@@ -134,6 +134,15 @@ class AutotunePlugin @Inject constructor(
             log("Tune day " + (i + 1) + " of " + daysBack)
             tunedProfile?.let { it ->
                 autotuneIob.initializeData(from, to, it)  //autotuneIob contains BG and Treatments data from history (<=> query for ns-treatments and ns-entries)
+                if (autotuneIob.boluses.size == 0) {
+                    result = rh.gs(R.string.autotune_error)
+                    log("No basal data on day ${i + 1}")
+                    autotuneFS.exportResult(result)
+                    autotuneFS.exportLogAndZip(lastRun)
+                    rxBus.send(EventAutotuneUpdateGui())
+                    calculationRunning = false
+                    return
+                }
                 autotuneFS.exportEntries(autotuneIob)               //<=> ns-entries.yyyymmdd.json files exported for results compare with oref0 autotune on virtual machine
                 autotuneFS.exportTreatments(autotuneIob)            //<=> ns-treatments.yyyymmdd.json files exported for results compare with oref0 autotune on virtual machine (include treatments ,tempBasal and extended
                 preppedGlucose = autotunePrep.categorize(it) //<=> autotune.yyyymmdd.json files exported for results compare with oref0 autotune on virtual machine

--- a/app/src/test/java/info/nightscout/androidaps/plugins/general/autotune/AutotunePrepTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/plugins/general/autotune/AutotunePrepTest.kt
@@ -317,7 +317,6 @@ class AutotunePrepTest : TestBaseWithProfile() {
         profileFunction,
         sp,
         dateUtil,
-        activePlugin,
         autotuneFS
     ) {
 


### PR DESCRIPTION
- Abort Autotune calculation if no valid profile is found on first selected day (hope this will fix https://console.firebase.google.com/project/androidaps-c34f8/crashlytics/app/android:info.nightscout.androidaps/issues/667547331e40a7ea87082169f808b6e3?versions=3.1.0.3%20(1500);3.1.0.3-dev-a%20(1500)&time=last-twenty-four-hours&sessionEventKey=62F9FA37021C000169B550D4A1BE2F62_1710456836716674665) 
- Fix ExtendedBolus management (should fix https://console.firebase.google.com/project/androidaps-c34f8/crashlytics/app/android:info.nightscout.androidaps/issues/7665b55ca3a35cbd967d1c323b796000?time=last-twenty-four-hours&deviceCategories=Google%EF%BF%BFPixel%206%20Pro&os=13&sessionEventKey=62FB6525038400016909CC348719C69B_1710851510392134216)