### PR TITLE
Fix duration calculation affecting overlapping TBRs

### DIFF
--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
@@ -217,8 +217,11 @@ class MedtronicHistoryData @Inject constructor(
             allHistory.removeAll(removeList.toSet())
             this.sort(allHistory)
             aapsLogger.debug(
-                LTag.PUMP, String.format(Locale.ENGLISH, "All History records [afterFilterCount=%d, removedItemsCount=%d, newItemsCount=%d]",
-                                         allHistory.size, removeList.size, newHistory.size))
+                LTag.PUMP, String.format(
+                    Locale.ENGLISH, "All History records [afterFilterCount=%d, removedItemsCount=%d, newItemsCount=%d]",
+                    allHistory.size, removeList.size, newHistory.size
+                )
+            )
         } else {
             aapsLogger.error("Since we couldn't determine date, we don't clean full history. This is just workaround.")
         }
@@ -227,12 +230,15 @@ class MedtronicHistoryData @Inject constructor(
 
     fun hasRelevantConfigurationChanged(): Boolean {
         return getStateFromFilteredList( //
-            setOf(PumpHistoryEntryType.ChangeBasalPattern,  //
+            setOf(
+                PumpHistoryEntryType.ChangeBasalPattern,  //
                 PumpHistoryEntryType.ClearSettings,  //
                 PumpHistoryEntryType.SaveSettings,  //
                 PumpHistoryEntryType.ChangeMaxBolus,  //
                 PumpHistoryEntryType.ChangeMaxBasal,  //
-                PumpHistoryEntryType.ChangeTempBasalType))
+                PumpHistoryEntryType.ChangeTempBasalType
+            )
+        )
     }
 
     private fun isCollectionEmpty(col: List<*>?): Boolean {
@@ -273,8 +279,10 @@ class MedtronicHistoryData @Inject constructor(
         }
         if (newAndAll.isEmpty()) return newAndAll
         this.sort(newAndAll)
-        var newAndAll2: MutableList<PumpHistoryEntry> = getFilteredItems(newAndAll,  //
-            setOf(PumpHistoryEntryType.Bolus,  //
+        var newAndAll2: MutableList<PumpHistoryEntry> = getFilteredItems(
+            newAndAll,  //
+            setOf(
+                PumpHistoryEntryType.Bolus,  //
                 PumpHistoryEntryType.TempBasalCombined,  //
                 PumpHistoryEntryType.Prime,  //
                 PumpHistoryEntryType.SuspendPump,  //
@@ -282,7 +290,9 @@ class MedtronicHistoryData @Inject constructor(
                 PumpHistoryEntryType.Rewind,  //
                 PumpHistoryEntryType.NoDeliveryAlarm,  //
                 PumpHistoryEntryType.BatteryChange,  //
-                PumpHistoryEntryType.BasalProfileStart))
+                PumpHistoryEntryType.BasalProfileStart
+            )
+        )
         newAndAll2 = filterPumpSuspend(newAndAll2, 10)
         return newAndAll2
     }
@@ -373,8 +383,11 @@ class MedtronicHistoryData @Inject constructor(
             throw ex
         }
         aapsLogger.debug(
-            LTag.PUMP, String.format(Locale.ENGLISH, "ProcessHistoryData: 'Delivery Suspend' Processed [count=%d, items=%s]", suspends.size,
-                                     gson.toJson(suspends)))
+            LTag.PUMP, String.format(
+                Locale.ENGLISH, "ProcessHistoryData: 'Delivery Suspend' Processed [count=%d, items=%s]", suspends.size,
+                gson.toJson(suspends)
+            )
+        )
         if (suspends.isNotEmpty()) {
             try {
                 processSuspends(suspends)  // TODO not tested yet
@@ -405,7 +418,8 @@ class MedtronicHistoryData @Inject constructor(
             }
         }
         if (lastPrimeRecord != null) {
-            uploadCareportalEventIfFoundInHistory(lastPrimeRecord,
+            uploadCareportalEventIfFoundInHistory(
+                lastPrimeRecord,
                 MedtronicConst.Statistics.LastPrime,
                 DetailedBolusInfo.EventType.CANNULA_CHANGE
             )
@@ -425,9 +439,11 @@ class MedtronicHistoryData @Inject constructor(
             }
         }
         if (lastRewindRecord != null) {
-            uploadCareportalEventIfFoundInHistory(lastRewindRecord,
+            uploadCareportalEventIfFoundInHistory(
+                lastRewindRecord,
                 MedtronicConst.Statistics.LastRewind,
-                DetailedBolusInfo.EventType.INSULIN_CHANGE)
+                DetailedBolusInfo.EventType.INSULIN_CHANGE
+            )
         }
     }
 
@@ -439,12 +455,16 @@ class MedtronicHistoryData @Inject constructor(
                 eventType, null,
                 historyRecord.pumpId,
                 medtronicPumpStatus.pumpType,
-                medtronicPumpStatus.serialNumber)
+                medtronicPumpStatus.serialNumber
+            )
 
             aapsLogger.debug(
-                LTag.PUMP, String.format(Locale.ROOT, "insertTherapyEventIfNewWithTimestamp [date=%d, eventType=%s, pumpId=%d, pumpSerial=%s] - Result: %b",
-                                         historyRecord.atechDateTime, eventType, historyRecord.pumpId,
-                                         medtronicPumpStatus.serialNumber, result))
+                LTag.PUMP, String.format(
+                    Locale.ROOT, "insertTherapyEventIfNewWithTimestamp [date=%d, eventType=%s, pumpId=%d, pumpSerial=%s] - Result: %b",
+                    historyRecord.atechDateTime, eventType, historyRecord.pumpId,
+                    medtronicPumpStatus.serialNumber, result
+                )
+            )
 
             sp.putLong(eventSP, historyRecord.atechDateTime)
         }
@@ -454,8 +474,11 @@ class MedtronicHistoryData @Inject constructor(
         val tdds = filterTDDs(tddsIn)
 
         aapsLogger.debug(
-            LTag.PUMP, String.format(Locale.ENGLISH, logPrefix + "TDDs found: %d.\n%s",
-                                     tdds.size, gson.toJson(tdds)))
+            LTag.PUMP, String.format(
+                Locale.ENGLISH, logPrefix + "TDDs found: %d.\n%s",
+                tdds.size, gson.toJson(tdds)
+            )
+        )
 
         for (tdd in tdds) {
             val totalsDTO = tdd.decodedData["Object"] as DailyTotalsDTO
@@ -474,6 +497,7 @@ class MedtronicHistoryData @Inject constructor(
 
     @Suppress("unused")
     private enum class ProcessHistoryRecord(val description: String) {
+
         Bolus("Bolus"),
         TBR("TBR"),
         Suspend("Suspend");
@@ -526,12 +550,16 @@ class MedtronicHistoryData @Inject constructor(
                     type = null,
                     pumpId = bolus.pumpId,
                     pumpType = medtronicPumpStatus.pumpType,
-                    pumpSerial = medtronicPumpStatus.serialNumber)
+                    pumpSerial = medtronicPumpStatus.serialNumber
+                )
 
                 aapsLogger.debug(
-                    LTag.PUMP, String.format(Locale.ENGLISH, "syncBolusWithTempId [date=%d, temporaryId=%d, pumpId=%d, insulin=%.2f, pumpSerial=%s] - Result: %b",
-                                             bolus.atechDateTime, temporaryId, bolus.pumpId, deliveredAmount,
-                                             medtronicPumpStatus.serialNumber, result))
+                    LTag.PUMP, String.format(
+                        Locale.ENGLISH, "syncBolusWithTempId [date=%d, temporaryId=%d, pumpId=%d, insulin=%.2f, pumpSerial=%s] - Result: %b",
+                        bolus.atechDateTime, temporaryId, bolus.pumpId, deliveredAmount,
+                        medtronicPumpStatus.serialNumber, result
+                    )
+                )
             } else {
                 val result = pumpSync.syncBolusWithPumpId(
                     timestamp = tryToGetByLocalTime(bolus.atechDateTime),
@@ -539,12 +567,16 @@ class MedtronicHistoryData @Inject constructor(
                     type = null,
                     pumpId = bolus.pumpId,
                     pumpType = medtronicPumpStatus.pumpType,
-                    pumpSerial = medtronicPumpStatus.serialNumber)
+                    pumpSerial = medtronicPumpStatus.serialNumber
+                )
 
                 aapsLogger.debug(
-                    LTag.PUMP, String.format(Locale.ENGLISH, "syncBolusWithPumpId [date=%d, pumpId=%d, insulin=%.2f, pumpSerial=%s] - Result: %b",
-                                             bolus.atechDateTime, bolus.pumpId, deliveredAmount,
-                                             medtronicPumpStatus.serialNumber, result))
+                    LTag.PUMP, String.format(
+                        Locale.ENGLISH, "syncBolusWithPumpId [date=%d, pumpId=%d, insulin=%.2f, pumpSerial=%s] - Result: %b",
+                        bolus.atechDateTime, bolus.pumpId, deliveredAmount,
+                        medtronicPumpStatus.serialNumber, result
+                    )
+                )
             }
 
             addCarbs(bolus)
@@ -561,25 +593,31 @@ class MedtronicHistoryData @Inject constructor(
             false,
             bolus.pumpId,
             medtronicPumpStatus.pumpType,
-            medtronicPumpStatus.serialNumber)
+            medtronicPumpStatus.serialNumber
+        )
 
         aapsLogger.debug(
-            LTag.PUMP, String.format(Locale.ENGLISH, "syncExtendedBolusWithPumpId [date=%d, amount=%.2f, duration=%d, pumpId=%d, pumpSerial=%s, multiwave=%b] - Result: %b",
-                                     bolus.atechDateTime, bolusDTO.deliveredAmount, bolusDTO.duration, bolus.pumpId,
-                                     medtronicPumpStatus.serialNumber, isMultiwave, result))
+            LTag.PUMP, String.format(
+                Locale.ENGLISH, "syncExtendedBolusWithPumpId [date=%d, amount=%.2f, duration=%d, pumpId=%d, pumpSerial=%s, multiwave=%b] - Result: %b",
+                bolus.atechDateTime, bolusDTO.deliveredAmount, bolusDTO.duration, bolus.pumpId,
+                medtronicPumpStatus.serialNumber, isMultiwave, result
+            )
+        )
     }
 
     private fun addCarbs(bolus: PumpHistoryEntry) {
         if (bolus.containsDecodedData("Estimate")) {
             val bolusWizard = bolus.decodedData["Estimate"] as BolusWizardDTO
 
-            pumpSyncStorage.addCarbs(info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntryCarbs(
-                tryToGetByLocalTime(bolus.atechDateTime),
-                bolusWizard.carbs.toDouble(),
-                medtronicPumpStatus.pumpType,
-                medtronicPumpStatus.serialNumber,
-                bolus.pumpId
-            ))
+            pumpSyncStorage.addCarbs(
+                info.nightscout.androidaps.plugins.pump.common.sync.PumpDbEntryCarbs(
+                    tryToGetByLocalTime(bolus.atechDateTime),
+                    bolusWizard.carbs.toDouble(),
+                    medtronicPumpStatus.pumpType,
+                    medtronicPumpStatus.serialNumber,
+                    bolus.pumpId
+                )
+            )
         }
     }
 
@@ -617,7 +655,7 @@ class MedtronicHistoryData @Inject constructor(
                 //aapsLogger.debug(LTag.PUMP, "DD: tempBasalProcessDTO.itemTwo: " + (if (tempBasalProcessDTO.itemTwo == null) "null" else gson.toJson(tempBasalProcessDTO.itemTwo!!)))
 
                 @Suppress("Unchecked_Cast")
-                val entryWithTempId = findDbEntry(tempBasalProcessDTO.itemOne, tbrRecords  as MutableList<PumpDbEntry>) as PumpDbEntryTBR?
+                val entryWithTempId = findDbEntry(tempBasalProcessDTO.itemOne, tbrRecords as MutableList<PumpDbEntry>) as PumpDbEntryTBR?
 
                 aapsLogger.debug(LTag.PUMP, "DD: entryWithTempId: " + (entryWithTempId?.toString() ?: "null"))
 
@@ -630,17 +668,19 @@ class MedtronicHistoryData @Inject constructor(
                     if (tbrEntry != null) {
                         aapsLogger.debug(
                             LTag.PUMP, "DD: tempIdEntry=${entryWithTempId}, tbrEntry=${tbrEntry}, " +
-                            "tempBasalProcessDTO=${tempBasalProcessDTO}, " +
-                            "pumpType=${medtronicPumpStatus.pumpType}, serial=${medtronicPumpStatus.serialNumber}")
+                                "tempBasalProcessDTO=${tempBasalProcessDTO}, " +
+                                "pumpType=${medtronicPumpStatus.pumpType}, serial=${medtronicPumpStatus.serialNumber}"
+                        )
 
                         aapsLogger.debug(
                             LTag.PUMP, "syncTemporaryBasalWithTempId " +
-                            "[date=${tempBasalProcessDTO.atechDateTime}, dateProcess=${tryToGetByLocalTime(tempBasalProcessDTO.atechDateTime)},  " +
-                            "tbrEntry.insulinRate=${tbrEntry.insulinRate}, " +
-                            "duration=${tempBasalProcessDTO.durationAsSeconds} s, " +
-                            "isAbsolute=${!tbrEntry.isPercent}, temporaryId=${entryWithTempId.temporaryId}, " +
-                            "pumpId=${tempBasalProcessDTO.pumpId}, pumpType=${medtronicPumpStatus.pumpType}, " +
-                            "pumpSerial=${medtronicPumpStatus.serialNumber}]")
+                                "[date=${tempBasalProcessDTO.atechDateTime}, dateProcess=${tryToGetByLocalTime(tempBasalProcessDTO.atechDateTime)},  " +
+                                "tbrEntry.insulinRate=${tbrEntry.insulinRate}, " +
+                                "duration=${tempBasalProcessDTO.durationAsSeconds} s, " +
+                                "isAbsolute=${!tbrEntry.isPercent}, temporaryId=${entryWithTempId.temporaryId}, " +
+                                "pumpId=${tempBasalProcessDTO.pumpId}, pumpType=${medtronicPumpStatus.pumpType}, " +
+                                "pumpSerial=${medtronicPumpStatus.serialNumber}]"
+                        )
 
                         if (tempBasalProcessDTO.durationAsSeconds <= 0) {
                             rxBus.send(EventNewNotification(Notification(Notification.MDT_INVALID_HISTORY_DATA, rh.gs(R.string.invalid_history_data), Notification.URGENT)))
@@ -680,8 +720,9 @@ class MedtronicHistoryData @Inject constructor(
 
                         aapsLogger.debug(
                             LTag.PUMP, "syncTemporaryBasalWithPumpId [date=${tempBasalProcessDTO.atechDateTime}, " +
-                            "pumpId=${tempBasalProcessDTO.pumpId}, rate=${tbrEntry.insulinRate} U, " +
-                            "duration=${tempBasalProcessDTO.durationAsSeconds} s, pumpSerial=${medtronicPumpStatus.serialNumber}]")
+                                "pumpId=${tempBasalProcessDTO.pumpId}, rate=${tbrEntry.insulinRate} U, " +
+                                "duration=${tempBasalProcessDTO.durationAsSeconds} s, pumpSerial=${medtronicPumpStatus.serialNumber}]"
+                        )
 
                         if (tempBasalProcessDTO.durationAsSeconds <= 0) {
                             rxBus.send(EventNewNotification(Notification(Notification.MDT_INVALID_HISTORY_DATA, rh.gs(R.string.invalid_history_data), Notification.URGENT)))
@@ -707,8 +748,11 @@ class MedtronicHistoryData @Inject constructor(
                             }
                         }
 
-                        if (isTBRActive(startTimestamp = tryToGetByLocalTime(tempBasalProcessDTO.atechDateTime),
-                                durationSeconds = tempBasalProcessDTO.durationAsSeconds)) {
+                        if (isTBRActive(
+                                startTimestamp = tryToGetByLocalTime(tempBasalProcessDTO.atechDateTime),
+                                durationSeconds = tempBasalProcessDTO.durationAsSeconds
+                            )
+                        ) {
                             if (medtronicPumpStatus.runningTBR == null) {
                                 medtronicPumpStatus.runningTBR = PumpDbEntryTBR(
                                     temporaryId = 0L,
@@ -719,7 +763,8 @@ class MedtronicHistoryData @Inject constructor(
                                     isAbsolute = !tbrEntry.isPercent,
                                     durationInSeconds = tempBasalProcessDTO.durationAsSeconds,
                                     tbrType = PumpSync.TemporaryBasalType.NORMAL,
-                                    pumpId = tempBasalProcessDTO.pumpId)
+                                    pumpId = tempBasalProcessDTO.pumpId
+                                )
                             }
                         }
                     } else {
@@ -730,8 +775,7 @@ class MedtronicHistoryData @Inject constructor(
         } // collection
     }
 
-
-    fun createTBRProcessList(entryList: MutableList<PumpHistoryEntry>) : MutableList<TempBasalProcessDTO> {
+    fun createTBRProcessList(entryList: MutableList<PumpHistoryEntry>): MutableList<TempBasalProcessDTO> {
 
         aapsLogger.debug(LTag.PUMP, "${ProcessHistoryRecord.TBR.description}  List (before filter): ${gson.toJson(entryList)}")
 
@@ -761,21 +805,23 @@ class MedtronicHistoryData @Inject constructor(
         }
 
         var previousItem: TempBasalProcessDTO? = null
-        val removalList : MutableList<TempBasalProcessDTO> = arrayListOf()
+        val removalList: MutableList<TempBasalProcessDTO> = arrayListOf()
 
         // fix for Zero TBRs
         for (tempBasalProcessDTO in processList) {
-            if (previousItem!=null) {
+            if (previousItem != null) {
 
                 val pheEnd = PumpHistoryEntry()
                 pheEnd.atechDateTime = DateTimeUtil.getATDWithAddedSeconds(tempBasalProcessDTO.itemOne.atechDateTime, -2)
                 pheEnd.addDecodedData("Object", TempBasalPair(0.0, false, 0))
 
-                val initialDuration = previousItem.durationAsSeconds
+                //val initialDuration = previousItem.durationAsSeconds
+                //fix overlapping temp basal times
+                val initialDuration = previousItem.itemOneTbr!!.durationMinutes * 60
 
                 previousItem.itemTwo = pheEnd
 
-                if (previousItem.durationAsSeconds <=0) {
+                if (previousItem.durationAsSeconds <= 0) {
                     // if we have duration of 0 or less, then we have invalid entry which needs to be removed
                     removalList.add(previousItem)
                 } else if (previousItem.durationAsSeconds > initialDuration) {
@@ -841,19 +887,20 @@ class MedtronicHistoryData @Inject constructor(
         return processList
     }
 
-    fun findNearestEntry(startTime: Long, endTime: Long, list: MutableList<PumpHistoryEntry>) : PumpHistoryEntry? {
+    fun findNearestEntry(startTime: Long, endTime: Long, list: MutableList<PumpHistoryEntry>): PumpHistoryEntry? {
         val outList: MutableList<PumpHistoryEntry> = mutableListOf()
 
         for (pumpHistoryEntry in list) {
             if ((pumpHistoryEntry.atechDateTime > startTime) &&
-                (pumpHistoryEntry.atechDateTime < endTime)) {
+                (pumpHistoryEntry.atechDateTime < endTime)
+            ) {
                 outList.add(pumpHistoryEntry)
             }
         }
 
         if (outList.size == 0) {
             return null
-        } else if (outList.size==1) {
+        } else if (outList.size == 1) {
             return outList[0]
         } else {
             // TODO
@@ -864,7 +911,8 @@ class MedtronicHistoryData @Inject constructor(
     fun isTBRActive(dbEntry: PumpDbEntryTBR): Boolean {
         return isTBRActive(
             startTimestamp = dbEntry.date,
-            durationSeconds = dbEntry.durationInSeconds)
+            durationSeconds = dbEntry.durationInSeconds
+        )
     }
 
     fun isTBRActive(startTimestamp: Long, durationSeconds: Int): Boolean {
@@ -925,15 +973,32 @@ class MedtronicHistoryData @Inject constructor(
                     }
                 }
                 if (outList.size == 1) {
-                    if (doubleBolusDebug) aapsLogger.debug(LTag.PUMP, String.format(Locale.ENGLISH, "DoubleBolusDebug: findDbEntry Treatment={}, FromDb={}. Type=EntrySelected, AtTimeMin={}, AtTimeSec={}", treatment, outList[0], min, sec))
+                    if (doubleBolusDebug) aapsLogger.debug(
+                        LTag.PUMP,
+                        String.format(
+                            Locale.ENGLISH,
+                            "DoubleBolusDebug: findDbEntry Treatment={}, FromDb={}. Type=EntrySelected, AtTimeMin={}, AtTimeSec={}",
+                            treatment,
+                            outList[0],
+                            min,
+                            sec
+                        )
+                    )
                     return outList[0]
                 }
                 if (min == 0 && sec == 10 && outList.size > 1) {
-                    aapsLogger.error(String.format(Locale.ENGLISH, "Too many entries (with too small diff): (timeDiff=[min=%d,sec=%d],count=%d,list=%s)",
-                        min, sec, outList.size, gson.toJson(outList)))
+                    aapsLogger.error(
+                        String.format(
+                            Locale.ENGLISH, "Too many entries (with too small diff): (timeDiff=[min=%d,sec=%d],count=%d,list=%s)",
+                            min, sec, outList.size, gson.toJson(outList)
+                        )
+                    )
                     if (doubleBolusDebug) aapsLogger.debug(
-                        LTag.PUMP, String.format(Locale.ENGLISH, "DoubleBolusDebug: findDbEntry Error - Too many entries (with too small diff): (timeDiff=[min=%d,sec=%d],count=%d,list=%s)",
-                                                 min, sec, outList.size, gson.toJson(outList)))
+                        LTag.PUMP, String.format(
+                            Locale.ENGLISH, "DoubleBolusDebug: findDbEntry Error - Too many entries (with too small diff): (timeDiff=[min=%d,sec=%d],count=%d,list=%s)",
+                            min, sec, outList.size, gson.toJson(outList)
+                        )
+                    )
                 }
                 sec += 10
             }
@@ -947,9 +1012,10 @@ class MedtronicHistoryData @Inject constructor(
 
             aapsLogger.debug(
                 LTag.PUMP, "processSuspends::syncTemporaryBasalWithPumpId [date=${tempBasalProcess.itemOne.atechDateTime}, " +
-                "rate=0.0, duration=${tempBasalProcess.durationAsSeconds} s, type=${PumpSync.TemporaryBasalType.PUMP_SUSPEND}, " +
-                "pumpId=${tempBasalProcess.itemOne.pumpId}, " +
-                "pumpSerial=${medtronicPumpStatus.serialNumber}]")
+                    "rate=0.0, duration=${tempBasalProcess.durationAsSeconds} s, type=${PumpSync.TemporaryBasalType.PUMP_SUSPEND}, " +
+                    "pumpId=${tempBasalProcess.itemOne.pumpId}, " +
+                    "pumpSerial=${medtronicPumpStatus.serialNumber}]"
+            )
 
             if (tempBasalProcess.durationAsSeconds <= 0) {
                 rxBus.send(EventNewNotification(Notification(Notification.MDT_INVALID_HISTORY_DATA, rh.gs(R.string.invalid_history_data), Notification.URGENT)))
@@ -984,8 +1050,10 @@ class MedtronicHistoryData @Inject constructor(
     }
 
     private fun getSuspendResumeRecordsList(): List<TempBasalProcessDTO> {
-        val filteredItems = getFilteredItems(newHistory,  //
-            setOf(PumpHistoryEntryType.SuspendPump, PumpHistoryEntryType.ResumePump))
+        val filteredItems = getFilteredItems(
+            newHistory,  //
+            setOf(PumpHistoryEntryType.SuspendPump, PumpHistoryEntryType.ResumePump)
+        )
 
         aapsLogger.debug(LTag.PUMP, "SuspendResume Records: $filteredItems")
 
@@ -1029,7 +1097,8 @@ class MedtronicHistoryData @Inject constructor(
                     val tbrProcess = TempBasalProcessDTO(
                         itemOne = filtered2Items[i],
                         aapsLogger = aapsLogger,
-                        objectType = TempBasalProcessDTO.ObjectType.Suspend)
+                        objectType = TempBasalProcessDTO.ObjectType.Suspend
+                    )
 
                     tbrProcess.itemTwo = filtered2Items[i + 1]
 
@@ -1044,19 +1113,24 @@ class MedtronicHistoryData @Inject constructor(
     }
 
     private fun getNoDeliveryRewindPrimeRecordsList(): List<TempBasalProcessDTO> {
-        val primeItems: MutableList<PumpHistoryEntry> = getFilteredItems(newHistory,  //
-            setOf(PumpHistoryEntryType.Prime))
+        val primeItems: MutableList<PumpHistoryEntry> = getFilteredItems(
+            newHistory,  //
+            setOf(PumpHistoryEntryType.Prime)
+        )
 
         aapsLogger.debug(LTag.PUMP, "Prime Records: $primeItems")
 
         val outList: MutableList<TempBasalProcessDTO> = ArrayList()
         if (primeItems.size == 0) return outList
-        val filteredItems: MutableList<PumpHistoryEntry> = getFilteredItems(newHistory,  //
-            setOf(PumpHistoryEntryType.Prime,
+        val filteredItems: MutableList<PumpHistoryEntry> = getFilteredItems(
+            newHistory,  //
+            setOf(
+                PumpHistoryEntryType.Prime,
                 PumpHistoryEntryType.Rewind,
                 PumpHistoryEntryType.NoDeliveryAlarm,
                 PumpHistoryEntryType.Bolus,
-                PumpHistoryEntryType.TempBasalCombined)
+                PumpHistoryEntryType.TempBasalCombined
+            )
         )
 
         aapsLogger.debug(LTag.PUMP, "Filtered Records: $filteredItems")
@@ -1070,7 +1144,8 @@ class MedtronicHistoryData @Inject constructor(
             }
             if (startedItems) {
                 if (filteredItem.entryType === PumpHistoryEntryType.Bolus ||
-                    filteredItem.entryType === PumpHistoryEntryType.TempBasalCombined) {
+                    filteredItem.entryType === PumpHistoryEntryType.TempBasalCombined
+                ) {
                     finishedItems = true
                     break
                 }
@@ -1078,15 +1153,19 @@ class MedtronicHistoryData @Inject constructor(
             }
         }
         if (!finishedItems) {
-            val filteredItemsOld: MutableList<PumpHistoryEntry> = getFilteredItems(allHistory,  //
-                setOf(PumpHistoryEntryType.Rewind,
+            val filteredItemsOld: MutableList<PumpHistoryEntry> = getFilteredItems(
+                allHistory,  //
+                setOf(
+                    PumpHistoryEntryType.Rewind,
                     PumpHistoryEntryType.NoDeliveryAlarm,
                     PumpHistoryEntryType.Bolus,
-                    PumpHistoryEntryType.TempBasalCombined)
+                    PumpHistoryEntryType.TempBasalCombined
+                )
             )
             for (filteredItem in filteredItemsOld) {
                 if (filteredItem.entryType === PumpHistoryEntryType.Bolus ||
-                    filteredItem.entryType === PumpHistoryEntryType.TempBasalCombined) {
+                    filteredItem.entryType === PumpHistoryEntryType.TempBasalCombined
+                ) {
                     finishedItems = true
                     break
                 }
@@ -1106,7 +1185,8 @@ class MedtronicHistoryData @Inject constructor(
             val tbrProcess = TempBasalProcessDTO(
                 itemOne = items[items.size - 1],
                 aapsLogger = aapsLogger,
-                objectType = TempBasalProcessDTO.ObjectType.Suspend)
+                objectType = TempBasalProcessDTO.ObjectType.Suspend
+            )
 
             tbrProcess.itemTwo = itemTwo
 
@@ -1121,7 +1201,8 @@ class MedtronicHistoryData @Inject constructor(
             val tbrProcess = TempBasalProcessDTO(
                 itemOne = items[0],
                 aapsLogger = aapsLogger,
-                objectType = TempBasalProcessDTO.ObjectType.Suspend)
+                objectType = TempBasalProcessDTO.ObjectType.Suspend
+            )
 
             tbrProcess.itemTwo = itemTwo
 
@@ -1158,15 +1239,15 @@ class MedtronicHistoryData @Inject constructor(
             PumpHistoryEntryType.EndResultTotals
         } else when (medtronicUtil.medtronicPumpModel) {
             MedtronicDeviceType.Medtronic_515,
-            MedtronicDeviceType.Medtronic_715     -> PumpHistoryEntryType.DailyTotals515
+            MedtronicDeviceType.Medtronic_715 -> PumpHistoryEntryType.DailyTotals515
             MedtronicDeviceType.Medtronic_522,
-            MedtronicDeviceType.Medtronic_722     -> PumpHistoryEntryType.DailyTotals522
+            MedtronicDeviceType.Medtronic_722 -> PumpHistoryEntryType.DailyTotals522
             MedtronicDeviceType.Medtronic_523_Revel,
             MedtronicDeviceType.Medtronic_723_Revel,
             MedtronicDeviceType.Medtronic_554_Veo,
             MedtronicDeviceType.Medtronic_754_Veo -> PumpHistoryEntryType.DailyTotals523
 
-            else                                  -> {
+            else -> {
                 PumpHistoryEntryType.EndResultTotals
             }
         }
@@ -1201,8 +1282,12 @@ class MedtronicHistoryData @Inject constructor(
     }
 
     fun hasPumpTimeChanged(): Boolean {
-        return getStateFromFilteredList(setOf(PumpHistoryEntryType.NewTimeSet,  //
-            PumpHistoryEntryType.ChangeTime))
+        return getStateFromFilteredList(
+            setOf(
+                PumpHistoryEntryType.NewTimeSet,  //
+                PumpHistoryEntryType.ChangeTime
+            )
+        )
     }
 
     fun setIsInInit(init: Boolean) {


### PR DESCRIPTION
# Fix negative basal IOBs from overlapping entries (Medtronic)

## Issue

I believe this is may be related to nightscout/AndroidAPS/#1597 and nightscout/AndroidAPS/#1724

The issue can be replicated by running MedtronicHistoryDataUTest.kt.

The troublesome temp basal (which has the overlapping duration) begins at 1:55:05. Then there is a zero duration temp basal at 1:59:43 and then a gap in time before the next one at 2:04:45. Here is the relevant data:

```

 {
	"entryType": "TempBasalCombined",
	"DT": "31.10.2021 01:55:05",
	"atechDateTime": 20211031015505,
	"decodedData": {
		"Object": {
			"durationMinutes": 30,
			"insulinRate": 0.0,
			"isPercent": false
		}
	}
}, {
	"entryType": "TempBasalCombined",
	"DT": "31.10.2021 01:59:43",
	"atechDateTime": 20211031015943,
	"decodedData": {
		"Object": {
			"durationMinutes": 0,
			"insulinRate": 0.0,
			"isPercent": false
		}
	}
}, {
	"entryType": "TempBasalCombined",
	"DT": "31.10.2021 02:04:45",
	"atechDateTime": 20211031020445,
	"decodedData": {
		"Object": {
			"durationMinutes": 30,
			"insulinRate": 0.55,
			"isPercent": false
		}
	}
}, 

```

The problem appears in the calculation of the duration of zero temp basals, which occurs in MedtronicHistoryData.kt. The condition 

```

(previousItem.durationAsSeconds > initialDuration) 

```

compares the time between the start of the temp basal at 1:55 with the start of the next valid temp basal at 2:04 (which is previousItem.durationAsSeconds) with the time between the start of the temp basal at 1:55 and the zero duration temp basal at 1:59 (initialDuration). Finding it to be larger, the duration is set to 30 minutes (1800 seconds) and we get a value like this: 

```

ItemOne: PumpHistoryEntry [type=TempBasalCombined    [-2 , 0xFE], DT: 31.10.2021 01:55:05, length=0,0,0(0), rawData=], ItemTwo: null, Duration: 1800, ObjectType: TemporaryBasal

```

with duration of 1800 seconds. But the temp basal starting at 1:55 could not have gone on longer than until 2:04 when the next one began.

## Solution

This fix adjusts the calculation by changing the value initialDuration to represent the duration of the temp basal set on the pump.

``` 

val initialDuration = previousItem.itemOneTbr!!.durationMinutes*60

```
