### PR TITLE
Dynamic ISF velocity

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -521,8 +521,12 @@
     <string name="openapssmb">OpenAPS SMB</string>
     <string name="openaps_smb_dynamic_isf">Dynamic ISF</string>
     <string name="key_DynISFAdjust" translatable="false">DynISFAdjust</string>
+    <string name="key_DynISFVelocity" translatable="false">DynISFVelocity</string>
     <string name="DynISFAdjust_title" formatted="false">DynamicISF Adjustment Factor %</string>
     <string name="DynISFAdjust_summary" formatted="false">Adjustment factor for DynamicISF. Set more than 100% for more aggressive correction doses, and less than 100% for less aggressive corrections.</string>
+    <string name="DynISFVelocity_title" formatted="false">ISF BG Scaling velocity %</string>
+    <string name="DynISFVelocity_summary" formatted="false">This controls how hard ISF will be changed with BG level change</string>
+    <string name="DynISFVelocity_dialogMessage" formatted="false">This controls how hard ISF will be changed with BG level change: 0% means no scaling at all, constant ISF value for every BG level; 100% - regular DynamicISF scaling</string>
     <string name="key_use_smb" translatable="false">use_smb</string>
     <string name="key_use_uam" translatable="false">use_uam</string>
     <string name="key_smb_enable_carbs_suggestions_threshold" translatable="false">smb_enable_carbs_suggestions_threshold</string>

--- a/app/src/main/res/xml/pref_openapssmbdynamicisf.xml
+++ b/app/src/main/res/xml/pref_openapssmbdynamicisf.xml
@@ -40,6 +40,17 @@
             validate:testType="floatNumericRange" />
 
         <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference
+            android:defaultValue="100"
+            android:inputType="numberDecimal"
+            android:key="@string/key_DynISFVelocity"
+            android:title="@string/DynISFVelocity_title"
+            android:summary="@string/DynISFVelocity_summary"
+            android:dialogMessage="@string/DynISFVelocity_dialogMessage"
+            validate:floatmaxNumber="200"
+            validate:floatminNumber="0"
+            validate:testType="floatNumericRange"/>
+
+        <info.nightscout.androidaps.utils.textValidator.ValidatingEditTextPreference
             android:defaultValue="65"
             android:inputType="numberDecimal"
             android:dialogMessage="@string/treatmentssafety_lgsThreshold_summary"


### PR DESCRIPTION
This introduces Dynamic ISF velocity setting - it allows to control how hard ISF changes with BG levels.
Demo is available [here](https://codepen.io/justmara/pen/yLjPvEm?editors=0010) (there are also scaled prediction.
TL;DR: It is a simple 0-200% scale, where 
`0` means '_ISF is constant for all the BG values and it is an ISF for normalTarget_';
`100` means '_same ISF scaling as for regular Dynamic ISF_'.
`200` means '_for every +1 BG point ISF changes like if it is +2_'

This allows user to fine tune DynISF aggressiveness on higher levels.