### PR TITLE
Wear CWF Fix delay in DayName and Month format after watchface loading

### DIFF
--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
@@ -164,6 +164,8 @@ class CustomWatchface : BaseWatchFace() {
                     .takeIf { it.matches(Regex("E{1,4}")) } ?: "E"
                 monthFormat = json.optString(MONTHFORMAT.key, "MMM")
                     .takeIf { it.matches(Regex("M{1,4}")) } ?: "MMM"
+                binding.dayName.text = dateUtil.dayNameString(dayNameFormat) // Update daynName and month according to format on cwf loading
+                binding.month.text = dateUtil.monthString(monthFormat)
                 bgColor = when (singleBg.sgvLevel) {
                     1L   -> highColor
                     0L   -> midColor


### PR DESCRIPTION
When format is customized (full day name or full month name) it can takes a few minutes before have full names updated within watchface

With this PR day and month are updated on watchface load to have result immediatly