### PR TITLE
Various combov2 and nsclient fixes and additions to core XML strings

### DIFF
--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
@@ -1135,13 +1135,7 @@ class ComboV2Plugin @Inject constructor (
                             "Cannot include base basal rate in JSON status " +
                             "since no basal profile is currently active"
                         )
-                    try {
-                        // TODO: What about the profileName argument?
-                        // Is it obsolete?
-                        put("ActiveProfile", profileFunction.getProfileName())
-                    } catch (e: Exception) {
-                        aapsLogger.error("Unhandled exception", e)
-                    }
+                    put("ActiveProfile", profileName)
                     when (val alert = lastComboAlert) {
                         is AlertScreenContent.Warning ->
                             put("WarningCode", alert.code)

--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
@@ -974,8 +974,19 @@ class ComboV2Plugin @Inject constructor (
         val cctlTbrType = when (tbrType) {
             PumpSync.TemporaryBasalType.NORMAL -> ComboCtlTbr.Type.NORMAL
             PumpSync.TemporaryBasalType.EMULATED_PUMP_SUSPEND -> ComboCtlTbr.Type.EMULATED_COMBO_STOP
-            PumpSync.TemporaryBasalType.PUMP_SUSPEND -> ComboCtlTbr.Type.COMBO_STOPPED // TODO: Can this happen? It is currently not allowed by ComboCtlPump.setTbr()
             PumpSync.TemporaryBasalType.SUPERBOLUS -> ComboCtlTbr.Type.SUPERBOLUS
+            PumpSync.TemporaryBasalType.PUMP_SUSPEND -> {
+                aapsLogger.error(
+                    LTag.PUMP,
+                    "PUMP_SUSPEND TBR type produced by AAPS for the TBR initiation even though this is supposed to only be produced by pump drivers"
+                )
+                pumpEnactResult.apply {
+                    success = false
+                    enacted = false
+                    comment = rh.gs(R.string.error)
+                }
+                return pumpEnactResult
+            }
         }
 
         setTbrInternal(limitedPercentage, durationInMinutes, cctlTbrType, force100Percent = false, pumpEnactResult)
@@ -994,8 +1005,19 @@ class ComboV2Plugin @Inject constructor (
         val cctlTbrType = when (tbrType) {
             PumpSync.TemporaryBasalType.NORMAL -> ComboCtlTbr.Type.NORMAL
             PumpSync.TemporaryBasalType.EMULATED_PUMP_SUSPEND -> ComboCtlTbr.Type.EMULATED_COMBO_STOP
-            PumpSync.TemporaryBasalType.PUMP_SUSPEND -> ComboCtlTbr.Type.COMBO_STOPPED // TODO: Can this happen? It is currently not allowed by ComboCtlPump.setTbr()
             PumpSync.TemporaryBasalType.SUPERBOLUS -> ComboCtlTbr.Type.SUPERBOLUS
+            PumpSync.TemporaryBasalType.PUMP_SUSPEND -> {
+                aapsLogger.error(
+                    LTag.PUMP,
+                    "PUMP_SUSPEND TBR type produced by AAPS for the TBR initiation even though this is supposed to only be produced by pump drivers"
+                )
+                pumpEnactResult.apply {
+                    success = false
+                    enacted = false
+                    comment = rh.gs(R.string.error)
+                }
+                return pumpEnactResult
+            }
         }
 
         setTbrInternal(limitedPercentage, durationInMinutes, cctlTbrType, force100Percent = false, pumpEnactResult)

--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
@@ -1324,9 +1324,17 @@ class ComboV2Plugin @Inject constructor (
     override fun canHandleDST() = true
 
     override fun timezoneOrDSTChanged(timeChangeType: TimeChangeType) {
-        // Currently just logging this; the ComboCtl.Pump code will set the new datetime
-        // (as localtime) as part of the on-connect checks automatically.
         aapsLogger.info(LTag.PUMP, "Time, Date and/or TimeZone changed. Time change type = $timeChangeType")
+
+        val reason = when (timeChangeType) {
+            TimeChangeType.TimezoneChanged -> rh.gs(R.string.combov2_timezone_changed)
+            TimeChangeType.TimeChanged -> rh.gs(R.string.combov2_datetime_changed)
+            TimeChangeType.DSTStarted -> rh.gs(R.string.combov2_dst_started)
+            TimeChangeType.DSTEnded -> rh.gs(R.string.combov2_dst_ended)
+        }
+        // Updating pump status implicitly also updates the pump's local datetime,
+        // which is what we want after the system datetime/timezone/DST changed.
+        commandQueue.readStatus(reason, null)
     }
 
     /*** Loop constraints ***/

--- a/pump/combov2/src/main/res/values/strings.xml
+++ b/pump/combov2/src/main/res/values/strings.xml
@@ -129,4 +129,8 @@ buttons at the same time to cancel pairing)\n
     <string name="combov2_automatic_battery_entry">Autodetect and automatically enter battery change</string>
     <string name="combov2_note_reservoir_change">Insulin reservoir change inserted automatically by combov2 driver</string>
     <string name="combov2_note_battery_change">Battery change inserted automatically by combov2 driver</string>
+    <string name="combov2_timezone_changed">Timezone changed</string>
+    <string name="combov2_datetime_changed">Date and/or time changed</string>
+    <string name="combov2_dst_started">Daylight savings time (DST) started</string>
+    <string name="combov2_dst_ended">Daylight savings time (DST) ended</string>
 </resources>


### PR DESCRIPTION
* combov2: Fix DST adjustment and adjust datetime immediately when AAPS detects a DST / timezone change
* combov2: Send EventInitializationChanged
* combov2: Fix race condition when AAPS connects to the Combo while the user unpairs the same Combo
* core: Add strings to XML about datetime, timezone, DST changes (adding these to core since they are not combov2 specific and could be useful for other drivers as well)
* nsclient: Add workaround for non-int devicestatus uploader battery value (fixes https://github.com/nightscout/AndroidAPS/issues/2223 )

Also there are minor fixes to combov2 to solve TODOs in the code.