### PR TITLE
Improved AAPSClient status lights when using OmniPod DASH

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/data/DeviceStatusData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/nsclient/data/DeviceStatusData.kt
@@ -16,6 +16,7 @@ class DeviceStatusData @Inject constructor() {
         var voltage = 0.0
         var status = "N/A"
         var reservoir = 0.0
+        var reservoirDisplayOverride = ""
         var extended: Spanned? = null
         var activeProfileName: String? = null
     }

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/StatusLightHandler.kt
@@ -43,13 +43,15 @@ class StatusLightHandler @Inject constructor(
         if (pump.pumpDescription.isBatteryReplaceable || pump.isBatteryChangeLoggingEnabled()) {
             handleAge(careportal_pb_age, TherapyEvent.Type.PUMP_BATTERY_CHANGE, R.string.key_statuslights_bage_warning, 216.0, R.string.key_statuslights_bage_critical, 240.0)
         }
+
+        val insulinUnit = rh.gs(R.string.insulin_unit_shortname)
+        if (pump.model() == PumpType.OMNIPOD_EROS || pump.model() == PumpType.OMNIPOD_DASH) {
+            handleOmnipodReservoirLevel(careportal_reservoir_level, R.string.key_statuslights_res_critical, 10.0, R.string.key_statuslights_res_warning, 80.0, pump.reservoirLevel, insulinUnit)
+        } else {
+            handleLevel(careportal_reservoir_level, R.string.key_statuslights_res_critical, 10.0, R.string.key_statuslights_res_warning, 80.0, pump.reservoirLevel, insulinUnit)
+        }
+
         if (!config.NSCLIENT) {
-            val insulinUnit = rh.gs(R.string.insulin_unit_shortname)
-            if (pump.model() == PumpType.OMNIPOD_EROS || pump.model() == PumpType.OMNIPOD_DASH) {
-                handleOmnipodReservoirLevel(careportal_reservoir_level, R.string.key_statuslights_res_critical, 10.0, R.string.key_statuslights_res_warning, 80.0, pump.reservoirLevel, insulinUnit)
-            } else {
-                handleLevel(careportal_reservoir_level, R.string.key_statuslights_res_critical, 10.0, R.string.key_statuslights_res_warning, 80.0, pump.reservoirLevel, insulinUnit)
-            }
             if (bgSource.sensorBatteryLevel != -1)
                 handleLevel(careportal_sensor_battery_level, R.string.key_statuslights_sbat_critical, 5.0, R.string.key_statuslights_sbat_warning, 20.0, bgSource.sensorBatteryLevel.toDouble(), "%")
             else
@@ -94,7 +96,7 @@ class StatusLightHandler @Inject constructor(
     // Omnipod only reports reservoir level when it's 50 units or less, so we display "50+U" for any value > 50
     @Suppress("SameParameterValue")
     private fun handleOmnipodReservoirLevel(view: TextView?, criticalSetting: Int, criticalDefaultValue: Double, warnSetting: Int, warnDefaultValue: Double, level: Double, units: String) {
-        if (level > OmnipodConstants.MAX_RESERVOIR_READING) {
+        if (level >= OmnipodConstants.MAX_RESERVOIR_READING) {
             @Suppress("SetTextI18n")
             view?.text = " 50+$units"
             view?.setTextColor(rh.gac(view.context, R.attr.defaultTextColor))


### PR DESCRIPTION
Before:

![Screenshot_20221023-165256](https://user-images.githubusercontent.com/5643940/197549746-e4659a2d-3f9e-4ab7-9d88-54f3e89be864.png)

After:

![Screenshot_20221024-161809](https://user-images.githubusercontent.com/5643940/197549802-184b28e1-29de-4716-82e4-ac0437b973f2.png)

With this PR I tried to improve upon the display of status information when using AAPSClient when using the OmniPod DASH. 

There were a few display issues:

- Internationalization of the insulin unit field
- Pump status was marked as critical due to the Dash not having a battery level
- Pump didn't show the reservoir_display_override field
- Reservoir level wasn't shown in the insulin age field

### Internationalization

This was added by retrieving the insulin_unit_shortname in NSDeviceStatus

### Pump status always critical

Added a check to see if the voltage is > 0 before checking the value

### reservoir display override 

The display override was added to the PumpData class. If the field is present and not empty it will be used to display the level. The translated insulin unit is appended.

### insulin age display

The status light handler wasn't setting the insulin age when running under NSClient. I couldn't see any reason why this was done. If this needs an additional check I'd be happy to add it. Here I used the existing Pod logic to display the insulin level. I did have to change the handling of `OmnipodConstants.MAX_RESERVOIR_READING` to >=

