### PR TITLE
Add Colab Support for Building AndroidAPS APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Build APK using Colab 
 
-[![Build APK using Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/robsonvn/AndroidAPS/blob/master/build.ipynb)
+[![Build APK using Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nightscout/AndroidAPS/blob/master/build.ipynb)
 
 [![Support Server](https://img.shields.io/discord/629952586895851530.svg?label=Discord&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.gg/4fQUWHZ4Mw)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 * Check the wiki: https://androidaps.readthedocs.io
 *  Everyone who’s been looping with AndroidAPS needs to fill out the form after 3 days of looping  https://docs.google.com/forms/d/14KcMjlINPMJHVt28MDRupa4sz4DDIooI4SrW0P3HSN8/viewform?c=0&w=1
 
+Build APK using Colab 
+
+[![Build APK using Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/robsonvn/AndroidAPS/blob/master/build.ipynb)
+
 [![Support Server](https://img.shields.io/discord/629952586895851530.svg?label=Discord&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.gg/4fQUWHZ4Mw)
 
 [![CircleCI](https://circleci.com/gh/nightscout/AndroidAPS/tree/master.svg?style=svg)](https://circleci.com/gh/nightscout/AndroidAPS/tree/master)

--- a/build.ipynb
+++ b/build.ipynb
@@ -48,6 +48,11 @@
         "## 5. Changing the Build Branch\n",
         "\n",
         "To build a different branch of the AndroidAAPS application, you can modify the value of the `AAPS_BRANCH` variable in the script. Set the variable to the desired branch name, and the script will build the application from that branch.\n",
+        "## 6. Confirming Terms and Conditions\n",
+        "\n",
+        "Before the build process begins, you will be prompted to confirm that you have read and agreed to the Terms and Conditions. If you have read and agreed to the Terms and Conditions, type 'yes' and the build process will start.\n",
+        "\n",
+        "**Please be patient, as the script will take approximately 30 minutes to complete.**\n",
         "\n",
         "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help.\n"
       ],
@@ -69,7 +74,7 @@
       "metadata": {
         "id": "ZuI2CQXShJJr"
       },
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": []
     },
     {

--- a/build.ipynb
+++ b/build.ipynb
@@ -21,18 +21,6 @@
         "\n",
         "This script is designed to help you build the AndroidAAPS application and save the built APK to your Google Drive. Please follow the instructions below to ensure a smooth process.\n",
         "\n",
-        "- [Spanish](https://translate.google.com/translate?sl=en&tl=es&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Chinese (Simplified)](https://translate.google.com/translate?sl=en&tl=zh-CN&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Chinese (Traditional)](https://translate.google.com/translate?sl=en&tl=zh-TW&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [French](https://translate.google.com/translate?sl=en&tl=fr&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [German](https://translate.google.com/translate?sl=en&tl=de&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Portuguese](https://translate.google.com/translate?sl=en&tl=pt&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Russian](https://translate.google.com/translate?sl=en&tl=ru&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Japanese](https://translate.google.com/translate?sl=en&tl=ja&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Arabic](https://translate.google.com/translate?sl=en&tl=ar&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "- [Hindi](https://translate.google.com/translate?sl=en&tl=hi&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
-        "\n",
-        "\n",
         "## 1. Running the Script\n",
         "\n",
         "To run the script, click on the top menu bar and select `Runtime`, then click on `Run all`. The script will start executing, and you will be prompted to follow the necessary steps.\n",
@@ -134,17 +122,8 @@
         "        print(\"You have not agreed to the Terms and Conditions. The script will now exit.\")\n",
         "        exit()\n",
         "\n",
-        "confirm_terms_and_conditions()\n"
-      ],
-      "metadata": {
-        "id": "RT_HknuLjJfT"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
+        "confirm_terms_and_conditions()\n",
+        "\n",
         "# Mount Google Drive folder to /content/gdrive\n",
         "from google.colab import drive\n",
         "drive.mount('/content/gdrive')\n",

--- a/build.ipynb
+++ b/build.ipynb
@@ -49,13 +49,7 @@
         "\n",
         "To build a different branch of the AndroidAAPS application, you can modify the value of the `AAPS_BRANCH` variable in the script. Set the variable to the desired branch name, and the script will build the application from that branch.\n",
         "\n",
-        "## 6. Confirming Terms and Conditions\n",
-        "\n",
-        "Before the build process begins, you will be prompted to confirm that you have read and agreed to the Terms and Conditions. If you have read and agreed to the Terms and Conditions, type 'yes' and the build process will start.\n",
-        "\n",
-        "**Please be patient, as the script will take approximately 15 to 20 minutes to complete.**\n",
-        "\n",
-        "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help."
+        "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help.\n"
       ],
       "metadata": {
         "id": "LXdFzRtRgq2d"
@@ -75,7 +69,7 @@
       "metadata": {
         "id": "ZuI2CQXShJJr"
       },
-      "execution_count": 1,
+      "execution_count": 3,
       "outputs": []
     },
     {
@@ -188,6 +182,12 @@
         "    output_apk_name = f\"AAPS_{aaps_version}.apk\"\n",
         "else:\n",
         "    output_apk_name = f\"AAPS_{AAPS_BRANCH}_{aaps_version}.apk\"\n",
+        "\n",
+        "# Temporary change the jvm memory to 4G and commit as Gradle script expect no changes in the code base\n",
+        "!git reset --hard\n",
+        "!sed -i 's/org.gradle.jvmargs=-Xmx2g/org.gradle.jvmargs=-Xmx4g -Xss4m/g' gradle.properties\n",
+        "!git config user.email \"fake.email@example.com\" && git config user.name \"Fake User\"\n",
+        "!git commit -am \"Temp commit\"\n",
         "\n",
         "# Build apk and save to mounted folder\n",
         "!./gradlew assembleFullRelease --no-watch-fs \\\n",

--- a/build.ipynb
+++ b/build.ipynb
@@ -49,7 +49,13 @@
         "\n",
         "To build a different branch of the AndroidAAPS application, you can modify the value of the `AAPS_BRANCH` variable in the script. Set the variable to the desired branch name, and the script will build the application from that branch.\n",
         "\n",
-        "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help.\n"
+        "## 6. Confirming Terms and Conditions\n",
+        "\n",
+        "Before the build process begins, you will be prompted to confirm that you have read and agreed to the Terms and Conditions. If you have read and agreed to the Terms and Conditions, type 'yes' and the build process will start.\n",
+        "\n",
+        "**Please be patient, as the script will take approximately 15 to 20 minutes to complete.**\n",
+        "\n",
+        "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help."
       ],
       "metadata": {
         "id": "LXdFzRtRgq2d"

--- a/build.ipynb
+++ b/build.ipynb
@@ -1,0 +1,222 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Documentation for Using the Script to Build AndroidAAPS\n",
+        "\n",
+        "This script is designed to help you build the AndroidAAPS application and save the built APK to your Google Drive. Please follow the instructions below to ensure a smooth process.\n",
+        "\n",
+        "- [Spanish](https://translate.google.com/translate?sl=en&tl=es&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Chinese (Simplified)](https://translate.google.com/translate?sl=en&tl=zh-CN&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Chinese (Traditional)](https://translate.google.com/translate?sl=en&tl=zh-TW&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [French](https://translate.google.com/translate?sl=en&tl=fr&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [German](https://translate.google.com/translate?sl=en&tl=de&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Portuguese](https://translate.google.com/translate?sl=en&tl=pt&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Russian](https://translate.google.com/translate?sl=en&tl=ru&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Japanese](https://translate.google.com/translate?sl=en&tl=ja&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Arabic](https://translate.google.com/translate?sl=en&tl=ar&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "- [Hindi](https://translate.google.com/translate?sl=en&tl=hi&u=https://github.com/robsonvn/AndroidAPS/build.ipynb)\n",
+        "\n",
+        "\n",
+        "## 1. Running the Script\n",
+        "\n",
+        "To run the script, click on the top menu bar and select `Runtime`, then click on `Run all`. The script will start executing, and you will be prompted to follow the necessary steps.\n",
+        "\n",
+        "## 2. Google Account and Google Drive Connection\n",
+        "\n",
+        "When you run this script, you will be prompted to log in with your Google Account. This is required for the script to access your Google Drive and save the built APK. Please follow the authentication steps to grant the necessary permissions for the script to connect to your Google Drive.\n",
+        "\n",
+        "## 3. Default Save Locations\n",
+        "\n",
+        "By default, the script will save the built APK in the following directory in your Google Drive: `AAPS/releases/`\n",
+        "\n",
+        "The key will be saved at: `AAPS/key/key.jks`, and the key password will be saved at: `AAPS/key/key_password.txt`\n",
+        "\n",
+        "## 4. Using an Existing Key\n",
+        "\n",
+        "If you already have a key that you want to use for the build, you should place it at the following location in your Google Drive: `AAPS/key/key.jks`\n",
+        "\n",
+        "Alternatively, you can modify the `KEYSTORE_FILE` variable in the script to point to the location of your existing key file.\n",
+        "\n",
+        "Additionally, you will need to update the `KEY_PASSWORD` variable in the script with the password for your existing key.\n",
+        "\n",
+        "Please ensure that you've placed the key file in the correct location and updated the necessary variables before running the script to avoid errors.\n",
+        "\n",
+        "## 5. Changing the Build Branch\n",
+        "\n",
+        "To build a different branch of the AndroidAAPS application, you can modify the value of the `AAPS_BRANCH` variable in the script. Set the variable to the desired branch name, and the script will build the application from that branch.\n",
+        "\n",
+        "By following this documentation, you will be able to successfully build the AndroidAAPS application and save the APK to your Google Drive. If you encounter any issues or need further assistance, please reach out for help.\n"
+      ],
+      "metadata": {
+        "id": "LXdFzRtRgq2d"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Set AAPS_HOME variable to default value\n",
+        "AAPS_HOME = \"/content/gdrive/MyDrive/AAPS\"\n",
+        "AAPS_BRANCH = \"master\"\n",
+        "KEY_HOME = f\"{AAPS_HOME}/key\"\n",
+        "KEYSTORE_FILE = f\"{KEY_HOME}/key.jks\"\n",
+        "KEYSTORE_ALIAS = \"key0\"\n",
+        "KEY_PASSWORD = \"\""
+      ],
+      "metadata": {
+        "id": "ZuI2CQXShJJr"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Terms and Conditions\n",
+        "\n",
+        "## Disclaimer\n",
+        "This script is provided \"as is\" without warranty of any kind, either expressed or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose. The entire risk as to the quality and performance of the script is with you. Should the script prove defective, you assume the cost of all necessary servicing, repair, or correction.\n",
+        "\n",
+        "## Scope of Usage\n",
+        "This script is intended for educational and informational purposes only. It is designed to help users build the AndroidAAPS application themselves. By using this script, you agree and acknowledge that you are solely responsible for building the AndroidAAPS application and that the developer of this script is not distributing the built application.\n",
+        "\n",
+        "## Limitation of Liability\n",
+        "In no event, unless required by applicable law or agreed to in writing, will the developer of this script be liable to you for damages, including any general, special, incidental, or consequential damages arising out of the use or inability to use the script (including but not limited to loss of data or data being rendered inaccurate or losses sustained by you or third parties or a failure of the script to operate with any other programs), even if the developer has been advised of the possibility of such damages.\n",
+        "\n",
+        "## Acknowledgement of Risks\n",
+        "By using this script, you acknowledge and agree that you understand the risks associated with building and using the AndroidAAPS application. You assume full responsibility for any consequences that may arise from the use of the built application and agree to indemnify, defend, and hold harmless the developer of this script from any claims, damages, losses, or expenses resulting from your use of the application.\n",
+        "\n",
+        "## Agreement to Additional Licenses\n",
+        "By using this script, you also agree to comply with the licenses of the AndroidAPS and the Android SDK.\n",
+        "\n",
+        "For the AndroidAPS license, please refer to the following link: https://github.com/nightscout/AndroidAPS/blob/master/LICENSE.txt\n",
+        "\n",
+        "For the Android SDK licenses, please refer to the following links:\n",
+        "\n",
+        "* Android SDK Terms and Conditions: https://developer.android.com/studio/terms\n",
+        "* Google APIs Terms of Service: https://developers.google.com/terms/\n",
+        "* Google Play Terms of Service: https://play.google.com/about/play-terms/index.html\n",
+        "\n",
+        "It is your responsibility to read, understand, and abide by the terms and conditions of these licenses while using this script and any associated software.\n",
+        "\n",
+        "By using this script, you confirm that you have read, understood, and agree to be bound by these terms and conditions. If you do not agree to these terms, you should not use this script."
+      ],
+      "metadata": {
+        "id": "p_FbBO3kCpWz"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def confirm_terms_and_conditions():\n",
+        "    print(\"Please carefully read and review the Terms and Conditions provided in the documentation.\")\n",
+        "    print(\"By proceeding to use this script, you confirm that you have read, understood, and agreed to be bound by these terms and conditions.\")\n",
+        "    response = input(\"Do you agree to the Terms and Conditions? Enter 'yes' to continue or 'no' to exit: \").lower()\n",
+        "    \n",
+        "    if response == 'yes':\n",
+        "        print(\"You have agreed to the Terms and Conditions. The script will now proceed.\")\n",
+        "    else:\n",
+        "        print(\"You have not agreed to the Terms and Conditions. The script will now exit.\")\n",
+        "        exit()\n",
+        "\n",
+        "confirm_terms_and_conditions()\n"
+      ],
+      "metadata": {
+        "id": "RT_HknuLjJfT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Mount Google Drive folder to /content/gdrive\n",
+        "from google.colab import drive\n",
+        "drive.mount('/content/gdrive')\n",
+        "\n",
+        "!mkdir -p $AAPS_HOME/releases\n",
+        "!mkdir -p $KEY_HOME\n",
+        "\n",
+        "# Create a new key and password if not exists\n",
+        "import os.path\n",
+        "if not os.path.exists(KEYSTORE_FILE):\n",
+        "    # Generate new key and password\n",
+        "    import string\n",
+        "    import random\n",
+        "    chars = string.ascii_letters + string.digits\n",
+        "    KEY_PASSWORD = ''.join(random.choice(chars) for _ in range(16))\n",
+        "    print(f\"New key password: {KEY_PASSWORD}\")\n",
+        "    os.system(f\"keytool -genkey -v -keystore {KEYSTORE_FILE} -alias {KEYSTORE_ALIAS} -storepass {KEY_PASSWORD} -keypass {KEY_PASSWORD} \\\n",
+        "               -keyalg RSA -keysize 2048 -validity 10000 -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown'\")\n",
+        "    # Save password to file\n",
+        "    with open(f\"{KEY_HOME}/key_password.txt\", 'w') as f:\n",
+        "        f.write(KEY_PASSWORD)\n",
+        "    # Prompt user to save key and password\n",
+        "    print(\"New key generated. Please save the key and password in a safe place.\")\n",
+        "\n",
+        "# Install dependencies and set up Android SDK\n",
+        "!apt-get update && \\\n",
+        "  apt-get install -y git wget unzip libarchive-tools && \\\n",
+        "  rm -rf /var/lib/apt/lists/*\n",
+        "  \n",
+        "!wget -q https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O android-sdk.zip && \\\n",
+        "  mkdir -p /opt/android-sdk-linux/cmdline-tools/latest && \\\n",
+        "  unzip -q android-sdk.zip -d /tmp && \\\n",
+        "  mv /tmp/cmdline-tools/* /opt/android-sdk-linux/cmdline-tools/latest && \\\n",
+        "  rm android-sdk.zip\n",
+        "  \n",
+        "!yes | /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --licenses\n",
+        "!yes | /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager \"platforms;android-28\" \"build-tools;28.0.3\"\n",
+        "\n",
+        "# Clone AndroidAPS repository to /src\n",
+        "!apt-get update && \\\n",
+        "  apt-get install -y git && \\\n",
+        "  rm -rf /var/lib/apt/lists/*\n",
+        "  \n",
+        "!git clone --branch $AAPS_BRANCH https://github.com/nightscout/AndroidAPS.git /src/AndroidAPS\n",
+        "\n",
+        "ANDROID_HOME = \"/opt/android-sdk-linux\"\n",
+        "!echo \"sdk.dir=$ANDROID_HOME\" > /src/AndroidAPS/local.properties\n",
+        "\n",
+        "# Fetch AAPS_VERSION\n",
+        "%cd /src/AndroidAPS\n",
+        "aaps_version = !grep -oE 'version \"\\S+\"' app/build.gradle | cut -d'\"' -f2\n",
+        "aaps_version = aaps_version[0]\n",
+        "\n",
+        "# Define the output apk name using Python\n",
+        "if AAPS_BRANCH == \"master\":\n",
+        "    output_apk_name = f\"AAPS_{aaps_version}.apk\"\n",
+        "else:\n",
+        "    output_apk_name = f\"AAPS_{AAPS_BRANCH}_{aaps_version}.apk\"\n",
+        "\n",
+        "# Build apk and save to mounted folder\n",
+        "!./gradlew assembleFullRelease --no-watch-fs \\\n",
+        "  -Pandroid.injected.signing.store.file=$KEYSTORE_FILE \\\n",
+        "  -Pandroid.injected.signing.store.password=$KEY_PASSWORD \\\n",
+        "  -Pandroid.injected.signing.key.alias=$KEYSTORE_ALIAS \\\n",
+        "  -Pandroid.injected.signing.key.password=$KEY_PASSWORD \\\n",
+        "  && cp app/build/outputs/apk/full/release/app-full-release.apk $AAPS_HOME/releases/{output_apk_name}\n"
+      ],
+      "metadata": {
+        "id": "QDiwy4RpCnCB"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new Jupyter Notebook (`build.ipynb`) which allows users to build the AndroidAPS APK using Google Colab. It also includes a README update with a Colab badge for easy access to the notebook.

Changes:

1. Added `build.ipynb` - a Jupyter Notebook that automates the process of building the AndroidAPS APK using Google Colab, including authenticating with Google Drive and saving the built APK to the user's Google Drive.
2. Updated `README.md` with a Colab badge linking to the `build.ipynb` file.

The new Jupyter Notebook simplifies the APK build process, making it easier for users to build the AndroidAPS application themselves. The script will take approximately 30 minutes to complete and will save the built APK to the user's Google Drive under the directory `AAPS/releases/`. The key will be saved at `AAPS/key/key.jks`, and the key password will be saved at `AAPS/key/key_password.txt`.

By incorporating Google Colab into the build process, users can build the AndroidAPS APK without needing to set up a local development environment. This change should make it more accessible for users to build and use the AndroidAPS application.


Link for test: https://colab.research.google.com/github/robsonvn/AndroidAPS/blob/master/build.ipynb