### PR TITLE
combov2: Fix pairing activity in pumpcontrol application

### DIFF
--- a/pump/combov2/src/main/AndroidManifest.xml
+++ b/pump/combov2/src/main/AndroidManifest.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="info.nightscout.androidaps.plugins.pump.combov2">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
     <application>
         <activity
-            android:name="info.nightscout.pump.combov2.activities.ComboV2PairingActivity"
+            android:name=".activities.ComboV2PairingActivity"
             android:exported="false"
             android:theme="@style/AppTheme.NoActionBar" />
     </application>

--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
@@ -44,6 +44,7 @@ import info.nightscout.interfaces.queue.CommandQueue
 import info.nightscout.interfaces.ui.UiInteraction
 import info.nightscout.interfaces.utils.DecimalFormatter
 import info.nightscout.interfaces.utils.TimeChangeType
+import info.nightscout.pump.combov2.activities.ComboV2PairingActivity
 import info.nightscout.rx.bus.RxBus
 import info.nightscout.rx.events.EventDismissNotification
 import info.nightscout.rx.events.EventInitializationChanged
@@ -325,6 +326,8 @@ class ComboV2Plugin @Inject constructor (
                 lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     val pairPref: Preference? = findPreference(rh.gs(R.string.key_combov2_pair_with_pump))
                     val unpairPref: Preference? = findPreference(rh.gs(R.string.key_combov2_unpair_pump))
+
+                    pairPref?.intent = Intent(activity, ComboV2PairingActivity::class.java)
 
                     val isInitiallyPaired = pairedStateUIFlow.value
                     pairPref?.isEnabled = !isInitiallyPaired

--- a/pump/combov2/src/main/res/layout/combov2_pairing_activity.xml
+++ b/pump/combov2/src/main/res/layout/combov2_pairing_activity.xml
@@ -7,7 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        tools:context=".plugins.pump.combov2.activities.ComboV2PairingActivity">
+        tools:context=".activities.ComboV2PairingActivity">
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:id="@+id/header"

--- a/pump/combov2/src/main/res/xml/pref_combov2.xml
+++ b/pump/combov2/src/main/res/xml/pref_combov2.xml
@@ -12,9 +12,6 @@
             android:title="@string/combov2_pair_with_pump_title"
             android:summary="@string/combov2_pair_with_pump_summary"
             android:shouldDisableView="true">
-            <intent
-                android:targetClass="info.nightscout.pump.combov2.activities.ComboV2PairingActivity"
-                android:targetPackage="info.nightscout.androidaps" />
         </Preference>
 
         <Preference


### PR DESCRIPTION
Adding a ComboV2PairingActivity Intent to the pairing Preferences within the XML causes pumpcontrol builds to crash because of the different package name prefix. Fix by adding the Intent in the preprocessPreferences function instead.

Also fix the manifest and remove unnecessary package prefixes.

Fixes https://github.com/nightscout/AndroidAPS/issues/2236 .