### PR TITLE
combov2: issue with Bluetooth permissions on MIUI phones

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH" tools:remove="android:maxSdkVersion" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />


### PR DESCRIPTION
Fixed Bluetooth permissions for Combo v2 driver on MIUI phones. Ref. [Stack Overflow](https://stackoverflow.com/questions/71552331/got-lacks-permission-android-permission-bluetooth-on-specific-device-after-and).

Repro steps:
1. On a MIUI 13 phone (e.g. POCO F3), in Config Builder, under Pump select the new Accu-Chek Combo driver (not the Ruffy one).
2. Tap the gear icon to the right of "Accu-Chek Combo".
3. Tap "Pair with pump"
4. Tap "Start pairing"
5. Observe the error: `Pairing failed due to error: java.lang.SecurityException: UID xxxxx / PID xxxxx lacks permission android.permission.BLUETOOTH`
![image](https://user-images.githubusercontent.com/42484840/204678885-a11a1e4e-f63d-4697-b309-94f67d5207ae.png)

This happens even though AAPS has been given every possible permission.
![image](https://user-images.githubusercontent.com/42484840/204679082-43e39fe3-7a38-4f3f-b29b-c973c35510f3.png)


