### PR TITLE
Custom Watchface 0.8 (include preference adjustment)

### DIFF
--- a/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
+++ b/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
@@ -96,8 +96,21 @@ enum class CustomWatchfaceMetadataKey(val key: String, @StringRes val label: Int
     CWF_CREATED_AT("created_at", R.string.metadata_label_watchface_created_at),
     CWF_VERSION("cwf_version", R.string.metadata_label_plugin_version),
     CWF_AUTHOR_VERSION("author_version", R.string.metadata_label_watchface_name_version),
-    CWF_COMMENT("comment", R.string.metadata_label_watchface_comment); // label not planed to be used for CWF_COMMENT
-
+    CWF_COMMENT("comment", R.string.metadata_label_watchface_comment), // label not planed to be used for CWF_COMMENT
+    CWF_AUTHORIZATION("cwf_authorization", R.string.metadata_label_watchface_authorization),
+    CWF_PREF_AAPS_DETAILED_IOB("key_wear_detailediob", R.string.metadata_label_watchface_pref),
+    CWF_PREF_AAPS_DETAILED_DELTA("key_wear_detailed_delta", R.string.metadata_label_watchface_pref),
+    CWF_PREF_AAPS_BGI("key_wear_showbgi", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_IOB("key_show_iob", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_COB("key_show_cob", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_DELTA("key_show_delta", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_AVG_DELTA("key_show_avg_delta", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_UPLOADER_BATTERY("key_show_uploader_battery", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_RIG_BATTERY("key_show_rig_battery", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_TEMP_BASAL("key_show_temp_basal", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_DIRECTION("key_show_direction", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_AGO("key_show_ago", R.string.metadata_label_watchface_pref),
+    CWF_PREF_WATCH_SHOW_BG("key_show_bg", R.string.metadata_label_watchface_pref);
     companion object {
         fun fromKey(key: String): CustomWatchfaceMetadataKey? =
             values().firstOrNull { it.key == key }
@@ -110,7 +123,7 @@ class ZipWatchfaceFormat {
         const val CUSTOM_WF_EXTENTION = ".zip"
         const val CUSTOM_JSON_FILE = "CustomWatchface.json"
 
-        fun loadCustomWatchface(cwfFile: File): CustomWatchfaceData? {
+        fun loadCustomWatchface(cwfFile: File, authorization: Boolean): CustomWatchfaceData? {
             var json = JSONObject()
             var metadata: CustomWatchfaceMetadataMap = mutableMapOf()
             val drawableDatas: CustomWatchfaceDrawableDataMap = mutableMapOf()
@@ -135,6 +148,7 @@ class ZipWatchfaceFormat {
                         json = JSONObject(jsonString)
                         metadata = loadMetadata(json)
                         metadata[CustomWatchfaceMetadataKey.CWF_FILENAME] = cwfFile.name
+                        metadata[CustomWatchfaceMetadataKey.CWF_AUTHORIZATION] = authorization.toString()
                     } else {
                         val customWatchfaceDrawableDataKey = CustomWatchfaceDrawableDataKey.fromFileName(entryName)
                         val drawableFormat = DrawableFormat.fromFileName(entryName)

--- a/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
+++ b/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
@@ -17,7 +17,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
-val CUSTOM_VERSION = "0.7"
+val CUSTOM_VERSION = "0.8"
 enum class CustomWatchfaceDrawableDataKey(val key: String, @DrawableRes val icon: Int?, val fileName: String) {
     UNKNOWN("unknown", null, "Unknown"),
     CUSTOM_WATCHFACE("customWatchface", R.drawable.watchface_custom, "CustomWatchface"),

--- a/app-wear-shared/shared/src/main/res/values/strings.xml
+++ b/app-wear-shared/shared/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="metadata_label_plugin_version">Plugin version: %1$s</string>
     <string name="metadata_label_watchface_name_version">Name: %1$s (%2$s)</string>
     <string name="metadata_label_watchface_comment" translatable="false">%1$s</string>
+    <string name="metadata_label_watchface_authorization" translatable="false">%1$s</string>
+    <string name="metadata_label_watchface_pref" translatable="false">%1$s</string>
     <string name="default_custom_watchface_comment">Default watchface, you can click on EXPORT WATCHFACE button to generate a template</string>
     <string name="wear_default_watchface">Default Watchface</string>
 

--- a/core/utils/src/main/res/values/keys.xml
+++ b/core/utils/src/main/res/values/keys.xml
@@ -115,6 +115,7 @@
     <string name="key_wearwizard_trend" translatable="false">wearwizard_trend</string>
     <string name="key_wearwizard_cob" translatable="false">wearwizard_cob</string>
     <string name="key_wearwizard_iob" translatable="false">wearwizard_iob</string>
+    <string name="key_wear_custom_watchface_autorization" translatable="false">wear_custom_watchface_autorization</string>
     <string name="key_objectives_bg_is_available_in_ns" translatable="false">ObjectivesbgIsAvailableInNS</string>
     <string name="key_objectives_pump_status_is_available_in_ns" translatable="false">ObjectivespumpStatusIsAvailableInNS</string>
     <string name="key_statuslights_cage_warning" translatable="false">statuslights_cage_warning</string>

--- a/plugins/configuration/src/main/java/info/nightscout/configuration/maintenance/PrefFileListProviderImpl.kt
+++ b/plugins/configuration/src/main/java/info/nightscout/configuration/maintenance/PrefFileListProviderImpl.kt
@@ -20,6 +20,7 @@ import info.nightscout.interfaces.versionChecker.VersionCheckerUtils
 import info.nightscout.rx.weardata.CustomWatchfaceData
 import info.nightscout.rx.weardata.ZipWatchfaceFormat
 import info.nightscout.shared.interfaces.ResourceHelper
+import info.nightscout.shared.sharedPreferences.SP
 import org.joda.time.DateTime
 import org.joda.time.Days
 import org.joda.time.Hours
@@ -38,6 +39,7 @@ class PrefFileListProviderImpl @Inject constructor(
     private val encryptedPrefsFormat: EncryptedPrefsFormat,
     private val storage: Storage,
     private val versionCheckerUtils: VersionCheckerUtils,
+    private val sp: SP,
     context: Context
 ) : PrefFileListProvider {
     private val path = File(Environment.getExternalStorageDirectory().toString())
@@ -92,11 +94,11 @@ class PrefFileListProviderImpl @Inject constructor(
 
     override fun listCustomWatchfaceFiles(): MutableList<CustomWatchfaceData> {
         val customWatchfaceFiles = mutableListOf<CustomWatchfaceData>()
-
+        val customAwtchfaceAuthorization = sp.getBoolean(info.nightscout.core.utils.R.string.key_wear_custom_watchface_autorization, false)
         // searching dedicated dir, only for new CWF format
         exportsPath.walk().filter { it.isFile && it.name.endsWith(ZipWatchfaceFormat.CUSTOM_WF_EXTENTION) }.forEach { file ->
             // Here loadCustomWatchface will unzip, check and load CustomWatchface
-            ZipWatchfaceFormat.loadCustomWatchface(file)?.also { customWatchface ->
+            ZipWatchfaceFormat.loadCustomWatchface(file, customAwtchfaceAuthorization)?.also { customWatchface ->
                 customWatchfaceFiles.add(customWatchface)
             }
         }

--- a/plugins/main/src/main/java/info/nightscout/plugins/general/wear/WearFragment.kt
+++ b/plugins/main/src/main/java/info/nightscout/plugins/general/wear/WearFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import dagger.android.support.DaggerFragment
 import info.nightscout.core.ui.toast.ToastUtils
 import info.nightscout.core.utils.fabric.FabricPrivacy
@@ -12,7 +13,6 @@ import info.nightscout.plugins.R
 import info.nightscout.plugins.databinding.WearFragmentBinding
 import info.nightscout.rx.AapsSchedulers
 import info.nightscout.rx.bus.RxBus
-import info.nightscout.rx.events.EventMobileDataToWear
 import info.nightscout.rx.events.EventMobileToWear
 import info.nightscout.rx.events.EventWearUpdateGui
 import info.nightscout.rx.logging.AAPSLogger
@@ -105,6 +105,7 @@ class WearFragment : DaggerFragment() {
     private fun updateGui() {
         _binding ?: return
         wearPlugin.savedCustomWatchface?.let {
+            wearPlugin.checkCustomWatchfacePreferences()
             binding.customName.text = rh.gs(R.string.wear_custom_watchface, it.metadata[CustomWatchfaceMetadataKey.CWF_NAME])
             binding.coverChart.setImageDrawable(it.drawableDatas[CustomWatchfaceDrawableDataKey.CUSTOM_WATCHFACE]?.toDrawable(resources))
         } ?:apply {
@@ -117,5 +118,12 @@ class WearFragment : DaggerFragment() {
 
     private fun loadCustom(cwf: CustomWatchfaceData) {
         wearPlugin.savedCustomWatchface = cwf
+    }
+
+    // This class containt mapping between keys used within json of Custom Watchface and preferences
+    enum class PrefMap(val key: String, @StringRes val prefKey: Int) {
+        DETAILED_IOB(CustomWatchfaceMetadataKey.CWF_PREF_AAPS_DETAILED_IOB.key, info.nightscout.core.utils.R.string.key_wear_detailediob),
+        CWF_PREF_AAPS_DETAILED_DELTA(CustomWatchfaceMetadataKey.CWF_PREF_AAPS_DETAILED_DELTA.key, info.nightscout.core.utils.R.string.key_wear_detailed_delta),
+        CWF_PREF_AAPS_BGI(CustomWatchfaceMetadataKey.CWF_PREF_AAPS_BGI.key, info.nightscout.core.utils.R.string.key_wear_showbgi)
     }
 }

--- a/plugins/main/src/main/res/values/strings.xml
+++ b/plugins/main/src/main/res/values/strings.xml
@@ -361,6 +361,9 @@
     <string name="wear_notifysmb_summary">Show SMB on the watch like a standard bolus.</string>
     <string name="wear_predictions_summary">Show the predictions on the watchface.</string>
     <string name="wear_predictions_title">Predictions</string>
+    <string name="wear_custom_watchface_settings">Custom Watchface Settings</string>
+    <string name="wear_custom_watchface_authorization_title">Custom Watchface Authorization</string>
+    <string name="wear_custom_watchface_authorization_summary">Authorize loaded Custom Watchface to modify AAPS and Watch settings according to the watchface design</string>
     <string name="wear_custom_watchface">Custom Watchface: %1$s</string>
     <string name="wear_load_watchface">Load Watchface</string>
     <string name="wear_send_watchface">Send Watchface</string>

--- a/plugins/main/src/main/res/xml/pref_wear.xml
+++ b/plugins/main/src/main/res/xml/pref_wear.xml
@@ -78,6 +78,17 @@
 
         </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/wear_custom_watchface_settings">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/key_wear_custom_watchface_autorization"
+            android:summary="@string/wear_custom_watchface_authorization_summary"
+            android:title="@string/wear_custom_watchface_authorization_title" />
+
+    </PreferenceCategory>
+
         <PreferenceCategory
             android:title="@string/wear_general_settings">
 


### PR DESCRIPTION
On setting is added in Wear plugin preferences to authorize or not Custom Watchface to adjust parameters (default value is false)
Watchface can now include within metadata bloc (json file) some keys to define parameters (on AAPS and/or Watch side) that are recommended for the design