### PR TITLE
Skipped creation of "dummy cancel temp basal" records for temp basals which are already paired with real cancels

### DIFF
--- a/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
+++ b/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
@@ -796,7 +796,7 @@ class MedtronicHistoryData @Inject constructor(
 
                 previousItem = null
             }
-            if (tempBasalProcessDTO.itemOneTbr!!.isZeroTBR) {
+            if (tempBasalProcessDTO.itemOneTbr!!.isZeroTBR  &&  tempBasalProcessDTO.itemTwo == null ) {
                 previousItem = tempBasalProcessDTO
             }
         }


### PR DESCRIPTION
[at least partial] fix for  #1724 

The "for loop" commented as   // fix for Zero TBRs in the 

`fun createTBRProcessList(entryList: MutableList<PumpHistoryEntry>) : MutableList<TempBasalProcessDTO>
`

should skip zero temps that already have their corresponding CancelTBRs paired in the previous section of the same function.
