### PR TITLE
Medtrum: Additional checks

### DIFF
--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
@@ -498,25 +498,25 @@ class MedtrumPump @Inject constructor(
 
     fun alarmStateToString(alarmState: AlarmState): String {
         val stringId = when (alarmState) {
-            AlarmState.NONE               -> R.string.alarm_none
-            AlarmState.PUMP_LOW_BATTERY   -> R.string.alarm_pump_low_battery
-            AlarmState.PUMP_LOW_RESERVOIR -> R.string.alarm_pump_low_reservoir
-            AlarmState.PUMP_EXPIRES_SOON  -> R.string.alarm_pump_expires_soon
-            AlarmState.LOW_BG_SUSPENDED   -> R.string.alarm_low_bg_suspended
-            AlarmState.LOW_BG_SUSPENDED2  -> R.string.alarm_low_bg_suspended2
+            AlarmState.NONE                 -> R.string.alarm_none
+            AlarmState.PUMP_LOW_BATTERY     -> R.string.alarm_pump_low_battery
+            AlarmState.PUMP_LOW_RESERVOIR   -> R.string.alarm_pump_low_reservoir
+            AlarmState.PUMP_EXPIRES_SOON    -> R.string.alarm_pump_expires_soon
+            AlarmState.LOW_BG_SUSPENDED     -> R.string.alarm_low_bg_suspended
+            AlarmState.LOW_BG_SUSPENDED2    -> R.string.alarm_low_bg_suspended2
             AlarmState.AUTO_SUSPENDED       -> R.string.alarm_auto_suspended
             AlarmState.HOURLY_MAX_SUSPENDED -> R.string.alarm_hourly_max_suspended
             AlarmState.DAILY_MAX_SUSPENDED  -> R.string.alarm_daily_max_suspended
             AlarmState.SUSPENDED            -> R.string.alarm_suspended
-            AlarmState.PAUSED             -> R.string.alarm_paused
-            AlarmState.OCCLUSION          -> R.string.alarm_occlusion
-            AlarmState.EXPIRED            -> R.string.alarm_expired
-            AlarmState.RESERVOIR_EMPTY    -> R.string.alarm_reservoir_empty
-            AlarmState.PATCH_FAULT        -> R.string.alarm_patch_fault
-            AlarmState.PATCH_FAULT2       -> R.string.alarm_patch_fault2
-            AlarmState.BASE_FAULT         -> R.string.alarm_base_fault
-            AlarmState.BATTERY_OUT        -> R.string.alarm_battery_out
-            AlarmState.NO_CALIBRATION     -> R.string.alarm_no_calibration
+            AlarmState.PAUSED               -> R.string.alarm_paused
+            AlarmState.OCCLUSION            -> R.string.alarm_occlusion
+            AlarmState.EXPIRED              -> R.string.alarm_expired
+            AlarmState.RESERVOIR_EMPTY      -> R.string.alarm_reservoir_empty
+            AlarmState.PATCH_FAULT          -> R.string.alarm_patch_fault
+            AlarmState.PATCH_FAULT2         -> R.string.alarm_patch_fault2
+            AlarmState.BASE_FAULT           -> R.string.alarm_base_fault
+            AlarmState.BATTERY_OUT          -> R.string.alarm_battery_out
+            AlarmState.NO_CALIBRATION       -> R.string.alarm_no_calibration
         }
         return rh.gs(stringId)
     }

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/SynchronizePacket.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/SynchronizePacket.kt
@@ -49,14 +49,12 @@ class SynchronizePacket(injector: HasAndroidInjector) : MedtrumPacket(injector) 
                 aapsLogger.debug(LTag.PUMPCOMM, "SynchronizePacket: fieldMask: $fieldMask")
             }
 
-            // Remove bolus fields from fieldMask if fields are present (we sync bolus trough other commands)
+            // Remove extended bolus field from fieldMask if field is present (extended bolus is not supported)
             if (fieldMask and MASK_SUSPEND != 0) {
                 offset += 4 // If field is present, skip 4 bytes
             }
             if (fieldMask and MASK_NORMAL_BOLUS != 0) {
-                aapsLogger.debug(LTag.PUMPCOMM, "SynchronizePacket: Normal bolus present removing from fieldMask")
-                fieldMask = fieldMask and MASK_NORMAL_BOLUS.inv()
-                syncData = syncData.copyOfRange(0, offset) + syncData.copyOfRange(offset + 3, syncData.size)
+                offset += 3 // If field is present, skip 3 bytes
             }
             if (fieldMask and MASK_EXTENDED_BOLUS != 0) {
                 aapsLogger.debug(LTag.PUMPCOMM, "SynchronizePacket: Extended bolus present removing from fieldMask")

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -103,7 +103,7 @@ class MedtrumOverviewViewModel @Inject constructor(
 
                     ConnectionState.DISCONNECTING -> {
                         _bleStatus.postValue("{fa-bluetooth-b spin}")
-                        _canDoRefresh.postValue(false)
+                        _canDoRefresh.postValue(true)
                     }
                 }
                 updateGUI()


### PR DESCRIPTION
- Check for bolus in progress, fixing a case where pump would accept a bolus command but not processing it because another bolus is in progress, leaving wrongly synced bolus information to AAPS
- Handle no connection possible after the instance where a user turns BL off and on during an active connection