### PR TITLE
fix: wear digital chart zoom

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/utils/WatchfaceViewAdapter.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/utils/WatchfaceViewAdapter.kt
@@ -70,7 +70,7 @@ class WatchfaceViewAdapter(
     val timePeriod = ds?.timePeriod
     val dayName = ds?.dayName
     val mainMenuTap = ds?.mainMenuTap ?: sP?.mainMenuTap
-    val chartZoomTap = sP?.chartZoomTap
+    val chartZoomTap = ds?.chartZoomTap ?: sP?.chartZoomTap
     val dateTime = ds?.dateTime ?: a2?.dateTime
     // val minuteHand = sP?.minuteHand
     // val secondaryLayout = aL?.secondaryLayout ?: a2?.secondaryLayout ?: aa?.secondaryLayout ?: ds?.secondaryLayout ?: sP?.secondaryLayout


### PR DESCRIPTION
Make watch face Digital Style zoom by tapping on the full right column, including the chart. Fixes #1966