### PR TITLE
Dash connecting improvements

### DIFF
--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
@@ -56,6 +56,8 @@ class Connection(
 
     private val bluetoothManager: BluetoothManager? = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager?
 
+    private var _connectionWaitCond: ConnectionWaitCondition? = null
+
     @Volatile
     var session: Session? = null
 
@@ -65,6 +67,7 @@ class Connection(
     @Synchronized
     fun connect(connectionWaitCond: ConnectionWaitCondition) {
         aapsLogger.debug("Connecting connectionWaitCond=$connectionWaitCond")
+        _connectionWaitCond = connectionWaitCond
         podState.connectionAttempts++
         podState.bluetoothConnectionState = OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTING
         val autoConnect = false
@@ -80,6 +83,7 @@ class Connection(
         val before = SystemClock.elapsedRealtime()
         if (waitForConnection(connectionWaitCond) !is Connected) {
             podState.bluetoothConnectionState = OmnipodDashPodStateManager.BluetoothConnectionState.DISCONNECTED
+            _connectionWaitCond = null
             throw FailedToConnectException(podDevice.address)
         }
         val waitedMs = SystemClock.elapsedRealtime() - before
@@ -92,6 +96,7 @@ class Connection(
             connectionWaitCond.timeoutMs = newTimeout
         }
         podState.bluetoothConnectionState = OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTED
+        _connectionWaitCond = null
 
         val discoverer = ServiceDiscoverer(aapsLogger, gatt, bleCommCallbacks, this)
         val discovered = discoverer.discoverServices(connectionWaitCond)
@@ -200,7 +205,13 @@ class Connection(
     // This will be called from a different thread !!!
     override fun onConnectionLost(status: Int) {
         aapsLogger.info(LTag.PUMPBTCOMM, "Lost connection with status: $status")
-        // This is called from onConnectionStateChange(), meaning BLE is already disconnected, so need to close gatt
+        // Check if waiting for connection, if so, stop waiting
+        _connectionWaitCond?.stopConnection?.let {
+            if (it.count > 0) {
+                _connectionWaitCond?.stopConnection?.countDown()
+            }
+        }
+        // BLE disconnected, so need to close gatt
         disconnect(true)
     }
 


### PR DESCRIPTION
Following:
https://github.com/nightscout/AndroidAPS/pull/2507

It seems that on some devices closing the gatt increases the likelyhood of getting an error during the connection attempt (we will get the infamous status 133 onConnectionStateChange()

Previously due to the @Synchronized of the connect and disconnect functions, disconnect(true) would be blocked until the timeout expired, and thus timing out the connection.

This change safely stops the waiting on the timer, and disconnects the connection. Allowing for a retry of the connection by the PumpQueue.

@MilosKozak Please consider if this can be merged before release of 3.2.0 or not, Limited testing has been done on this. And the Dash implementation seems to behave very differently on different phones. I think if we have another Beta before release it should be safe to merge as the impact should not be that big, and its mainly a bugfix. However if we wait, please also revert https://github.com/nightscout/AndroidAPS/pull/2507 as these changes go hand in hand. When reverted I will rebase this PR to include https://github.com/nightscout/AndroidAPS/pull/2507