### PR TITLE
fix usage of SMB munites instead of UAMSMB minutes on negative iob

### DIFF
--- a/app/src/main/assets/OpenAPSSMB/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMB/determine-basal.js
@@ -1053,23 +1053,26 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
         if (microBolusAllowed && enableSMB && bg > threshold) {
             // never bolus more than maxSMBBasalMinutes worth of basal
-            var mealInsulinReq = round( meal_data.mealCOB / profile.carb_ratio ,3);
-            if (typeof profile.maxSMBBasalMinutes === 'undefined' ) {
-                var maxBolus = round( profile.current_basal * 30 / 60 ,1);
-                console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
-            // if IOB covers more than COB, limit maxBolus to 30m of basal
-            } else if ( iob_data.iob > mealInsulinReq && iob_data.iob > 0 ) {
-                console.error("IOB",iob_data.iob,"> COB",meal_data.mealCOB+"; mealInsulinReq =",mealInsulinReq);
+            var mealInsulinReq = round(meal_data.mealCOB / carb_ratio, 3);
+            console.error("IOB", iob_data.iob, "COB", meal_data.mealCOB + "; mealInsulinReq =", mealInsulinReq);
+            if (meal_data.mealCOB > 0 && iob_data.iob <= mealInsulinReq) {
+                if (typeof profile.maxSMBBasalMinutes === 'undefined') {
+                    var maxBolus = round(profile.current_basal * 30 / 60, 1);
+                    console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
+                }
+                else {
+                    console.error("profile.maxSMBBasalMinutes:", profile.maxSMBBasalMinutes, "profile.current_basal:", profile.current_basal);
+                    maxBolus = round(profile.current_basal * profile.maxSMBBasalMinutes / 60, 1);
+                }
+            }
+            else {
                 if (profile.maxUAMSMBBasalMinutes) {
-                    console.error("profile.maxUAMSMBBasalMinutes:",profile.maxUAMSMBBasalMinutes,"profile.current_basal:",profile.current_basal);
-                    maxBolus = round( profile.current_basal * profile.maxUAMSMBBasalMinutes / 60 ,1);
+                    console.error("profile.maxUAMSMBBasalMinutes:", profile.maxUAMSMBBasalMinutes, "profile.current_basal:", profile.current_basal);
+                    maxBolus = round(profile.current_basal * profile.maxUAMSMBBasalMinutes / 60, 1);
                 } else {
                     console.error("profile.maxUAMSMBBasalMinutes undefined: defaulting to 30m");
-                    maxBolus = round( profile.current_basal * 30 / 60 ,1);
+                    maxBolus = round(profile.current_basal * 30 / 60, 1);
                 }
-            } else {
-                console.error("profile.maxSMBBasalMinutes:",profile.maxSMBBasalMinutes,"profile.current_basal:",profile.current_basal);
-                maxBolus = round( profile.current_basal * profile.maxSMBBasalMinutes / 60 ,1);
             }
             // bolus 1/2 the insulinReq, up to maxBolus, rounding down to nearest bolus increment
             var roundSMBTo = 1 / profile.bolus_increment;

--- a/app/src/main/assets/OpenAPSSMBDynamicISF/determine-basal.js
+++ b/app/src/main/assets/OpenAPSSMBDynamicISF/determine-basal.js
@@ -1092,23 +1092,26 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
         if (microBolusAllowed && enableSMB && bg > threshold) {
             // never bolus more than maxSMBBasalMinutes worth of basal
-            var mealInsulinReq = round( meal_data.mealCOB / profile.carb_ratio ,3);
-            if (typeof profile.maxSMBBasalMinutes === 'undefined' ) {
-                var maxBolus = round( profile.current_basal * 30 / 60 ,1);
-                console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
-            // if IOB covers more than COB, limit maxBolus to 30m of basal
-            } else if ( iob_data.iob > mealInsulinReq && iob_data.iob > 0 ) {
-                console.error("IOB",iob_data.iob,"> COB",meal_data.mealCOB+"; mealInsulinReq =",mealInsulinReq);
+            var mealInsulinReq = round(meal_data.mealCOB / carb_ratio, 3);
+            console.error("IOB", iob_data.iob, "COB", meal_data.mealCOB + "; mealInsulinReq =", mealInsulinReq);
+            if (meal_data.mealCOB > 0 && iob_data.iob <= mealInsulinReq) {
+                if (typeof profile.maxSMBBasalMinutes === 'undefined') {
+                    var maxBolus = round(profile.current_basal * 30 / 60, 1);
+                    console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
+                }
+                else {
+                    console.error("profile.maxSMBBasalMinutes:", profile.maxSMBBasalMinutes, "profile.current_basal:", profile.current_basal);
+                    maxBolus = round(profile.current_basal * profile.maxSMBBasalMinutes / 60, 1);
+                }
+            }
+            else {
                 if (profile.maxUAMSMBBasalMinutes) {
-                    console.error("profile.maxUAMSMBBasalMinutes:",profile.maxUAMSMBBasalMinutes,"profile.current_basal:",profile.current_basal);
-                    maxBolus = round( profile.current_basal * profile.maxUAMSMBBasalMinutes / 60 ,1);
+                    console.error("profile.maxUAMSMBBasalMinutes:", profile.maxUAMSMBBasalMinutes, "profile.current_basal:", profile.current_basal);
+                    maxBolus = round(profile.current_basal * profile.maxUAMSMBBasalMinutes / 60, 1);
                 } else {
                     console.error("profile.maxUAMSMBBasalMinutes undefined: defaulting to 30m");
-                    maxBolus = round( profile.current_basal * 30 / 60 ,1);
+                    maxBolus = round(profile.current_basal * 30 / 60, 1);
                 }
-            } else {
-                console.error("profile.maxSMBBasalMinutes:",profile.maxSMBBasalMinutes,"profile.current_basal:",profile.current_basal);
-                maxBolus = round( profile.current_basal * profile.maxSMBBasalMinutes / 60 ,1);
             }
             // bolus 1/2 the insulinReq, up to maxBolus, rounding down to nearest bolus increment
             var roundSMBTo = 1 / profile.bolus_increment;


### PR DESCRIPTION
fixes #2042

uses `meal_data.mealCOB > 0 && iob_data.iob <= mealInsulinReq` as a switch to SMB minutes, if it fails - falls back to UAM minutes