### PR TITLE
Fix pump disconnect alarms

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/receivers/KeepAliveWorker.kt
+++ b/app/src/main/java/info/nightscout/androidaps/receivers/KeepAliveWorker.kt
@@ -191,7 +191,10 @@ class KeepAliveWorker(
         }
         if (loop.isDisconnected) {
             // do nothing if pump is disconnected
-        } else if (runningProfile == null || ((!pump.isThisProfileSet(requestedProfile) || !requestedProfile.isEqual(runningProfile) || (runningProfile is ProfileSealed.EPS && runningProfile.value.originalEnd < dateUtil.now())) && !commandQueue.isRunning(Command.CommandType.BASAL_PROFILE))) {
+        } else if (runningProfile == null || ((!pump.isThisProfileSet(requestedProfile) || !requestedProfile.isEqual(runningProfile)
+                || (runningProfile is ProfileSealed.EPS && runningProfile.value.originalEnd < dateUtil.now() && runningProfile.value.originalDuration != 0L))
+                && !commandQueue.isRunning(Command.CommandType.BASAL_PROFILE)))
+        {
             rxBus.send(EventProfileSwitchChanged())
         } else if (isStatusOutdated && !pump.isBusy()) {
             lastReadStatus = now


### PR DESCRIPTION
Fix https://github.com/nightscout/AndroidAPS/issues/2567

Tested:
- Temporary profile ends as expected
- Alarm is generated around the expected time as set in settings