### PR TITLE
bg data smoothing

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/activities/HistoryBrowseActivity.kt
@@ -290,7 +290,7 @@ class HistoryBrowseActivity : NoSplashAppCompatActivity() {
         val graphData = GraphData(injector, binding.bgGraph, historyBrowserData.overviewData)
         val menuChartSettings = overviewMenus.setting
         graphData.addInRangeArea(historyBrowserData.overviewData.fromTime, historyBrowserData.overviewData.endTime, defaultValueHelper.determineLowLine(), defaultValueHelper.determineHighLine())
-        graphData.addBgReadings(menuChartSettings[0][OverviewMenus.CharType.PRE.ordinal], context)
+        graphData.addBgReadings(menuChartSettings[0][OverviewMenus.CharType.PRE.ordinal], menuChartSettings[0][OverviewMenus.CharType.RAW.ordinal], context)
         if (buildHelper.isDev()) graphData.addBucketedData()
         graphData.addTreatments(context)
         graphData.addEps(context, 0.95)

--- a/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dialogs/WizardDialog.kt
@@ -377,7 +377,7 @@ class WizardDialog : DaggerDialogFragment() {
             binding.bgInput.step = if (units == GlucoseUnit.MGDL) 1.0 else 0.1
 
             // Set BG if not old
-            binding.bgInput.value = iobCobCalculator.ads.actualBg()?.valueToUnits(units) ?: 0.0
+            binding.bgInput.value = iobCobCalculator.ads.actualBg()?.valueToUnits(units, sp) ?: 0.0
 
             binding.ttCheckbox.isEnabled = tempTarget is ValueWrapper.Existing
             binding.ttCheckboxIcon.visibility = binding.ttCheckbox.isEnabled.toVisibility()

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -1020,7 +1020,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         val menuChartSettings = overviewMenus.setting
         if (menuChartSettings.isEmpty()) return
         graphData.addInRangeArea(overviewData.fromTime, overviewData.endTime, defaultValueHelper.determineLowLine(), defaultValueHelper.determineHighLine())
-        graphData.addBgReadings(menuChartSettings[0][OverviewMenus.CharType.PRE.ordinal], context)
+        graphData.addBgReadings(menuChartSettings[0][OverviewMenus.CharType.PRE.ordinal], menuChartSettings[0][OverviewMenus.CharType.RAW.ordinal], context)
         if (buildHelper.isDev()) graphData.addBucketedData()
         graphData.addTreatments(context)
         graphData.addEps(context, 0.95)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -800,7 +800,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         val lastBgDescription = overviewData.lastBgDescription
         runOnUiThread {
             _binding ?: return@runOnUiThread
-            binding.infoLayout.bg.text = lastBg?.valueToUnitsString(units)
+            binding.infoLayout.bg.text = lastBg?.valueToUnitsString(units, sp)
                 ?: rh.gs(R.string.value_unavailable_short)
             binding.infoLayout.bg.setTextColor(lastBgColor)
             binding.infoLayout.arrow.setImageResource(trendArrow.directionToIcon())

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewMenus.kt
@@ -38,6 +38,7 @@ class OverviewMenus @Inject constructor(
 ) {
 
     enum class CharType(@StringRes val nameId: Int, @AttrRes val attrId: Int, @AttrRes val attrTextId: Int, val primary: Boolean, val secondary: Boolean, @StringRes val shortnameId: Int) {
+        RAW(R.string.overview_show_raw_bg, R.attr.defaultTextColor, R.attr.menuTextColorInverse, primary = true, secondary = false, shortnameId = R.string.activity_shortname),
         PRE(R.string.overview_show_predictions, R.attr.predictionColor, R.attr.menuTextColor, primary = true, secondary = false, shortnameId = R.string.prediction_shortname),
         TREAT(R.string.overview_show_treatments, R.attr.cobColor, R.attr.menuTextColor, primary = true, secondary = false, shortnameId = R.string.treatments_shortname),
         BAS(R.string.overview_show_basals, R.attr.basal, R.attr.menuTextColor, primary = true, secondary = false, shortnameId = R.string.basal_shortname),
@@ -126,6 +127,7 @@ class OverviewMenus @Inject constructor(
                     if (g == 0 && !m.primary) return@forEach
                     if (g > 0 && !m.secondary) return@forEach
                     var insert = true
+                    if (m == CharType.RAW) insert = sp.getBoolean(info.nightscout.androidaps.core.R.string.key_use_data_smoothing, false)
                     if (m == CharType.PRE) insert = predictionsAvailable
                     if (m == CharType.DEVSLOPE) insert = buildHelper.isDev()
                     if (used.contains(m.ordinal)) insert = false

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
@@ -57,6 +57,7 @@ class GraphData(
             if (units == GlucoseUnit.MGDL) 180.0 else 10.0
         } else overviewData.maxBgValue
         minY = 0.0
+        if (!overviewData.bgReadingRawGraphSeries.isEmpty) addSeries(overviewData.bgReadingRawGraphSeries)
         addSeries(overviewData.bgReadingGraphSeries)
         if (addPredictions) addSeries(overviewData.predictionsGraphSeries)
         overviewData.bgReadingGraphSeries.setOnDataPointTapListener { _, dataPoint ->
@@ -97,7 +98,7 @@ class GraphData(
         maxY = maxOf(maxY, overviewData.maxTreatmentsValue)
         addSeries(overviewData.treatmentsSeries)
         overviewData.treatmentsSeries.setOnDataPointTapListener { _, dataPoint ->
-            if (dataPoint is BolusDataPoint) ToastUtils.infoToast(context, dataPoint.label)
+            if (dataPoint is BolusDataPoint) ToastUtils.graphicalToast(context, dataPoint.label, R.drawable.ic_bolus)
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphData/GraphData.kt
@@ -52,12 +52,12 @@ class GraphData(
         addSeries(overviewData.bucketedGraphSeries)
     }
 
-    fun addBgReadings(addPredictions: Boolean, context: Context?) {
+    fun addBgReadings(addPredictions: Boolean, addRawBg: Boolean, context: Context?) {
         maxY = if (overviewData.bgReadingsArray.isEmpty()) {
             if (units == GlucoseUnit.MGDL) 180.0 else 10.0
         } else overviewData.maxBgValue
         minY = 0.0
-        if (!overviewData.bgReadingRawGraphSeries.isEmpty) addSeries(overviewData.bgReadingRawGraphSeries)
+        if (addRawBg && !overviewData.bgReadingRawGraphSeries.isEmpty) addSeries(overviewData.bgReadingRawGraphSeries)
         addSeries(overviewData.bgReadingGraphSeries)
         if (addPredictions) addSeries(overviewData.predictionsGraphSeries)
         overviewData.bgReadingGraphSeries.setOnDataPointTapListener { _, dataPoint ->
@@ -98,7 +98,7 @@ class GraphData(
         maxY = maxOf(maxY, overviewData.maxTreatmentsValue)
         addSeries(overviewData.treatmentsSeries)
         overviewData.treatmentsSeries.setOnDataPointTapListener { _, dataPoint ->
-            if (dataPoint is BolusDataPoint) ToastUtils.graphicalToast(context, dataPoint.label, R.drawable.ic_bolus)
+            if (dataPoint is BolusDataPoint) ToastUtils.infoToast(context, dataPoint.label)
         }
     }
 

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -31,6 +31,7 @@ import info.nightscout.rx.events.EventAutosensCalculationFinished
 import info.nightscout.rx.events.EventInitializationChanged
 import info.nightscout.rx.events.EventRefreshOverview
 import info.nightscout.rx.logging.AAPSLogger
+import info.nightscout.shared.sharedPreferences.SP
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
 import javax.inject.Inject
@@ -42,6 +43,7 @@ class PersistentNotificationPlugin @Inject constructor(
     injector: HasAndroidInjector,
     aapsLogger: AAPSLogger,
     rh: ResourceHelper,
+    private val sp: SP,
     private val aapsSchedulers: AapsSchedulers,
     private val profileFunction: ProfileFunction,
     private val fabricPrivacy: FabricPrivacy,
@@ -120,7 +122,7 @@ class PersistentNotificationPlugin @Inject constructor(
             val lastBG = iobCobCalculator.ads.lastBg()
             val glucoseStatus = glucoseStatusProvider.glucoseStatusData
             if (lastBG != null) {
-                line1aa = lastBG.valueToUnitsString(units)
+                line1aa = lastBG.valueToUnitsString(units, sp)
                 line1 = line1aa
                 if (glucoseStatus != null) {
                     line1 += ("  Δ" + Profile.toSignedUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units)

--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/DataHandlerMobile.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/wear/wearintegration/DataHandlerMobile.kt
@@ -391,7 +391,7 @@ class DataHandlerMobile @Inject constructor(
             tempTarget = tempTarget,
             carbs = carbsAfterConstraints,
             cob = cobInfo.displayCob!!,
-            bg = bgReading.valueToUnits(profileFunction.getUnits()),
+            bg = bgReading.valueToUnits(profileFunction.getUnits(), sp),
             correction = 0.0,
             percentageCorrection = percentage,
             useBg = sp.getBoolean(R.string.key_wearwizard_bg, true),
@@ -855,7 +855,7 @@ class DataHandlerMobile @Inject constructor(
         val finalLastRun = loop.lastRun
         if (sp.getBoolean("wear_predictions", true) && finalLastRun?.request?.hasPredictions == true && finalLastRun.constraintsProcessed != null) {
             val predArray = finalLastRun.constraintsProcessed!!.predictions
-                .stream().map { bg: GlucoseValue -> GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh) }
+                .stream().map { bg: GlucoseValue -> GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh, sp) }
                 .collect(Collectors.toList())
             if (predArray.isNotEmpty())
                 for (bg in predArray) if (bg.data.value > 39)
@@ -942,7 +942,7 @@ class DataHandlerMobile @Inject constructor(
 
         return EventData.SingleBg(
             timeStamp = glucoseValue.timestamp,
-            sgvString = glucoseValue.valueToUnitsString(units),
+            sgvString = glucoseValue.valueToUnitsString(units, sp),
             glucoseUnits = units.asText,
             slopeArrow = trendCalculator.getTrendArrow(glucoseValue).symbol,
             delta = glucoseStatus?.let { deltaString(it.delta, it.delta * Constants.MGDL_TO_MMOLL, units) } ?: "--",

--- a/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobCalculatorPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobCalculatorPlugin.kt
@@ -85,7 +85,7 @@ class IobCobCalculatorPlugin @Inject constructor(
     private var iobTable = LongSparseArray<IobTotal>() // oldest at index 0
     private var basalDataTable = LongSparseArray<BasalData>() // oldest at index 0
 
-    override var ads: AutosensDataStore = AutosensDataStore()
+    override var ads: AutosensDataStore = AutosensDataStore(sp)
 
     private val dataLock = Any()
     private var thread: Thread? = null

--- a/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobOref1Worker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobOref1Worker.kt
@@ -134,14 +134,14 @@ class IobCobOref1Worker(
                 //console.error(bgTime , bucketed_data[i].glucose);
                 var avgDelta: Double
                 var delta: Double
-                val bg: Double = bucketedData[i].value
-                if (bg < 39 || bucketedData[i + 3].value < 39) {
+                val bg: Double = bucketedData[i].rawOrSmoothed(sp)
+                if (bg < 39 || bucketedData[i + 3].rawOrSmoothed(sp) < 39) {
                     aapsLogger.error("! value < 39")
                     continue
                 }
                 autosensData.bg = bg
-                delta = bg - bucketedData[i + 1].value
-                avgDelta = (bg - bucketedData[i + 3].value) / 3
+                delta = bg - bucketedData[i + 1].rawOrSmoothed(sp)
+                avgDelta = (bg - bucketedData[i + 3].rawOrSmoothed(sp)) / 3
                 val iob = data.iobCobCalculator.calculateFromTreatmentsAndTemps(bgTime, profile)
                 val bgi = -iob.activity * sens * 5
                 val deviation = delta - bgi

--- a/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobOrefWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/IobCobOrefWorker.kt
@@ -128,14 +128,14 @@ class IobCobOrefWorker @Inject internal constructor(
                 //console.error(bgTime , bucketed_data[i].glucose);
                 var avgDelta: Double
                 var delta: Double
-                val bg: Double = bucketedData[i].value
-                if (bg < 39 || bucketedData[i + 3].value < 39) {
+                val bg: Double = bucketedData[i].rawOrSmoothed(sp)
+                if (bg < 39 || bucketedData[i + 3].rawOrSmoothed(sp) < 39) {
                     aapsLogger.error("! value < 39")
                     continue
                 }
                 autosensData.bg = bg
-                delta = bg - bucketedData[i + 1].value
-                avgDelta = (bg - bucketedData[i + 3].value) / 3
+                delta = bg - bucketedData[i + 1].rawOrSmoothed(sp)
+                avgDelta = (bg - bucketedData[i + 3].rawOrSmoothed(sp)) / 3
                 val iob = data.iobCobCalculatorPlugin.calculateFromTreatmentsAndTemps(bgTime, profile)
                 val bgi = -iob.activity * sens * 5
                 val deviation = delta - bgi

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/AidexPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/AidexPlugin.kt
@@ -99,6 +99,7 @@ class AidexPlugin @Inject constructor(
             glucoseValues += CgmSourceTransaction.TransactionGlucoseValue(
                 timestamp = timestamp,
                 value = bgValueTarget,
+                smoothed = null,
                 raw = null,
                 noise = null,
                 trendArrow = GlucoseValue.TrendArrow.fromString(bundle.getString(Intents.AIDEX_BG_SLOPE_NAME)),

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/DexcomPlugin.kt
@@ -150,8 +150,9 @@ class DexcomPlugin @Inject constructor(
                         glucoseValues += CgmSourceTransaction.TransactionGlucoseValue(
                             timestamp = timestamp,
                             value = glucoseValueBundle.getInt("glucoseValue").toDouble(),
-                            noise = null,
                             raw = null,
+                            smoothed = null,
+                            noise = null,
                             trendArrow = GlucoseValue.TrendArrow.fromString(glucoseValueBundle.getString("trendArrow")!!),
                             sourceSensor = sourceSensor
                         )

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/EversensePlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/EversensePlugin.kt
@@ -107,6 +107,7 @@ class EversensePlugin @Inject constructor(
                             timestamp = glucoseTimestamps[i],
                             value = glucoseLevels[i].toDouble(),
                             raw = glucoseLevels[i].toDouble(),
+                            smoothed = null,
                             noise = null,
                             trendArrow = GlucoseValue.TrendArrow.NONE,
                             sourceSensor = GlucoseValue.SourceSensor.EVERSENSE

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/GlimpPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/GlimpPlugin.kt
@@ -67,6 +67,7 @@ class GlimpPlugin @Inject constructor(
                 timestamp = inputData.getLong("myTimestamp", 0),
                 value = inputData.getDouble("mySGV", 0.0),
                 raw = inputData.getDouble("mySGV", 0.0),
+                smoothed = null,
                 noise = null,
                 trendArrow = GlucoseValue.TrendArrow.fromString(inputData.getString("myTrend")),
                 sourceSensor = GlucoseValue.SourceSensor.GLIMP

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/GlunovoPlugin.kt
@@ -124,6 +124,7 @@ class GlunovoPlugin @Inject constructor(
                             timestamp = timestamp,
                             value = value * Constants.MMOLL_TO_MGDL,
                             raw = 0.0,
+                        smoothed = null,
                             noise = null,
                             trendArrow = GlucoseValue.TrendArrow.NONE,
                             sourceSensor = GlucoseValue.SourceSensor.GLUNOVO_NATIVE

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/IntelligoPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/IntelligoPlugin.kt
@@ -135,6 +135,7 @@ class IntelligoPlugin @Inject constructor(
                         timestamp = timestamp,
                         value = value * Constants.MMOLL_TO_MGDL,
                         raw = 0.0,
+                        smoothed = null,
                         noise = null,
                         trendArrow = GlucoseValue.TrendArrow.NONE,
                         sourceSensor = GlucoseValue.SourceSensor.INTELLIGO_NATIVE

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/MM640gPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/MM640gPlugin.kt
@@ -80,6 +80,7 @@ class MM640gPlugin @Inject constructor(
                                         timestamp = jsonObject.getLong("date"),
                                         value = jsonObject.getDouble("sgv"),
                                         raw = jsonObject.getDouble("sgv"),
+                                        smoothed = null,
                                         noise = null,
                                         trendArrow = GlucoseValue.TrendArrow.fromString(jsonObject.getString("direction")),
                                         sourceSensor = GlucoseValue.SourceSensor.MM_600_SERIES

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/PoctechPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/PoctechPlugin.kt
@@ -74,6 +74,7 @@ class PoctechPlugin @Inject constructor(
                         timestamp = json.getLong("date"),
                         value = if (safeGetString(json, "units", Constants.MGDL) == "mmol/L") json.getDouble("current") * Constants.MMOLL_TO_MGDL
                         else json.getDouble("current"),
+                        smoothed = null,
                         raw = json.getDouble("raw"),
                         noise = null,
                         trendArrow = GlucoseValue.TrendArrow.fromString(json.getString("direction")),

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/RandomBgPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/RandomBgPlugin.kt
@@ -115,6 +115,7 @@ class RandomBgPlugin @Inject constructor(
             value = bgMgdl,
             raw = 0.0,
             noise = null,
+            smoothed = null,
             trendArrow = GlucoseValue.TrendArrow.NONE,
             sourceSensor = GlucoseValue.SourceSensor.RANDOM
         )

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/TomatoPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/TomatoPlugin.kt
@@ -68,6 +68,7 @@ class TomatoPlugin @Inject constructor(
                 value = inputData.getDouble("com.fanqies.tomatofn.Extras.BgEstimate", 0.0),
                 raw = 0.0,
                 noise = null,
+                smoothed = null,
                 trendArrow = GlucoseValue.TrendArrow.NONE,
                 sourceSensor = GlucoseValue.SourceSensor.LIBRE_1_TOMATO
             )

--- a/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/source/XdripPlugin.kt
@@ -85,6 +85,7 @@ class XdripPlugin @Inject constructor(
                 timestamp = bundle.getLong(Intents.EXTRA_TIMESTAMP, 0),
                 value = bundle.getDouble(Intents.EXTRA_BG_ESTIMATE, 0.0),
                 raw = bundle.getDouble(Intents.EXTRA_RAW, 0.0),
+                smoothed = null,
                 noise = null,
                 trendArrow = GlucoseValue.TrendArrow.fromString(bundle.getString(Intents.EXTRA_BG_SLOPE_NAME)),
                 sourceSensor = GlucoseValue.SourceSensor.fromString(bundle.getString(Intents.XDRIP_DATA_SOURCE_DESCRIPTION)

--- a/app/src/main/java/info/nightscout/androidaps/utils/wizard/QuickWizardEntry.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/wizard/QuickWizardEntry.kt
@@ -103,7 +103,7 @@ class QuickWizardEntry @Inject constructor(private val injector: HasAndroidInjec
         //BG
         var bg = 0.0
         if (useBG() == YES) {
-            bg = lastBG.valueToUnits(profileFunction.getUnits())
+            bg = lastBG.valueToUnits(profileFunction.getUnits(), sp)
         }
         // COB
         val cob =

--- a/app/src/main/java/info/nightscout/androidaps/workflow/PrepareBgDataWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/workflow/PrepareBgDataWorker.kt
@@ -5,7 +5,9 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import dagger.android.HasAndroidInjector
+import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.AppRepository
+import info.nightscout.androidaps.extensions.rawOrSmoothed
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.androidaps.interfaces.IobCobCalculator
 import info.nightscout.androidaps.interfaces.Profile
@@ -18,6 +20,7 @@ import info.nightscout.androidaps.receivers.DataWorkerStorage
 import info.nightscout.androidaps.utils.DefaultValueHelper
 import info.nightscout.interfaces.utils.Round
 import info.nightscout.shared.interfaces.ResourceHelper
+import info.nightscout.shared.sharedPreferences.SP
 import java.util.ArrayList
 import javax.inject.Inject
 
@@ -29,6 +32,7 @@ class PrepareBgDataWorker(
     @Inject lateinit var dataWorkerStorage: DataWorkerStorage
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var rh: ResourceHelper
+    @Inject lateinit var sp: SP
     @Inject lateinit var defaultValueHelper: DefaultValueHelper
     @Inject lateinit var repository: AppRepository
 
@@ -45,14 +49,15 @@ class PrepareBgDataWorker(
 
         val data = dataWorkerStorage.pickupObject(inputData.getLong(DataWorkerStorage.STORE_KEY, -1)) as PrepareBgData?
             ?: return Result.failure(workDataOf("Error" to "missing input data"))
+        val useSmoothed = sp.getBoolean(R.string.key_use_data_smoothing, false)
 
         data.overviewData.maxBgValue = Double.MIN_VALUE
         data.overviewData.bgReadingsArray = repository.compatGetBgReadingsDataFromTime(data.overviewData.fromTime, data.overviewData.toTime, false).blockingGet()
         val bgListArray: MutableList<DataPointWithLabelInterface> = ArrayList()
         for (bg in data.overviewData.bgReadingsArray) {
             if (bg.timestamp < data.overviewData.fromTime || bg.timestamp > data.overviewData.toTime) continue
-            if (bg.value > data.overviewData.maxBgValue) data.overviewData.maxBgValue = bg.value
-            bgListArray.add(GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh))
+            if (bg.rawOrSmoothed(useSmoothed) > data.overviewData.maxBgValue) data.overviewData.maxBgValue = bg.rawOrSmoothed(useSmoothed)
+            bgListArray.add(GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh, sp))
         }
         bgListArray.sortWith { o1: DataPointWithLabelInterface, o2: DataPointWithLabelInterface -> o1.x.compareTo(o2.x) }
         data.overviewData.bgReadingGraphSeries = PointsWithLabelGraphSeries(Array(bgListArray.size) { i -> bgListArray[i] })

--- a/app/src/main/java/info/nightscout/androidaps/workflow/PrepareBucketedDataWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/workflow/PrepareBucketedDataWorker.kt
@@ -14,6 +14,7 @@ import info.nightscout.androidaps.plugins.general.overview.graphExtensions.InMem
 import info.nightscout.androidaps.plugins.general.overview.graphExtensions.PointsWithLabelGraphSeries
 import info.nightscout.androidaps.receivers.DataWorkerStorage
 import info.nightscout.rx.logging.AAPSLogger
+import info.nightscout.shared.sharedPreferences.SP
 import javax.inject.Inject
 
 class PrepareBucketedDataWorker(
@@ -25,6 +26,7 @@ class PrepareBucketedDataWorker(
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var rh: ResourceHelper
     @Inject lateinit var aapsLogger: AAPSLogger
+    @Inject lateinit var sp: SP
 
     init {
         (context.applicationContext as HasAndroidInjector).androidInjector().inject(this)
@@ -48,7 +50,7 @@ class PrepareBucketedDataWorker(
         val bucketedListArray: MutableList<DataPointWithLabelInterface> = ArrayList()
         for (inMemoryGlucoseValue in bucketedData) {
             if (inMemoryGlucoseValue.timestamp < data.overviewData.fromTime || inMemoryGlucoseValue.timestamp > data.overviewData.toTime) continue
-            bucketedListArray.add(InMemoryGlucoseValueDataPoint(inMemoryGlucoseValue, profileFunction, rh))
+            bucketedListArray.add(InMemoryGlucoseValueDataPoint(inMemoryGlucoseValue, profileFunction, rh, sp))
         }
         bucketedListArray.sortWith { o1: DataPointWithLabelInterface, o2: DataPointWithLabelInterface -> o1.x.compareTo(o2.x) }
         data.overviewData.bucketedGraphSeries = PointsWithLabelGraphSeries(Array(bucketedListArray.size) { i -> bucketedListArray[i] })

--- a/app/src/main/java/info/nightscout/androidaps/workflow/PreparePredictionsWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/workflow/PreparePredictionsWorker.kt
@@ -20,6 +20,7 @@ import info.nightscout.plugins.sync.nsclient.data.ProcessedDeviceStatusData
 import info.nightscout.rx.bus.RxBus
 import info.nightscout.shared.interfaces.ResourceHelper
 import info.nightscout.shared.utils.T
+import info.nightscout.shared.sharedPreferences.SP
 import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.ceil
@@ -43,6 +44,7 @@ class PreparePredictionsWorker(
     @Inject lateinit var defaultValueHelper: DefaultValueHelper
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var rh: ResourceHelper
+    @Inject lateinit var sp: SP
 
     init {
         (context.applicationContext as HasAndroidInjector).androidInjector().inject(this)
@@ -83,7 +85,7 @@ class PreparePredictionsWorker(
 
         val bgListArray: MutableList<DataPointWithLabelInterface> = ArrayList()
         val predictions: MutableList<GlucoseValueDataPoint>? = apsResult?.predictions
-            ?.map { bg -> GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh) }
+            ?.map { bg -> GlucoseValueDataPoint(bg, defaultValueHelper, profileFunction, rh, sp) }
             ?.toMutableList()
         if (predictions != null) {
             predictions.sortWith { o1: GlucoseValueDataPoint, o2: GlucoseValueDataPoint -> o1.x.compareTo(o2.x) }

--- a/app/src/main/java/info/nightscout/androidaps/workflow/PrepareTreatmentsDataWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/workflow/PrepareTreatmentsDataWorker.kt
@@ -8,6 +8,7 @@ import dagger.android.HasAndroidInjector
 import info.nightscout.androidaps.database.AppRepository
 import info.nightscout.androidaps.database.entities.Bolus
 import info.nightscout.androidaps.database.entities.TherapyEvent
+import info.nightscout.androidaps.extensions.rawOrSmoothed
 import info.nightscout.androidaps.interfaces.ActivePlugin
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.androidaps.interfaces.Profile
@@ -28,6 +29,7 @@ import info.nightscout.interfaces.utils.Round
 import info.nightscout.shared.utils.T
 import info.nightscout.androidaps.utils.Translator
 import info.nightscout.rx.bus.RxBus
+import info.nightscout.shared.sharedPreferences.SP
 import javax.inject.Inject
 
 class PrepareTreatmentsDataWorker(
@@ -43,6 +45,7 @@ class PrepareTreatmentsDataWorker(
     @Inject lateinit var activePlugin: ActivePlugin
     @Inject lateinit var repository: AppRepository
     @Inject lateinit var defaultValueHelper: DefaultValueHelper
+    @Inject lateinit var sp: SP
 
     init {
         (context.applicationContext as HasAndroidInjector).androidInjector().inject(this)
@@ -143,9 +146,10 @@ class PrepareTreatmentsDataWorker(
         overviewData.bgReadingsArray.let { bgReadingsArray ->
             for (reading in bgReadingsArray) {
                 if (reading.timestamp > date) continue
-                return Profile.fromMgdlToUnits(reading.value, profileFunction.getUnits())
+                return Profile.fromMgdlToUnits(reading.rawOrSmoothed(sp), profileFunction
+                    .getUnits())
             }
-            return if (bgReadingsArray.isNotEmpty()) Profile.fromMgdlToUnits(bgReadingsArray[0].value, profileFunction.getUnits())
+            return if (bgReadingsArray.isNotEmpty()) Profile.fromMgdlToUnits(bgReadingsArray[0].rawOrSmoothed(sp), profileFunction.getUnits())
             else Profile.fromMgdlToUnits(100.0, profileFunction.getUnits())
         }
     }

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -715,4 +715,11 @@
     <string name="database_cleanup">Очистка базы данных</string>
     <string name="cleanup_db_confirm">Вы хотите очистить базу данных?\nЭто удалит отслеживаемые изменения и данные старше 3 месяцев.</string>
     <string name="cleared_entries">Удалённые записи</string>
+
+    <!-- Tsunami Data Smoothing -->
+    <string name="key_use_data_smoothing" translatable="false">use_data_smoothing</string>
+    <string name="use_data_smoothing_summary" translatable="false">Использовать сглаженные показания данных ГК с сенсора. Рекомендуется в случе, если ваш сенсор не поддерживает сглаживание сам, а вы всё же хотите использовать SMB.</string>
+    <string name="use_data_smoothing_title" translatable="false">Сглаживать данные ГК с сенсора</string>
+    <string name="internal_smoothing_enabled">Сглаживание значений сенсора включено.</string>
+    <!-- Tsunami Data Smoothing end-->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="basal_shortname">BAS</string>
     <string name="deviation_shortname">DEV</string>
     <string name="activity_shortname">ACT</string>
+    <string name="raw_bg_shortname">RAW</string>
     <string name="bgi_shortname">-BGI</string>
     <string name="abs_insulin_shortname">ABS</string>
     <string name="devslope_shortname">DEVSLOPE</string>
@@ -391,6 +392,7 @@
     <string name="do_not_bolus_record_only">Do not bolus, record only</string>
     <string name="bolusrecordedonly">Bolus will be recorded only (not delivered by pump)</string>
     <string name="loop_smbsetbypump_label">SMB set by pump</string>
+    <string name="overview_show_raw_bg">Raw BG</string>
     <string name="overview_show_activity">Activity</string>
     <string name="overview_show_bgi">Blood Glucose Impact</string>
     <string name="overview_show_sensitivity">Sensitivity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -681,4 +681,10 @@
     <string name="cleanup_db_confirm">Do you want to cleanup the database?\nIt will remove tracked changes and historic data older than 3 months.</string>
     <string name="cleared_entries">Cleared entries</string>
 
+    <!-- Tsunami Data Smoothing -->
+    <string name="key_use_data_smoothing" translatable="false">use_data_smoothing</string>
+    <string name="use_data_smoothing_summary" translatable="false">Smooth and display incoming sensor data in the main chart. Recommended if your glucose source does not smooth sensor readings by itself and you would like to enable SMB always.</string>
+    <string name="use_data_smoothing_title" translatable="false">Smooth incoming glucose values</string>
+    <string name="internal_smoothing_enabled">Smoothing of incoming sensor readings is enabled.</string>
+    <!-- Tsunami Data Smoothing end-->
 </resources>

--- a/app/src/main/res/xml/pref_overview.xml
+++ b/app/src/main/res/xml/pref_overview.xml
@@ -14,6 +14,12 @@
             android:summary="@string/keep_screen_on_summary"
             android:title="@string/keep_screen_on_title" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/key_use_data_smoothing"
+            android:summary="@string/use_data_smoothing_summary"
+            android:title="@string/use_data_smoothing_title" />
+
         <androidx.preference.PreferenceScreen
             android:key="@string/overview_buttons_selection"
             android:title="@string/overview_buttons_selection">

--- a/core/src/main/java/info/nightscout/androidaps/data/InMemoryGlucoseValue.kt
+++ b/core/src/main/java/info/nightscout/androidaps/data/InMemoryGlucoseValue.kt
@@ -1,9 +1,19 @@
 package info.nightscout.androidaps.data
 
+import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.GlucoseValue
+import info.nightscout.shared.sharedPreferences.SP
 
-class InMemoryGlucoseValue constructor(var timestamp: Long = 0L, var value: Double = 0.0, var interpolated: Boolean = false) {
+class InMemoryGlucoseValue constructor(var timestamp: Long = 0L, var value: Double = 0.0, var smoothed: Double? = null, var interpolated: Boolean = false) {
 
-    constructor(gv: GlucoseValue) : this(gv.timestamp, gv.value)
+    constructor(gv: GlucoseValue) : this(gv.timestamp, gv.value, gv.smoothed)
     // var generated : value doesn't correspond to real value with timestamp close to real BG
+    private fun useDataSmoothing(sp: SP): Boolean {
+        return sp.getBoolean(R.string.key_use_data_smoothing, false)
+    }
+
+    fun rawOrSmoothed(sp: SP): Double {
+        if (useDataSmoothing(sp)) return smoothed ?: value
+        else return value
+    }
 }

--- a/core/src/main/java/info/nightscout/androidaps/extensions/GlucoseValueExtension.kt
+++ b/core/src/main/java/info/nightscout/androidaps/extensions/GlucoseValueExtension.kt
@@ -1,19 +1,35 @@
 package info.nightscout.androidaps.extensions
 
+import info.nightscout.androidaps.core.R
 import info.nightscout.interfaces.Constants
 import info.nightscout.androidaps.database.entities.GlucoseValue
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.shared.utils.DateUtil
 import info.nightscout.androidaps.utils.DecimalFormatter
+import info.nightscout.shared.sharedPreferences.SP
 import org.json.JSONObject
 
-fun GlucoseValue.valueToUnits(units: GlucoseUnit): Double =
-    if (units == GlucoseUnit.MGDL) value
-    else value * Constants.MGDL_TO_MMOLL
+fun useDataSmoothing(sp: SP): Boolean {
+    return sp.getBoolean(R.string.key_use_data_smoothing, false)
+}
 
-fun GlucoseValue.valueToUnitsString(units: GlucoseUnit): String =
-    if (units == GlucoseUnit.MGDL) DecimalFormatter.to0Decimal(value)
-    else DecimalFormatter.to1Decimal(value * Constants.MGDL_TO_MMOLL)
+fun GlucoseValue.rawOrSmoothed(sp: SP): Double {
+    if (useDataSmoothing(sp)) return smoothed ?: value
+    else return value
+}
+
+fun GlucoseValue.rawOrSmoothed(useSmoothed: Boolean): Double {
+    if (useSmoothed) return smoothed ?: value
+    else return value
+}
+
+fun GlucoseValue.valueToUnits(units: GlucoseUnit, sp: SP): Double =
+    if (units == GlucoseUnit.MGDL) rawOrSmoothed(sp)
+    else rawOrSmoothed(sp) * Constants.MGDL_TO_MMOLL
+
+fun GlucoseValue.valueToUnitsString(units: GlucoseUnit, sp: SP): String =
+    if (units == GlucoseUnit.MGDL) DecimalFormatter.to0Decimal(rawOrSmoothed(sp))
+    else DecimalFormatter.to1Decimal(rawOrSmoothed(sp) * Constants.MGDL_TO_MMOLL)
 
 fun GlucoseValue.toJson(isAdd : Boolean, dateUtil: DateUtil): JSONObject =
     JSONObject()

--- a/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/aps/loop/APSResult.kt
@@ -199,6 +199,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                                 raw = 0.0,
                                 noise = 0.0,
                                 value = iob.getInt(i).toDouble(),
+                                smoothed = iob.getInt(i).toDouble(),
                                 timestamp = startTime + i * 5 * 60 * 1000L,
                                 sourceSensor = GlucoseValue.SourceSensor.IOB_PREDICTION,
                                 trendArrow = GlucoseValue.TrendArrow.NONE
@@ -213,6 +214,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                                 raw = 0.0,
                                 noise = 0.0,
                                 value = iob.getInt(i).toDouble(),
+                                smoothed = iob.getInt(i).toDouble(),
                                 timestamp = startTime + i * 5 * 60 * 1000L,
                                 sourceSensor = GlucoseValue.SourceSensor.A_COB_PREDICTION,
                                 trendArrow = GlucoseValue.TrendArrow.NONE
@@ -227,6 +229,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                                 raw = 0.0,
                                 noise = 0.0,
                                 value = iob.getInt(i).toDouble(),
+                                smoothed = iob.getInt(i).toDouble(),
                                 timestamp = startTime + i * 5 * 60 * 1000L,
                                 sourceSensor = GlucoseValue.SourceSensor.COB_PREDICTION,
                                 trendArrow = GlucoseValue.TrendArrow.NONE
@@ -241,6 +244,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                                 raw = 0.0,
                                 noise = 0.0,
                                 value = iob.getInt(i).toDouble(),
+                                smoothed = iob.getInt(i).toDouble(),
                                 timestamp = startTime + i * 5 * 60 * 1000L,
                                 sourceSensor = GlucoseValue.SourceSensor.UAM_PREDICTION,
                                 trendArrow = GlucoseValue.TrendArrow.NONE
@@ -255,6 +259,7 @@ open class APSResult @Inject constructor(val injector: HasAndroidInjector) {
                                 raw = 0.0,
                                 noise = 0.0,
                                 value = iob.getInt(i).toDouble(),
+                                smoothed = iob.getInt(i).toDouble(),
                                 timestamp = startTime + i * 5 * 60 * 1000L,
                                 sourceSensor = GlucoseValue.SourceSensor.ZT_PREDICTION,
                                 trendArrow = GlucoseValue.TrendArrow.NONE

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -126,12 +126,12 @@ class OverviewData @Inject constructor(
 
     val isLow: Boolean
         get() = lastBg?.let { lastBg ->
-            lastBg.valueToUnits(profileFunction.getUnits()) < defaultValueHelper.determineLowLine()
+            lastBg.valueToUnits(profileFunction.getUnits(), sp) < defaultValueHelper.determineLowLine()
         } ?: false
 
     val isHigh: Boolean
         get() = lastBg?.let { lastBg ->
-            lastBg.valueToUnits(profileFunction.getUnits()) > defaultValueHelper.determineHighLine()
+            lastBg.valueToUnits(profileFunction.getUnits(), sp) > defaultValueHelper.determineHighLine()
         } ?: false
 
     @ColorInt

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -252,6 +252,7 @@ class OverviewData @Inject constructor(
     var maxBgValue = Double.MIN_VALUE
     var bucketedGraphSeries: PointsWithLabelGraphSeries<DataPointWithLabelInterface> = PointsWithLabelGraphSeries()
     var bgReadingGraphSeries: PointsWithLabelGraphSeries<DataPointWithLabelInterface> = PointsWithLabelGraphSeries()
+    var bgReadingRawGraphSeries: PointsWithLabelGraphSeries<DataPointWithLabelInterface> = PointsWithLabelGraphSeries()
     var predictionsGraphSeries: PointsWithLabelGraphSeries<DataPointWithLabelInterface> = PointsWithLabelGraphSeries()
 
     val basalScale = Scale()

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
@@ -5,6 +5,7 @@ import info.nightscout.interfaces.Constants
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.GlucoseValue
 import info.nightscout.androidaps.extensions.rawOrSmoothed
+import info.nightscout.androidaps.extensions.useDataSmoothing
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.androidaps.interfaces.Profile
 import info.nightscout.androidaps.interfaces.ProfileFunction
@@ -17,25 +18,54 @@ class GlucoseValueDataPoint(
     private val defaultValueHelper: DefaultValueHelper,
     private val profileFunction: ProfileFunction,
     private val rh: ResourceHelper,
-    private val sp: SP
 ) : DataPointWithLabelInterface {
 
+    private var useSmoothed : Boolean = false
+    private var isAdditional : Boolean = false
+
+    constructor(data: GlucoseValue,
+                defaultValueHelper: DefaultValueHelper,
+                profileFunction: ProfileFunction,
+                rh: ResourceHelper,
+                useSmoothed: Boolean,
+                isAdditional: Boolean = false) : this(
+        data,
+        defaultValueHelper,
+        profileFunction,
+        rh) {
+        this.useSmoothed = useSmoothed
+        this.isAdditional = isAdditional
+    }
+
+    constructor(data: GlucoseValue,
+                defaultValueHelper: DefaultValueHelper,
+                profileFunction: ProfileFunction,
+                rh: ResourceHelper,
+                sp: SP) : this(
+        data,
+        defaultValueHelper,
+        profileFunction,
+        rh) {
+        useSmoothed = useDataSmoothing(sp)
+    }
+
     fun valueToUnits(units: GlucoseUnit): Double =
-        if (units == GlucoseUnit.MGDL) data.rawOrSmoothed(sp) else data.rawOrSmoothed(sp) * Constants.MGDL_TO_MMOLL
+        if (units == GlucoseUnit.MGDL) data.rawOrSmoothed(useSmoothed) else data.rawOrSmoothed(useSmoothed) * Constants.MGDL_TO_MMOLL
 
     override fun getX(): Double = data.timestamp.toDouble()
     override fun getY(): Double = valueToUnits(profileFunction.getUnits())
 
     override fun setY(y: Double) {}
-    override val label: String = Profile.toCurrentUnitsString(profileFunction, data.rawOrSmoothed(sp))
+    override val label: String = Profile.toCurrentUnitsString(profileFunction, data.rawOrSmoothed(useSmoothed))
     override val duration = 0L
     override val shape get() = if (isPrediction) PointsWithLabelGraphSeries.Shape.PREDICTION else PointsWithLabelGraphSeries.Shape.BG
-    override val size = 1f
+    override val size get() = if (isAdditional) 0.5f else 1f
     override fun color(context: Context?): Int {
         val units = profileFunction.getUnits()
         val lowLine = defaultValueHelper.determineLowLine()
         val highLine = defaultValueHelper.determineHighLine()
         return when {
+            isAdditional                   -> rh.gac(context, R.attr.defaultTextColor)
             isPrediction                   -> predictionColor(context)
             valueToUnits(units) < lowLine  -> rh.gac(context, R.attr.bgLow)
             valueToUnits(units) > highLine -> rh.gac(context, R.attr.highColor)

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/GlucoseValueDataPoint.kt
@@ -4,27 +4,30 @@ import android.content.Context
 import info.nightscout.interfaces.Constants
 import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.database.entities.GlucoseValue
+import info.nightscout.androidaps.extensions.rawOrSmoothed
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.androidaps.interfaces.Profile
 import info.nightscout.androidaps.interfaces.ProfileFunction
 import info.nightscout.shared.interfaces.ResourceHelper
+import info.nightscout.shared.sharedPreferences.SP
 import info.nightscout.androidaps.utils.DefaultValueHelper
 
 class GlucoseValueDataPoint(
     val data: GlucoseValue,
     private val defaultValueHelper: DefaultValueHelper,
     private val profileFunction: ProfileFunction,
-    private val rh: ResourceHelper
+    private val rh: ResourceHelper,
+    private val sp: SP
 ) : DataPointWithLabelInterface {
 
     fun valueToUnits(units: GlucoseUnit): Double =
-        if (units == GlucoseUnit.MGDL) data.value else data.value * Constants.MGDL_TO_MMOLL
+        if (units == GlucoseUnit.MGDL) data.rawOrSmoothed(sp) else data.rawOrSmoothed(sp) * Constants.MGDL_TO_MMOLL
 
     override fun getX(): Double = data.timestamp.toDouble()
     override fun getY(): Double = valueToUnits(profileFunction.getUnits())
 
     override fun setY(y: Double) {}
-    override val label: String = Profile.toCurrentUnitsString(profileFunction, data.value)
+    override val label: String = Profile.toCurrentUnitsString(profileFunction, data.rawOrSmoothed(sp))
     override val duration = 0L
     override val shape get() = if (isPrediction) PointsWithLabelGraphSeries.Shape.PREDICTION else PointsWithLabelGraphSeries.Shape.BG
     override val size = 1f

--- a/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/InMemoryGlucoseValueDataPoint.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/general/overview/graphExtensions/InMemoryGlucoseValueDataPoint.kt
@@ -7,15 +7,18 @@ import info.nightscout.androidaps.data.InMemoryGlucoseValue
 import info.nightscout.androidaps.interfaces.GlucoseUnit
 import info.nightscout.androidaps.interfaces.ProfileFunction
 import info.nightscout.shared.interfaces.ResourceHelper
+import info.nightscout.shared.sharedPreferences.SP
 
 class InMemoryGlucoseValueDataPoint(
     val data: InMemoryGlucoseValue,
     private val profileFunction: ProfileFunction,
-    private val rh: ResourceHelper
+    private val rh: ResourceHelper,
+    private val sp: SP
 ) : DataPointWithLabelInterface {
 
     fun valueToUnits(units: GlucoseUnit): Double =
-        if (units == GlucoseUnit.MGDL) data.value else data.value * Constants.MGDL_TO_MMOLL
+        if (units == GlucoseUnit.MGDL) data.rawOrSmoothed(sp)
+        else data.rawOrSmoothed(sp) * Constants.MGDL_TO_MMOLL
 
     override fun getX(): Double = data.timestamp.toDouble()
     override fun getY(): Double = valueToUnits(profileFunction.getUnits())

--- a/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/AutosensDataStore.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/AutosensDataStore.kt
@@ -3,9 +3,11 @@ package info.nightscout.androidaps.plugins.iob.iobCobCalculator
 import androidx.collection.LongSparseArray
 import androidx.collection.size
 import info.nightscout.androidaps.annotations.OpenForTesting
+import info.nightscout.androidaps.core.R
 import info.nightscout.androidaps.data.InMemoryGlucoseValue
 import info.nightscout.androidaps.database.AppRepository
 import info.nightscout.androidaps.database.entities.GlucoseValue
+import info.nightscout.androidaps.extensions.rawOrSmoothed
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.data.AutosensData
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.events.EventBucketedDataCreated
 import info.nightscout.shared.utils.DateUtil
@@ -13,11 +15,12 @@ import info.nightscout.shared.utils.T
 import info.nightscout.rx.bus.RxBus
 import info.nightscout.rx.logging.AAPSLogger
 import info.nightscout.rx.logging.LTag
+import info.nightscout.shared.sharedPreferences.SP
 import kotlin.math.abs
 import kotlin.math.roundToLong
 
 @OpenForTesting
-class AutosensDataStore {
+class AutosensDataStore (val sp: SP) {
 
     private val dataLock = Any()
     var lastUsed5minCalculation: Boolean? = null // true if used 5min bucketed data
@@ -39,7 +42,7 @@ class AutosensDataStore {
         @Synchronized get
 
     fun clone(): AutosensDataStore =
-        AutosensDataStore().also {
+        AutosensDataStore(sp).also {
             synchronized(dataLock) {
                 it.bgReadings = this.bgReadings.toMutableList()
                 it.autosensDataTable = LongSparseArray<AutosensData>(this.autosensDataTable.size).apply { putAll(this@AutosensDataStore.autosensDataTable) }
@@ -236,6 +239,7 @@ class AutosensDataStore {
             bucketedData = null
             return
         }
+        val  useBgSmoothing = sp.getBoolean(R.string.key_use_data_smoothing, false)
         val newBucketedData = ArrayList<InMemoryGlucoseValue>()
         var currentTime = bgReadings[0].timestamp - bgReadings[0].timestamp % T.mins(5).msecs()
         val adjustedTime = adjustToReferenceTime(currentTime)
@@ -251,10 +255,13 @@ class AutosensDataStore {
             if (older.timestamp == newer.timestamp) { // direct hit
                 newBucketedData.add(InMemoryGlucoseValue(newer))
             } else {
-                val bgDelta = newer.value - older.value
+                val bgDeltaRaw = newer.value - older.value
+                val bgDeltaSmoothed = newer.rawOrSmoothed(useBgSmoothing) - older.rawOrSmoothed(useBgSmoothing)
                 val timeDiffToNew = newer.timestamp - currentTime
-                val currentBg = newer.value - timeDiffToNew.toDouble() / (newer.timestamp - older.timestamp) * bgDelta
-                val newBgReading = InMemoryGlucoseValue(currentTime, currentBg.roundToLong().toDouble(), true)
+                val currentBgRaw = newer.value - timeDiffToNew.toDouble() / (newer.timestamp - older.timestamp) * bgDeltaRaw
+                val currentBgSmoothed = newer.rawOrSmoothed(useBgSmoothing) - timeDiffToNew.toDouble() / (newer.timestamp - older.timestamp) * bgDeltaSmoothed
+
+                val newBgReading = InMemoryGlucoseValue(currentTime, currentBgRaw.roundToLong().toDouble(), currentBgSmoothed.roundToLong().toDouble(),true)
                 newBucketedData.add(newBgReading)
                 //log.debug("BG: " + newBgReading.value + " (" + new Date(newBgReading.date).toLocaleString() + ") Prev: " + older.value + " (" + new Date(older.date).toLocaleString() + ") Newer: " + newer.value + " (" + new Date(newer.date).toLocaleString() + ")");
             }
@@ -269,6 +276,7 @@ class AutosensDataStore {
             return
         }
         val bData: MutableList<InMemoryGlucoseValue> = ArrayList()
+        val useBgSmoothing = sp.getBoolean(R.string.key_use_data_smoothing, false)
         bData.add(InMemoryGlucoseValue(bgReadings[0]))
         aapsLogger.debug(LTag.AUTOSENS) { "Adding. bgTime: ${dateUtil.toISOString(bgReadings[0].timestamp)} lastBgTime: none-first-value ${bgReadings[0]}" }
         var j = 0
@@ -280,39 +288,44 @@ class AutosensDataStore {
             when {
                 abs(elapsedMinutes) > 8 -> {
                     // interpolate missing data points
-                    var lastBg = bgReadings[i - 1].value
+                    var lastBgRaw = bgReadings[i - 1].value
+                    var lastBgSmoothed = bgReadings[i - 1].rawOrSmoothed(useBgSmoothing)
                     elapsedMinutes = abs(elapsedMinutes)
                     //console.error(elapsed_minutes);
                     var nextBgTime: Long
                     while (elapsedMinutes > 5) {
                         nextBgTime = lastBgTime - 5 * 60 * 1000
                         j++
-                        val gapDelta = bgReadings[i].value - lastBg
+                        val gapDeltaRaw = bgReadings[i].value - lastBgRaw
+                        val gapDeltaSmoothed = bgReadings[i].value - lastBgSmoothed
                         //console.error(gapDelta, lastBg, elapsed_minutes);
-                        val nextBg = lastBg + 5.0 / elapsedMinutes * gapDelta
-                        val newBgReading = InMemoryGlucoseValue(nextBgTime, nextBg.roundToLong().toDouble(), true)
+                        val nextBgRaw = lastBgRaw + 5.0 / elapsedMinutes * gapDeltaRaw
+                        val nextBgSmoothed = lastBgSmoothed + 5.0 / elapsedMinutes * gapDeltaSmoothed
+                        val newBgReading = InMemoryGlucoseValue(nextBgTime, nextBgRaw.roundToLong().toDouble(), nextBgSmoothed.roundToLong().toDouble(), true)
                         //console.error("Interpolated", bData[j]);
                         bData.add(newBgReading)
                         aapsLogger.debug(LTag.AUTOSENS) { "Adding. bgTime: ${dateUtil.toISOString(bgTime)} lastBgTime: ${dateUtil.toISOString(lastBgTime)} $newBgReading" }
                         elapsedMinutes -= 5
-                        lastBg = nextBg
+                        lastBgRaw = nextBgRaw
+                        lastBgSmoothed = nextBgSmoothed
                         lastBgTime = nextBgTime
                     }
                     j++
-                    val newBgReading = InMemoryGlucoseValue(bgTime, bgReadings[i].value)
+                    val newBgReading = InMemoryGlucoseValue(bgTime, bgReadings[i].value, bgReadings[i].smoothed)
                     bData.add(newBgReading)
                     aapsLogger.debug(LTag.AUTOSENS) { "Adding. bgTime: ${dateUtil.toISOString(bgTime)} lastBgTime: ${dateUtil.toISOString(lastBgTime)} $newBgReading" }
                 }
 
                 abs(elapsedMinutes) > 2 -> {
                     j++
-                    val newBgReading = InMemoryGlucoseValue(bgTime, bgReadings[i].value)
+                    val newBgReading = InMemoryGlucoseValue(bgTime, bgReadings[i].value, bgReadings[i].smoothed)
                     bData.add(newBgReading)
                     aapsLogger.debug(LTag.AUTOSENS) { "Adding. bgTime: ${dateUtil.toISOString(bgTime)} lastBgTime: ${dateUtil.toISOString(lastBgTime)} $newBgReading" }
                 }
 
                 else                    -> {
                     bData[j].value = (bData[j].value + bgReadings[i].value) / 2
+                    bData[j].smoothed = (bData[j].rawOrSmoothed(sp) + bgReadings[i].rawOrSmoothed(useBgSmoothing)) / 2
                     //log.error("***** Average");
                 }
             }

--- a/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/GlucoseStatusProvider.kt
+++ b/core/src/main/java/info/nightscout/androidaps/plugins/iob/iobCobCalculator/GlucoseStatusProvider.kt
@@ -1,10 +1,13 @@
 package info.nightscout.androidaps.plugins.iob.iobCobCalculator
 
 import dagger.Reusable
+import info.nightscout.androidaps.extensions.rawOrSmoothed
+import info.nightscout.androidaps.extensions.useDataSmoothing
 import info.nightscout.androidaps.interfaces.IobCobCalculator
 import info.nightscout.shared.utils.DateUtil
 import info.nightscout.rx.logging.AAPSLogger
 import info.nightscout.rx.logging.LTag
+import info.nightscout.shared.sharedPreferences.SP
 import javax.inject.Inject
 import kotlin.math.roundToLong
 
@@ -12,7 +15,8 @@ import kotlin.math.roundToLong
 class GlucoseStatusProvider @Inject constructor(
     private val aapsLogger: AAPSLogger,
     private val iobCobCalculator: IobCobCalculator,
-    private val dateUtil: DateUtil
+    private val dateUtil: DateUtil,
+    private val sp: SP
 ) {
 
     val glucoseStatusData: GlucoseStatus?
@@ -49,7 +53,7 @@ class GlucoseStatusProvider @Inject constructor(
         val longDeltas = ArrayList<Double>()
 
         // Use the latest sgv value in the now calculations
-        nowValueList.add(now.value)
+        nowValueList.add(now.rawOrSmoothed(sp))
         for (i in 1 until sizeRecords) {
             if (data[i].value > 38) {
                 val then = data[i]
@@ -57,15 +61,15 @@ class GlucoseStatusProvider @Inject constructor(
 
                 val minutesAgo = ((nowDate - thenDate) / (1000.0 * 60)).roundToLong()
                 // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
-                change = now.value - then.value
+                change = now.rawOrSmoothed(sp) - then.rawOrSmoothed(sp)
                 val avgDel = change / minutesAgo * 5
                 aapsLogger.debug(LTag.GLUCOSE, "$then minutesAgo=$minutesAgo avgDelta=$avgDel")
 
                 // use the average of all data points in the last 2.5m for all further "now" calculations
                 if (0 < minutesAgo && minutesAgo < 2.5) {
                     // Keep and average all values within the last 2.5 minutes
-                    nowValueList.add(then.value)
-                    now.value = average(nowValueList)
+                    nowValueList.add(then.rawOrSmoothed(sp))
+                    if (useDataSmoothing(sp)) now.smoothed = average(nowValueList) else now.value = average(nowValueList)
                     // short_deltas are calculated from everything ~5-15 minutes ago
                 } else if (2.5 < minutesAgo && minutesAgo < 17.5) {
                     //console.error(minutesAgo, avgDelta);
@@ -90,7 +94,7 @@ class GlucoseStatusProvider @Inject constructor(
             average(lastDeltas)
         }
         return GlucoseStatus(
-            glucose = now.value,
+            glucose = now.rawOrSmoothed(sp),
             date = nowDate,
             noise = 0.0, //for now set to nothing as not all CGMs report noise
             shortAvgDelta = shortAverageDelta,

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -659,6 +659,7 @@
     <string name="autotune_run_with_error">Error during last Autotune run</string>
     <string name="autotune_run_cancelled">Another run of Autotune is detected, run cancelled</string>
     <string name="needconnectpermission">Application needs bluetooth permission</string>
+    <string name="key_use_data_smoothing" translatable="false">use_data_smoothing</string>
 
     <!-- Alerts -->
     <string name="key_raise_notifications_as_android_notifications" translatable="false">raise_urgent_alarms_as_android_notification</string>

--- a/database/schemas/info.nightscout.androidaps.database.AppDatabase/23.json
+++ b/database/schemas/info.nightscout.androidaps.database.AppDatabase/23.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 22,
-    "identityHash": "9efbf222b2454f2d47bf179c65df24c0",
+    "version": 23,
+    "identityHash": "dda7fa990182c143f1b89139d96e40f7",
     "entities": [
       {
         "tableName": "apsResults",
@@ -195,7 +195,7 @@
       },
       {
         "tableName": "boluses",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `version` INTEGER NOT NULL, `dateCreated` INTEGER NOT NULL, `isValid` INTEGER NOT NULL, `referenceId` INTEGER, `timestamp` INTEGER NOT NULL, `utcOffset` INTEGER NOT NULL, `amount` REAL NOT NULL, `type` TEXT NOT NULL, `isBasalInsulin` INTEGER NOT NULL, `nightscoutSystemId` TEXT, `nightscoutId` TEXT, `pumpType` TEXT, `pumpSerial` TEXT, `temporaryId` INTEGER, `pumpId` INTEGER, `startId` INTEGER, `endId` INTEGER, `insulinLabel` TEXT, `insulinEndTime` INTEGER, `peak` INTEGER, FOREIGN KEY(`referenceId`) REFERENCES `boluses`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `version` INTEGER NOT NULL, `dateCreated` INTEGER NOT NULL, `isValid` INTEGER NOT NULL, `referenceId` INTEGER, `timestamp` INTEGER NOT NULL, `utcOffset` INTEGER NOT NULL, `amount` REAL NOT NULL, `type` TEXT NOT NULL, `notes` TEXT, `isBasalInsulin` INTEGER NOT NULL, `nightscoutSystemId` TEXT, `nightscoutId` TEXT, `pumpType` TEXT, `pumpSerial` TEXT, `temporaryId` INTEGER, `pumpId` INTEGER, `startId` INTEGER, `endId` INTEGER, `insulinLabel` TEXT, `insulinEndTime` INTEGER, `peak` INTEGER, FOREIGN KEY(`referenceId`) REFERENCES `boluses`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "id",
@@ -250,6 +250,12 @@
             "columnName": "type",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
           },
           {
             "fieldPath": "isBasalInsulin",
@@ -747,7 +753,7 @@
       },
       {
         "tableName": "carbs",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `version` INTEGER NOT NULL, `dateCreated` INTEGER NOT NULL, `isValid` INTEGER NOT NULL, `referenceId` INTEGER, `timestamp` INTEGER NOT NULL, `utcOffset` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `amount` REAL NOT NULL, `nightscoutSystemId` TEXT, `nightscoutId` TEXT, `pumpType` TEXT, `pumpSerial` TEXT, `temporaryId` INTEGER, `pumpId` INTEGER, `startId` INTEGER, `endId` INTEGER, FOREIGN KEY(`referenceId`) REFERENCES `carbs`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `version` INTEGER NOT NULL, `dateCreated` INTEGER NOT NULL, `isValid` INTEGER NOT NULL, `referenceId` INTEGER, `timestamp` INTEGER NOT NULL, `utcOffset` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `amount` REAL NOT NULL, `notes` TEXT, `nightscoutSystemId` TEXT, `nightscoutId` TEXT, `pumpType` TEXT, `pumpSerial` TEXT, `temporaryId` INTEGER, `pumpId` INTEGER, `startId` INTEGER, `endId` INTEGER, FOREIGN KEY(`referenceId`) REFERENCES `carbs`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "id",
@@ -802,6 +808,12 @@
             "columnName": "amount",
             "affinity": "REAL",
             "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
           },
           {
             "fieldPath": "interfaceIDs_backing.nightscoutSystemId",
@@ -3682,7 +3694,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9efbf222b2454f2d47bf179c65df24c0')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dda7fa990182c143f1b89139d96e40f7')"
     ]
   }
 }

--- a/database/src/main/java/info/nightscout/androidaps/database/AppDatabase.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/AppDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.TypeConverters
 import info.nightscout.androidaps.database.daos.*
 import info.nightscout.androidaps.database.entities.*
 
-const val DATABASE_VERSION = 22
+const val DATABASE_VERSION = 23
 
 @Database(version = DATABASE_VERSION,
     entities = [APSResult::class, Bolus::class, BolusCalculatorResult::class, Carbs::class,

--- a/database/src/main/java/info/nightscout/androidaps/database/DatabaseModule.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/DatabaseModule.kt
@@ -1,6 +1,8 @@
 package info.nightscout.androidaps.database
 
 import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteException
 import androidx.room.Room
 import androidx.room.RoomDatabase.Callback
 import androidx.room.migration.Migration
@@ -26,8 +28,11 @@ open class DatabaseModule {
  //           .addMigrations(migration6to7)
  //           .addMigrations(migration7to8)
  //           .addMigrations(migration11to12)
-            .addMigrations(migration20to21)
-            .addMigrations(migration21to22)
+            .addMigrations(
+                migration20to21,
+                migration21to22,
+                migration22to23,
+            )
             .addCallback(object : Callback() {
                 override fun onOpen(db: SupportSQLiteDatabase) {
                     super.onOpen(db)
@@ -73,11 +78,35 @@ open class DatabaseModule {
 
     private val migration21to22 = object : Migration(21,22) {
         override fun migrate(database: SupportSQLiteDatabase) {
-            database.execSQL("ALTER TABLE `carbs` ADD COLUMN `notes` TEXT")
-            database.execSQL("ALTER TABLE `boluses` ADD COLUMN `notes` TEXT")
+            addColumnIfNotExists(database,"carbs", "notes", "TEXT")
+            addColumnIfNotExists(database,"boluses", "notes", "TEXT")
             // Custom indexes must be dropped on migration to pass room schema checking after upgrade
             dropCustomIndexes(database)
         }
     }
 
+    private val migration22to23 = object : Migration(22,23) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            addColumnIfNotExists(database,"glucoseValues", "smoothed", "REAL")
+            dropCustomIndexes(database)
+        }
+    }
+
+    private fun addColumnIfNotExists(db: SupportSQLiteDatabase, table: String, columnToCheck: String, columnTypeDefinition: String) {
+        if(!columnExistsInTable(db, table, columnToCheck)) {
+            db.execSQL("ALTER TABLE `$table` ADD COLUMN `$columnToCheck` $columnTypeDefinition")
+        }
+    }
+
+    private fun columnExistsInTable(db: SupportSQLiteDatabase?, table: String, columnToCheck: String?): Boolean {
+        var cursor: Cursor? = null
+        return try {
+            cursor = db?.query("SELECT * FROM $table LIMIT 0", null)
+            cursor?.getColumnIndex(columnToCheck) !== -1
+        } catch (Exp: SQLiteException) {
+            false
+        } finally {
+            cursor?.close()
+        }
+    }
 }

--- a/database/src/main/java/info/nightscout/androidaps/database/entities/GlucoseValue.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/entities/GlucoseValue.kt
@@ -39,6 +39,7 @@ data class GlucoseValue(
     override var utcOffset: Long = TimeZone.getDefault().getOffset(timestamp).toLong(),
     var raw: Double?,
     var value: Double,
+    var smoothed: Double?,
     var trendArrow: TrendArrow,
     var noise: Double?,
     var sourceSensor: SourceSensor

--- a/database/src/main/java/info/nightscout/androidaps/database/transactions/CgmSourceTransaction.kt
+++ b/database/src/main/java/info/nightscout/androidaps/database/transactions/CgmSourceTransaction.kt
@@ -1,8 +1,10 @@
 package info.nightscout.androidaps.database.transactions
 
 import info.nightscout.androidaps.database.entities.GlucoseValue
-import info.nightscout.androidaps.database.entities.ProfileSwitch
 import info.nightscout.androidaps.database.entities.TherapyEvent
+import java.util.ArrayList
+import kotlin.math.max
+import kotlin.math.round
 
 /**
  * Inserts data from a CGM source into the database
@@ -10,7 +12,11 @@ import info.nightscout.androidaps.database.entities.TherapyEvent
 class CgmSourceTransaction constructor(
     private val glucoseValues: List<TransactionGlucoseValue>,
     private val calibrations: List<Calibration>,
-    private val sensorInsertionTime: Long?
+    private val sensorInsertionTime: Long?,
+    private var bgReadings: List<GlucoseValue> = listOf(),
+    private val updateWindow: Int = 10 // max number of smoothed glucose values to be updated per cycle to avoid updating the database with all entries stored in bgReadings
+    // syncer is allowed create records
+    // update synchronization ID
 ) : Transaction<CgmSourceTransaction.TransactionResult>() {
 
     override fun run(): TransactionResult {
@@ -21,6 +27,7 @@ class CgmSourceTransaction constructor(
                 timestamp = it.timestamp,
                 raw = it.raw,
                 value = it.value,
+                smoothed = it.smoothed,
                 noise = it.noise,
                 trendArrow = it.trendArrow,
                 sourceSensor = it.sourceSensor,
@@ -33,6 +40,13 @@ class CgmSourceTransaction constructor(
                 current?.let { existing -> glucoseValue.interfaceIDs.nightscoutId = existing.interfaceIDs.nightscoutId }
             // preserve invalidated status (user may delete record in UI)
             current?.let { existing -> glucoseValue.isValid = existing.isValid }
+            // calculate smoothed values and update DB entries
+            bgReadings += database.glucoseValueDao.compatGetBgReadingsDataFromTime(glucoseValue.timestamp - 125 * 60 * 1000, glucoseValue.timestamp) //MP Get all readings from up to 125 mins ago
+                .blockingGet()
+            bgReadings += glucoseValue
+            bgReadings = smooth(bgReadings.reversed(), updateWindow) //reverse the list as the smoothing function expects the 0th entry to be the most recent one
+            //bgReadings += database.glucoseValueDao.findByTimestampAndSensor(it.timestamp, it.sourceSensor)
+            glucoseValue.smoothed = bgReadings[0].smoothed
             when {
                 // new record, create new
                 current == null                                                      -> {
@@ -52,6 +66,12 @@ class CgmSourceTransaction constructor(
                     result.updatedNsId.add(glucoseValue)
                 }
             }
+        }
+        // Update the smoothed glucose values of the entries included in bgReadings
+        bgReadings = bgReadings.reversed().takeLast(updateWindow) // reverse again so that in the DB, the newest values have the largest ID (for cosmetic and logical reasons :P). Also, keep only the last 10 entries to avoid unnecessarily updating older values that
+        for (i in bgReadings) {
+            database.glucoseValueDao.updateExistingEntry(i)
+            result.updated.add(i)
         }
         calibrations.forEach {
             if (database.therapyEventDao.findByTimestamp(TherapyEvent.Type.FINGER_STICK_BG_VALUE, it.timestamp) == null) {
@@ -79,10 +99,119 @@ class CgmSourceTransaction constructor(
         return result
     }
 
+    private fun smooth(Data: List<GlucoseValue>, updateWindow: Int): List<GlucoseValue> {
+        /**
+         *  TSUNAMI DATA SMOOTHING CORE
+         *
+         *  Calculated a weighted average of 1st and 2nd order exponential smoothing functions
+         *  to reduce the effect of sensor noise on APS performance. The weighted average
+         *  is a compromise between the fast response to changing BGs at the cost of smoothness
+         *  as offered by 1st order exponential smoothing, and the predictive, trend-sensitive but
+         *  slower-to-respond smoothing as offered by 2nd order functions.
+         *
+         */
+        val sizeRecords = Data.size
+        val o1_sBG: ArrayList<Double> = ArrayList() //MP array for 1st order Smoothed Blood Glucose
+        val o2_sBG: ArrayList<Double> = ArrayList() //MP array for 2nd order Smoothed Blood Glucose
+        val o2_sD: ArrayList<Double> = ArrayList() //MP array for 2nd order Smoothed delta
+        val ssBG: ArrayList<Double> = ArrayList() //MP array for weighted averaged, doubly smoothed Blood Glucose
+        //val ssD: ArrayList<Double> = ArrayList() //MP array for deltas of doubly smoothed Blood Glucose
+        var windowSize = 25 //MP number of bg readings to include in smoothing window
+        val o1_weight = 0.4
+        val o1_a = 0.5
+        val o2_a = 0.4
+        val o2_b = 1.0
+        var insufficientSmoothingData = false
+
+        // ADJUST SMOOTHING WINDOW TO ONLY INCLUDE VALID READINGS
+        // Valid readings include:
+        // - Values that actually exist (windowSize may not be larger than sizeRecords)
+        // - Values that come in approx. every 5 min. If the time gap between two readings is larger, this is likely due to a sensor error or warmup of a new sensor.d
+        // - Values that are not 38 mg/dl; 38 mg/dl reflects an xDrip error state (according to a comment in determine-basal.js)
+
+        //MP: Adjust smoothing window if database size is smaller than the default value + 1 (+1 because the reading before the oldest reading to be smoothed will be used in the calculations
+        if (sizeRecords <= windowSize) { //MP standard smoothing window
+            windowSize =
+                (sizeRecords - 1).coerceAtLeast(0) //MP Adjust smoothing window to the size of database if it is smaller than the original window size; -1 to always have at least one older value to compare against as a buffer to prevent app crashes
+        }
+
+        //MP: Adjust smoothing window further if a gap in the BG database is detected, e.g. due to sensor errors of sensor swaps, or if 38 mg/dl are reported (xDrip error state)
+        for (i in 0 until windowSize) {
+            if (Math.round((Data[i].timestamp - Data[i + 1].timestamp) / (1000.0 * 60)) >= 12) { //MP: 12 min because a missed reading (i.e. readings coming in after 10 min) can occur for various reasons, like walking away from the phone or reinstalling AAPS
+                //if (Math.round((data.get(i).date - data.get(i + 1).date) / 60000L) <= 7) { //MP crashes the app, useful for testing
+                windowSize =
+                    i + 1 //MP: If time difference between two readings exceeds 7 min, adjust windowSize to *include* the more recent reading (i = reading; +1 because windowSize reflects number of valid readings);
+                break
+            } else if (Data[i].value == 38.0) {
+                windowSize = i //MP: 38 mg/dl reflects an xDrip error state; Chain of valid readings ends here, *exclude* this value (windowSize = i; i + 1 would include the current value)
+                break
+            }
+        }
+
+        // CALCULATE SMOOTHING WINDOW - 1st order exponential smoothing
+        o1_sBG.clear() // MP reset smoothed bg array
+
+        if (windowSize >= 4) { //MP: Require a valid windowSize of at least 4 readings
+            o1_sBG.add(Data[windowSize - 1].value) //MP: Initialise smoothing with the oldest valid data point
+            for (i in 0 until windowSize) { //MP calculate smoothed bg window of valid readings
+                o1_sBG.add(
+                    0,
+                    o1_sBG[0] + o1_a * (Data[windowSize - 1 - i].value - o1_sBG[0])
+                ) //MP build array of 1st order smoothed bgs
+            }
+        } else {
+            insufficientSmoothingData = true
+        }
+
+        // CALCULATE SMOOTHING WINDOW - 2nd order exponential smoothing
+        if (windowSize >= 4) { //MP: Require a valid windowSize of at least 4 readings
+            o2_sBG.add(Data[windowSize - 1].value) //MP Start 2nd order exponential data smoothing with the oldest valid bg
+            o2_sD.add(Data[windowSize - 2].value - Data[windowSize - 1].value) //MP Start 2nd order exponential data smoothing with the oldest valid delta
+            for (i in 0 until windowSize - 1) { //MP calculated smoothed bg window of last 1 h
+                o2_sBG.add(
+                    0,
+                    o2_a * Data[windowSize - 2 - i].value + (1 - o2_a) * (o2_sBG[0] + o2_sD[0])
+                ) //MP build array of 2nd order smoothed bgs; windowSize-1 is the oldest valid bg value, so windowSize-2 is from when on the smoothing begins;
+                o2_sD.add(
+                    0,
+                    o2_b * (o2_sBG[0] - o2_sBG[1]) + (1 - o2_b) * o2_sD[0]
+                ) //MP build array of 1st order smoothed bgs
+            }
+        } else {
+            insufficientSmoothingData = true
+        }
+
+        // CALCULATE WEIGHTED AVERAGES OF GLUCOSE & DELTAS
+        //ssBG.clear() // MP reset doubly smoothed bg array
+        //ssD.clear() // MP reset doubly smoothed delta array
+
+        if (!insufficientSmoothingData) { //MP Build doubly smoothed array only if there is enough valid readings
+            for (i in o2_sBG.indices) { //MP calculated doubly smoothed bg of all o1/o2 smoothed data available; o2 & o1 smoothbg array sizes are equal in size, so only one is used as a condition here
+                ssBG.add(o1_weight * o1_sBG[i] + (1 - o1_weight) * o2_sBG[i]) //MP build array of doubly smoothed bgs
+            }
+            /*
+            for (i in 0 until ssBG.size - 1) {
+                ssD.add(ssBG[i] - ssBG[i + 1]) //MP build array of doubly smoothed bg deltas
+            }
+             */
+            for (i in 0 until minOf(ssBG.size, updateWindow)) { // noise at the beginning of the smoothing window is the greatest, so only include the 10 most recent values in the output
+                Data[i].smoothed = max(round(ssBG[i]), 39.0) //Make 39 the smallest value as smaller values trigger errors (xDrip error state = 38)
+            }
+        } else {
+            for (i in 0 until minOf(Data.size, updateWindow)) { // noise at the beginning of the smoothing window is the greatest, so only include the 10 most recent values in the output
+                Data[i].smoothed = max(Data[i].value, 39.0) // if insufficient smoothing data, copy 'value' into 'smoothed' data column so that it isn't empty; Make 39 the smallest value as smaller
+            // values trigger errors (xDrip error state = 38)
+            }
+        }
+
+        return Data
+    }
+
     data class TransactionGlucoseValue(
         val timestamp: Long,
         val value: Double,
         val raw: Double?,
+        val smoothed: Double?,
         val noise: Double?,
         val trendArrow: GlucoseValue.TrendArrow,
         val nightscoutId: String? = null,

--- a/plugins/src/main/java/info/nightscout/plugins/general/autotune/data/BGDatum.kt
+++ b/plugins/src/main/java/info/nightscout/plugins/general/autotune/data/BGDatum.kt
@@ -35,7 +35,7 @@ class BGDatum {
     constructor(json: JSONObject, dateUtil: DateUtil) {
         this.dateUtil = dateUtil
         try {
-            //if (json.has("_id")) id = json.getLong("_id")
+            if (json.has("_id")) id = json.getLong("_id")
             if (json.has("date")) date = json.getLong("date")
             if (json.has("sgv")) value = json.getDouble("sgv")
             if (json.has("direction")) direction = TrendArrow.fromString(json.getString("direction"))

--- a/plugins/src/main/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/plugins/src/main/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -355,11 +355,11 @@ class SmsCommunicatorPlugin @Inject constructor(
         var reply = ""
         val units = profileFunction.getUnits()
         if (actualBG != null) {
-            reply = rh.gs(R.string.sms_actual_bg) + " " + actualBG.valueToUnitsString(units) + ", "
+            reply = rh.gs(R.string.sms_actual_bg) + " " + actualBG.valueToUnitsString(units, sp) + ", "
         } else if (lastBG != null) {
             val agoMilliseconds = dateUtil.now() - lastBG.timestamp
             val agoMin = (agoMilliseconds / 60.0 / 1000.0).toInt()
-            reply = rh.gs(R.string.sms_last_bg) + " " + lastBG.valueToUnitsString(units) + " " + rh.gs(R.string.sms_min_ago, agoMin) + ", "
+            reply = rh.gs(R.string.sms_last_bg) + " " + lastBG.valueToUnitsString(units, sp) + " " + rh.gs(R.string.sms_min_ago, agoMin) + ", "
         }
         val glucoseStatus = glucoseStatusProvider.glucoseStatusData
         if (glucoseStatus != null) reply += rh.gs(R.string.sms_delta) + " " + Profile.toUnitsString(glucoseStatus.delta, glucoseStatus.delta * Constants.MGDL_TO_MMOLL, units) + " " + units + ", "

--- a/plugins/src/main/java/info/nightscout/plugins/source/BGSourceFragment.kt
+++ b/plugins/src/main/java/info/nightscout/plugins/source/BGSourceFragment.kt
@@ -41,6 +41,7 @@ import info.nightscout.shared.extensions.toVisibility
 import info.nightscout.shared.interfaces.ResourceHelper
 import info.nightscout.shared.utils.DateUtil
 import info.nightscout.shared.utils.T
+import info.nightscout.shared.sharedPreferences.SP
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
 import java.util.concurrent.TimeUnit
@@ -58,6 +59,7 @@ class BGSourceFragment : DaggerFragment(), MenuProvider {
     @Inject lateinit var uel: UserEntryLogger
     @Inject lateinit var activePlugin: ActivePlugin
     @Inject lateinit var aapsLogger: AAPSLogger
+    @Inject lateinit var sp: SP
 
     private val disposable = CompositeDisposable()
     private val millsToThePast = T.hours(36).msecs()
@@ -142,7 +144,7 @@ class BGSourceFragment : DaggerFragment(), MenuProvider {
             holder.binding.date.visibility = newDay.toVisibility()
             holder.binding.date.text = if (newDay) dateUtil.dateStringRelative(glucoseValue.timestamp, rh) else ""
             holder.binding.time.text = dateUtil.timeString(glucoseValue.timestamp)
-            holder.binding.value.text = glucoseValue.valueToUnitsString(profileFunction.getUnits())
+            holder.binding.value.text = glucoseValue.valueToUnitsString(profileFunction.getUnits(), sp)
             holder.binding.direction.setImageResource(glucoseValue.trendArrow.directionToIcon())
             if (position > 0) {
                 val previous = glucoseValues[position - 1]
@@ -183,7 +185,7 @@ class BGSourceFragment : DaggerFragment(), MenuProvider {
     private fun getConfirmationText(selectedItems: SparseArray<GlucoseValue>): String {
         if (selectedItems.size() == 1) {
             val glucoseValue = selectedItems.valueAt(0)
-            return dateUtil.dateAndTimeString(glucoseValue.timestamp) + "\n" + glucoseValue.valueToUnitsString(profileFunction.getUnits())
+            return dateUtil.dateAndTimeString(glucoseValue.timestamp) + "\n" + glucoseValue.valueToUnitsString(profileFunction.getUnits(), sp)
         }
         return rh.gs(R.string.confirm_remove_multiple_items, selectedItems.size())
     }

--- a/plugins/src/main/java/info/nightscout/plugins/source/NSClientSourcePlugin.kt
+++ b/plugins/src/main/java/info/nightscout/plugins/source/NSClientSourcePlugin.kt
@@ -108,8 +108,9 @@ class NSClientSourcePlugin @Inject constructor(
             return CgmSourceTransaction.TransactionGlucoseValue(
                 timestamp = sgv.mills ?: return null,
                 value = sgv.mgdl?.toDouble() ?: return null,
-                noise = null,
                 raw = sgv.filtered?.toDouble() ?: sgv.mgdl?.toDouble(),
+                smoothed = null,
+                noise = null,
                 trendArrow = GlucoseValue.TrendArrow.fromString(sgv.direction),
                 nightscoutId = sgv.id,
                 sourceSensor = GlucoseValue.SourceSensor.fromString(sgv.device)
@@ -122,6 +123,7 @@ class NSClientSourcePlugin @Inject constructor(
                 value = sgv.sgv,
                 noise = sgv.noise?.toDouble(),
                 raw = sgv.filtered ?: sgv.sgv,
+                smoothed = null,
                 trendArrow = GlucoseValue.TrendArrow.fromString(sgv.direction.nsName),
                 nightscoutId = sgv.identifier,
                 sourceSensor = GlucoseValue.SourceSensor.fromString(sgv.device),

--- a/plugins/src/test/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
+++ b/plugins/src/test/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
@@ -88,7 +88,7 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
     private var hasBeenRun = false
 
     @Before fun prepareTests() {
-        val reading = GlucoseValue(raw = 0.0, noise = 0.0, value = 100.0, timestamp = 1514766900000, sourceSensor = GlucoseValue.SourceSensor.UNKNOWN, trendArrow = GlucoseValue.TrendArrow.FLAT)
+        val reading = GlucoseValue(raw = 0.0, noise = 0.0, value = 100.0, smoothed = null, timestamp = 1514766900000, sourceSensor = GlucoseValue.SourceSensor.UNKNOWN, trendArrow = GlucoseValue.TrendArrow.FLAT)
         val bgList: MutableList<GlucoseValue> = ArrayList()
         bgList.add(reading)
 

--- a/ui/src/main/java/info/nightscout/ui/dialogs/CarbsDialog.kt
+++ b/ui/src/main/java/info/nightscout/ui/dialogs/CarbsDialog.kt
@@ -17,6 +17,7 @@ import info.nightscout.androidaps.database.entities.ValueWithUnit
 import info.nightscout.androidaps.database.transactions.InsertAndCancelCurrentTemporaryTargetTransaction
 import info.nightscout.androidaps.dialogs.DialogFragmentWithDate
 import info.nightscout.androidaps.extensions.formatColor
+import info.nightscout.androidaps.extensions.rawOrSmoothed
 import info.nightscout.interfaces.ActivityNames
 import info.nightscout.interfaces.BolusTimer
 import info.nightscout.interfaces.CarbTimer
@@ -198,7 +199,7 @@ class CarbsDialog : DialogFragmentWithDate() {
         }
 
         iobCobCalculator.ads.actualBg()?.let { bgReading ->
-            if (bgReading.value < 72)
+            if (bgReading.rawOrSmoothed(sp) < 72)
                 binding.hypoTt.isChecked = true
         }
         binding.hypoTt.setOnClickListener {

--- a/ui/src/main/java/info/nightscout/ui/widget/Widget.kt
+++ b/ui/src/main/java/info/nightscout/ui/widget/Widget.kt
@@ -125,7 +125,7 @@ class Widget : AppWidgetProvider() {
 
     private fun updateBg(views: RemoteViews) {
         val units = profileFunction.getUnits()
-        views.setTextViewText(R.id.bg, overviewData.lastBg?.valueToUnitsString(units) ?: rh.gs(R.string.value_unavailable_short))
+        views.setTextViewText(R.id.bg, overviewData.lastBg?.valueToUnitsString(units, sp) ?: rh.gs(R.string.value_unavailable_short))
         views.setTextColor(
             R.id.bg, when {
                 overviewData.isLow  -> rh.gc(R.color.widget_low)


### PR DESCRIPTION
This is incoming BG data smoothing taken from Tsunami project (I've contacted author long time ago, he has nothing against this move, but for some reason still didn't managed to make a PR).

It is a switchable option under 'Overview' settings group.
<img width="435" alt="image" src="https://user-images.githubusercontent.com/4157587/200762709-e05dad05-e153-42f6-a5e3-a2bc6c85bc01.png">

It uses sliding weighted average algo for calculating smoother curve. This acts much better than existing `use long_delta`.

This can be used as a replace of 'advanced filtering' option to allow SMB usage on any data source.