### PR TITLE
Dash: Add option to disable pod expiration alert

### DIFF
--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -131,9 +131,11 @@
     <string name="omnipod_common_preferences_suspend_delivery_button_enabled">Show Suspend Delivery button in Omnipod tab</string>
     <string name="omnipod_common_preferences_time_change_enabled">DST/Time zone detection enabled</string>
     <string name="omnipod_common_preferences_expiration_reminder_enabled">Expiration reminder enabled</string>
-    <string name="omnipod_common_preferences_expiration_reminder_hours_before_shutdown">Reminder at hours before shutdown</string>
-    <string name="omnipod_common_preferences_expiration_alarm_enabled">Expiration alarm enabled</string>
-    <string name="omnipod_common_preferences_expiration_alarm_hours_before_shutdown">Alarm at hours before shutdown</string>
+    <string name="omnipod_common_preferences_expiration_reminder_enabled_summary">When enabled the pod will beep when the specified time is reached</string>
+    <string name="omnipod_common_preferences_expiration_reminder_hours_before_shutdown">Reminder at hours before shutdown (80 Hours)</string>
+    <string name="omnipod_common_preferences_expiration_alarm_enabled">Expiration alert enabled</string>
+    <string name="omnipod_common_preferences_expiration_alarm_enabled_summary">When enabled the pod will beep when the specified time is reached and every hour after that</string>
+    <string name="omnipod_common_preferences_expiration_alarm_hours_before_shutdown">Alert at hours before shutdown (80 Hours)</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_enabled">Low reservoir alert enabled</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_units">Number of units</string>
     <string name="omnipod_common_preferences_automatically_silence_alerts">Automatically silence Pod alerts</string>

--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="key_omnipod_common_time_change_event_enabled" translatable="false">AAPS.Omnipod.time_change_enabled</string>
     <string name="key_omnipod_common_expiration_reminder_enabled" translatable="false">AAPS.Omnipod.expiration_reminder_enabled</string>
     <string name="key_omnipod_common_expiration_reminder_hours_before_shutdown" translatable="false">AAPS.Omnipod.expiration_reminder_hours_before_shutdown</string>
+    <string name="key_omnipod_common_expiration_alarm_enabled" translatable="false">AAPS.Omnipod.expiration_alarm_enabled</string>
+    <string name="key_omnipod_common_expiration_alarm_hours_before_shutdown" translatable="false">AAPS.Omnipod.expiration_alarm_hours_before_shutdown</string>
     <string name="key_omnipod_common_low_reservoir_alert_enabled" translatable="false">AAPS.Omnipod.low_reservoir_alert_enabled</string>
     <string name="key_omnipod_common_low_reservoir_alert_units" translatable="false">AAPS.Omnipod.low_reservoir_alert_units</string>
     <string name="key_omnipod_common_automatically_silence_alerts_enabled" translatable="false">AAPS.Omnipod.automatically_acknowledge_alerts_enabled</string>
@@ -129,7 +131,9 @@
     <string name="omnipod_common_preferences_suspend_delivery_button_enabled">Show Suspend Delivery button in Omnipod tab</string>
     <string name="omnipod_common_preferences_time_change_enabled">DST/Time zone detection enabled</string>
     <string name="omnipod_common_preferences_expiration_reminder_enabled">Expiration reminder enabled</string>
-    <string name="omnipod_common_preferences_expiration_reminder_hours_before_shutdown">Hours before shutdown</string>
+    <string name="omnipod_common_preferences_expiration_reminder_hours_before_shutdown">Reminder at hours before shutdown</string>
+    <string name="omnipod_common_preferences_expiration_alarm_enabled">Expiration alarm enabled</string>
+    <string name="omnipod_common_preferences_expiration_alarm_hours_before_shutdown">Alarm at hours before shutdown</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_enabled">Low reservoir alert enabled</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_units">Number of units</string>
     <string name="omnipod_common_preferences_automatically_silence_alerts">Automatically silence Pod alerts</string>

--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="omnipod_common_preferences_expiration_reminder_enabled_summary">When enabled the pod will beep when the specified time is reached</string>
     <string name="omnipod_common_preferences_expiration_reminder_hours_before_expiry">Reminder at hours before expiry (72 Hours)</string>
     <string name="omnipod_common_preferences_expiration_alarm_enabled">Expiration alert enabled</string>
-    <string name="omnipod_common_preferences_expiration_alarm_enabled_summary">When enabled the pod will beep when the specified time is reached and every hour after that</string>
+    <string name="omnipod_common_preferences_expiration_alarm_enabled_summary">When enabled the pod will beep when the specified time is reached and 1 hour before shutdown</string>
     <string name="omnipod_common_preferences_expiration_alarm_hours_before_shutdown">Alert at hours before shutdown (80 Hours)</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_enabled">Low reservoir alert enabled</string>
     <string name="omnipod_common_preferences_low_reservoir_alert_units">Number of units</string>

--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="key_omnipod_common_suspend_delivery_button_enabled" translatable="false">AAPS.Omnipod.suspend_delivery_button_enabled</string>
     <string name="key_omnipod_common_time_change_event_enabled" translatable="false">AAPS.Omnipod.time_change_enabled</string>
     <string name="key_omnipod_common_expiration_reminder_enabled" translatable="false">AAPS.Omnipod.expiration_reminder_enabled</string>
-    <string name="key_omnipod_common_expiration_reminder_hours_before_shutdown" translatable="false">AAPS.Omnipod.expiration_reminder_hours_before_shutdown</string>
+    <string name="key_omnipod_common_expiration_reminder_hours_before_expiry" translatable="false">AAPS.Omnipod.expiration_reminder_hours_before_expiry</string>
     <string name="key_omnipod_common_expiration_alarm_enabled" translatable="false">AAPS.Omnipod.expiration_alarm_enabled</string>
     <string name="key_omnipod_common_expiration_alarm_hours_before_shutdown" translatable="false">AAPS.Omnipod.expiration_alarm_hours_before_shutdown</string>
     <string name="key_omnipod_common_low_reservoir_alert_enabled" translatable="false">AAPS.Omnipod.low_reservoir_alert_enabled</string>
@@ -132,7 +132,7 @@
     <string name="omnipod_common_preferences_time_change_enabled">DST/Time zone detection enabled</string>
     <string name="omnipod_common_preferences_expiration_reminder_enabled">Expiration reminder enabled</string>
     <string name="omnipod_common_preferences_expiration_reminder_enabled_summary">When enabled the pod will beep when the specified time is reached</string>
-    <string name="omnipod_common_preferences_expiration_reminder_hours_before_shutdown">Reminder at hours before shutdown (80 Hours)</string>
+    <string name="omnipod_common_preferences_expiration_reminder_hours_before_expiry">Reminder at hours before expiry (72 Hours)</string>
     <string name="omnipod_common_preferences_expiration_alarm_enabled">Expiration alert enabled</string>
     <string name="omnipod_common_preferences_expiration_alarm_enabled_summary">When enabled the pod will beep when the specified time is reached and every hour after that</string>
     <string name="omnipod_common_preferences_expiration_alarm_hours_before_shutdown">Alert at hours before shutdown (80 Hours)</string>

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -22,6 +22,7 @@ import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definitio
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.BeepType
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.DeliveryStatus
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_IMMINENT_ALERT_HOURS_REMAINING
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.response.ResponseType
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.state.CommandConfirmed
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.state.OmnipodDashPodStateManager
@@ -84,6 +85,7 @@ import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.Date
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.concurrent.thread
@@ -481,6 +483,8 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 {
                     if (it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_enabled)) ||
                         it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown)) ||
+                        it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_enabled)) ||
+                        it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_hours_before_shutdown)) ||
                         it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_enabled)) ||
                         it.isChanged(rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_units))
                     ) {
@@ -1102,16 +1106,22 @@ class OmnipodDashPumpPlugin @Inject constructor(
         return when (customCommand) {
             is CommandSilenceAlerts            ->
                 silenceAlerts()
+
             is CommandResumeDelivery           ->
                 resumeDelivery()
+
             is CommandDeactivatePod            ->
                 deactivatePod()
+
             is CommandHandleTimeChange         ->
                 handleTimeChange()
+
             is CommandUpdateAlertConfiguration ->
                 updateAlertConfiguration()
+
             is CommandPlayTestBeep             ->
                 playTestBeep()
+
             is CommandDisableSuspendAlerts     ->
                 disableSuspendAlerts()
 
@@ -1214,14 +1224,18 @@ class OmnipodDashPumpPlugin @Inject constructor(
     private fun updateAlertConfiguration(): PumpEnactResult {
 
         val expirationReminderEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_enabled, true)
-        val expirationHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown, 7)
+        val expirationReminderHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown, 7)
+        val expirationAlarmEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_enabled, true)
+        val expirationAlarmHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_hours_before_shutdown, 8)
         val lowReservoirAlertEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_enabled, true)
         val lowReservoirAlertUnits = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_units, 10)
 
         when {
             podStateManager.sameAlertSettings(
                 expirationReminderEnabled,
-                expirationHours,
+                expirationReminderHours,
+                expirationAlarmEnabled,
+                expirationAlarmHours,
                 lowReservoirAlertEnabled,
                 lowReservoirAlertUnits
             )                             -> {
@@ -1236,12 +1250,30 @@ class OmnipodDashPumpPlugin @Inject constructor(
         }
 
         val podLifeLeft = Duration.between(ZonedDateTime.now(), podStateManager.expiry)
-        val expiryAlertDelay = podLifeLeft.minus(Duration.ofHours(expirationHours.toLong()))
+        val expiryAlertDelay = podLifeLeft.minus(Duration.ofHours(expirationReminderHours.toLong()))
         if (expiryAlertDelay.isNegative) {
             aapsLogger.warn(
                 LTag.PUMPBTCOMM,
                 "updateAlertConfiguration negative " +
                     "expiryAlertDuration=$expiryAlertDelay"
+            )
+            PumpEnactResult(injector).success(false).enacted(false)
+        }
+        val expiryAlarmDelay = podLifeLeft.minus(Duration.ofHours(expirationAlarmHours.toLong()))
+        if (expiryAlarmDelay.isNegative) {
+            aapsLogger.warn(
+                LTag.PUMPBTCOMM,
+                "updateAlertConfiguration negative " +
+                    "expiryAlarmDuration=$expiryAlarmDelay"
+            )
+            PumpEnactResult(injector).success(false).enacted(false)
+        }
+        val expiryImminentDelay = podLifeLeft.minus(Duration.ofHours(POD_EXPIRATION_IMMINENT_ALERT_HOURS_REMAINING))
+        if (expiryImminentDelay.isNegative) {
+            aapsLogger.warn(
+                LTag.PUMPBTCOMM,
+                "updateAlertConfiguration negative " +
+                    "expiryImminentDuration=$expiryImminentDelay"
             )
             PumpEnactResult(injector).success(false).enacted(false)
         }
@@ -1265,14 +1297,39 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 ),
                 BeepType.FOUR_TIMES_BIP_BEEP,
                 BeepRepetitionType.EVERY_MINUTE_AND_EVERY_15_MIN
+            ),
+            AlertConfiguration(
+                AlertType.EXPIRATION,
+                enabled = expirationAlarmEnabled,
+                durationInMinutes = TimeUnit.HOURS.toMinutes(expirationAlarmHours.toLong()).toShort(),
+                autoOff = false,
+                AlertTrigger.TimerTrigger(
+                    expiryAlarmDelay.toMinutes().toShort()
+                ),
+                BeepType.FOUR_TIMES_BIP_BEEP,
+                BeepRepetitionType.XXX3
+            ),
+            AlertConfiguration(
+                AlertType.EXPIRATION_IMMINENT,
+                enabled = expirationAlarmEnabled,
+                durationInMinutes = 0,
+                autoOff = false,
+                AlertTrigger.TimerTrigger(
+                    expiryImminentDelay.toMinutes().toShort()
+                ),
+                BeepType.FOUR_TIMES_BIP_BEEP,
+                BeepRepetitionType.XXX3
             )
         )
+
         return executeProgrammingCommand(
             historyEntry = history.createRecord(OmnipodCommandType.CONFIGURE_ALERTS),
             command = omnipodManager.programAlerts(alerts).ignoreElements(),
             post = podStateManager.updateExpirationAlertSettings(
                 expirationReminderEnabled,
-                expirationHours
+                expirationReminderHours,
+                expirationAlarmEnabled,
+                expirationAlarmHours
             ).andThen(
                 podStateManager.updateLowReservoirAlertSettings(
                     lowReservoirAlertEnabled,
@@ -1513,10 +1570,10 @@ class OmnipodDashPumpPlugin @Inject constructor(
             // Cancel TBR running on Pump
             return@defer observeNoActiveTempBasal()
                 .concatWith(podStateManager.updateActiveCommand()
-                    .map { handleCommandConfirmation(it) }
-                    .ignoreElement())
+                                .map { handleCommandConfirmation(it) }
+                                .ignoreElement())
         }
-        
+
         return@defer Completable.complete()
     }
 
@@ -1537,10 +1594,13 @@ class OmnipodDashPumpPlugin @Inject constructor(
         return when (notificationType) {
             Notification.OMNIPOD_TBR_ALERTS    ->
                 sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_notification_uncertain_tbr_sound_enabled, true)
+
             Notification.OMNIPOD_UNCERTAIN_SMB ->
                 sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_notification_uncertain_smb_sound_enabled, true)
+
             Notification.OMNIPOD_POD_SUSPENDED ->
                 sp.getBoolean(R.string.key_omnipod_common_notification_delivery_suspended_sound_enabled, true)
+
             else                               -> true
         }
     }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -1254,8 +1254,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
         if (expiryReminderDelay.isNegative) {
             aapsLogger.warn(
                 LTag.PUMPBTCOMM,
-                "updateAlertConfiguration negative " +
-                    "expiryAlertDuration=$expiryReminderDelay"
+                "updateAlertConfiguration negative expiryAlertDuration=$expiryReminderDelay"
             )
             PumpEnactResult(injector).success(false).enacted(false)
         }
@@ -1264,8 +1263,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
         if (expiryAlarmDelay.isNegative) {
             aapsLogger.warn(
                 LTag.PUMPBTCOMM,
-                "updateAlertConfiguration negative " +
-                    "expiryAlarmDuration=$expiryAlarmDelay"
+                "updateAlertConfiguration negative expiryAlarmDuration=$expiryAlarmDelay"
             )
             PumpEnactResult(injector).success(false).enacted(false)
         }
@@ -1273,8 +1271,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
         if (expiryImminentDelay.isNegative) {
             aapsLogger.warn(
                 LTag.PUMPBTCOMM,
-                "updateAlertConfiguration negative " +
-                    "expiryImminentDuration=$expiryImminentDelay"
+                "updateAlertConfiguration negative expiryImminentDuration=$expiryImminentDelay"
             )
             PumpEnactResult(injector).success(false).enacted(false)
         }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManager.kt
@@ -15,7 +15,7 @@ interface OmnipodDashManager {
 
     fun activatePodPart1(lowReservoirAlertTrigger: AlertTrigger.ReservoirVolumeTrigger?): Observable<PodEvent>
 
-    fun activatePodPart2(basalProgram: BasalProgram, userConfiguredExpirationHours: Long?): Observable<PodEvent>
+    fun activatePodPart2(basalProgram: BasalProgram, userConfiguredExpirationReminderHours: Long?, userConfiguredExpirationAlarmHours: Long?): Observable<PodEvent>
 
     fun getStatus(type: ResponseType.StatusResponseType): Observable<PodEvent>
 

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -23,11 +23,9 @@ import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definitio
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.BasalProgram
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.BeepRepetitionType
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.BeepType
-import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.MAX_POD_LIFETIME
-import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_ALERT_HOURS
-import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_ALERT_HOURS_DURATION
-import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_IMMINENT_ALERT_HOURS
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_ALERT_HOURS_REMAINING_DEFAULT
+import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_EXPIRATION_IMMINENT_ALERT_HOURS_REMAINING
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodConstants.Companion.POD_PULSE_BOLUS_UNITS
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.PodStatus
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.pod.definition.ProgramReminder
@@ -161,9 +159,9 @@ class OmnipodDashManagerImpl @Inject constructor(
         // TODO move somewhere else
         val expectedResponseType = when (type) {
             ResponseType.StatusResponseType.DEFAULT_STATUS_RESPONSE -> DefaultStatusResponse::class
-            ResponseType.StatusResponseType.ALARM_STATUS -> AlarmStatusResponse::class
+            ResponseType.StatusResponseType.ALARM_STATUS            -> AlarmStatusResponse::class
 
-            else -> return Observable.error(UnsupportedOperationException("No response type to class mapping for ${type.name}"))
+            else                                                    -> return Observable.error(UnsupportedOperationException("No response type to class mapping for ${type.name}"))
         }
 
         return Observable.defer {
@@ -368,19 +366,19 @@ class OmnipodDashManagerImpl @Inject constructor(
         return observables.reversed()
     }
 
-    override fun activatePodPart2(basalProgram: BasalProgram, userConfiguredExpirationHours: Long?):
+    override fun activatePodPart2(basalProgram: BasalProgram, userConfiguredExpirationReminderHours: Long?, userConfiguredExpirationAlarmHours: Long?):
         Observable<PodEvent> {
         return Observable.concat(
             observePodReadyForActivationPart2,
             observeConnectToPod,
-            observeActivationPart2Commands(basalProgram, userConfiguredExpirationHours)
+            observeActivationPart2Commands(basalProgram, userConfiguredExpirationReminderHours, userConfiguredExpirationAlarmHours)
         ).doOnComplete(ActivationProgressUpdater(ActivationProgress.COMPLETED))
             .interceptPodEvents()
     }
 
-    private fun observeActivationPart2Commands(basalProgram: BasalProgram, userConfiguredExpirationHours: Long?):
+    private fun observeActivationPart2Commands(basalProgram: BasalProgram, userConfiguredExpirationReminderHours: Long?, userConfiguredExpirationAlarmHours: Long?):
         Observable<PodEvent> {
-        val observables = createActivationPart2Observables(basalProgram, userConfiguredExpirationHours)
+        val observables = createActivationPart2Observables(basalProgram, userConfiguredExpirationReminderHours, userConfiguredExpirationAlarmHours)
 
         return if (observables.isEmpty()) {
             Observable.empty()
@@ -391,7 +389,8 @@ class OmnipodDashManagerImpl @Inject constructor(
 
     private fun createActivationPart2Observables(
         basalProgram: BasalProgram,
-        userConfiguredExpirationHours: Long?
+        userConfiguredExpirationReminderHours: Long?,
+        userConfiguredExpirationAlarmHours: Long?
     ):
         List<Observable<PodEvent>> {
         val observables = ArrayList<Observable<PodEvent>>()
@@ -422,32 +421,42 @@ class OmnipodDashManagerImpl @Inject constructor(
         if (podStateManager.activationProgress.isBefore(ActivationProgress.UPDATED_EXPIRATION_ALERTS)) {
             val podLifeLeft = Duration.between(ZonedDateTime.now(), podStateManager.expiry)
 
+            val expirationAlarmEnabled = userConfiguredExpirationAlarmHours != null && userConfiguredExpirationAlarmHours > 0
+            val expirationAlarmDelay = podLifeLeft.minus(
+                Duration.ofHours(userConfiguredExpirationAlarmHours ?: POD_EXPIRATION_ALERT_HOURS_REMAINING_DEFAULT)
+            )
+            val expirationImminnentDelay = podLifeLeft.minus(
+                Duration.ofHours(POD_EXPIRATION_IMMINENT_ALERT_HOURS_REMAINING)
+            )
+
             val alerts = mutableListOf(
                 AlertConfiguration(
                     AlertType.EXPIRATION,
-                    enabled = true,
-                    durationInMinutes = TimeUnit.HOURS.toMinutes(POD_EXPIRATION_ALERT_HOURS_DURATION).toShort(),
+                    enabled = expirationAlarmEnabled,
+                    durationInMinutes = TimeUnit.HOURS.toMinutes(
+                        userConfiguredExpirationAlarmHours ?: POD_EXPIRATION_ALERT_HOURS_REMAINING_DEFAULT
+                    ).toShort(),
                     autoOff = false,
                     AlertTrigger.TimerTrigger(
-                        TimeUnit.HOURS.toMinutes(POD_EXPIRATION_ALERT_HOURS).toShort()
-                    ), // FIXME use activation time
+                        expirationAlarmDelay.toMinutes().toShort()
+                    ),
                     BeepType.FOUR_TIMES_BIP_BEEP,
                     BeepRepetitionType.XXX3
                 ),
                 AlertConfiguration(
                     AlertType.EXPIRATION_IMMINENT,
-                    enabled = true,
+                    enabled = expirationAlarmEnabled,
                     durationInMinutes = 0,
                     autoOff = false,
                     AlertTrigger.TimerTrigger(
-                        TimeUnit.HOURS.toMinutes(POD_EXPIRATION_IMMINENT_ALERT_HOURS).toShort()
-                    ), // FIXME use activation time
+                        expirationImminnentDelay.toMinutes().toShort()
+                    ),
                     BeepType.FOUR_TIMES_BIP_BEEP,
                     BeepRepetitionType.XXX4
                 )
             )
             val userExpiryAlertDelay = podLifeLeft.minus(
-                Duration.ofHours(userConfiguredExpirationHours ?: MAX_POD_LIFETIME.toHours() + 1)
+                Duration.ofHours(userConfiguredExpirationReminderHours ?: MAX_POD_LIFETIME.toHours() + 1)
             )
             if (userExpiryAlertDelay.isNegative) {
                 logger.warn(
@@ -693,16 +702,16 @@ class OmnipodDashManagerImpl @Inject constructor(
             logger.debug(LTag.PUMP, "Intercepted PodEvent in OmnipodDashManagerImpl: ${event.javaClass.simpleName}")
 
             when (event) {
-                is PodEvent.AlreadyConnected -> {
+                is PodEvent.AlreadyConnected        -> {
                 }
 
-                is PodEvent.BluetoothConnected -> {
+                is PodEvent.BluetoothConnected      -> {
                 }
 
-                is PodEvent.Connected -> {
+                is PodEvent.Connected               -> {
                 }
 
-                is PodEvent.CommandSent -> {
+                is PodEvent.CommandSent             -> {
                     logger.debug(LTag.PUMP, "Command sent: ${event.command.commandType}")
                     podStateManager.activeCommand?.let {
                         if (it.sequence == event.command.sequenceNumber) {
@@ -721,16 +730,16 @@ class OmnipodDashManagerImpl @Inject constructor(
                     podStateManager.increaseMessageSequenceNumber()
                 }
 
-                is PodEvent.ResponseReceived -> {
+                is PodEvent.ResponseReceived        -> {
                     podStateManager.increaseMessageSequenceNumber()
                     handleResponse(event.response)
                 }
 
-                is PodEvent.Paired -> {
+                is PodEvent.Paired                  -> {
                     podStateManager.uniqueId = event.uniqueId.toLong()
                 }
 
-                else -> {
+                else                                -> {
                     // Do nothing
                 }
             }
@@ -738,11 +747,11 @@ class OmnipodDashManagerImpl @Inject constructor(
 
         private fun handleResponse(response: Response) {
             when (response) {
-                is VersionResponse -> {
+                is VersionResponse       -> {
                     podStateManager.updateFromVersionResponse(response)
                 }
 
-                is SetUniqueIdResponse -> {
+                is SetUniqueIdResponse   -> {
                     podStateManager.updateFromSetUniqueIdResponse(response)
                 }
 
@@ -750,7 +759,7 @@ class OmnipodDashManagerImpl @Inject constructor(
                     podStateManager.updateFromDefaultStatusResponse(response)
                 }
 
-                is AlarmStatusResponse -> {
+                is AlarmStatusResponse   -> {
                     podStateManager.updateFromAlarmStatusResponse(response)
                 }
             }

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
@@ -6,12 +6,11 @@ class PodConstants {
     companion object {
         val MAX_POD_LIFETIME: Duration = Duration.ofHours(80)
 
-        // Expiration alert time in minutes since activation and  duration in minutes
-        const val POD_EXPIRATION_ALERT_HOURS = 72L
-        const val POD_EXPIRATION_ALERT_HOURS_DURATION = 7L
+        // Expiration alert time in hours before lifetime end
+        const val POD_EXPIRATION_ALERT_HOURS_REMAINING_DEFAULT = 7L
 
-        // Expiration eminent alert time in minutes since activation
-        const val POD_EXPIRATION_IMMINENT_ALERT_HOURS = 79L
+        // Imminent expiration alert time in hours before lifetime end
+        const val POD_EXPIRATION_IMMINENT_ALERT_HOURS_REMAINING = 1L
 
         // Bolus & Priming units
         const val POD_PULSE_BOLUS_UNITS = 0.05

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -112,8 +112,20 @@ interface OmnipodDashPodStateManager {
        - after getPodStatus was successful(we have an up-to-date podStatus)
      */
     fun recoverActivationFromPodStatus(): String?
-    fun sameAlertSettings(expirationReminderEnabled: Boolean, expirationHours: Int, lowReservoirAlertEnabled: Boolean, lowReservoirAlertUnits: Int): Boolean
-    fun updateExpirationAlertSettings(expirationReminderEnabled: Boolean, expirationHours: Int): Completable
+    fun sameAlertSettings(
+        expirationReminderEnabled: Boolean,
+        expirationReminderHours: Int,
+        expirationAlarmEnabled: Boolean,
+        expirationAlarmHours: Int,
+        lowReservoirAlertEnabled: Boolean,
+        lowReservoirAlertUnits: Int
+    ): Boolean
+    fun updateExpirationAlertSettings(
+        expirationReminderEnabled: Boolean,
+        expirationReminderHours: Int,
+        expirationAlarmEnabled: Boolean,
+        expirationAlarmHours: Int
+    ): Completable
     fun updateLowReservoirAlertSettings(lowReservoirAlertEnabled: Boolean, lowReservoirAlertUnits: Int): Completable
 
     data class ActiveCommand(

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
@@ -67,7 +67,7 @@ class DashInsertCannulaViewModel @Inject constructor(
                 basalProgram
             )
             val expirationReminderEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_enabled, true)
-            val expirationReminderHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown, 9)
+            val expirationReminderHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_expiry, 9)
 
             val expirationReminderHoursBeforeShutdown = if (expirationReminderEnabled)
                 expirationReminderHours.toLong()

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/wizard/activation/viewmodel/action/DashInsertCannulaViewModel.kt
@@ -67,16 +67,24 @@ class DashInsertCannulaViewModel @Inject constructor(
                 basalProgram
             )
             val expirationReminderEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_enabled, true)
-            val expirationHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown, 9)
+            val expirationReminderHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown, 9)
 
-            val expirationHoursBeforeShutdown = if (expirationReminderEnabled)
-                expirationHours.toLong()
+            val expirationReminderHoursBeforeShutdown = if (expirationReminderEnabled)
+                expirationReminderHours.toLong()
             else
                 null
 
-            super.disposable += omnipodManager.activatePodPart2(basalProgram, expirationHoursBeforeShutdown)
+            val expirationAlarmEnabled = sp.getBoolean(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_enabled, true)
+            val expirationAlarmHours = sp.getInt(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_alarm_hours_before_shutdown, 8)
+
+            val expirationAlarmHoursBeforeShutdown = if (expirationAlarmEnabled)
+                expirationAlarmHours.toLong()
+            else
+                null
+
+            super.disposable += omnipodManager.activatePodPart2(basalProgram, expirationReminderHoursBeforeShutdown, expirationAlarmHoursBeforeShutdown)
                 .ignoreElements()
-                .andThen(podStateManager.updateExpirationAlertSettings(expirationReminderEnabled, expirationHours))
+                .andThen(podStateManager.updateExpirationAlertSettings(expirationReminderEnabled, expirationReminderHours, expirationAlarmEnabled, expirationAlarmHours))
                 .andThen(
                     history.createRecord(
                         OmnipodCommandType.INSERT_CANNULA,

--- a/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -37,7 +37,8 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="@string/key_omnipod_common_expiration_reminder_enabled"
-            android:title="@string/omnipod_common_preferences_expiration_reminder_enabled" />
+            android:title="@string/omnipod_common_preferences_expiration_reminder_enabled"
+            android:summary="@string/omnipod_common_preferences_expiration_reminder_enabled_summary" />
 
         <info.nightscout.core.validators.ValidatingEditTextPreference
             android:defaultValue="9"
@@ -53,7 +54,8 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="@string/key_omnipod_common_expiration_alarm_enabled"
-            android:title="@string/omnipod_common_preferences_expiration_alarm_enabled" />
+            android:title="@string/omnipod_common_preferences_expiration_alarm_enabled" 
+            android:summary="@string/omnipod_common_preferences_expiration_alarm_enabled_summary" />
 
         <info.nightscout.core.validators.ValidatingEditTextPreference
             android:defaultValue="8"

--- a/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -45,8 +45,8 @@
             android:dependency="@string/key_omnipod_common_expiration_reminder_enabled"
             android:digits="0123456789"
             android:inputType="number"
-            android:key="@string/key_omnipod_common_expiration_reminder_hours_before_shutdown"
-            android:title="@string/omnipod_common_preferences_expiration_reminder_hours_before_shutdown"
+            android:key="@string/key_omnipod_common_expiration_reminder_hours_before_expiry"
+            android:title="@string/omnipod_common_preferences_expiration_reminder_hours_before_expiry"
             validate:maxNumber="24"
             validate:minNumber="2"
             validate:testType="numericRange" />
@@ -64,7 +64,7 @@
             android:inputType="number"
             android:key="@string/key_omnipod_common_expiration_alarm_hours_before_shutdown"
             android:title="@string/omnipod_common_preferences_expiration_alarm_hours_before_shutdown"
-            validate:maxNumber="24"
+            validate:maxNumber="8"
             validate:minNumber="1"
             validate:testType="numericRange" />
 

--- a/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -52,6 +52,22 @@
 
         <SwitchPreference
             android:defaultValue="true"
+            android:key="@string/key_omnipod_common_expiration_alarm_enabled"
+            android:title="@string/omnipod_common_preferences_expiration_alarm_enabled" />
+
+        <info.nightscout.core.validators.ValidatingEditTextPreference
+            android:defaultValue="8"
+            android:dependency="@string/key_omnipod_common_expiration_alarm_enabled"
+            android:digits="0123456789"
+            android:inputType="number"
+            android:key="@string/key_omnipod_common_expiration_alarm_hours_before_shutdown"
+            android:title="@string/omnipod_common_preferences_expiration_alarm_hours_before_shutdown"
+            validate:maxNumber="24"
+            validate:minNumber="1"
+            validate:testType="numericRange" />
+
+        <SwitchPreference
+            android:defaultValue="true"
             android:key="@string/key_omnipod_common_low_reservoir_alert_enabled"
             android:title="@string/omnipod_common_preferences_low_reservoir_alert_enabled" />
 

--- a/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/pump/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -41,14 +41,14 @@
             android:summary="@string/omnipod_common_preferences_expiration_reminder_enabled_summary" />
 
         <info.nightscout.core.validators.ValidatingEditTextPreference
-            android:defaultValue="9"
+            android:defaultValue="4"
             android:dependency="@string/key_omnipod_common_expiration_reminder_enabled"
             android:digits="0123456789"
             android:inputType="number"
             android:key="@string/key_omnipod_common_expiration_reminder_hours_before_expiry"
             android:title="@string/omnipod_common_preferences_expiration_reminder_hours_before_expiry"
             validate:maxNumber="24"
-            validate:minNumber="2"
+            validate:minNumber="1"
             validate:testType="numericRange" />
 
         <SwitchPreference

--- a/pump/omnipod-eros/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/definition/OmnipodErosStorageKeys.java
+++ b/pump/omnipod-eros/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/definition/OmnipodErosStorageKeys.java
@@ -14,7 +14,7 @@ public class OmnipodErosStorageKeys {
         public static final int PULSE_LOG_BUTTON_ENABLED = R.string.key_omnipod_eros_pulse_log_button_enabled;
         public static final int TIME_CHANGE_EVENT_ENABLED = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_time_change_event_enabled;
         public static final int EXPIRATION_REMINDER_ENABLED = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_enabled;
-        public static final int EXPIRATION_REMINDER_HOURS_BEFORE_SHUTDOWN = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_shutdown;
+        public static final int EXPIRATION_REMINDER_HOURS_BEFORE_SHUTDOWN = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_expiration_reminder_hours_before_expiry;
         public static final int LOW_RESERVOIR_ALERT_ENABLED = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_enabled;
         public static final int LOW_RESERVOIR_ALERT_UNITS = info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.key_omnipod_common_low_reservoir_alert_units;
         public static final int NOTIFICATION_UNCERTAIN_TBR_SOUND_ENABLED = R.string.key_omnipod_eros_notification_uncertain_tbr_sound_enabled;

--- a/pump/omnipod-eros/src/main/res/xml/omnipod_eros_preferences.xml
+++ b/pump/omnipod-eros/src/main/res/xml/omnipod_eros_preferences.xml
@@ -76,8 +76,8 @@
             android:dependency="@string/key_omnipod_common_expiration_reminder_enabled"
             android:digits="0123456789"
             android:inputType="number"
-            android:key="@string/key_omnipod_common_expiration_reminder_hours_before_shutdown"
-            android:title="@string/omnipod_common_preferences_expiration_reminder_hours_before_shutdown"
+            android:key="@string/key_omnipod_common_expiration_reminder_hours_before_expiry"
+            android:title="@string/omnipod_common_preferences_expiration_reminder_hours_before_expiry"
             validate:maxNumber="24"
             validate:minNumber="2"
             validate:testType="numericRange" />


### PR DESCRIPTION
Solution for: https://github.com/nightscout/AndroidAPS/issues/2691

Feature has been tested by multiple ppl.
During testing we found that there is no feedback when the setting command failed, however this is an existing thing and I propose to do this in a new ticket/pr

Screenshot:
<img src="https://github.com/nightscout/AndroidAPS/assets/60566713/79a382b1-9af4-48b7-8401-7034e378e0ae" width="200">
