### PR TITLE
Fix: closed loop button visbility

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/LoopDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/LoopDialog.kt
@@ -153,7 +153,7 @@ class LoopDialog : DaggerDialogFragment() {
         aapsLogger.debug("UpdateGUI from $from")
         val pumpDescription: PumpDescription = activePlugin.activePump.pumpDescription
         val closedLoopAllowed = constraintChecker.isClosedLoopAllowed(Constraint(true))
-        val closedLoopAllowed2 = objectivePlugin.objectives[ObjectivesPlugin.MAXIOB_OBJECTIVE].isCompleted
+        val closedLoopAllowed2 = objectivePlugin.objectives[ObjectivesPlugin.MAXIOB_OBJECTIVE].isAccomplished
         val lgsEnabled = constraintChecker.isLgsAllowed(Constraint(true))
         val apsMode = sp.getString(R.string.key_aps_mode, "open")
         val pump = activePlugin.activePump


### PR DESCRIPTION
The closed Loop button should be available when objective 6 has been accomplished in the past. Fixes #2003
(Completed does do an active check if the current conditions are completed, which will never be, as it requires the state to closed)