### PR TITLE
Medtrum: Handle pumpType when SN is entered

### DIFF
--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPlugin.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPlugin.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.text.Editable
+import android.text.TextWatcher
 import android.text.format.DateFormat
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
@@ -127,6 +129,27 @@ import kotlin.math.abs
         super.preprocessPreferences(preferenceFragment)
         val serialSetting = preferenceFragment.findPreference<EditTextPreference>(rh.gs(R.string.key_sn_input))
         serialSetting?.isEnabled = !isInitialized()
+        serialSetting?.setOnBindEditTextListener { editText ->
+            editText.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(newValue: Editable?) {
+                    val newSN = newValue.toString().toLongOrNull(radix = 16)
+                    val newDeviceType = MedtrumSnUtil().getDeviceTypeFromSerial(newSN ?: 0)
+                    if (newDeviceType == MedtrumSnUtil.INVALID) {
+                        editText.error = rh.gs(R.string.sn_input_invalid)
+                    } else {
+                        editText.error = null
+                    }
+                }
+
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                    // Nothing to do here
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    // Nothing to do here
+                }
+            })
+        }
         serialSetting?.setOnPreferenceChangeListener { _, newValue ->
             if (newValue is String) {
                 val newSN = newValue.toLongOrNull(radix = 16)

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
@@ -12,6 +12,7 @@ import info.nightscout.pump.medtrum.comm.enums.BasalType
 import info.nightscout.pump.medtrum.comm.enums.MedtrumPumpState
 import info.nightscout.pump.medtrum.extension.toByteArray
 import info.nightscout.pump.medtrum.extension.toInt
+import info.nightscout.pump.medtrum.util.MedtrumSnUtil
 import info.nightscout.rx.events.EventOverviewBolusProgress
 import info.nightscout.rx.logging.AAPSLogger
 import info.nightscout.rx.logging.LTag
@@ -170,7 +171,7 @@ class MedtrumPump @Inject constructor(
             sp.putLong(R.string.key_last_connection, value)
         }
 
-    private var _deviceType: Int = 80 // As reported by pump
+    private var _deviceType: Int = 0 // As reported by pump
     var deviceType: Int
         get() = _deviceType
         set(value) {
@@ -280,14 +281,16 @@ class MedtrumPump @Inject constructor(
         try {
             _actualBasalProfile = Base64.decode(encodedString, Base64.DEFAULT)
         } catch (e: Exception) {
-            aapsLogger.error(LTag.PUMP, "Error decoding basal profile from SP: $encodedString")
+            aapsLogger.warn(LTag.PUMP, "Error decoding basal profile from SP: $encodedString")
         }
     }
 
-    fun pumpType(): PumpType =
-        when (deviceType) {
-            80, 88 -> PumpType.MEDTRUM_NANO
-            else   -> PumpType.MEDTRUM_UNTESTED
+    fun pumpType(): PumpType = pumpType(deviceType)
+
+    fun pumpType(type: Int): PumpType =
+        when (type) {
+            MedtrumSnUtil.MD_0201, MedtrumSnUtil.MD_8201 -> PumpType.MEDTRUM_NANO
+            else                                         -> PumpType.MEDTRUM_UNTESTED
         }
 
     fun loadUserSettingsFromSP() {

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/AuthorizePacket.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/AuthorizePacket.kt
@@ -45,6 +45,7 @@ class AuthorizePacket(injector: HasAndroidInjector) : MedtrumPacket(injector) {
             ).toInt()
 
             if (medtrumPump.deviceType != deviceType) {
+                aapsLogger.warn(LTag.PUMPCOMM, "GetDeviceTypeState: deviceType changed from ${medtrumPump.deviceType} to $deviceType")
                 medtrumPump.deviceType = deviceType
             }
             if (medtrumPump.swVersion != swVersion) {

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/MedtrumActivity.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/MedtrumActivity.kt
@@ -29,7 +29,7 @@ class MedtrumActivity : MedtrumBaseActivity<ActivityMedtrumBinding>() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
-        title = getString(R.string.step_prepare_patch)
+        title = getString(R.string.change_patch_label)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setDisplayShowHomeEnabled(true)
 

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/util/MedtrumSnUtil.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/util/MedtrumSnUtil.kt
@@ -1,0 +1,33 @@
+package info.nightscout.pump.medtrum.util
+
+import info.nightscout.pump.medtrum.encryption.Crypt
+
+class MedtrumSnUtil {
+
+    companion object {
+
+        const val INVALID = -1
+        const val MD_0201 = 80
+        const val MD_5201 = 81
+        const val MD_0202 = 82
+        const val MD_5202 = 83
+        const val MD_8201 = 88
+        const val MD_8301 = 98
+    }
+
+    fun getDeviceTypeFromSerial(serial: Long): Int {
+        if (serial in 106000000..106999999) {
+            return INVALID
+        }
+
+        return when (Crypt().simpleDecrypt(serial)) {
+            in 126000000..126999999 -> MD_0201
+            in 127000000..127999999 -> MD_5201
+            in 128000000..128999999 -> MD_8201
+            in 130000000..130999999 -> MD_0202
+            in 131000000..131999999 -> MD_5202
+            in 148000000..148999999 -> MD_8301
+            else                    -> INVALID
+        }
+    }
+}

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="patch_expiry_label">Patch expires</string>
     <string name="refresh_label">Refresh</string>
     <string name="reset_alarms_label">Reset alarms</string>
-    <string name="change_patch_label">Change patch</string>
+    <string name="change_patch_label">Change Patch</string>
     <string name="requested_by_user" comment="26 characters max for translation">Requested by user</string>
     <string name="expiry_not_enabled">Not enabled</string>
 

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -28,7 +28,6 @@
     <string name="medtrum_pump_description">Pump integration for Medtrum Nano</string>
     <string name="medtrum_pump_setting">Medtrum pump settings</string>
     <string name="pump_error">Pump error: %1$s !! </string>
-    <string name="pump_unsupported">Pump untested: %1$d! Please contact us at discord or github for support</string>
     <string name="pump_is_suspended">Pump is suspended</string>
     <string name="pump_is_suspended_hour_max">Pump is suspended due to hourly max insulin exceeded</string>
     <string name="pump_is_suspended_day_max">Pump is suspended due to daily max insulin exceeded</string>
@@ -131,6 +130,8 @@
     <!-- settings-->
     <string name="sn_input_title">Serial Number</string>
     <string name="sn_input_summary">Enter the serial number of your pump base.</string>
+    <string name="sn_input_invalid">Invalid serial number! Check serial number and try again.</string>
+    <string name="pump_unsupported">Pump untested: %1$d! Please contact us at discord or github for support</string>
     <string name="alarm_setting_title">Alarm Settings</string>
     <string name="alarm_setting_summary">Select your preferred pump alarm settings.</string>
     <string name="patch_expiration_title">Patch Expiration</string>

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
     <!-- settings-->
     <string name="sn_input_title">Serial Number</string>
     <string name="sn_input_summary">Enter the serial number of your pump base.</string>
-    <string name="sn_input_invalid">Invalid serial number! Check serial number and try again.</string>
+    <string name="sn_input_invalid">Invalid serial number!</string>
     <string name="pump_unsupported">Pump untested: %1$d! Please contact us at discord or github for support</string>
     <string name="alarm_setting_title">Alarm Settings</string>
     <string name="alarm_setting_summary">Select your preferred pump alarm settings.</string>


### PR DESCRIPTION
- Make sure pumpType is set correctly before connectNewPump() is called, Move check for untested pump to settings
- Use Change Patch for activity title
- Add invalid warning during serial number input

User can still press OK when he inputs an invalid SN, But it is not saved and additional pop up is shown. I could not find a neat way to prevent the OK click. If there are any suggestions let me know.