### PR TITLE
fix to always by default check alarm tickbox in bolus calc wizard when carb time is >0

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -92,11 +92,13 @@ class WizardDialog : DaggerDialogFragment() {
     }
 
     private val timeTextWatcher = object : TextWatcher {
-        override fun afterTextChanged(s: Editable) {}
+        override fun afterTextChanged(s: Editable) {
+            binding.alarm.isChecked = binding.carbTimeInput.value > 0
+        }
+
         override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
         override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
             calculateInsulin()
-            binding.alarm.isChecked = binding.carbTimeInput.value > 0
         }
     }
 
@@ -367,7 +369,7 @@ class WizardDialog : DaggerDialogFragment() {
             // Set BG if not old
             binding.bgInput.value = iobCobCalculator.ads.actualBg()?.valueToUnits(units) ?: 0.0
 
-            binding.ttCheckbox.isEnabled =  tempTarget is ValueWrapper.Existing
+            binding.ttCheckbox.isEnabled = tempTarget is ValueWrapper.Existing
             binding.ttCheckboxIcon.visibility = binding.ttCheckbox.isEnabled.toVisibility()
             binding.iobInsulin.text = rh.gs(R.string.formatinsulinunits, -bolusIob.iob - basalIob.basaliob)
 


### PR DESCRIPTION
There is an issue that tickbox for enabling alarm is not always enabled.

Issue reproduction:
- open calc wizard, set whatever fields you want to apart from carb time
- click on carb time numeric field, provide **single digit** number and click ok
- on confirmation window you can notice that alarm will not trigger, but carbs delay will applied correctly.
Lack of this alarm caused may cause some troubles, talking from own experience :)

Explanation:
When calling onTextChanged bindings still have old value, so you cannot rely on reading them. Between onTextChanged and afterTextChanged values are updated. 

Default expected behavior is to turn on this alarm when delay is set. Note that, if you enter 2 digit number or event use single digit and modify it, or you modify any other field after entering carbs delay tickbox will be checked correctly because on subsequent calls to onTextChanged carb time binding value will be already updated. Issue does not reproduce when using +/- buttons, probably there are at least 2 actions involved

