### PR TITLE
Fix wrong IOB in loop run when bolus finishes within 2 min of new BG

### DIFF
--- a/plugins/aps/src/main/java/info/nightscout/plugins/aps/loop/LoopPlugin.kt
+++ b/plugins/aps/src/main/java/info/nightscout/plugins/aps/loop/LoopPlugin.kt
@@ -247,6 +247,14 @@ class LoopPlugin @Inject constructor(
                 return
             }
 
+            // Check if pump is not running, and wait for any pending commands to finish (e.g. bolus)
+            // Do this before calling usedAPS to make sure used IOB is correct
+            if (!isEmptyQueue()) {
+                aapsLogger.debug(LTag.APS, rh.gs(info.nightscout.core.ui.R.string.pump_busy))
+                rxBus.send(EventLoopSetLastRunGui(rh.gs(info.nightscout.core.ui.R.string.pump_busy)))
+                return
+            }
+
             // Check if pump info is loaded
             if (pump.baseBasalRate < 0.01) return
             val usedAPS = activePlugin.activeAPS
@@ -258,12 +266,6 @@ class LoopPlugin @Inject constructor(
             // Check if we have any result
             if (apsResult == null) {
                 rxBus.send(EventLoopSetLastRunGui(rh.gs(R.string.no_aps_selected)))
-                return
-            }
-
-            if (!isEmptyQueue()) {
-                aapsLogger.debug(LTag.APS, rh.gs(info.nightscout.core.ui.R.string.pump_busy))
-                rxBus.send(EventLoopSetLastRunGui(rh.gs(info.nightscout.core.ui.R.string.pump_busy)))
                 return
             }
 


### PR DESCRIPTION
Issue:
When a large SMB/Bolus is running and new BG comes in, a new APS invocation is started, but waits for the pump to finish. The loop invocation will use the IOB before the pump was synced with AAPS, thus is using the wrong IOB in the insulin calculations, which can lead to too much insulin being given

Solution:
Move check for empty queue before the APS invovocation, making sure the APS invocation uses the updated IOB.

Testing:
- Unit tests still working
- The error situation has been checked by forcing every SMB to last around 5 minutes in the pump driver, with fix it works as expected and correct IOB is being used
- Normal usage has been tested no change there works as expected