### PR TITLE
Fixed AAPSClient build 

### DIFF
--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -69,12 +69,12 @@ android {
             dimension "standard"
             versionName version + "-pumpcontrol"
         }
-        nsclient {
+        aapsclient {
             applicationId "info.nightscout.aapsclient"
             dimension "standard"
             versionName version + "-aapsclient"
         }
-        nsclient2 {
+        aapsclient2 {
             applicationId "info.nightscout.aapsclient2"
             dimension "standard"
             versionName version + "-aapsclient"


### PR DESCRIPTION
The productflavours for the wear app wasn't renamed from nsclient to aapsclient. This broke the build.

Fixes: https://github.com/nightscout/AndroidAPS/issues/2127