### PR TITLE
Dash: Workaround for long 0temp

### DIFF
--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/insulin/program/util/ProgramTempBasalUtil.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/insulin/program/util/ProgramTempBasalUtil.kt
@@ -22,10 +22,15 @@ object ProgramTempBasalUtil {
     fun mapTempBasalToTenthPulsesPerSlot(durationInSlots: Int, rateInUnitsPerHour: Double): ShortArray {
         val pulsesPerHour = (rateInUnitsPerHour * 20).roundToInt().toShort()
         val tenthPulsesPerSlot = ShortArray(durationInSlots)
-        var i = 0
-        while (durationInSlots > i) {
-            tenthPulsesPerSlot[i] = (roundToHalf(pulsesPerHour / 2.0) * 10).toInt().toShort()
-            i++
+        val tenthPulsesPerSlotShort = if (pulsesPerHour == 0.toShort() && durationInSlots > 4) {
+            // Workaround for 0.0 U/h long temp basals being cancelled by pod
+            // This will result in a 0.01 U/h temp basal for 0temps > 120 minutes
+            1.toShort()
+        } else {
+            (roundToHalf(pulsesPerHour / 2.0) * 10).toInt().toShort()
+        }
+        for (i in tenthPulsesPerSlot.indices) {
+            tenthPulsesPerSlot[i] = tenthPulsesPerSlotShort
         }
         return tenthPulsesPerSlot
     }

--- a/pump/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramTempBasalCommandTest.kt
+++ b/pump/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/command/ProgramTempBasalCommandTest.kt
@@ -35,7 +35,39 @@ class ProgramTempBasalCommandTest {
             .build()
 
         Assert.assertArrayEquals(
-            Hex.decodeHex("024200011C201A0E494E532E0100820A384000009000160EC000000A6B49D200000AEB49D20001DE"),
+            Hex.decodeHex("024200011C201A0E494E532E0100820A384000009000160EC000000A6B49D200000A6B49D20001E3"),
+            command.encoded
+        )
+    }
+
+    @Test @Throws(DecoderException::class) fun testZeroTempBasalShort() {
+        val command = ProgramTempBasalCommand.Builder()
+            .setUniqueId(37879809)
+            .setNonce(1229869870)
+            .setSequenceNumber(7.toShort())
+            .setRateInUnitsPerHour(0.0)
+            .setDurationInMinutes(30.toShort())
+            .setProgramReminder(ProgramReminder(true, true, 0.toByte()))
+            .build()
+
+        Assert.assertArrayEquals(
+            Hex.decodeHex("024200011C201A0E494E532E01007901384000000000160EC00000016B49D2000001EB49D200815B"),
+            command.encoded
+        )
+    }
+
+    @Test @Throws(DecoderException::class) fun testZeroTempBasalVeryLong() {
+        val command = ProgramTempBasalCommand.Builder()
+            .setUniqueId(37879809)
+            .setNonce(1229869870)
+            .setSequenceNumber(7.toShort())
+            .setRateInUnitsPerHour(0.0)
+            .setDurationInMinutes(720.toShort())
+            .setProgramReminder(ProgramReminder(true, true, 0.toByte()))
+            .build()
+
+        Assert.assertArrayEquals(
+            Hex.decodeHex("024200011C221A10494E532E0100901838400000F0007000160EC00000186B49D20000186B49D2000132"),
             command.encoded
         )
     }


### PR DESCRIPTION

Fix for DASH cancelling long 0temps as outlined here: https://github.com/nightscout/AndroidAPS/issues/2524

Note: This does not include the proper pump sync when a TBR gets cancelled by the POD for whatever reason, this will be a new PR

Inspired by: https://github.com/LoopKit/OmniBLE/pull/30

It seems that for long 0temps there is some kind of safety in the pod (maybe to prevent occlusions?), that it cancels the TBR because there is no insulin delivered.
Solution is to set a near zero temp for 0temps. For zero temps up and including 120minutes a true zero temp is set, because these 0temps are used by the loop algorithm and there a true zero temp is desired. For longer 0temps a near zero temp is used to work around this issue.

Note: Still in draft, but open for code review. Tests of different scenarios are in progress but these take some time, will set PR out of draft when tests are finished successfully.

@MilosKozak Do you want us to test if this issue also affects master (which it likely is)? If so let me know and I can test it and we can backport this to master.