### PR TITLE
Average smoothing

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/di/PluginsListModule.kt
+++ b/app/src/main/java/info/nightscout/androidaps/di/PluginsListModule.kt
@@ -52,6 +52,7 @@ import info.nightscout.sensitivity.SensitivityAAPSPlugin
 import info.nightscout.sensitivity.SensitivityOref1Plugin
 import info.nightscout.sensitivity.SensitivityWeightedAveragePlugin
 import info.nightscout.smoothing.ExponentialSmoothingPlugin
+import info.nightscout.smoothing.AvgSmoothingPlugin
 import info.nightscout.smoothing.NoSmoothingPlugin
 import info.nightscout.source.AidexPlugin
 import info.nightscout.source.DexcomPlugin
@@ -447,6 +448,12 @@ abstract class PluginsListModule {
     @IntoMap
     @IntKey(605)
     abstract fun bindExponentialSmoothingPlugin(plugin: ExponentialSmoothingPlugin): PluginBase
+
+    @Binds
+    @AllConfigs
+    @IntoMap
+    @IntKey(610)
+    abstract fun bindAvgSmoothingPlugin(plugin: AvgSmoothingPlugin): PluginBase
 
     @Qualifier
     annotation class AllConfigs

--- a/plugins/smoothing/src/main/java/info/nightscout/smoothing/AvgSmoothingPlugin.kt
+++ b/plugins/smoothing/src/main/java/info/nightscout/smoothing/AvgSmoothingPlugin.kt
@@ -1,0 +1,60 @@
+package info.nightscout.smoothing
+
+import dagger.android.HasAndroidInjector
+import info.nightscout.androidaps.annotations.OpenForTesting
+import info.nightscout.interfaces.iob.InMemoryGlucoseValue
+import info.nightscout.interfaces.plugin.PluginBase
+import info.nightscout.interfaces.plugin.PluginDescription
+import info.nightscout.interfaces.plugin.PluginType
+import info.nightscout.interfaces.smoothing.Smoothing
+import info.nightscout.rx.logging.AAPSLogger
+import info.nightscout.shared.interfaces.ResourceHelper
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.max
+import kotlin.math.round
+
+@OpenForTesting
+@Singleton
+class AvgSmoothingPlugin @Inject constructor(
+    injector: HasAndroidInjector,
+    aapsLogger: AAPSLogger,
+    rh: ResourceHelper
+) : PluginBase(
+    PluginDescription()
+        .mainType(PluginType.SMOOTHING)
+        .pluginIcon(info.nightscout.core.ui.R.drawable.ic_timeline_24)
+        .pluginName(R.string.avg_smoothing_name)
+        .shortName(R.string.smoothing_shortname)
+        .description(R.string.description_avg_smoothing),
+    aapsLogger, rh, injector
+), Smoothing {
+
+    @Suppress("LocalVariableName")
+    override fun smooth(data: MutableList<InMemoryGlucoseValue>): MutableList<InMemoryGlucoseValue> {
+
+        for (i in data.lastIndex -1 downTo 1) {
+            // TODO: Bucketed is always calculated to 5 min (CHECK!), Maybe add a separate timecheck?
+            // TODO: We could further improve this by adding a weight to the neighbours
+            if (isValid(data[i].value) && isValid(data[i - 1].value) && isValid(data[i + 1].value))
+            {
+                var result = ((data[i - 1].value + data[i].value + data[i + 1].value) / 3.0)
+                data[i].smoothed = result
+                aapsLogger.debug("RESULT $result")
+            }
+            else
+            {
+                // TODO: Decide what to do here
+                data[i].smoothed = data[i].value
+            }
+        }
+
+        // append data we cannot smooth
+        data[data.lastIndex].smoothed = data[data.lastIndex].value
+        data[0].smoothed = data[0].value
+        return data
+    }
+    private fun isValid(n: Double): Boolean {
+        return n > 39 && n < 401
+    }
+}

--- a/plugins/smoothing/src/main/java/info/nightscout/smoothing/AvgSmoothingPlugin.kt
+++ b/plugins/smoothing/src/main/java/info/nightscout/smoothing/AvgSmoothingPlugin.kt
@@ -34,6 +34,11 @@ class AvgSmoothingPlugin @Inject constructor(
 
     @Suppress("LocalVariableName")
     override fun smooth(data: MutableList<InMemoryGlucoseValue>): MutableList<InMemoryGlucoseValue> {
+        if (data.lastIndex < 4)
+        {
+            aapsLogger.debug(LTag.GLUCOSE, "Not enough value's to smooth!")
+            return data
+        }
 
         for (i in data.lastIndex -1 downTo 1) {            
             // Check if value's are in a valid range

--- a/plugins/smoothing/src/main/res/values/strings.xml
+++ b/plugins/smoothing/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="exponential_smoothing_name">Exponential smoothing</string>
     <string name="description_exponential_smoothing">"Second-order exponential smoothing algorithm"</string>
     <string name="avg_smoothing_name">Average smoothing</string>
-    <string name="description_avg_smoothing">"(Weighted) Average smoothing, newest data is not affected"</string>
+    <string name="description_avg_smoothing">"Average smoothing algorithm, newest value is not affected"</string>
     <string name="no_smoothing_name">No smoothing</string>
     <string name="description_no_smoothing">"No smoothing performed on input glucose data"</string>
 </resources>

--- a/plugins/smoothing/src/main/res/values/strings.xml
+++ b/plugins/smoothing/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="smoothing_shortname">SMOOTH</string>
     <string name="exponential_smoothing_name">Exponential smoothing</string>
     <string name="description_exponential_smoothing">"Second-order exponential smoothing algorithm"</string>
+    <string name="avg_smoothing_name">Average smoothing</string>
+    <string name="description_avg_smoothing">"(Weighted) Average smoothing, newest data is not affected"</string>
     <string name="no_smoothing_name">No smoothing</string>
     <string name="description_no_smoothing">"No smoothing performed on input glucose data"</string>
 </resources>


### PR DESCRIPTION
This algorithm is inspired by the (back) smoothing algorithm that is present in BYODA. 
It is really simple but effective. And less aggressive compared to the exponential smoothing. For dexcom G6 sensors which are not older then 10 days or faulty this is mostly enough. I think it would be a nice addition for AAPS smoothing options

This method only works reliably if the data is evenly spaced, luckily before the data enters this plugin it is already checked if the value's are 5 minutes apart. But for future integrations it is checked anyway.