### PR TITLE
Show correct icon when AutoSens data is available under AAPSClient

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewFragment.kt
@@ -1102,7 +1102,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
 
     private fun updateSensitivity() {
         _binding ?: return
-        if (constraintChecker.isAutosensModeEnabled().value()) {
+        if (constraintChecker.isAutosensModeEnabled().value() || !(config.NSCLIENT && overviewData.lastAutosensData(iobCobCalculator) == null)) {
             binding.infoLayout.sensitivityIcon.setImageResource(R.drawable.ic_swap_vert_black_48dp_green)
         } else {
             binding.infoLayout.sensitivityIcon.setImageResource(R.drawable.ic_x_swap_vert)


### PR DESCRIPTION
This change will show an AutoSens available icon when using AAPSClient with available data. The data was already shown, just not the correct icon.
![studio64_zJkswJUoky](https://user-images.githubusercontent.com/5643940/200167857-9ebb59d4-e35b-4d0e-8fda-54fa6d0a4cef.png)
