### PR TITLE
Dash close gatt on disconnected, Improving connection times

### DIFF
--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
@@ -200,7 +200,8 @@ class Connection(
     // This will be called from a different thread !!!
     override fun onConnectionLost(status: Int) {
         aapsLogger.info(LTag.PUMPBTCOMM, "Lost connection with status: $status")
-        disconnect(false)
+        // This is called from onConnectionStateChange(), meaning BLE is already disconnected, so need to close gatt
+        disconnect(true)
     }
 
     companion object {


### PR DESCRIPTION
The gatt connection was not properly closed on disconnect.
As discussed on discord here: https://discord.com/channels/629952586895851530/866343285294104588/1097589809763057695 Thanks NickB for pointing this out

This change closes the gatt properly when the BLE device is disconnected (triggered by driver or by connection loss)

This improves connection times, from arround 60 seconds to under 5 seconds on the tested phones

Tested on the following devices:
NickB > Pixel 7 pro
jbr7rr > Pixel 6 Pro
emmatovar27 > Pixel 6
nxth4n > Samsung S20+
mountcrg > AtomXL
Robby > S21 5G FE