### PR TITLE
overview: temp basal as percentage

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="treatments_shortname">TREAT</string>
     <string name="wear_shortname">WEAR</string>
     <string name="short_tabtitles">Shorten tab titles</string>
+    <string name="show_tbr_as_percent">Show TBR as percentage</string>
     <string name="always_use_shortavg">Always use short average delta instead of simple delta</string>
     <string name="always_use_shortavg_summary">Useful when data from unfiltered sources like xDrip+ gets noisy.</string>
     <string name="openapsama_max_daily_safety_multiplier_summary">Default value: 3 This is a key OpenAPS safety cap. What this does is limit your basals to be 3x (in this people) your biggest basal rate. You likely will not need to change this, but you should be aware that’s what is discussed about “3x max daily; 4x current” for safety caps.</string>
@@ -411,6 +412,7 @@
     <string name="loop_openmode_min_change">Minimal request change [%]</string>
     <string name="loop_openmode_min_change_summary" formatted="false">Open Loop will popup new change request only if change is bigger than this value in %. Default value is 20%</string>
     <string name="key_short_tabtitles" translatable="false">short_tabtitles</string>
+    <string name="key_show_tbr_as_percent" translatable="false">show_tbr_as_percent</string>
     <string name="profile_total">== ∑  %1$s U</string>
     <string name="key_smbmaxminutes" translatable="false">smbmaxminutes</string>
     <string name="key_uamsmbmaxminutes" translatable="false">uamsmbmaxminutes</string>

--- a/app/src/main/res/xml/pref_overview.xml
+++ b/app/src/main/res/xml/pref_overview.xml
@@ -262,6 +262,11 @@
 
         <SwitchPreference
             android:defaultValue="false"
+            android:key="@string/key_show_tbr_as_percent"
+            android:title="@string/show_tbr_as_percent" />
+
+        <SwitchPreference
+            android:defaultValue="false"
             android:key="@string/key_short_tabtitles"
             android:title="@string/short_tabtitles" />
 

--- a/core/core-main/src/main/java/info/nightscout/androidaps/extensions/TemporaryBasalExtension.kt
+++ b/core/core-main/src/main/java/info/nightscout/androidaps/extensions/TemporaryBasalExtension.kt
@@ -60,6 +60,13 @@ fun TemporaryBasal.toStringShort(): String =
     if (isAbsolute || type == TemporaryBasal.Type.FAKE_EXTENDED) DecimalFormatter.to2Decimal(rate) + "U/h"
     else "${DecimalFormatter.to0Decimal(rate)}%"
 
+fun TemporaryBasal.toStringShort(forcePercentage: Boolean, profileBasal: Double): String =
+    if (isAbsolute || type == TemporaryBasal.Type.FAKE_EXTENDED) {
+        if (forcePercentage) to0Decimal(rate / profileBasal * 100) + "%"
+        else to2Decimal(rate) + "U/h"
+    }
+    else "${to0Decimal(rate)}%"
+
 fun TemporaryBasal.iobCalc(time: Long, profile: Profile, insulinInterface: Insulin): IobTotal {
     val result = IobTotal(time)
     val realDuration = getPassedDurationToTimeInMinutes(time)

--- a/core/core-main/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
+++ b/core/core-main/src/main/java/info/nightscout/androidaps/plugins/general/overview/OverviewData.kt
@@ -164,7 +164,7 @@ class OverviewData @Inject constructor(
         profileFunction.getProfile()?.let { profile ->
             var temporaryBasal = iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())
             if (temporaryBasal?.isInProgress == false) temporaryBasal = null
-            temporaryBasal?.let { "T:" + it.toStringShort() }
+            temporaryBasal?.let { "T:" + it.toStringShort(sp.getBoolean(rh.gs(R.string.key_show_tbr_as_percent), false), profile.getBasal()) }
                 ?: rh.gs(R.string.pump_basebasalrate, profile.getBasal())
         } ?: rh.gs(R.string.value_unavailable_short)
 


### PR DESCRIPTION
An option to show TBR as percentage of current profile basal for any pump, not only ones that actually use basal percentage.

I (maybe temporary) switched to Dash and its TBR absolute values keep me frustrating: every time looking at it I must remember whats current 'normal' value so how this one is compared to it... The percentage value is much more informative. So I added an option to show TBR as percentage on overview screen (for aaps/nsclient/widget).