### PR TITLE
TDD calculation cache optimization

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/utils/stats/TddCalculator.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/stats/TddCalculator.kt
@@ -41,6 +41,7 @@ class TddCalculator @Inject constructor(
     fun calculate(days: Long): LongSparseArray<TotalDailyDose> {
         var startTime = MidnightTime.calc(dateUtil.now() - T.days(days).msecs())
         val endTime = MidnightTime.calc(dateUtil.now())
+        val stepSize = T.hours(24).msecs()
 
         val result = LongSparseArray<TotalDailyDose>()
         // Try to load cached values
@@ -48,47 +49,17 @@ class TddCalculator @Inject constructor(
             val tdd = repository.getCalculatedTotalDailyDose(startTime).blockingGet()
             if (tdd is ValueWrapper.Existing) result.put(startTime, tdd.value)
             else break
-            startTime += T.hours(24).msecs()
+            startTime += stepSize
         }
 
         if (endTime > startTime) {
-            repository.getBolusesDataFromTimeToTime(startTime, endTime, true).blockingGet()
-                .filter { it.type != Bolus.Type.PRIMING }
-                .forEach { t ->
-                    val midnight = MidnightTime.calc(t.timestamp)
-                    val tdd = result[midnight] ?: TotalDailyDose(timestamp = midnight)
-                    tdd.bolusAmount += t.amount
-                    result.put(midnight, tdd)
-                }
-            repository.getCarbsDataFromTimeToTimeExpanded(startTime, endTime, true).blockingGet().forEach { t ->
-                val midnight = MidnightTime.calc(t.timestamp)
-                val tdd = result[midnight] ?: TotalDailyDose(timestamp = midnight)
-                tdd.carbs += t.amount
-                result.put(midnight, tdd)
-            }
-
-            val calculationStep = T.mins(5).msecs()
-            val tempBasals = iobCobCalculator.getTempBasalIncludingConvertedExtendedForRange(startTime, endTime, calculationStep)
-            for (t in startTime until endTime step calculationStep) {
-                val midnight = MidnightTime.calc(t)
-                val tdd = result[midnight] ?: TotalDailyDose(timestamp = midnight)
-                val tbr = tempBasals[t]
-                val profile = profileFunction.getProfile(t) ?: continue
-                val absoluteRate = tbr?.convertedToAbsolute(t, profile) ?: profile.getBasal(t)
-                tdd.basalAmount += absoluteRate / T.mins(60).msecs().toDouble() * calculationStep.toDouble()
-
-                if (!activePlugin.activePump.isFakingTempsByExtendedBoluses) {
-                    // they are not included in TBRs
-                    val eb = iobCobCalculator.getExtendedBolus(t)
-                    val absoluteEbRate = eb?.rate ?: 0.0
-                    tdd.bolusAmount += absoluteEbRate / T.mins(60).msecs().toDouble() * calculationStep.toDouble()
-                }
+            for (midnight in startTime until endTime step stepSize) {
+                val tdd = calculate(midnight, midnight + stepSize)
                 result.put(midnight, tdd)
             }
         }
         for (i in 0 until result.size()) {
             val tdd = result.valueAt(i)
-            tdd.totalAmount = tdd.bolusAmount + tdd.basalAmount
             if (tdd.interfaceIDs.pumpType != InterfaceIDs.PumpType.CACHE) {
                 tdd.interfaceIDs.pumpType = InterfaceIDs.PumpType.CACHE
                 aapsLogger.debug(LTag.CORE, "Storing TDD $tdd")


### PR DESCRIPTION
TDD calculation is based on 5-minute timeframes, but it uses 1-second granulated cache-keys when retrieving data. That makes all the TDD calculation calls to miss caches badly. Mostly it affects TDD-based Loop plugins, like Dynamic ISF.

Here I align time-range for TDD calculation on a 5-minute base. This significantly drops calculation times of subsequent calls.

First run
![image](https://user-images.githubusercontent.com/4157587/189527459-f08e8569-df36-4eb8-948a-de15fbe3e8eb.png)

Second run (original)
![image](https://user-images.githubusercontent.com/4157587/189527467-b770d46d-0f0b-460b-9dde-9da086e30666.png)

Second run over 5-minute aligned interval
![image](https://user-images.githubusercontent.com/4157587/189527476-22c7ba63-829a-46f7-8fc8-04d58782d2a7.png)

After some warmup it speeds up even more :)