### PR TITLE
DASH: handle tbr out of sync

### DIFF
--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/DeliveryStatus.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/DeliveryStatus.kt
@@ -16,6 +16,10 @@ enum class DeliveryStatus(override val value: Byte) : HasValue {
         return value in arrayOf(BOLUS_AND_BASAL_ACTIVE.value, BOLUS_AND_TEMP_BASAL_ACTIVE.value)
     }
 
+    fun basalActive(): Boolean {
+        return value in arrayOf(BOLUS_AND_BASAL_ACTIVE.value, BASAL_ACTIVE.value)
+    }
+
     fun tempBasalActive(): Boolean {
         return value in arrayOf(BOLUS_AND_TEMP_BASAL_ACTIVE.value, TEMP_BASAL_ACTIVE.value)
     }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/data/HistoryRecord.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/data/HistoryRecord.kt
@@ -9,6 +9,7 @@ data class HistoryRecord(
     val commandType: OmnipodCommandType,
     val initialResult: InitialResult,
     val record: Record?,
+    val totalAmountDelivered: Double?,
     val resolvedResult: ResolvedResult?,
     val resolvedAt: Long?
 ) {

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/DashHistoryDatabase.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/DashHistoryDatabase.kt
@@ -18,7 +18,7 @@ abstract class DashHistoryDatabase : RoomDatabase() {
 
     companion object {
 
-        const val VERSION = 3
+        const val VERSION = 4
 
         fun build(context: Context) =
             Room.databaseBuilder(

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordDao.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordDao.kt
@@ -36,4 +36,7 @@ abstract class HistoryRecordDao {
 
     @Query("UPDATE historyrecords SET initialResult = :initialResult  WHERE id = :id ")
     abstract fun setInitialResult(id: Long, initialResult: InitialResult): Completable
+
+    @Query("UPDATE historyrecords SET totalAmountDelivered = :totalAmountDelivered WHERE id = :id ")
+    abstract fun setTotalAmountDelivered(id: Long, totalAmountDelivered: Double?): Completable
 }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordEntity.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/database/HistoryRecordEntity.kt
@@ -27,6 +27,7 @@ data class HistoryRecordEntity(
     @Embedded(prefix = "tempBasalRecord_") val tempBasalRecord: TempBasalRecord?,
     @Embedded(prefix = "bolusRecord_") val bolusRecord: BolusRecord?,
     @Embedded(prefix = "basalprofile_") val basalProfileRecord: BasalValuesRecord?,
+    val totalAmountDelivered: Double?,
     val resolvedResult: ResolvedResult?,
     val resolvedAt: Long?
 )

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/mapper/HistoryMapper.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/history/mapper/HistoryMapper.kt
@@ -13,6 +13,7 @@ class HistoryMapper {
             initialResult = entity.initialResult,
             commandType = entity.commandType,
             record = entity.bolusRecord ?: entity.tempBasalRecord ?: entity.basalProfileRecord,
+            totalAmountDelivered = entity.totalAmountDelivered,
             resolvedResult = entity.resolvedResult,
             resolvedAt = entity.resolvedAt
         )

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/DashPodHistoryActivity.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/DashPodHistoryActivity.kt
@@ -299,7 +299,7 @@ class DashPodHistoryActivity : TranslatedDaggerAppCompatActivity() {
         }
 
         private fun setAmount(historyEntry: HistoryRecord, amountView: TextView) {
-            amountView.text = historyEntry.totalAmountDelivered?.let { rh.gs(R.string.omnipod_common_history_total_delivered, it) ?: "" }
+            amountView.text = historyEntry.totalAmountDelivered?.let { rh.gs(R.string.omnipod_common_history_total_delivered, it) }
             // Set some color
             setTextViewColor(check_result = false, amountView, historyEntry)
         }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/DashPodHistoryActivity.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/DashPodHistoryActivity.kt
@@ -213,6 +213,7 @@ class DashPodHistoryActivity : TranslatedDaggerAppCompatActivity() {
                 holder.timeView.text = DateTimeUtil.toStringFromTimeInMillis(it.displayTimestamp())
                 setValue(it, holder.valueView)
                 setType(it, holder.typeView)
+                setAmount(it, holder.amountView)
             }
         }
 
@@ -297,6 +298,12 @@ class DashPodHistoryActivity : TranslatedDaggerAppCompatActivity() {
             setTextViewColor(check_result = false, valueView, historyEntry)
         }
 
+        private fun setAmount(historyEntry: HistoryRecord, amountView: TextView) {
+            amountView.text = historyEntry.totalAmountDelivered?.let { rh.gs(R.string.omnipod_common_history_total_delivered, it) ?: "" }
+            // Set some color
+            setTextViewColor(check_result = false, amountView, historyEntry)
+        }
+
         override fun getItemCount(): Int {
             return historyList.size
         }
@@ -306,6 +313,7 @@ class DashPodHistoryActivity : TranslatedDaggerAppCompatActivity() {
             val timeView: TextView = itemView.findViewById(R.id.omnipod_history_time)
             val typeView: TextView = itemView.findViewById(R.id.omnipod_history_source)
             val valueView: TextView = itemView.findViewById(R.id.omnipod_history_description)
+            val amountView: TextView = itemView.findViewById(R.id.omnipod_history_amount)
         }
     }
 

--- a/pump/omnipod-dash/src/main/res/layout/omnipod_dash_pod_history_item.xml
+++ b/pump/omnipod-dash/src/main/res/layout/omnipod_dash_pod_history_item.xml
@@ -14,18 +14,36 @@
         android:text="@string/omnipod_dash_history_item_date"
         android:textSize="12sp" />
 
-    <TextView
-        android:id="@+id/omnipod_history_source"
-        android:layout_width="132dp"
-        android:layout_height="match_parent"
-        android:text="@string/omnipod_dash_history_item_source"
-        android:textSize="12sp" />
+    <RelativeLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1">
 
-    <TextView
-        android:id="@+id/omnipod_history_description"
-        android:layout_width="fill_parent"
-        android:layout_height="match_parent"
-        android:text="@string/omnipod_dash_history_item_description"
-        android:textSize="12sp" />
+        <TextView
+            android:id="@+id/omnipod_history_source"
+            android:layout_width="132dp"
+            android:layout_height="wrap_content"
+            android:text="@string/omnipod_dash_history_item_source"
+            android:layout_alignParentTop="true"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/omnipod_history_description"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/omnipod_dash_history_item_description"
+            android:layout_toEndOf="@id/omnipod_history_source"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/omnipod_history_amount"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/omnipod_dash_history_item_amount"
+            android:layout_below="@+id/omnipod_history_description"
+            android:layout_toEndOf="@id/omnipod_history_source"
+            android:textSize="12sp" />
+
+    </RelativeLayout>
 
 </LinearLayout>

--- a/pump/omnipod-dash/src/main/res/values/strings.xml
+++ b/pump/omnipod-dash/src/main/res/values/strings.xml
@@ -17,7 +17,6 @@
     <string name="omnipod_dash_history_type">Type:</string>
     <string name="omnipod_dash_history_bolus_value">%1$.2f U</string>
     <string name="omnipod_dash_history_bolus_value_with_carbs">%1$.2f U, CH=%2$.1f g</string>
-    <string name="omnipod_dash_history_tbr_value">Rate: %1$.2f U, duration: %2$d minutes</string>
 
     <!-- Omnipod Dash - Overview -->
     <string name="omnipod_dash_overview_bluetooth_status">Bluetooth Status</string>
@@ -45,7 +44,7 @@
     <string name="omnipod_dash_command_not_sent">Command not sent</string>
     <string name="omnipod_dash_command_not_received_by_the_pod">Command not received by the pod</string>
     <string name="omnipod_dash_unknown">Unknown state for the command</string>
-    <string name="omnipod_common_history_tbr_value">Rate: %1$.2f U, duration: %2$d minutes</string>
+    <string name="omnipod_common_history_tbr_value">%1$.2f U/h, %2$d minutes</string>
     <string name="omnipod_common_history_bolus_value">%1$.2f U</string>
     <string name="omnipod_common_alert_delivery_suspended">Insulin delivery is suspended</string>
     <string name="omnipod_common_history_total_delivered">Total delivered: %1$.2f U</string>

--- a/pump/omnipod-dash/src/main/res/values/strings.xml
+++ b/pump/omnipod-dash/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <!-- Omnipod Dash - History -->
     <string name="omnipod_dash_history_title">Pod History</string>
     <string name="omnipod_dash_history_item_description">Description</string>
+    <string name="omnipod_dash_history_item_amount">Amount</string>
     <string name="omnipod_dash_history_item_source">Source</string>
     <string name="omnipod_dash_history_item_date">Date</string>
     <string name="omnipod_dash_history_type">Type:</string>
@@ -47,6 +48,7 @@
     <string name="omnipod_common_history_tbr_value">Rate: %1$.2f U, duration: %2$d minutes</string>
     <string name="omnipod_common_history_bolus_value">%1$.2f U</string>
     <string name="omnipod_common_alert_delivery_suspended">Insulin delivery is suspended</string>
+    <string name="omnipod_common_history_total_delivered">Total delivered: %1$.2f U</string>
     <string name="omnipod_dash_connection_lost">Lost connection to pod</string>
     <string name="omnipod_dash_bolus_already_in_progress">Another bolus is being delivered</string>
     <string name="omnipod_dash_not_enough_insulin">Not enough insulin left in the reservoir</string>
@@ -60,6 +62,7 @@
     <string name="failed_to_set_the_new_basal_profile">Failed to set the new basal profile. Delivery suspended</string>
     <string name="setting_basal_profile_might_have_failed">Setting basal profile might have failed. Delivery might be suspended! Please manually refresh the Pod status from the Omnipod tab and resume delivery if needed.</string>
     <string name="bolus_delivery_status_uncertain">Bolus delivery status uncertain. Refresh pod status to confirm or deny.</string>
+    <string name="temp_basal_out_of_sync">Temp basal status not as expected! If a temp basal was previously running, it has been cancelled. Please check delivered insulin and pod history</string>
     <string name="checking_delivery_status">Checking delivery status</string>
     <string name="setting_temp_basal_might_have_basal_failed">Setting temp basal might have basal failed. If a temp basal was previously running, it has been cancelled. Please manually refresh the Pod status from the Omnipod tab.</string>
     <string name="cancel_temp_basal_result_is_uncertain">Cancel temp basal result is uncertain</string>


### PR DESCRIPTION
Fix for AAPS not recognizing TBR state change of dash #2524 : 

Handling pump TBR cancellation and unknown TBRs in AAPS. Added total delivered insulin to History view for user information.

Note: While it would be ideal to estimate the timestamp of TBR cancellation by DASH, doing so would introduce significant complexity. This situation should not occur under normal circumstances. If there are cases where it does happen and cannot be avoided, we can consider adding this feature in a future pull request (PR).

Screenshot of changed history view:
![WhatsApp Image 2023-05-22 at 09 59 58](https://github.com/nightscout/AndroidAPS/assets/60566713/d0b0ed89-6612-4ae9-9f48-d85d6a128201)
