### PR TITLE
 pump status and receivers for SMS reply option

### DIFF
--- a/plugins/main/src/main/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
+++ b/plugins/main/src/main/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPlugin.kt
@@ -448,7 +448,8 @@ class SmsCommunicatorPlugin @Inject constructor(
                             override fun run() {
                                 if (!result.success) {
                                     var replyText = rh.gs(R.string.smscommunicator_tempbasal_failed)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                    if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                 }
                             }
@@ -493,10 +494,11 @@ class SmsCommunicatorPlugin @Inject constructor(
                                         rxBus.send(EventRefreshOverview("SMS_LOOP_SUSPENDED"))
                                         val replyText = rh.gs(R.string.smscommunicator_loop_suspended) + " " +
                                             rh.gs(if (result.success) R.string.smscommunicator_tempbasal_canceled else R.string.smscommunicator_tempbasal_cancel_failed)
-                                        sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                        sendReport(receivedSms.phoneNumber, replyText)
                                     } else {
                                         var replyText = rh.gs(R.string.smscommunicator_tempbasal_cancel_failed)
-                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                        if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                            replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                         sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                     }
                                 }
@@ -673,16 +675,13 @@ class SmsCommunicatorPlugin @Inject constructor(
                     commandQueue.cancelTempBasal(true, object : Callback() {
                         override fun run() {
                             if (result.success) {
-                                var replyText = rh.gs(R.string.smscommunicator_tempbasal_canceled)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
-                                uel.log(
-                                    Action.TEMP_BASAL, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_tempbasal_canceled),
-                                    ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_tempbasal_canceled))
-                                )
+                                sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_tempbasal_canceled),true)
+                                uel.log(Action.TEMP_BASAL, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_tempbasal_canceled),
+                                        ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_tempbasal_canceled)))
                             } else {
                                 var replyText = rh.gs(R.string.smscommunicator_tempbasal_cancel_failed)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                 sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                 uel.log(
                                     Action.TEMP_BASAL, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_tempbasal_cancel_failed),
@@ -718,8 +717,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                                             result.absolute,
                                             result.duration
                                         )
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                    sendReport(receivedSms.phoneNumber, replyText, true)
                                     if (result.isPercent)
                                         uel.log(
                                             Action.TEMP_BASAL, Sources.SMS,
@@ -736,7 +734,8 @@ class SmsCommunicatorPlugin @Inject constructor(
                                         )
                                 } else {
                                     var replyText = rh.gs(R.string.smscommunicator_tempbasal_failed)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                    if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                     uel.log(
                                         Action.TEMP_BASAL, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_tempbasal_failed),
@@ -767,10 +766,10 @@ class SmsCommunicatorPlugin @Inject constructor(
                         commandQueue.tempBasalAbsolute(aDouble(), secondInteger(), true, profile, PumpSync.TemporaryBasalType.NORMAL, object : Callback() {
                             override fun run() {
                                 if (result.success) {
-                                    var replyText = if (result.isPercent) rh.gs(R.string.smscommunicator_tempbasal_set_percent, result.percent, result.duration)
-                                    else rh.gs(R.string.smscommunicator_tempbasal_set, result.absolute, result.duration)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                    var replyText =
+                                        if (result.isPercent) rh.gs(R.string.smscommunicator_tempbasal_set_percent, result.percent, result.duration)
+                                        else rh.gs(R.string.smscommunicator_tempbasal_set, result.absolute, result.duration)
+                                    sendReport(receivedSms.phoneNumber, replyText, true)
                                     if (result.isPercent)
                                         uel.log(
                                             Action.TEMP_BASAL,
@@ -789,7 +788,8 @@ class SmsCommunicatorPlugin @Inject constructor(
                                         )
                                 } else {
                                     var replyText = rh.gs(R.string.smscommunicator_tempbasal_failed)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                    if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                     uel.log(
                                         Action.TEMP_BASAL, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_tempbasal_failed),
@@ -814,12 +814,11 @@ class SmsCommunicatorPlugin @Inject constructor(
                     commandQueue.cancelExtended(object : Callback() {
                         override fun run() {
                             if (result.success) {
-                                var replyText = rh.gs(R.string.smscommunicator_extended_canceled)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_extended_canceled), true)
                             } else {
                                 var replyText = rh.gs(R.string.smscommunicator_extended_cancel_failed)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                 sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                 uel.log(
                                     Action.EXTENDED_BOLUS, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_extended_canceled),
@@ -848,8 +847,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                                 if (result.success) {
                                     var replyText = rh.gs(R.string.smscommunicator_extended_set, aDouble, duration)
                                     if (config.APS) replyText += "\n" + rh.gs(info.nightscout.core.ui.R.string.loopsuspended)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                    sendReport(receivedSms.phoneNumber, replyText, true)
                                     if (config.APS)
                                         uel.log(
                                             Action.EXTENDED_BOLUS,
@@ -867,7 +865,8 @@ class SmsCommunicatorPlugin @Inject constructor(
                                         )
                                 } else {
                                     var replyText = rh.gs(R.string.smscommunicator_extended_failed)
-                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                    if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                     sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                     uel.log(
                                         Action.EXTENDED_BOLUS, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_extended_failed),
@@ -910,7 +909,8 @@ class SmsCommunicatorPlugin @Inject constructor(
                                             rh.gs(R.string.smscommunicator_meal_bolus_delivered, resultBolusDelivered)
                                         else
                                             rh.gs(R.string.smscommunicator_bolus_delivered, resultBolusDelivered)
-                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                        if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                            replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                         lastRemoteBolusTime = dateUtil.now()
                                         if (isMeal) {
                                             profileFunction.getProfile()?.let { currentProfile ->
@@ -949,11 +949,12 @@ class SmsCommunicatorPlugin @Inject constructor(
                                                 replyText += "\n" + rh.gs(R.string.smscommunicator_meal_bolus_delivered_tt, tt, eatingSoonTTDuration)
                                             }
                                         }
-                                        sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                        sendReport(receivedSms.phoneNumber, replyText)
                                         uel.log(Action.BOLUS, Sources.SMS, replyText)
                                     } else {
                                         var replyText = rh.gs(R.string.smscommunicator_bolus_failed)
-                                        replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                        if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                            replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                         sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                         uel.log(
                                             Action.BOLUS, Sources.SMS, activePlugin.activePump.shortStatus(true) + "\n" + rh.gs(R.string.smscommunicator_bolus_failed),
@@ -1012,16 +1013,15 @@ class SmsCommunicatorPlugin @Inject constructor(
                     commandQueue.bolus(detailedBolusInfo, object : Callback() {
                         override fun run() {
                             if (result.success) {
-                                var replyText = rh.gs(R.string.smscommunicator_carbs_set, anInteger)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
-                                sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                                sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_carbs_set, anInteger), true)
                                 uel.log(
                                     Action.CARBS, Sources.SMS, activePlugin.activePump.shortStatus(true) + ": " + rh.gs(R.string.smscommunicator_carbs_set, anInteger),
                                     ValueWithUnit.Gram(anInteger ?: 0)
                                 )
                             } else {
                                 var replyText = rh.gs(R.string.smscommunicator_carbs_failed, anInteger)
-                                replyText += "\n" + activePlugin.activePump.shortStatus(true)
+                                if (sp.getBoolean(R.string.smscommunicator_add_pump_status, true))
+                                    replyText += "\n" + activePlugin.activePump.shortStatus(true)
                                 sendSMS(Sms(receivedSms.phoneNumber, replyText))
                                 uel.log(
                                     Action.CARBS, Sources.SMS, activePlugin.activePump.shortStatus(true) + ": " + rh.gs(R.string.smscommunicator_carbs_failed, anInteger),
@@ -1101,8 +1101,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                                     aapsLogger.error(LTag.DATABASE, "Error while saving temporary target", it)
                                 })
                     val ttString = if (units == GlucoseUnit.MMOL) DecimalFormatter.to1Decimal(tt) else DecimalFormatter.to0Decimal(tt)
-                    val replyText = rh.gs(R.string.smscommunicator_tt_set, ttString, ttDuration)
-                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                    sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_tt_set, ttString, ttDuration))
                     uel.log(
                         Action.TT, Sources.SMS,
                         ValueWithUnit.fromGlucoseUnit(tt, units.asText),
@@ -1122,8 +1121,7 @@ class SmsCommunicatorPlugin @Inject constructor(
                                    }, {
                                        aapsLogger.error(LTag.DATABASE, "Error while saving temporary target", it)
                                    })
-                    val replyText = rh.gs(R.string.smscommunicator_tt_canceled)
-                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                    sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_tt_canceled))
                     uel.log(
                         Action.CANCEL_TT, Sources.SMS, rh.gs(R.string.smscommunicator_tt_canceled),
                         ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_tt_canceled))
@@ -1144,8 +1142,7 @@ class SmsCommunicatorPlugin @Inject constructor(
             messageToConfirm = AuthRequest(injector, receivedSms, reply, passCode, object : SmsAction(pumpCommand = false) {
                 override fun run() {
                     sp.putBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)
-                    val replyText = rh.gs(R.string.smscommunicator_stopped_sms)
-                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                    sendReport(receivedSms.phoneNumber, rh.gs(R.string.smscommunicator_stopped_sms))
                     uel.log(
                         Action.STOP_SMS, Sources.SMS, rh.gs(R.string.smscommunicator_stopped_sms),
                         ValueWithUnit.SimpleString(rh.gsNotLocalised(R.string.smscommunicator_stopped_sms))
@@ -1165,8 +1162,9 @@ class SmsCommunicatorPlugin @Inject constructor(
                 override fun run() {
                     val result = xDripBroadcast.sendCalibration(aDouble!!)
                     val replyText =
-                        if (result) rh.gs(R.string.smscommunicator_calibration_sent) else rh.gs(R.string.smscommunicator_calibration_failed)
-                    sendSMSToAllNumbers(Sms(receivedSms.phoneNumber, replyText))
+                        if (result) rh.gs(R.string.smscommunicator_calibration_sent)
+                        else rh.gs(R.string.smscommunicator_calibration_failed)
+                    sendReport(receivedSms.phoneNumber, replyText)
                     if (result)
                         uel.log(
                             Action.CALIBRATION, Sources.SMS, rh.gs(R.string.smscommunicator_calibration_sent),
@@ -1195,6 +1193,15 @@ class SmsCommunicatorPlugin @Inject constructor(
         for (number in allowedNumbers) {
             sendSMS(Sms(sms, number))
         }
+    }
+
+    private fun sendReport(senderNumber: String, replyText: String, tryAddingPumpStatus: Boolean = false) {
+        val message =
+            if (tryAddingPumpStatus && sp.getBoolean(R.string.key_smscommunicator_add_pump_status, true)) replyText + "\n" + activePlugin.activePump.shortStatus(true)
+            else replyText
+        val sms = Sms(senderNumber, message)
+        if (sp.getBoolean(R.string.key_smscommunicator_report_to_all, true)) sendSMSToAllNumbers(sms)
+        else sendSMS(sms)
     }
 
     override fun sendSMS(sms: Sms): Boolean {

--- a/plugins/main/src/main/res/values/strings.xml
+++ b/plugins/main/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="key_smscommunicator_remote_bolus_min_distance" translatable="false">smscommunicator_remotebolusmindistance</string>
     <string name="key_smscommunicator_allowednumbers" translatable="false">smscommunicator_allowednumbers</string>
     <string name="key_smscommunicator_remote_commands_allowed" translatable="false">smscommunicator_remotecommandsallowed</string>
+    <string name="key_smscommunicator_add_pump_status" translatable="false">smscommunicator_addpumpstatus</string>
+    <string name="key_smscommunicator_report_to_all" translatable="false">smscommunicator_reporttoall</string>
 
     <string name="smscommunicator">SMS Communicator</string>
     <string name="smscommunicator_shortname">SMS</string>
@@ -52,6 +54,9 @@
     <string name="smscommunicator_tt_set">Target %1$s for %2$d minutes set successfully</string>
     <string name="smscommunicator_tt_canceled">Temp Target canceled successfully</string>
     <string name="smscommunicator_remote_commands_allowed">Allow remote commands via SMS</string>
+    <string name="smscommunicator_add_pump_status">Add pump status to report message</string>
+    <string name="smscommunicator_report_to_all">Send report to all</string>
+    <string name="smscommunicator_report_to_all_summary">Disabling this option will send successful command report to sender only</string>
     <string name="smscommunicator_loop_has_been_disabled">Loop has been disabled</string>
     <string name="smscommunicator_loop_has_been_enabled">Loop has been enabled</string>
     <string name="smscommunicator_loop_is_enabled">Loop is enabled</string>

--- a/plugins/main/src/main/res/xml/pref_smscommunicator.xml
+++ b/plugins/main/src/main/res/xml/pref_smscommunicator.xml
@@ -19,6 +19,17 @@
             android:key="@string/key_smscommunicator_remote_commands_allowed"
             android:title="@string/smscommunicator_remote_commands_allowed" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_smscommunicator_add_pump_status"
+            android:title="@string/smscommunicator_add_pump_status" />
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_smscommunicator_report_to_all"
+            android:title="@string/smscommunicator_report_to_all"
+            android:summary="@string/smscommunicator_report_to_all_summary"/>
+
         <info.nightscout.core.validators.ValidatingEditTextPreference
             android:defaultValue="15"
             android:key="@string/key_smscommunicator_remote_bolus_min_distance"


### PR DESCRIPTION
fixes #2257 

1. made pump status optional in successful reply messages. by default it is added to keep current behaviour unchanhed
2. added an option to send successful reply messages only to comand sender. defaults to false to maintain current behaviour