### PR TITLE
Group "About Screen" strings in UI strings file inc. one from combo strings file

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
+++ b/app/src/main/java/info/nightscout/androidaps/MainActivity.kt
@@ -347,8 +347,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
                 message += "${rh.gs(info.nightscout.configuration.R.string.configbuilder_nightscoutversion_label)} ${activePlugin.activeNsClient?.detectedNsVersion() ?: rh.gs(info.nightscout.plugins.R.string.not_available_full)}"
                 if (config.isEngineeringMode()) message += "\n${rh.gs(info.nightscout.configuration.R.string.engineering_mode_enabled)}"
                 if (config.isUnfinishedMode()) message += "\nUnfinished mode enabled"
-                if (!fabricPrivacy.fabricEnabled()) message += "\n${rh.gs(R.string.fabric_upload_disabled)}"
-                message += rh.gs(info.nightscout.pump.combo.R.string.about_link_urls)
+                if (!fabricPrivacy.fabricEnabled()) message += "\n${rh.gs(info.nightscout.core.ui.R.string.fabric_upload_disabled)}"
+                message += rh.gs(info.nightscout.core.ui.R.string.about_link_urls)
                 val messageSpanned = SpannableString(message)
                 Linkify.addLinks(messageSpanned, Linkify.WEB_URLS)
                 MaterialAlertDialogBuilder(this, info.nightscout.core.ui.R.style.DialogTheme)
@@ -356,7 +356,7 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
                     .setIcon(iconsProvider.getIcon())
                     .setMessage(messageSpanned)
                     .setPositiveButton(rh.gs(info.nightscout.core.ui.R.string.ok), null)
-                    .setNeutralButton(rh.gs(R.string.cta_dont_kill_my_app_info)) { _, _ ->
+                    .setNeutralButton(rh.gs(info.nightscout.core.ui.R.string.cta_dont_kill_my_app_info)) { _, _ ->
                         startActivity(
                             Intent(
                                 Intent.ACTION_VIEW,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,8 +78,6 @@
     <string name="chartmenu">Chart menu</string>
     <string name="authorizationfailed">Authorization failed</string>
     <string name="copytolocalprofile_invalid">Unable to create profile. Profile is invalid.</string>
-    <string name="cta_dont_kill_my_app_info">Don\'t kill my app?</string>
-    <string name="fabric_upload_disabled">Crash logs upload disabled!</string>
     <string name="clear_filter">Clear filter</string>
     <string name="cannula">Cannula</string>
     <string name="email_address">Email address</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -602,6 +602,11 @@
     <!-- SmsCommunicator -->
     <string name="smscommunicator_missingsmspermission">Missing SMS permission</string>
 
+    <!-- About -->
+    <string name="cta_dont_kill_my_app_info">Don\'t kill my app?</string>
+    <string name="fabric_upload_disabled">Crash logs upload disabled!</string>
+    <string name="about_link_urls">\n\nDocumentation:\nhttps://wiki.aaps.app\n\nFacebook:\nhttps://www.facebook.com/groups/AndroidAPSUsers</string>
+    
     <plurals name="days">
         <item quantity="one">%1$d day</item>
         <item quantity="other">%1$d days</item>

--- a/pump/combo/src/main/res/values/strings.xml
+++ b/pump/combo/src/main/res/values/strings.xml
@@ -46,7 +46,6 @@
     <string name="combo_error_failure_reading_changed_basal_rate">Basal rate changed on pump, but reading it failed</string>
     <string name="combo_activity_checking_for_history_changes">Checking for history changes</string>
     <string name="combo_error_multiple_boluses_with_identical_timestamp">Multiple boluses with the same amount within the same minute were just imported. Only one record could be added to treatments. Please check the pump and manually add a bolus record using the Careportal tab. Make sure to create a bolus with a time no other bolus uses.</string>
-    <string name="about_link_urls">\n\ndocumentation:\nhttps://wiki.aaps.app\n\nfacebook:\nhttps://www.facebook.com/groups/AndroidAPSUsers</string>
     <string name="combo_check_date">The last bolus is older than 24 hours or is in the future. Please check the date on the pump is set correctly.</string>
     <string name="combo_suspious_bolus_time">Time/date of the delivered bolus on pump seems wrong, IOB is likely incorrect. Please check pump time/date.</string>
     <string name="combo_bolus_count">Bolus count</string>


### PR DESCRIPTION
Grouped the "About Screen" strings in the UI strings file
including moving one out of the combo strings file
Capitalised Documentation and Facebook in this string

I didn't move the nightscout version and engineering mode enabled strings due to them being used elsewhere. 

Does Crowdin take care of the translated string movements?