### PR TITLE
[Bugfix] [Wear] digitalstyle Watchface missing digits on timeLastSGV-value - letters to large, so one digit was cut off   -> Update dimens.xml

### DIFF
--- a/wear/src/main/res/values-sw200dp/dimens.xml
+++ b/wear/src/main/res/values-sw200dp/dimens.xml
@@ -15,7 +15,7 @@
     <dimen name="watch_face_big_chart_delta_text_size">29sp</dimen>
     <dimen name="watch_face_digital_svg_text_size">23sp</dimen>
     <dimen name="watch_face_digital_direction_text_size">17sp</dimen>
-    <dimen name="watch_face_digital_timestamp_text_size">14sp</dimen>
+    <dimen name="watch_face_digital_timestamp_text_size">11sp</dimen>
     <dimen name="watch_face_digital_sub_text_size">15sp</dimen>
 
     <dimen name="watch_face_large_svg_text_size">55sp</dimen>


### PR DESCRIPTION
On Fossil Gen 5, the timeLastSGV-Timestamp was drop off, when time is higher as 9 minutes. So the second digit was drop off and "1" was displayed instead "15" min.
