### PR TITLE
3.2.0 beta1

### DIFF
--- a/plugins/aps/src/main/assets/OpenAPSSMBDynamicISF/determine-basal.js
+++ b/plugins/aps/src/main/assets/OpenAPSSMBDynamicISF/determine-basal.js
@@ -746,8 +746,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             rT.reason += "Dosing sensitivity: " +future_sens+" using eventual BG;";
          }
          future_sens = round(future_sens,1);
-     } else future_sens = variable_sens
-
+     } else {
+        var future_sens = variable_sens;
+     }
 
     var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average both


### PR DESCRIPTION
Fixed the case where there is no TDD value. Original code didn't declare future_sens as a variable and resulted in an error, plus there was a syntax error after the else that has been fixed. 

Apologies for the multiple commits - wasn't able to squash them for some reason.