### PR TITLE
Carry over changes from comboctl ; disable pairing UI when BT permissions are not granted

### DIFF
--- a/pump/combov2/README.md
+++ b/pump/combov2/README.md
@@ -146,6 +146,10 @@ is much simpler, and builds ComboCtl as a kotlin-android project, not a Kotlin M
 This simplifies integration into AndroidAPS, and avoids multiplatform problems (after all,
 Kotlin Multiplatform is still marked as an alpha version feature).
 
+The `comboctl/src/androidMain/AndroidManifest.xml` file also differs in that the `ComboCtl` version
+contains `package="info.nightscout.comboctl.android"` in its `<manifest>` tag, while the AndroidAPS
+version doesn't.
+
 When updating ComboCtl, it is important to keep these differences in mind.
 
 Differences between the copy in `comboctl/` and the original ComboCtl code must be kept as little

--- a/pump/combov2/comboctl/src/androidMain/kotlin/info/nightscout/comboctl/android/AndroidBluetoothDevice.kt
+++ b/pump/combov2/comboctl/src/androidMain/kotlin/info/nightscout/comboctl/android/AndroidBluetoothDevice.kt
@@ -1,8 +1,5 @@
 package info.nightscout.comboctl.android
 
-import android.bluetooth.BluetoothAdapter as SystemBluetoothAdapter
-import android.bluetooth.BluetoothDevice as SystemBluetoothDevice
-import android.bluetooth.BluetoothSocket as SystemBluetoothSocket
 import android.content.Context
 import info.nightscout.comboctl.base.BluetoothAddress
 import info.nightscout.comboctl.base.BluetoothDevice
@@ -12,11 +9,14 @@ import info.nightscout.comboctl.base.ComboIOException
 import info.nightscout.comboctl.base.LogLevel
 import info.nightscout.comboctl.base.Logger
 import info.nightscout.comboctl.utils.retryBlocking
+import kotlinx.coroutines.Dispatchers
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.Locale
-import kotlinx.coroutines.Dispatchers
+import android.bluetooth.BluetoothAdapter as SystemBluetoothAdapter
+import android.bluetooth.BluetoothDevice as SystemBluetoothDevice
+import android.bluetooth.BluetoothSocket as SystemBluetoothSocket
 
 private val logger = Logger.get("AndroidBluetoothDevice")
 

--- a/pump/combov2/comboctl/src/androidMain/kotlin/info/nightscout/comboctl/android/AndroidBluetoothInterface.kt
+++ b/pump/combov2/comboctl/src/androidMain/kotlin/info/nightscout/comboctl/android/AndroidBluetoothInterface.kt
@@ -1,11 +1,6 @@
 package info.nightscout.comboctl.android
 
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter as SystemBluetoothAdapter
-import android.bluetooth.BluetoothDevice as SystemBluetoothDevice
-import android.bluetooth.BluetoothManager as SystemBluetoothManager
-import android.bluetooth.BluetoothServerSocket as SystemBluetoothServerSocket
-import android.bluetooth.BluetoothSocket as SystemBluetoothSocket
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -20,6 +15,11 @@ import info.nightscout.comboctl.base.toBluetoothAddress
 import java.io.IOException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.thread
+import android.bluetooth.BluetoothAdapter as SystemBluetoothAdapter
+import android.bluetooth.BluetoothDevice as SystemBluetoothDevice
+import android.bluetooth.BluetoothManager as SystemBluetoothManager
+import android.bluetooth.BluetoothServerSocket as SystemBluetoothServerSocket
+import android.bluetooth.BluetoothSocket as SystemBluetoothSocket
 
 private val logger = Logger.get("AndroidBluetoothInterface")
 

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/ApplicationLayer.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/ApplicationLayer.kt
@@ -524,14 +524,18 @@ object ApplicationLayer {
     )
 
     /**
-     * Possible bolus types used in COMMAND mode commands.
+     * Possible immediate bolus types used in COMMAND mode commands.
+     *
+     * "Immediate" means that the bolus gets delivered immediately once the command is sent.
+     * A standard bolus only has an immediate delivery, an extended bolus has none, and
+     * a multiwave bolus is partially made up of an immediate and an extended delivery.
      */
-    enum class CMDBolusType(val id: Int) {
+    enum class CMDImmediateBolusType(val id: Int) {
         STANDARD(0x47),
         MULTI_WAVE(0xB7);
 
         companion object {
-            private val values = CMDBolusType.values()
+            private val values = CMDImmediateBolusType.values()
             fun fromInt(value: Int) = values.firstOrNull { it.id == value }
         }
     }
@@ -565,7 +569,7 @@ object ApplicationLayer {
      *            "57" means 5.7 IU.
      */
     data class CMDBolusDeliveryStatus(
-        val bolusType: CMDBolusType,
+        val bolusType: CMDImmediateBolusType,
         val deliveryState: CMDBolusDeliveryState,
         val remainingAmount: Int
     )
@@ -1068,7 +1072,7 @@ object ApplicationLayer {
      * @param bolusType The type of the bolus to cancel.
      * @return The produced packet.
      */
-    fun createCMDCancelBolusPacket(bolusType: CMDBolusType) = Packet(
+    fun createCMDCancelBolusPacket(bolusType: CMDImmediateBolusType) = Packet(
         command = Command.CMD_CANCEL_BOLUS,
         payload = byteArrayListOfInts(bolusType.id)
     )
@@ -1477,7 +1481,7 @@ object ApplicationLayer {
         val payload = packet.payload
 
         val bolusTypeInt = payload[2].toPosInt()
-        val bolusType = CMDBolusType.fromInt(bolusTypeInt)
+        val bolusType = CMDImmediateBolusType.fromInt(bolusTypeInt)
             ?: throw PayloadDataCorruptionException(
                 packet,
                 "Invalid bolus type ${bolusTypeInt.toHexString(2, true)}"

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/DisplayFrameAssembler.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/DisplayFrameAssembler.kt
@@ -138,7 +138,7 @@ class DisplayFrameAssembler {
         // frame, this means it contains 8 pixel rows. This in turn means that this
         // layout stores one byte per column. So, the first byte in the display frame row
         // contains the pixels from (x 95 y 0) to (x 95 y 7). The second byte contains
-        // pixels from (x 94 y 0) to (x 94 y 7) etc. 
+        // pixels from (x 94 y 0) to (x 94 y 7) etc.
         for (row in 0 until 4) {
             val rtDisplayFrameRow = rtDisplayFrameRows[row]!!
             for (column in 0 until DISPLAY_FRAME_WIDTH) {

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/ProgressReporter.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/ProgressReporter.kt
@@ -1,8 +1,8 @@
 package info.nightscout.comboctl.base
 
-import kotlin.reflect.KClassifier
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlin.reflect.KClassifier
 
 private val logger = Logger.get("Pump")
 

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/PumpIO.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/PumpIO.kt
@@ -1038,7 +1038,7 @@ class PumpIO(
         // TODO: Test that this function does the expected thing
         // when no bolus is actually ongoing.
         val packet = sendPacketWithResponse(
-            ApplicationLayer.createCMDCancelBolusPacket(ApplicationLayer.CMDBolusType.STANDARD),
+            ApplicationLayer.createCMDCancelBolusPacket(ApplicationLayer.CMDImmediateBolusType.STANDARD),
             ApplicationLayer.Command.CMD_CANCEL_BOLUS_RESPONSE
         )
 

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/PumpIO.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/PumpIO.kt
@@ -1012,11 +1012,29 @@ class PumpIO(
      *   of a packet's payload does not match the expected size.
      * @throws ComboIOException if IO with the pump fails.
      */
-    suspend fun deliverCMDStandardBolus(bolusAmount: Int): Boolean =
+    suspend fun deliverCMDStandardBolus(totalBolusAmount: Int): Boolean =
+        deliverCMDStandardBolus(
+            totalBolusAmount,
+            immediateBolusAmount = 0,
+            durationInMinutes = 0,
+            bolusType = ApplicationLayer.CMDDeliverBolusType.STANDARD_BOLUS
+        )
+
+    suspend fun deliverCMDStandardBolus(
+        totalBolusAmount: Int,
+        immediateBolusAmount: Int,
+        durationInMinutes: Int,
+        bolusType: ApplicationLayer.CMDDeliverBolusType
+    ): Boolean =
         runPumpIOCall("deliver standard bolus", Mode.COMMAND) {
 
         val packet = sendPacketWithResponse(
-            ApplicationLayer.createCMDDeliverBolusPacket(bolusAmount),
+            ApplicationLayer.createCMDDeliverBolusPacket(
+                totalBolusAmount,
+                immediateBolusAmount,
+                durationInMinutes,
+                bolusType
+            ),
             ApplicationLayer.Command.CMD_DELIVER_BOLUS_RESPONSE
         )
 

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/Utility.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/base/Utility.kt
@@ -1,11 +1,11 @@
 package info.nightscout.comboctl.base
 
-import kotlin.math.max
-import kotlin.math.min
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.atTime
+import kotlin.math.max
+import kotlin.math.min
 
 // Utility function for cases when only the time and no date is known.
 // monthNumber and dayOfMonth are set to 1 instead of 0 since 0 is

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/Pump.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/Pump.kt
@@ -29,10 +29,6 @@ import info.nightscout.comboctl.parser.BatteryState
 import info.nightscout.comboctl.parser.MainScreenContent
 import info.nightscout.comboctl.parser.ParsedScreen
 import info.nightscout.comboctl.parser.ReservoirState
-import kotlin.math.absoluteValue
-import kotlin.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
@@ -53,6 +49,10 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.offsetAt
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.math.absoluteValue
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 private val logger = Logger.get("Pump")
 
@@ -1747,7 +1747,10 @@ class Pump(
             // the button, meaning that it will always press the button at least initially,
             // moving to entry #2 in the TDD history. Thus, if we don't look at the screen now,
             // we miss entry #1, which is the current day.
-            val firstTDDScreen = navigateToRTScreen(rtNavigationContext, ParsedScreen.MyDataDailyTotalsScreen::class, pumpSuspended) as ParsedScreen.MyDataDailyTotalsScreen
+            val firstTDDScreen = navigateToRTScreen(
+                rtNavigationContext,
+                ParsedScreen.MyDataDailyTotalsScreen::class,
+                pumpSuspended) as ParsedScreen.MyDataDailyTotalsScreen
             processTDDScreen(firstTDDScreen)
 
             longPressRTButtonUntil(rtNavigationContext, RTNavigationButton.DOWN) { parsedScreen ->
@@ -2523,7 +2526,8 @@ class Pump(
                         val expectedCurrentTbrPercentage = currentTbrState.tbr.percentage
                         val actualCurrentTbrPercentage = status.tbrPercentage
                         val elapsedTimeSinceTbrStart = now - currentTbrState.tbr.timestamp
-                        val expectedRemainingDurationInMinutes = currentTbrState.tbr.durationInMinutes - elapsedTimeSinceTbrStart.inWholeMinutes.toInt()
+                        val expectedRemainingDurationInMinutes =
+                            currentTbrState.tbr.durationInMinutes - elapsedTimeSinceTbrStart.inWholeMinutes.toInt()
                         val actualRemainingDurationInMinutes = status.remainingTbrDurationInMinutes
 
                         // The remaining duration check uses a tolerance range of 10 minutes, since
@@ -2765,7 +2769,8 @@ class Pump(
 
                 numRetrievedFactors++
                 logger(LogLevel.DEBUG) {
-                    "Got basal profile factor #$factorIndexOnScreen : $factor; $numRetrievedFactors factor(s) read and $numObservedScreens screen(s) observed thus far"
+                    "Got basal profile factor #$factorIndexOnScreen : $factor; $numRetrievedFactors " +
+                    "factor(s) read and $numObservedScreens screen(s) observed thus far"
                 }
 
                 getBasalProfileReporter.setCurrentProgressStage(

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/RTNavigation.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/RTNavigation.kt
@@ -1004,7 +1004,9 @@ suspend fun navigateToRTScreen(
         // when remaining TBR duration is shown on the main screen and the
         // duration happens to change during this loop. If this occurs,
         // skip the redundant screen.
-        if ((previousScreenType != null) && (previousScreenType == parsedScreen::class)) {
+        if ((parsedScreen::class != ParsedScreen.UnrecognizedScreen::class) &&
+            (previousScreenType != null) &&
+            (previousScreenType == parsedScreen::class)) {
             logger(LogLevel.DEBUG) { "Got a screen of the same type ${parsedScreen::class}; skipping" }
             continue
         }

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/RTNavigation.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/main/RTNavigation.kt
@@ -422,7 +422,7 @@ suspend fun longPressRTButtonUntil(
         // that is documented in TransportLayer.IO.sendInternal().)
         val elapsedTime = getElapsedTimeInMs() - timestampBeforeDisplayFrameRetrieval
         if (elapsedTime < MINIMUM_WAIT_PERIOD_DURING_LONG_RT_BUTTON_PRESS_IN_MS) {
-            val waitingPeriodInMs =  MINIMUM_WAIT_PERIOD_DURING_LONG_RT_BUTTON_PRESS_IN_MS - elapsedTime
+            val waitingPeriodInMs = MINIMUM_WAIT_PERIOD_DURING_LONG_RT_BUTTON_PRESS_IN_MS - elapsedTime
             logger(LogLevel.VERBOSE) { "Waiting $waitingPeriodInMs milliseconds before continuing button long-press" }
             delay(timeMillis = waitingPeriodInMs)
         }
@@ -449,8 +449,7 @@ suspend fun longPressRTButtonUntil(
             // Record the screen we just saw so we can return it.
             lastParsedScreen = parsedScreen
             return@startLongButtonPress false
-        }
-        else
+        } else
             return@startLongButtonPress true
     }
 

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/parser/Parser.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/parser/Parser.kt
@@ -1416,7 +1416,7 @@ class ExtendedAndMultiwaveBolusMainScreenParser : Parser() {
         }
 
         val batteryState = batteryStateFromSymbol(
-            if (parseResult.size >= 7) parseResult.valueAt<Glyph.SmallSymbol>(5).symbol else null
+            if (parseResult.size >= 7) parseResult.valueAt<Glyph.SmallSymbol>(6).symbol else null
         )
 
         val remainingBolusDuration = parseResult.valueAt<LocalDateTime>(0)

--- a/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/parser/Parser.kt
+++ b/pump/combov2/comboctl/src/commonMain/kotlin/info/nightscout/comboctl/parser/Parser.kt
@@ -4,10 +4,10 @@ import info.nightscout.comboctl.base.ComboException
 import info.nightscout.comboctl.base.DisplayFrame
 import info.nightscout.comboctl.base.combinedDateTime
 import info.nightscout.comboctl.base.timeWithoutDate
-import kotlin.reflect.KClassifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.atTime
+import kotlin.reflect.KClassifier
 
 /*****************************************
  *** Screen and screen content classes ***

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PairingSessionTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PairingSessionTest.kt
@@ -3,11 +3,11 @@ package info.nightscout.comboctl.base
 import info.nightscout.comboctl.base.testUtils.TestBluetoothDevice
 import info.nightscout.comboctl.base.testUtils.TestPumpStateStore
 import info.nightscout.comboctl.base.testUtils.runBlockingWithWatchdog
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.channels.Channel
 
 class PairingSessionTest {
     enum class PacketDirection {

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PumpIOTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PumpIOTest.kt
@@ -7,12 +7,12 @@ import info.nightscout.comboctl.base.testUtils.TestRefPacketItem
 import info.nightscout.comboctl.base.testUtils.checkTestPacketSequence
 import info.nightscout.comboctl.base.testUtils.produceTpLayerPacket
 import info.nightscout.comboctl.base.testUtils.runBlockingWithWatchdog
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.UtcOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PumpIOTest {
     // Common test code.

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PumpIOTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/PumpIOTest.kt
@@ -599,23 +599,23 @@ class PumpIOTest {
                 ApplicationLayer.CMDHistoryEvent(
                     LocalDateTime(year = 2021, monthNumber = 2, dayOfMonth = 9, hour = 17, minute = 0, second = 19),
                     80666,
-                    ApplicationLayer.CMDHistoryEventDetail.ExtendedBolusStarted(177, 15)
+                    ApplicationLayer.CMDHistoryEventDetail.ExtendedBolusStarted(177, 15, true)
                 ),
                 ApplicationLayer.CMDHistoryEvent(
                     LocalDateTime(year = 2021, monthNumber = 2, dayOfMonth = 9, hour = 17, minute = 15, second = 18),
                     80668,
-                    ApplicationLayer.CMDHistoryEventDetail.ExtendedBolusEnded(177, 15)
+                    ApplicationLayer.CMDHistoryEventDetail.ExtendedBolusEnded(177, 15, true)
                 ),
 
                 ApplicationLayer.CMDHistoryEvent(
                     LocalDateTime(year = 2021, monthNumber = 2, dayOfMonth = 9, hour = 17, minute = 21, second = 31),
                     80670,
-                    ApplicationLayer.CMDHistoryEventDetail.MultiwaveBolusStarted(193, 37, 30)
+                    ApplicationLayer.CMDHistoryEventDetail.MultiwaveBolusStarted(193, 37, 30, true)
                 ),
                 ApplicationLayer.CMDHistoryEvent(
                     LocalDateTime(year = 2021, monthNumber = 2, dayOfMonth = 9, hour = 17, minute = 51, second = 8),
                     80672,
-                    ApplicationLayer.CMDHistoryEventDetail.MultiwaveBolusEnded(193, 37, 30)
+                    ApplicationLayer.CMDHistoryEventDetail.MultiwaveBolusEnded(193, 37, 30, true)
                 ),
 
                 ApplicationLayer.CMDHistoryEvent(

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/TransportLayerTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/TransportLayerTest.kt
@@ -5,6 +5,8 @@ import info.nightscout.comboctl.base.testUtils.TestPumpStateStore
 import info.nightscout.comboctl.base.testUtils.WatchdogTimeoutException
 import info.nightscout.comboctl.base.testUtils.coroutineScopeWithWatchdog
 import info.nightscout.comboctl.base.testUtils.runBlockingWithWatchdog
+import kotlinx.coroutines.Job
+import kotlinx.datetime.UtcOffset
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -13,8 +15,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.Job
-import kotlinx.datetime.UtcOffset
 
 class TransportLayerTest {
     @Test

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/TestBluetoothDevice.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/TestBluetoothDevice.kt
@@ -4,7 +4,6 @@ import info.nightscout.comboctl.base.BluetoothAddress
 import info.nightscout.comboctl.base.BluetoothDevice
 import info.nightscout.comboctl.base.ComboFrameParser
 import info.nightscout.comboctl.base.ComboIO
-import info.nightscout.comboctl.base.ProgressReporter
 import info.nightscout.comboctl.base.byteArrayListOfInts
 import info.nightscout.comboctl.base.toComboFrame
 import kotlinx.coroutines.CoroutineScope

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/TestComboIO.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/TestComboIO.kt
@@ -6,8 +6,8 @@ import info.nightscout.comboctl.base.ComboIO
 import info.nightscout.comboctl.base.TransportLayer
 import info.nightscout.comboctl.base.byteArrayListOfInts
 import info.nightscout.comboctl.base.toTransportLayerPacket
-import kotlin.test.assertNotNull
 import kotlinx.coroutines.channels.Channel
+import kotlin.test.assertNotNull
 
 class TestComboIO : ComboIO {
     val sentPacketData = newTestPacketSequence()

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/UtilityFunctions.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/base/testUtils/UtilityFunctions.kt
@@ -4,14 +4,14 @@ import info.nightscout.comboctl.base.Cipher
 import info.nightscout.comboctl.base.ComboException
 import info.nightscout.comboctl.base.Nonce
 import info.nightscout.comboctl.base.TransportLayer
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.fail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.fail
 
 // Utility function to combine runBlocking() with a watchdog.
 // A coroutine is started with runBlocking(), and inside that

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/main/ParsedDisplayFrameStreamTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/main/ParsedDisplayFrameStreamTest.kt
@@ -20,17 +20,17 @@ import info.nightscout.comboctl.parser.testFrameW6CancelTbrWarningScreen
 import info.nightscout.comboctl.parser.testTimeAndDateSettingsHourPolishScreen
 import info.nightscout.comboctl.parser.testTimeAndDateSettingsHourRussianScreen
 import info.nightscout.comboctl.parser.testTimeAndDateSettingsHourTurkishScreen
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.BeforeAll
 
 class ParsedDisplayFrameStreamTest {
     companion object {

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/main/RTNavigationTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/main/RTNavigationTest.kt
@@ -13,13 +13,6 @@ import info.nightscout.comboctl.parser.MainScreenContent
 import info.nightscout.comboctl.parser.ParsedScreen
 import info.nightscout.comboctl.parser.Quickinfo
 import info.nightscout.comboctl.parser.ReservoirState
-import kotlin.reflect.KClassifier
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -29,7 +22,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
 import org.junit.jupiter.api.BeforeAll
+import kotlin.reflect.KClassifier
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class RTNavigationTest {
     /* RTNavigationContext implementation for testing out RTNavigation functionality.
@@ -360,7 +360,6 @@ class RTNavigationTest {
             decrementButton = RTNavigationButton.DOWN
         )
         assertEquals(Pair(0, RTNavigationButton.CHECK), result)
-
     }
 
     @Test

--- a/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/parser/ParserTest.kt
+++ b/pump/combov2/comboctl/src/jvmTest/kotlin/info/nightscout/comboctl/parser/ParserTest.kt
@@ -2,12 +2,12 @@ package info.nightscout.comboctl.parser
 
 import info.nightscout.comboctl.base.DisplayFrame
 import info.nightscout.comboctl.base.timeWithoutDate
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.fail
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
 
 class ParserTest {
     class TestContext(displayFrame: DisplayFrame, tokenOffset: Int, skipTitleString: Boolean = false, parseTopLeftTime: Boolean = false) {

--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Fragment.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Fragment.kt
@@ -81,7 +81,7 @@ class ComboV2Fragment : DaggerFragment() {
                                         else
                                             rh.gs(R.string.combov2_cancelling_tbr)
                                     is ComboCtlPump.DeliveringBolusCommandDesc ->
-                                        rh.gs(R.string.combov2_delivering_bolus_cmddesc, desc.bolusAmount.cctlBolusToIU())
+                                        rh.gs(R.string.combov2_delivering_bolus_cmddesc, desc.immediateBolusAmount.cctlBolusToIU())
                                     is ComboCtlPump.FetchingTDDHistoryCommandDesc ->
                                         rh.gs(R.string.combov2_fetching_tdd_history_cmddesc)
                                     is ComboCtlPump.UpdatingPumpDateTimeCommandDesc ->

--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Plugin.kt
@@ -1768,8 +1768,8 @@ class ComboV2Plugin @Inject constructor (
                                 is RTCommandProgressStage.DeliveringBolus ->
                                     rh.gs(
                                         R.string.combov2_delivering_bolus,
-                                        stage.deliveredAmount.cctlBolusToIU(),
-                                        stage.totalAmount.cctlBolusToIU()
+                                        stage.deliveredImmediateAmount .cctlBolusToIU(),
+                                        stage.totalImmediateAmount.cctlBolusToIU()
                                     )
                                 else -> ""
                             }

--- a/pump/combov2/src/main/res/layout/combov2_pairing_activity.xml
+++ b/pump/combov2/src/main/res/layout/combov2_pairing_activity.xml
@@ -42,6 +42,43 @@
         </androidx.appcompat.widget.LinearLayoutCompat>
 
         <ScrollView
+            android:id="@+id/combov2_pairing_section_cannot_pair_driver_not_initialized"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp"
+                    android:singleLine="false"
+                    android:text="@string/combov2_cannot_pair_driver_not_initialized_explanation"
+                    android:textSize="16sp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="horizontal">
+
+                    <Button
+                        android:id="@+id/combov2_cannot_pair_go_back"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/combov2_go_back" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </ScrollView>
+
+        <ScrollView
             android:id="@+id/combov2_pairing_section_initial"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/pump/combov2/src/main/res/values/strings.xml
+++ b/pump/combov2/src/main/res/values/strings.xml
@@ -137,4 +137,6 @@ buttons at the same time to cancel pairing)\n
     <string name="combov2_dst_ended">Daylight savings time (DST) ended</string>
     <string name="combov2_cannot_connect_pump_error_observed">Cannot connect to pump because the pump reported an error. User must handle the error and then either wait 5 minutes or press the Refresh button in the driver tab.</string>
     <string name="combov2_refresh_pump_status_after_error">Refreshing pump status after the pump reported an error</string>
+    <string name="combov2_go_back">Go back</string>
+    <string name="combov2_cannot_pair_driver_not_initialized_explanation">Cannot perform pairing because the driver is not initialized. This typically happens because the necessary Bluetooth permissions have not been granted. Go back, grant the Bluetooth permissions, then try again to pair.</string>
 </resources>


### PR DESCRIPTION
[ComboCtl](https://github.com/dv1/ComboCtl) was recently updated. AAPS contains a copy. This carries over the recent changes to keep the copy in sync. Major changes:

* ComboCtl now supports extended and multiwave boluses. These are not yet integrated in AAPS. They may be integrated in the future for pumpcontrol builds for example.
* If Bluetooth permission are not granted, and users try regardless to pair with a pump, AAPS crashes. This is essentially undefined behavior because the driver is not initialized yet. Fix by adding a special UI that is active in this particular case and which replaces the regular pairing UI controls.
* Fix an RT navigation freeze that happens when an unrecognized screen is encountered.