### PR TITLE
[fix] change string to make it clearer what it does

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,7 +351,7 @@
     <string name="pumpsuspended">Pump suspended</string>
     <string name="executing">Executing</string>
     <string name="virtualpump_settings">Virtual pump settings</string>
-    <string name="virtualpump_uploadstatus_title">Upload status to NS</string>
+    <string name="virtualpump_uploadstatus_title">Upload pump status to NS</string>
     <string name="nsclientinternal">NSClient</string>
     <string name="nsclientinternal_shortname">NSCI</string>
     <string name="nsclientinternal_url">URL:</string>


### PR DESCRIPTION
When doing Objective 1, this string was presented without context and it took me more than an hour (and a search through the source code) to figure out what it meant. At first I was searching though the NSClient config, but it is in the pump config. Adding the work "pump" would be a good clue for this. 