### PR TITLE
Rewrite test files that have assertTrues instead of matchers

### DIFF
--- a/app/src/test/java/info/nightscout/plugins/constraints/ConstraintsCheckerTest.kt
+++ b/app/src/test/java/info/nightscout/plugins/constraints/ConstraintsCheckerTest.kt
@@ -1,5 +1,6 @@
 package info.nightscout.plugins.constraints
 
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.androidaps.danar.DanaRPlugin
@@ -43,7 +44,6 @@ import info.nightscout.pump.danars.DanaRSPlugin
 import info.nightscout.pump.virtual.VirtualPumpPlugin
 import info.nightscout.sharedtests.TestBaseWithProfile
 import info.nightscout.source.GlimpPlugin
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
@@ -237,9 +237,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
         comboPlugin.setPluginEnabled(PluginType.PUMP, true)
         comboPlugin.setValidBasalRateProfileSelectedOnPump(false)
         val c = constraintChecker.isLoopInvocationAllowed()
-        Assertions.assertEquals(true, c.reasonList.size == 2) // Combo & Objectives
-        Assertions.assertEquals(true, c.mostLimitedReasonList.size == 2) // Combo & Objectives
-        Assertions.assertEquals(java.lang.Boolean.FALSE, c.value())
+        assertThat(c.reasonList).hasSize(2) // Combo & Objectives
+        assertThat(c.mostLimitedReasonList).hasSize(2) // Combo & Objectives
+        assertThat(c.value()).isFalse()
     }
 
     // Safety & Objectives
@@ -250,13 +250,13 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
         objectivesPlugin.objectives[Objectives.MAXIOB_ZERO_CL_OBJECTIVE].startedOn = 0
         var c: Constraint<Boolean> = constraintChecker.isClosedLoopAllowed()
         aapsLogger.debug("Reason list: " + c.reasonList.toString())
-//        Assertions.assertTrue(c.reasonList[0].toString().contains("Closed loop is disabled")) // Safety & Objectives
-        Assertions.assertEquals(false, c.value())
+//        assertThat(c.reasonList[0].toString()).contains("Closed loop is disabled") // Safety & Objectives
+        assertThat(c.value()).isFalse()
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn(ApsMode.OPEN.name)
         c = constraintChecker.isClosedLoopAllowed()
-        Assertions.assertTrue(c.reasonList[0].contains("Closed loop mode disabled in preferences")) // Safety & Objectives
-//        Assertions.assertEquals(3, c.reasonList.size) // 2x Safety & Objectives
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.reasonList[0]).contains("Closed loop mode disabled in preferences") // Safety & Objectives
+//        assertThat(c.reasonList).hasThat(3) // 2x Safety & Objectives
+        assertThat(c.value()).isFalse()
     }
 
     // Safety & Objectives
@@ -266,9 +266,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
         objectivesPlugin.objectives[Objectives.AUTOSENS_OBJECTIVE].startedOn = 0
         `when`(sp.getBoolean(info.nightscout.plugins.aps.R.string.key_openapsama_use_autosens, false)).thenReturn(false)
         val c = constraintChecker.isAutosensModeEnabled()
-        Assertions.assertEquals(true, c.reasonList.size == 2) // Safety & Objectives
-        Assertions.assertEquals(true, c.mostLimitedReasonList.size == 2) // Safety & Objectives
-        Assertions.assertEquals(java.lang.Boolean.FALSE, c.value())
+        assertThat(c.reasonList).hasSize(2) // Safety & Objectives
+        assertThat(c.mostLimitedReasonList).hasSize(2) // Safety & Objectives
+        assertThat( c.value()).isFalse()
     }
 
     // Safety
@@ -276,9 +276,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
     fun isAdvancedFilteringEnabledTest() {
         `when`(activePlugin.activeBgSource).thenReturn(glimpPlugin)
         val c = constraintChecker.isAdvancedFilteringEnabled()
-        Assertions.assertEquals(true, c.reasonList.size == 1) // Safety
-        Assertions.assertEquals(true, c.mostLimitedReasonList.size == 1) // Safety
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.reasonList).hasSize(1) // Safety
+        assertThat(c.mostLimitedReasonList).hasSize(1) // Safety
+        assertThat( c.value()).isFalse()
     }
 
     // SMB should limit
@@ -286,7 +286,7 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
     fun isSuperBolusEnabledTest() {
         openAPSSMBPlugin.setPluginEnabled(PluginType.APS, true)
         val c = constraintChecker.isSuperBolusEnabled()
-        Assertions.assertEquals(java.lang.Boolean.FALSE, c.value()) // SMB should limit
+        assertThat( c.value()).isFalse() // SMB should limit
     }
 
     // Safety & Objectives
@@ -298,9 +298,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn(ApsMode.OPEN.name)
 //        `when`(constraintChecker.isClosedLoopAllowed()).thenReturn(Constraint(true))
         val c = constraintChecker.isSMBModeEnabled()
-        Assertions.assertEquals(true, c.reasonList.size == 3) // 2x Safety & Objectives
-        Assertions.assertEquals(true, c.mostLimitedReasonList.size == 3) // 2x Safety & Objectives
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.reasonList).hasSize(3) // 2x Safety & Objectives
+        assertThat(c.mostLimitedReasonList).hasSize(3) // 2x Safety & Objectives
+        assertThat( c.value()).isFalse()
     }
 
     // applyBasalConstraints tests
@@ -326,9 +326,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val d = constraintChecker.getMaxBasalAllowed(validProfile)
-        Assertions.assertEquals(0.8, d.value(), 0.01)
-        Assertions.assertEquals(3, d.reasonList.size)
-        Assertions.assertEquals("DanaR: Limiting max basal rate to 0.80 U/h because of pump limit", d.getMostLimitedReasons(aapsLogger))
+        assertThat( d.value()).isWithin( 0.01).of(0.8)
+        assertThat(d.reasonList).hasSize(3)
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("DanaR: Limiting max basal rate to 0.80 U/h because of pump limit")
     }
 
     @Test
@@ -353,9 +353,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val i = constraintChecker.getMaxBasalPercentAllowed(validProfile)
-        Assertions.assertEquals(200, i.value())
-        Assertions.assertEquals(6, i.reasonList.size)
-        Assertions.assertEquals("Safety: Limiting max percent rate to 200% because of pump limit", i.getMostLimitedReasons(aapsLogger))
+        assertThat(i.value()).isEqualTo(200)
+        assertThat(i.reasonList).hasSize(6)
+        assertThat(i.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting max percent rate to 200% because of pump limit")
     }
 
     // applyBolusConstraints tests
@@ -380,9 +380,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val d = constraintChecker.getMaxBolusAllowed()
-        Assertions.assertEquals(3.0, d.value(), 0.01)
-        Assertions.assertEquals(4, d.reasonList.size) // 2x Safety & RS & R
-        Assertions.assertEquals("Safety: Limiting bolus to 3.0 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+        assertThat( d.value()).isWithin( 0.01).of(3.0)
+        assertThat(d.reasonList).hasSize(4) // 2x Safety & RS & R
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting bolus to 3.0 U because of max value in preferences")
     }
 
     // applyCarbsConstraints tests
@@ -393,9 +393,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val i = constraintChecker.getMaxCarbsAllowed()
-        Assertions.assertEquals(48, i.value())
-        Assertions.assertEquals(true, i.reasonList.size == 1)
-        Assertions.assertEquals("Safety: Limiting carbs to 48 g because of max value in preferences", i.getMostLimitedReasons(aapsLogger))
+        assertThat(i.value()).isEqualTo(48)
+        assertThat(i.reasonList).hasSize(1)
+        assertThat(i.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting carbs to 48 g because of max value in preferences")
     }
 
     // applyMaxIOBConstraints tests
@@ -410,9 +410,9 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val d = constraintChecker.getMaxIOBAllowed()
-        Assertions.assertEquals(1.5, d.value(), 0.01)
-        Assertions.assertEquals(2, d.reasonList.size)
-        Assertions.assertEquals("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+        assertThat( d.value()).isWithin( 0.01).of(1.5)
+        assertThat(d.reasonList).hasSize(2)
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences")
     }
 
     @Test
@@ -426,8 +426,8 @@ class ConstraintsCheckerTest : TestBaseWithProfile() {
 
         // Apply all limits
         val d = constraintChecker.getMaxIOBAllowed()
-        Assertions.assertEquals(3.0, d.value(), 0.01)
-        Assertions.assertEquals(2, d.reasonList.size)
-        Assertions.assertEquals("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+        assertThat( d.value()).isWithin( 0.01).of(3.0)
+        assertThat(d.reasonList).hasSize(2)
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences")
     }
 }

--- a/app/src/test/java/info/nightscout/plugins/safety/SafetyPluginTest.kt
+++ b/app/src/test/java/info/nightscout/plugins/safety/SafetyPluginTest.kt
@@ -1,5 +1,6 @@
 package info.nightscout.plugins.safety
 
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.database.impl.AppRepository
@@ -21,7 +22,6 @@ import info.nightscout.plugins.constraints.safety.SafetyPlugin
 import info.nightscout.pump.virtual.VirtualPumpPlugin
 import info.nightscout.sharedtests.TestBaseWithProfile
 import info.nightscout.source.GlimpPlugin
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
@@ -88,8 +88,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         pumpDescription.isTempBasalCapable = false
         var c = Constraint(true)
         c = safetyPlugin.isLoopInvocationAllowed(c)
-        Assertions.assertEquals("Safety: Pump is not temp basal capable", c.getReasons(aapsLogger))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).isEqualTo("Safety: Pump is not temp basal capable")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -98,8 +98,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(config.isEngineeringModeOrRelease()).thenReturn(false)
         var c = Constraint(true)
         c = safetyPlugin.isClosedLoopAllowed(c)
-        Assertions.assertTrue(c.getReasons(aapsLogger).contains("Running dev version. Closed loop is disabled."))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).contains("Running dev version. Closed loop is disabled.")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -107,8 +107,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn(ApsMode.OPEN.name)
         var c = Constraint(true)
         c = safetyPlugin.isClosedLoopAllowed(c)
-        Assertions.assertTrue(c.getReasons(aapsLogger).contains("Closed loop mode disabled in preferences"))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).contains("Closed loop mode disabled in preferences")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -117,8 +117,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(constraintChecker.isClosedLoopAllowed(anyObject())).thenReturn(Constraint(true))
         var c = Constraint(true)
         c = openAPSSMBPlugin.isSMBModeEnabled(c)
-        Assertions.assertTrue(c.getReasons(aapsLogger).contains("SMB disabled in preferences"))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).contains("SMB disabled in preferences")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -127,8 +127,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(constraintChecker.isClosedLoopAllowed(anyObject())).thenReturn(Constraint(false))
         var c = Constraint(true)
         c = safetyPlugin.isSMBModeEnabled(c)
-        Assertions.assertTrue(c.getReasons(aapsLogger).contains("SMB not allowed in open loop mode"))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).contains("SMB not allowed in open loop mode")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -136,8 +136,8 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(activePlugin.activeBgSource).thenReturn(glimpPlugin)
         var c = Constraint(true)
         c = safetyPlugin.isAdvancedFilteringEnabled(c)
-        Assertions.assertEquals("Safety: SMB always and after carbs disabled because active BG source doesn\\'t support advanced filtering", c.getReasons(aapsLogger))
-        Assertions.assertEquals(false, c.value())
+        assertThat(c.getReasons(aapsLogger)).isEqualTo("Safety: SMB always and after carbs disabled because active BG source doesn\\'t support advanced filtering")
+        assertThat(c.value()).isFalse()
     }
 
     @Test
@@ -148,13 +148,12 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         val c = Constraint(Constants.REALLYHIGHBASALRATE)
         safetyPlugin.applyBasalConstraints(c, validProfile)
-        Assertions.assertEquals(2.0, c.value(), 0.01)
-        Assertions.assertEquals(
+        assertThat(c.value()).isWithin(0.01).of(2.0)
+        assertThat(c.getReasons(aapsLogger)).isEqualTo(
             """
     Safety: Limiting max basal rate to 2.00 U/h because of hard limit
-    """.trimIndent(), c.getReasons(aapsLogger)
-        )
-        Assertions.assertEquals("Safety: Limiting max basal rate to 2.00 U/h because of hard limit", c.getMostLimitedReasons(aapsLogger))
+    """.trimIndent())
+        assertThat(c.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting max basal rate to 2.00 U/h because of hard limit")
     }
 
     @Test
@@ -162,8 +161,9 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         val d = Constraint(-0.5)
         safetyPlugin.applyBasalConstraints(d, validProfile)
-        Assertions.assertEquals(0.0, d.value(), 0.01)
-        Assertions.assertEquals("Safety: Limiting max basal rate to 0.00 U/h because of it must be positive value", d.getReasons(aapsLogger))
+        assertThat(d.value()).isWithin(0.01).of(0.0)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo(
+        "Safety: Limiting max basal rate to 0.00 U/h because of it must be positive value")
     }
 
     @Test
@@ -175,16 +175,17 @@ class SafetyPluginTest : TestBaseWithProfile() {
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         val i = Constraint(Constants.REALLYHIGHPERCENTBASALRATE)
         safetyPlugin.applyBasalPercentConstraints(i, validProfile)
-        Assertions.assertEquals(200, i.value())
-        Assertions.assertEquals(
+        assertThat(i.value()).isEqualTo(200)
+        assertThat(i.getReasons(aapsLogger)).isEqualTo(
             """
 Safety: Percent rate 1111111% recalculated to 11111.11 U/h with current basal 1.00 U/h
 Safety: Limiting max basal rate to 2.00 U/h because of hard limit
 Safety: Limiting max percent rate to 200% because of pump limit
 Safety: Limiting max basal rate to 500.00 U/h because of pump limit
-    """.trimIndent(), i.getReasons(aapsLogger)
+    """.trimIndent()
         )
-        Assertions.assertEquals("Safety: Limiting max percent rate to 200% because of pump limit", i.getMostLimitedReasons(aapsLogger))
+        assertThat(i.getMostLimitedReasons(aapsLogger)).isEqualTo(
+        "Safety: Limiting max percent rate to 200% because of pump limit")
     }
 
     @Test
@@ -197,15 +198,14 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         openAPSSMBPlugin.setPluginEnabled(PluginType.APS, true)
         val i = Constraint(Constants.REALLYHIGHBASALRATE)
         openAPSSMBPlugin.applyBasalConstraints(i, validProfile)
-        Assertions.assertEquals(1.0, i.value(), 0.01)
-        Assertions.assertEquals(
+        assertThat(i.value()).isWithin(0.01).of(1.0)
+        assertThat(i.getReasons(aapsLogger)).isEqualTo(
             """
             OpenAPSSMB: Limiting max basal rate to 1.00 U/h because of max value in preferences
             OpenAPSSMB: Limiting max basal rate to 4.00 U/h because of max basal multiplier
             OpenAPSSMB: Limiting max basal rate to 3.00 U/h because of max daily basal multiplier
-            """.trimIndent(), i.getReasons(aapsLogger)
-        )
-        Assertions.assertEquals("OpenAPSSMB: Limiting max basal rate to 1.00 U/h because of max value in preferences", i.getMostLimitedReasons(aapsLogger))
+            """.trimIndent())
+        assertThat(i.getMostLimitedReasons(aapsLogger)).isEqualTo("OpenAPSSMB: Limiting max basal rate to 1.00 U/h because of max value in preferences")
     }
 
     @Test
@@ -213,15 +213,14 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         val i = Constraint(-22)
         safetyPlugin.applyBasalPercentConstraints(i, validProfile)
-        Assertions.assertEquals(0, i.value())
-        Assertions.assertEquals(
+        assertThat(i.value()).isEqualTo(0)
+        assertThat(i.getReasons(aapsLogger)).isEqualTo(
             """
     Safety: Percent rate -22% recalculated to -0.22 U/h with current basal 1.00 U/h
     Safety: Limiting max basal rate to 0.00 U/h because of it must be positive value
     Safety: Limiting max percent rate to 0% because of pump limit
-    """.trimIndent(), i.getReasons(aapsLogger)
-        )
-        Assertions.assertEquals("Safety: Limiting max percent rate to 0% because of pump limit", i.getMostLimitedReasons(aapsLogger))
+    """.trimIndent())
+        assertThat(i.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting max percent rate to 0% because of pump limit")
     }
 
     @Test
@@ -230,14 +229,13 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         var d = Constraint(Constants.REALLYHIGHBOLUS)
         d = safetyPlugin.applyBolusConstraints(d)
-        Assertions.assertEquals(3.0, d.value(), 0.01)
-        Assertions.assertEquals(
+        assertThat(d.value()).isWithin(0.01).of(3.0)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo(
             """
     Safety: Limiting bolus to 3.0 U because of max value in preferences
     Safety: Limiting bolus to 5.0 U because of hard limit
-    """.trimIndent(), d.getReasons(aapsLogger)
-        )
-        Assertions.assertEquals("Safety: Limiting bolus to 3.0 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+    """.trimIndent())
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting bolus to 3.0 U because of max value in preferences")
     }
 
     @Test
@@ -246,9 +244,9 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_age, "")).thenReturn("child")
         var d = Constraint(-22.0)
         d = safetyPlugin.applyBolusConstraints(d)
-        Assertions.assertEquals(0.0, d.value(), 0.01)
-        Assertions.assertEquals("Safety: Limiting bolus to 0.0 U because of it must be positive value", d.getReasons(aapsLogger))
-        Assertions.assertEquals("Safety: Limiting bolus to 0.0 U because of it must be positive value", d.getMostLimitedReasons(aapsLogger))
+        assertThat(d.value()).isWithin(0.01).of(0.0)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo("Safety: Limiting bolus to 0.0 U because of it must be positive value")
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting bolus to 0.0 U because of it must be positive value")
     }
 
     @Test
@@ -259,13 +257,13 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         // Negative carbs not allowed
         var i = Constraint(-22)
         safetyPlugin.applyCarbsConstraints(i)
-        Assertions.assertEquals(0, i.value())
-        Assertions.assertEquals("Safety: Limiting carbs to 0 g because of it must be positive value", i.getReasons(aapsLogger))
+        assertThat(i.value()).isEqualTo(0)
+        assertThat(i.getReasons(aapsLogger)).isEqualTo("Safety: Limiting carbs to 0 g because of it must be positive value")
 
         // Apply all limits
         i = safetyPlugin.applyCarbsConstraints(Constraint(Constants.REALLYHIGHCARBS))
-        Assertions.assertEquals(48, i.value())
-        Assertions.assertEquals("Safety: Limiting carbs to 48 g because of max value in preferences", i.getReasons(aapsLogger))
+        assertThat(i.value()).isEqualTo(48)
+        assertThat(i.getReasons(aapsLogger)).isEqualTo("Safety: Limiting carbs to 48 g because of max value in preferences")
     }
 
     @Test
@@ -282,22 +280,22 @@ Safety: Limiting max basal rate to 500.00 U/h because of pump limit
         // Apply all limits
         var d = Constraint(Constants.REALLYHIGHIOB)
         d = safetyPlugin.applyMaxIOBConstraints(d)
-        Assertions.assertEquals(HardLimits.MAX_IOB_LGS, d.value(), 0.01)
-        Assertions.assertEquals("Safety: Limiting IOB to 0.0 U because of Low Glucose Suspend", d.getReasons(aapsLogger))
-        Assertions.assertEquals("Safety: Limiting IOB to 0.0 U because of Low Glucose Suspend", d.getMostLimitedReasons(aapsLogger))
+        assertThat(d.value()).isWithin(0.01).of(HardLimits.MAX_IOB_LGS)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo("Safety: Limiting IOB to 0.0 U because of Low Glucose Suspend")
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("Safety: Limiting IOB to 0.0 U because of Low Glucose Suspend")
 
         // Apply all limits
         d = Constraint(Constants.REALLYHIGHIOB)
         val a = openAPSAMAPlugin.applyMaxIOBConstraints(d)
-        Assertions.assertEquals(1.5, a.value(), 0.01)
-        Assertions.assertEquals("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences\nOpenAPSAMA: Limiting IOB to 7.0 U because of hard limit", d.getReasons(aapsLogger))
-        Assertions.assertEquals("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+        assertThat(a.value()).isWithin(0.01).of(1.5)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences\nOpenAPSAMA: Limiting IOB to 7.0 U because of hard limit")
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("OpenAPSAMA: Limiting IOB to 1.5 U because of max value in preferences")
 
         // Apply all limits
         d = Constraint(Constants.REALLYHIGHIOB)
         val s = openAPSSMBPlugin.applyMaxIOBConstraints(d)
-        Assertions.assertEquals(3.0, s.value(), 0.01)
-        Assertions.assertEquals("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences\nOpenAPSSMB: Limiting IOB to 22.0 U because of hard limit", d.getReasons(aapsLogger))
-        Assertions.assertEquals("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences", d.getMostLimitedReasons(aapsLogger))
+        assertThat(s.value()).isWithin(0.01).of(3.0)
+        assertThat(d.getReasons(aapsLogger)).isEqualTo("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences\nOpenAPSSMB: Limiting IOB to 22.0 U because of hard limit")
+        assertThat(d.getMostLimitedReasons(aapsLogger)).isEqualTo("OpenAPSSMB: Limiting IOB to 3.0 U because of max value in preferences")
     }
 }

--- a/core/main/src/test/java/info/nightscout/core/data/IobTest.kt
+++ b/core/main/src/test/java/info/nightscout/core/data/IobTest.kt
@@ -1,7 +1,7 @@
 package info.nightscout.core.data
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.interfaces.iob.Iob
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class IobTest {
@@ -10,23 +10,23 @@ class IobTest {
         val a = Iob().iobContrib(1.0).activityContrib(2.0)
         val b = Iob().iobContrib(3.0).activityContrib(4.0)
         a.plus(b)
-        Assertions.assertEquals(4.0, a.iobContrib, 0.01)
-        Assertions.assertEquals(6.0, a.activityContrib, 0.01)
+        assertThat(a.iobContrib).isWithin(0.01).of(4.0)
+        assertThat(a.activityContrib).isWithin(0.01).of(6.0)
     }
 
     @Test fun equalTest() {
         val a1 = Iob().iobContrib(1.0).activityContrib(2.0)
         val a2 = Iob().iobContrib(1.0).activityContrib(2.0)
         val b = Iob().iobContrib(3.0).activityContrib(4.0)
-        Assertions.assertTrue(a1 == a2)
-        Assertions.assertFalse(a1 == b)
-        @Suppress("SENSELESS_COMPARISON")
-        Assertions.assertFalse(a1 == null)
-        Assertions.assertFalse(a1 == Any())
+        assertThat(a1).isEqualTo(a1)
+        assertThat(a1).isEqualTo(a2)
+        assertThat(a1).isNotEqualTo(b)
+        assertThat(a1).isNotNull()
+        assertThat(a1).isNotEqualTo(Any())
     }
 
     @Test fun hashCodeTest() {
         val a = Iob().iobContrib(1.0).activityContrib(2.0)
-        Assertions.assertNotEquals(0, a.hashCode().toLong())
+        assertThat(a.hashCode().toLong()).isNotEqualTo(0L)
     }
 }

--- a/core/main/src/test/java/info/nightscout/core/utils/MidnightTimeTest.kt
+++ b/core/main/src/test/java/info/nightscout/core/utils/MidnightTimeTest.kt
@@ -1,7 +1,7 @@
 package info.nightscout.core.utils
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.interfaces.utils.MidnightTime
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.Calendar
 
@@ -10,40 +10,40 @@ class MidnightTimeTest {
     @Test fun calc() {
         // We get real midnight
         val now = System.currentTimeMillis()
-        Assertions.assertTrue(now >= MidnightTime.calc())
+        assertThat(MidnightTime.calc()).isAtMost(now)
         val c = Calendar.getInstance()
         c.timeInMillis = MidnightTime.calc()
-        Assertions.assertEquals(c[Calendar.HOUR_OF_DAY].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.MINUTE].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.SECOND].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.MILLISECOND].toLong(), 0)
+        assertThat(c[Calendar.HOUR_OF_DAY].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.MINUTE].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.SECOND].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.MILLISECOND].toLong()).isEqualTo(0L)
     }
 
     @Test fun calc_time() {
         // We get real midnight
         val now = System.currentTimeMillis()
         val midnight = MidnightTime.calc(now)
-        Assertions.assertTrue(now >= midnight)
+        assertThat(midnight).isAtMost(now)
         val c = Calendar.getInstance()
         c.timeInMillis = MidnightTime.calc(now)
-        Assertions.assertEquals(c[Calendar.HOUR_OF_DAY].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.MINUTE].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.SECOND].toLong(), 0)
-        Assertions.assertEquals(c[Calendar.MILLISECOND].toLong(), 0)
+        assertThat(c[Calendar.HOUR_OF_DAY].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.MINUTE].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.SECOND].toLong()).isEqualTo(0L)
+        assertThat(c[Calendar.MILLISECOND].toLong()).isEqualTo(0L)
         // Assure we get the same time from cache
-        Assertions.assertEquals(midnight, MidnightTime.calc(now))
+        assertThat(midnight).isEqualTo(MidnightTime.calc(now))
     }
 
     @Test fun resetCache() {
         val now = System.currentTimeMillis()
         MidnightTime.calc(now)
         MidnightTime.resetCache()
-        Assertions.assertEquals(0, MidnightTime.times.size().toLong())
+        assertThat(MidnightTime.times.size().toLong()).isEqualTo(0L)
     }
 
     @Test fun log() {
         val now = System.currentTimeMillis()
         MidnightTime.calc(now)
-        Assertions.assertTrue(MidnightTime.log().startsWith("Hits:"))
+        assertThat(MidnightTime.log()).startsWith("Hits:")
     }
 }

--- a/core/main/src/test/java/info/nightscout/core/utils/TTest.kt
+++ b/core/main/src/test/java/info/nightscout/core/utils/TTest.kt
@@ -1,7 +1,7 @@
 package info.nightscout.core.utils
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.shared.utils.T
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import kotlin.math.abs
 
@@ -9,33 +9,33 @@ import kotlin.math.abs
 class TTest {
 
     @Test fun toUnits() {
-        Assertions.assertEquals(1, T.msecs(1000).secs())
-        Assertions.assertEquals(1, T.secs(60).mins())
-        Assertions.assertEquals(1, T.mins(60).hours())
-        Assertions.assertEquals(1, T.hours(24).days())
-        Assertions.assertEquals(24, T.days(1).hours())
-        Assertions.assertEquals(60000, T.mins(1).msecs())
+        assertThat(T.msecs(1000).secs()).isEqualTo(1)
+        assertThat(T.secs(60).mins()).isEqualTo(1)
+        assertThat(T.mins(60).hours()).isEqualTo(1)
+        assertThat(T.hours(24).days()).isEqualTo(1)
+        assertThat(T.days(1).hours()).isEqualTo(24)
+        assertThat(T.mins(1).msecs()).isEqualTo(60000)
     }
 
     @Test fun now() {
-        Assertions.assertTrue(abs(T.now().msecs() - System.currentTimeMillis()) < 5000)
+        assertThat(abs(T.now().msecs() - System.currentTimeMillis())).isLessThan(5_000L)
     }
 
     @Test fun additions() {
         val nowMsecs = System.currentTimeMillis()
         val now = T.msecs(nowMsecs)
-        Assertions.assertEquals(now.plus(T.secs(5)).msecs(), nowMsecs + 5 * 1000)
-        Assertions.assertEquals(now.plus(T.mins(5)).msecs(), nowMsecs + 5 * 60 * 1000)
-        Assertions.assertEquals(now.plus(T.hours(5)).msecs(), nowMsecs + 5 * 60 * 60 * 1000)
-        Assertions.assertEquals(now.plus(T.days(5)).msecs(), nowMsecs + 5 * 24 * 60 * 60 * 1000)
+        assertThat(nowMsecs + 5 * 1000).isEqualTo(now.plus(T.secs(5)).msecs())
+        assertThat(nowMsecs + 5 * 60 * 1000).isEqualTo(now.plus(T.mins(5)).msecs())
+        assertThat(nowMsecs + 5 * 60 * 60 * 1000).isEqualTo(now.plus(T.hours(5)).msecs())
+        assertThat(nowMsecs + 5 * 24 * 60 * 60 * 1000).isEqualTo(now.plus(T.days(5)).msecs())
     }
 
     @Test fun subtractions() {
         val nowMsecs = System.currentTimeMillis()
         val now = T.msecs(nowMsecs)
-        Assertions.assertEquals(now.minus(T.secs(5)).msecs(), nowMsecs - 5 * 1000)
-        Assertions.assertEquals(now.minus(T.mins(5)).msecs(), nowMsecs - 5 * 60 * 1000)
-        Assertions.assertEquals(now.minus(T.hours(5)).msecs(), nowMsecs - 5 * 60 * 60 * 1000)
-        Assertions.assertEquals(now.minus(T.days(5)).msecs(), nowMsecs - 5 * 24 * 60 * 60 * 1000)
+        assertThat(nowMsecs - 5 * 1000).isEqualTo(now.minus(T.secs(5)).msecs())
+        assertThat(nowMsecs - 5 * 60 * 1000).isEqualTo(now.minus(T.mins(5)).msecs())
+        assertThat(nowMsecs - 5 * 60 * 60 * 1000).isEqualTo(now.minus(T.hours(5)).msecs())
+        assertThat(nowMsecs - 5 * 24 * 60 * 60 * 1000).isEqualTo(now.minus(T.days(5)).msecs())
     }
 }

--- a/implementation/src/test/java/info/nightscout/implementation/wizard/BolusWizardTest.kt
+++ b/implementation/src/test/java/info/nightscout/implementation/wizard/BolusWizardTest.kt
@@ -1,5 +1,6 @@
 package info.nightscout.implementation.wizard
 
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.core.wizard.BolusWizard
@@ -14,7 +15,6 @@ import info.nightscout.interfaces.pump.defs.PumpDescription
 import info.nightscout.interfaces.queue.CommandQueue
 import info.nightscout.rx.bus.RxBus
 import info.nightscout.sharedtests.TestBaseWithProfile
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
@@ -113,7 +113,7 @@ class BolusWizardTest : TestBaseWithProfile() {
                 useAlarm = false
             )
         val bolusForBg54 = bw.calculatedTotalInsulin
-        Assertions.assertEquals(bolusForBg42, bolusForBg54, 0.01)
+        assertThat(bolusForBg54).isWithin( 0.01).of(bolusForBg42)
     }
 
     @Test
@@ -159,7 +159,7 @@ class BolusWizardTest : TestBaseWithProfile() {
                 useAlarm = false
             )
         val bolusForBgInRange = bw.calculatedTotalInsulin
-        Assertions.assertTrue(bolusForHighBg > bolusForBgInRange)
+        assertThat(bolusForHighBg).isGreaterThan(bolusForBgInRange)
     }
 
     @Test
@@ -205,6 +205,6 @@ class BolusWizardTest : TestBaseWithProfile() {
                 useAlarm = false
             )
         val bolusForBgInRange = bw.calculatedTotalInsulin
-        Assertions.assertTrue(bolusForLowBg < bolusForBgInRange)
+        assertThat(bolusForLowBg).isLessThan(bolusForBgInRange)
     }
 }

--- a/plugins/automation/src/test/java/info/nightscout/automation/triggers/TriggerConnectorTest.kt
+++ b/plugins/automation/src/test/java/info/nightscout/automation/triggers/TriggerConnectorTest.kt
@@ -1,8 +1,8 @@
 package info.nightscout.automation.triggers
 
+import com.google.common.truth.Truth.assertThat
 import org.json.JSONException
 import org.json.JSONObject
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class TriggerConnectorTest : TriggerTestBase() {
@@ -15,66 +15,65 @@ class TriggerConnectorTest : TriggerTestBase() {
         val t = TriggerConnector(injector)
         val t2 = TriggerConnector(injector)
         val t3 = TriggerConnector(injector)
-        Assertions.assertTrue(t.size() == 0)
+        assertThat(t.size()).isEqualTo(0)
         t.list.add(t2)
-        Assertions.assertTrue(t.size() == 1)
-        Assertions.assertEquals(t2, t.list[0])
+        assertThat(t.size()).isEqualTo(1)
+        assertThat(t.list).containsExactly(t2)
         t.list.add(t3)
-        Assertions.assertTrue(t.size() == 2)
-        Assertions.assertEquals(t2, t.list[0])
-        Assertions.assertEquals(t3, t.list[1])
-        Assertions.assertTrue(t.list.remove(t2))
-        Assertions.assertTrue(t.size() == 1)
-        Assertions.assertEquals(t3, t.list[0])
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.size()).isEqualTo(2)
+        assertThat(t.list).containsExactly(t2, t3).inOrder()
+        assertThat(t.list.remove(t2)).isTrue()
+        assertThat(t.size()).isEqualTo(1)
+        assertThat(t.list).containsExactly(t3)
+        assertThat(t.shouldRun()).isTrue()
     }
 
     @Test fun testListTriggerOR() {
         val t = TriggerConnector(injector, TriggerConnector.Type.OR)
         t.list.add(TriggerDummy(injector))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t.list.add(TriggerDummy(injector, true))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
     }
 
     @Test fun testListTriggerXOR() {
         val t = TriggerConnector(injector, TriggerConnector.Type.XOR)
         t.list.add(TriggerDummy(injector))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t.list.add(TriggerDummy(injector, true))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
         t.list.add(TriggerDummy(injector, true))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
     }
 
     @Test fun testListTriggerAND() {
         val t = TriggerConnector(injector, TriggerConnector.Type.AND)
         t.list.add(TriggerDummy(injector, true))
         t.list.add(TriggerDummy(injector, true))
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
         t.list.add(TriggerDummy(injector, true))
         t.list.add(TriggerDummy(injector))
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
     }
 
     @Test fun toJSONTest() {
         val t = TriggerConnector(injector)
-        Assertions.assertEquals(empty, t.toJSON())
+        assertThat(t.toJSON()).isEqualTo(empty)
         t.list.add(TriggerConnector(injector))
-        Assertions.assertEquals(oneItem, t.toJSON())
+        assertThat(t.toJSON()).isEqualTo(oneItem)
     }
 
     @Test @Throws(JSONException::class) fun fromJSONTest() {
         val t = TriggerConnector(injector)
         t.list.add(TriggerConnector(injector))
         val t2 = TriggerDummy(injector).instantiate(JSONObject(t.toJSON())) as TriggerConnector
-        Assertions.assertEquals(1, t2.size().toLong())
-        Assertions.assertTrue(t2.list[0] is TriggerConnector)
+        assertThat(t2.size()).isEqualTo(1)
+        assertThat(t2.list[0]).isInstanceOf(TriggerConnector::class.java)
     }
 
 }

--- a/plugins/automation/src/test/java/info/nightscout/automation/triggers/TriggerDeltaTest.kt
+++ b/plugins/automation/src/test/java/info/nightscout/automation/triggers/TriggerDeltaTest.kt
@@ -1,6 +1,6 @@
 package info.nightscout.automation.triggers
 
-import com.google.common.base.Optional
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.automation.R
 import info.nightscout.automation.elements.Comparator
 import info.nightscout.automation.elements.InputDelta.DeltaType
@@ -8,7 +8,6 @@ import info.nightscout.database.entities.GlucoseValue
 import info.nightscout.interfaces.GlucoseUnit
 import info.nightscout.interfaces.iob.InMemoryGlucoseValue
 import org.json.JSONObject
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
@@ -25,40 +24,40 @@ class TriggerDeltaTest : TriggerTestBase() {
     @Test fun shouldRunTest() {
         `when`(autosensDataStore.getBucketedDataTableCopy()).thenReturn(generateValidBgData())
         var t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(73.0, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL)
-        Assertions.assertFalse(t.shouldRun())
-        Assertions.assertEquals(DeltaType.LONG_AVERAGE, t.delta.deltaType)
+        assertThat(t.shouldRun()).isFalse()
+        assertThat(t.delta.deltaType).isEqualTo(DeltaType.LONG_AVERAGE)
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(-2.0, DeltaType.SHORT_AVERAGE).comparator(Comparator.Compare.IS_EQUAL)
-        Assertions.assertFalse(t.shouldRun())
-        Assertions.assertEquals(DeltaType.SHORT_AVERAGE, t.delta.deltaType)
+        assertThat(t.shouldRun()).isFalse()
+        assertThat(t.delta.deltaType).isEqualTo(DeltaType.SHORT_AVERAGE)
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(-3.0, DeltaType.DELTA).comparator(Comparator.Compare.IS_EQUAL_OR_GREATER)
-        Assertions.assertTrue(t.shouldRun())
-        Assertions.assertEquals(DeltaType.DELTA, t.delta.deltaType)
+        assertThat(t.shouldRun()).isTrue()
+        assertThat(t.delta.deltaType).isEqualTo(DeltaType.DELTA)
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(2.0, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL_OR_LESSER)
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(2.0, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL)
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(0.3, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL_OR_LESSER)
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(0.1, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL_OR_GREATER)
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(-0.5, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL_OR_GREATER)
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(-0.2, DeltaType.LONG_AVERAGE).comparator(Comparator.Compare.IS_EQUAL_OR_LESSER)
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
         `when`(autosensDataStore.getBucketedDataTableCopy()).thenReturn(ArrayList())
         t = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(213.0, DeltaType.DELTA).comparator(Comparator.Compare.IS_EQUAL_OR_LESSER)
-        Assertions.assertFalse(t.shouldRun())
+        assertThat(t.shouldRun()).isFalse()
         t = TriggerDelta(injector).comparator(Comparator.Compare.IS_NOT_AVAILABLE)
-        Assertions.assertTrue(t.shouldRun())
+        assertThat(t.shouldRun()).isTrue()
     }
 
     @Test fun copyConstructorTest() {
         val t: TriggerDelta = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(213.0, DeltaType.DELTA).comparator(Comparator.Compare.IS_EQUAL_OR_LESSER)
         val t1 = t.duplicate() as TriggerDelta
-        Assertions.assertEquals(213.0, t1.delta.value, 0.01)
-        Assertions.assertEquals(GlucoseUnit.MGDL, t1.units)
-        Assertions.assertEquals(DeltaType.DELTA, t.delta.deltaType)
-        Assertions.assertEquals(Comparator.Compare.IS_EQUAL_OR_LESSER, t.comparator.value)
+        assertThat( t1.delta.value).isWithin( 0.01).of(213.0)
+        assertThat(t1.units).isEqualTo(GlucoseUnit.MGDL)
+        assertThat(t.delta.deltaType).isEqualTo(DeltaType.DELTA)
+        assertThat(t.comparator.value).isEqualTo(Comparator.Compare.IS_EQUAL_OR_LESSER)
     }
 
     private var deltaJson = "{\"data\":{\"comparator\":\"IS_EQUAL\",\"deltaType\":\"DELTA\",\"units\":\"mg/dl\",\"value\":4.1},\"type\":\"TriggerDelta\"}"
@@ -66,26 +65,26 @@ class TriggerDeltaTest : TriggerTestBase() {
     @Test
     fun toJSONTest() {
         val t: TriggerDelta = TriggerDelta(injector).units(GlucoseUnit.MGDL).setValue(4.1, DeltaType.DELTA).comparator(Comparator.Compare.IS_EQUAL)
-        Assertions.assertEquals(deltaJson, t.toJSON())
+        assertThat(t.toJSON()).isEqualTo(deltaJson)
     }
 
     @Test
     fun fromJSONTest() {
         val t: TriggerDelta = TriggerDelta(injector).units(GlucoseUnit.MMOL).setValue(4.1, DeltaType.DELTA).comparator(Comparator.Compare.IS_EQUAL)
         val t2 = TriggerDummy(injector).instantiate(JSONObject(t.toJSON())) as TriggerDelta
-        Assertions.assertEquals(Comparator.Compare.IS_EQUAL, t2.comparator.value)
-        Assertions.assertEquals(4.1, t2.delta.value, 0.01)
-        Assertions.assertEquals(GlucoseUnit.MMOL, t2.units)
-        Assertions.assertEquals(DeltaType.DELTA, t2.delta.deltaType)
+        assertThat(t2.comparator.value).isEqualTo(Comparator.Compare.IS_EQUAL)
+        assertThat( t2.delta.value).isWithin( 0.01).of(4.1)
+        assertThat(t2.units).isEqualTo(GlucoseUnit.MMOL)
+        assertThat(t2.delta.deltaType).isEqualTo(DeltaType.DELTA)
     }
 
     @Test fun iconTest() {
-        Assertions.assertEquals(Optional.of(R.drawable.ic_auto_delta), TriggerDelta(injector).icon())
+        assertThat(TriggerDelta(injector).icon()).hasValue(R.drawable.ic_auto_delta)
     }
 
     @Test fun initializerTest() {
         val t = TriggerDelta(injector)
-        Assertions.assertTrue(t.units == GlucoseUnit.MGDL)
+        assertThat(t.units).isEqualTo(GlucoseUnit.MGDL)
     }
 
     private fun generateValidBgData(): MutableList<InMemoryGlucoseValue> {

--- a/plugins/constraints/src/test/java/info/nightscout/plugins/constraints/objectives/SntpClientTest.kt
+++ b/plugins/constraints/src/test/java/info/nightscout/plugins/constraints/objectives/SntpClientTest.kt
@@ -1,8 +1,8 @@
 package info.nightscout.plugins.constraints.objectives
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.shared.utils.DateUtil
 import info.nightscout.sharedtests.TestBase
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import kotlin.math.abs
@@ -16,16 +16,16 @@ class SntpClientTest : TestBase() {
         // no internet
         SntpClient(aapsLogger, dateUtil).ntpTime(object : SntpClient.Callback() {
             override fun run() {
-                Assertions.assertFalse(networkConnected)
-                Assertions.assertFalse(success)
-                Assertions.assertEquals(0L, time)
+                assertThat(networkConnected).isFalse()
+                assertThat(success).isFalse()
+                assertThat(time).isEqualTo(0L)
             }
         }, false)
         // internet
         SntpClient(aapsLogger, dateUtil).doNtpTime(object : SntpClient.Callback() {
             override fun run() {
-                Assertions.assertTrue(success)
-                Assertions.assertTrue(abs(time - System.currentTimeMillis()) < 60000)
+                assertThat(success).isTrue()
+                assertThat(abs(time - System.currentTimeMillis())).isLessThan(60_000L)
             }
         })
     }

--- a/plugins/insulin/src/test/java/info/nightscout/insulin/InsulinOrefBasePluginTest.kt
+++ b/plugins/insulin/src/test/java/info/nightscout/insulin/InsulinOrefBasePluginTest.kt
@@ -1,5 +1,6 @@
 package info.nightscout.insulin
 
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.database.entities.Bolus
@@ -13,7 +14,6 @@ import info.nightscout.rx.bus.RxBus
 import info.nightscout.rx.logging.AAPSLogger
 import info.nightscout.shared.interfaces.ResourceHelper
 import org.json.JSONObject
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -81,12 +81,12 @@ class InsulinOrefBasePluginTest {
 
     @Test
     fun testGetDia() {
-        Assertions.assertEquals(5.0, sut.dia, 0.0)
+        assertThat(sut.dia).isEqualTo(5.0)
         testUserDefinedDia = 5.0 + 1
-        Assertions.assertEquals(5.0 + 1, sut.dia, 0.0)
+        assertThat(sut.dia).isEqualTo(5.0 + 1)
         testUserDefinedDia = 5.0 - 1
-        Assertions.assertEquals(5.0, sut.dia, 0.0)
-        Assertions.assertTrue(shortDiaNotificationSend)
+        assertThat(sut.dia).isEqualTo(5.0)
+        assertThat(shortDiaNotificationSend).isTrue()
     }
 
     @Test
@@ -98,22 +98,22 @@ class InsulinOrefBasePluginTest {
         // check directly after bolus
         treatment.timestamp = time
         treatment.amount = 10.0
-        Assertions.assertEquals(10.0, sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib, 0.1)
+        assertThat(sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib).isWithin(0.01).of(10.0)
         // check after 1 hour
         treatment.timestamp = time - 1 * 60 * 60 * 1000 // 1 hour
         treatment.amount = 10.0
-        Assertions.assertEquals(3.92, sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib, 0.1)
+        assertThat(sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib).isWithin(0.01).of(3.92)
         // check after 2 hour
         treatment.timestamp = time - 2 * 60 * 60 * 1000 // 2 hours
         treatment.amount = 10.0
-        Assertions.assertEquals(0.77, sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib, 0.1)
+        assertThat(sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib).isWithin(0.01).of(0.77)
         // check after 3 hour
         treatment.timestamp = time - 3 * 60 * 60 * 1000 // 3 hours
         treatment.amount = 10.0
-        Assertions.assertEquals(0.10, sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib, 0.1)
+        assertThat(sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib).isWithin(0.01).of(0.10)
         // check after dia
         treatment.timestamp = time - 4 * 60 * 60 * 1000 // 4 hours
         treatment.amount = 10.0
-        Assertions.assertEquals(0.0, sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib, 0.1)
+        assertThat(sut.iobCalcForTreatment(treatment, time, Constants.defaultDIA).iobContrib).isWithin(0.01).of(0.0)
     }
 }

--- a/plugins/main/src/test/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
+++ b/plugins/main/src/test/java/info/nightscout/plugins/general/smsCommunicator/SmsCommunicatorPluginTest.kt
@@ -1,6 +1,7 @@
 package info.nightscout.plugins.general.smsCommunicator
 
 import android.telephony.SmsManager
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.database.entities.GlucoseValue
@@ -34,7 +35,6 @@ import info.nightscout.shared.utils.DateUtil
 import info.nightscout.shared.utils.T
 import info.nightscout.sharedtests.TestBaseWithProfile
 import io.reactivex.rxjava3.core.Single
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
@@ -249,27 +249,27 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
     @Test
     fun processSettingsTest() {
         // called from constructor
-        Assertions.assertEquals("1234", smsCommunicatorPlugin.allowedNumbers[0])
-        Assertions.assertEquals("5678", smsCommunicatorPlugin.allowedNumbers[1])
-        Assertions.assertEquals(2, smsCommunicatorPlugin.allowedNumbers.size)
+        assertThat(smsCommunicatorPlugin.allowedNumbers[0]).isEqualTo("1234")
+        assertThat(smsCommunicatorPlugin.allowedNumbers[1]).isEqualTo("5678")
+        assertThat(smsCommunicatorPlugin.allowedNumbers).hasSize(2)
     }
 
     @Test
     fun isCommandTest() {
-        Assertions.assertTrue(smsCommunicatorPlugin.isCommand("BOLUS", ""))
+        assertThat(smsCommunicatorPlugin.isCommand("BOLUS", "")).isTrue()
         smsCommunicatorPlugin.messageToConfirm = null
-        Assertions.assertFalse(smsCommunicatorPlugin.isCommand("BLB", ""))
+        assertThat(smsCommunicatorPlugin.isCommand("BLB", "")).isFalse()
         smsCommunicatorPlugin.messageToConfirm = AuthRequest(injector, Sms("1234", "ddd"), "RequestText", "ccode", object : SmsAction(false) {
             override fun run() {}
         })
-        Assertions.assertTrue(smsCommunicatorPlugin.isCommand("BLB", "1234"))
-        Assertions.assertFalse(smsCommunicatorPlugin.isCommand("BLB", "2345"))
+        assertThat(smsCommunicatorPlugin.isCommand("BLB", "1234")).isTrue()
+        assertThat(smsCommunicatorPlugin.isCommand("BLB", "2345")).isFalse()
         smsCommunicatorPlugin.messageToConfirm = null
     }
 
     @Test fun isAllowedNumberTest() {
-        Assertions.assertTrue(smsCommunicatorPlugin.isAllowedNumber("5678"))
-        Assertions.assertFalse(smsCommunicatorPlugin.isAllowedNumber("56"))
+        assertThat(smsCommunicatorPlugin.isAllowedNumber("5678")).isTrue()
+        assertThat(smsCommunicatorPlugin.isAllowedNumber("56")).isFalse()
     }
 
     @Test fun processSmsTest() {
@@ -278,32 +278,32 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("12", "aText")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertTrue(sms.ignored)
-        Assertions.assertEquals("aText", smsCommunicatorPlugin.messages[0].text)
+        assertThat(sms.ignored).isTrue()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("aText")
 
         //UNKNOWN
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "UNKNOWN")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("UNKNOWN", smsCommunicatorPlugin.messages[0].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("UNKNOWN")
 
         //BG
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BG")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BG", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("IOB:"))
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("Last BG: 100"))
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("COB: 10(2)g"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BG")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("IOB:")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("Last BG: 100")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("COB: 10(2)g")
 
         // LOOP : test remote control disabled
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(false)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP STATUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("Remote command is not allowed"))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //LOOP STATUS : disabled
@@ -311,8 +311,8 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP STATUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is disabled", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is disabled")
 
         //LOOP STATUS : suspended
         `when`(loop.minutesToEndOfSuspend()).thenReturn(10)
@@ -321,8 +321,8 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP STATUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Suspended (10 m)", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Suspended (10 m)")
 
         //LOOP STATUS : enabled - APS mode - Closed
         `when`(loop.enabled).thenReturn(true)
@@ -331,51 +331,51 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP STATUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is enabled - $modeClosed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is enabled - $modeClosed")
 
         //LOOP STATUS : enabled - APS mode - Open
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn(ApsMode.OPEN.name)
         smsCommunicatorPlugin.messages = ArrayList()
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is enabled - $modeOpen", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is enabled - $modeOpen")
 
         //LOOP STATUS : enabled - APS mode - LGS
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn(ApsMode.LGS.name)
         smsCommunicatorPlugin.messages = ArrayList()
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is enabled - $modeLgs", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is enabled - $modeLgs")
 
         //LOOP STATUS : enabled - APS mode - unknown
         `when`(sp.getString(info.nightscout.core.utils.R.string.key_aps_mode, ApsMode.OPEN.name)).thenReturn("some wrong value")
         smsCommunicatorPlugin.messages = ArrayList()
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is enabled - $modeUnknown", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is enabled - $modeUnknown")
 
         //LOOP : wrong format
         `when`(loop.enabled).thenReturn(true)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //LOOP DISABLE : already disabled
         `when`(loop.enabled).thenReturn(false)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP DISABLE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP DISABLE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is disabled", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP DISABLE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is disabled")
 
         //LOOP DISABLE : from enabled
         hasBeenRun = false
@@ -387,23 +387,23 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP DISABLE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP DISABLE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To disable loop reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP DISABLE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To disable loop reply with code ")
         var passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Loop has been disabled Temp basal canceled", smsCommunicatorPlugin.messages[3].text)
-        //Assertions.assertTrue(hasBeenRun)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Loop has been disabled Temp basal canceled")
+        //assertThat(hasBeenRun).isTrue()
 
         //LOOP ENABLE : already enabled
         `when`(loop.enabled).thenReturn(true)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP ENABLE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP ENABLE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Loop is enabled", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP ENABLE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Loop is enabled")
 
         //LOOP ENABLE : from disabled
         hasBeenRun = false
@@ -415,14 +415,14 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP ENABLE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP ENABLE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To enable loop reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP ENABLE")
+        assertThat(smsCommunicatorPlugin.messages[1].text.contains("To enable loop reply with code ")).isTrue()
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Loop has been enabled", smsCommunicatorPlugin.messages[3].text)
-        //Assertions.assertTrue(hasBeenRun)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Loop has been enabled")
+        //assertThat(hasBeenRun).isTrue()
 
         //LOOP RESUME : already enabled
         `when`(
@@ -432,29 +432,29 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP RESUME")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP RESUME", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To resume loop reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP RESUME")
+        assertThat(smsCommunicatorPlugin.messages[1].text.contains("To resume loop reply with code ")).isTrue()
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Loop resumed", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Loop resumed")
 
         //LOOP SUSPEND 1 2: wrong format
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP SUSPEND 1 2")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP SUSPEND 1 2", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP SUSPEND 1 2")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //LOOP SUSPEND 0 : wrong duration
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP SUSPEND 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP SUSPEND 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong duration", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP SUSPEND 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong duration")
 
         //LOOP SUSPEND 100 : suspend for 100 min + correct answer
         `when`(
@@ -464,41 +464,41 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP SUSPEND 100")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP SUSPEND 100", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To suspend loop for 100 minutes reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP SUSPEND 100")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To suspend loop for 100 minutes reply with code ")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Loop suspended Temp basal canceled", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Loop suspended Temp basal canceled")
 
         //LOOP SUSPEND 200 : limit to 180 min + wrong answer
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP SUSPEND 200")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP SUSPEND 200", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To suspend loop for 180 minutes reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP SUSPEND 200")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To suspend loop for 180 minutes reply with code ")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         // ignore from other number
         smsCommunicatorPlugin.processSms(Sms("5678", passCode))
         `when`(otp.checkOTP(ArgumentMatchers.anyString())).thenReturn(OneTimePasswordValidationResult.ERROR_WRONG_OTP)
         smsCommunicatorPlugin.processSms(Sms("1234", "XXXX"))
         `when`(otp.checkOTP(ArgumentMatchers.anyString())).thenReturn(OneTimePasswordValidationResult.OK)
-        Assertions.assertEquals("XXXX", smsCommunicatorPlugin.messages[3].text)
-        Assertions.assertEquals("Wrong code. Command cancelled.", smsCommunicatorPlugin.messages[4].text)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("XXXX")
+        assertThat(smsCommunicatorPlugin.messages[4].text).isEqualTo("Wrong code. Command cancelled.")
         //then correct code should not work
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[5].text)
-        Assertions.assertEquals(6, smsCommunicatorPlugin.messages.size.toLong()) // processed as common message
+        assertThat(smsCommunicatorPlugin.messages[5].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages).hasSize(6) // processed as common message
 
         //LOOP BLABLA
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "LOOP BLABLA")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("LOOP BLABLA", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("LOOP BLABLA")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //LOOP CLOSED
         var smsCommand = "LOOP CLOSED"
@@ -508,13 +508,13 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", smsCommand)
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals(smsCommand, smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains(replyClosed))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo(smsCommand)
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains(replyClosed)
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Current loop mode: $modeClosed", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Current loop mode: $modeClosed")
 
         //LOOP LGS
         smsCommand = "LOOP LGS"
@@ -523,13 +523,13 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", smsCommand)
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals(smsCommand, smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains(replyLgs))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo(smsCommand)
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains(replyLgs)
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Current loop mode: $modeLgs", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Current loop mode: $modeLgs")
 
         //NSCLIENT RESTART
         `when`(loop.isEnabled()).thenReturn(true)
@@ -537,9 +537,9 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "NSCLIENT RESTART")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("NSCLIENT RESTART", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("NSCLIENT RESTART"))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("NSCLIENT RESTART")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("NSCLIENT RESTART")
 
         //NSCLIENT BLA BLA
         `when`(loop.isEnabled()).thenReturn(true)
@@ -547,9 +547,9 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "NSCLIENT BLA BLA")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("NSCLIENT BLA BLA", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("NSCLIENT BLA BLA")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //NSCLIENT BLABLA
         `when`(loop.isEnabled()).thenReturn(true)
@@ -557,32 +557,32 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "NSCLIENT BLABLA")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("NSCLIENT BLABLA", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("NSCLIENT BLABLA")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PUMP
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PUMP", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Virtual Pump", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Virtual Pump")
 
         //PUMP CONNECT 1 2: wrong format
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP CONNECT 1 2")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP CONNECT 1 2", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP CONNECT 1 2")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PUMP CONNECT BLABLA
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP BLABLA")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP BLABLA", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP BLABLA")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PUMP CONNECT
         `when`(
@@ -593,116 +593,116 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP CONNECT")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP CONNECT", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To connect pump reply with code "))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP CONNECT")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To connect pump reply with code ")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Pump reconnected", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Pump reconnected")
 
         //PUMP DISCONNECT 1 2: wrong format
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP DISCONNECT 1 2")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP DISCONNECT 1 2", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP DISCONNECT 1 2")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PUMP DISCONNECT 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP DISCONNECT 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("Wrong duration", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong duration")
 
         //PUMP DISCONNECT 30
         `when`(profileFunction.getProfile()).thenReturn(validProfile)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP DISCONNECT 30")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP DISCONNECT 30", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To disconnect pump for"))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP DISCONNECT 30")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To disconnect pump for")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Pump disconnected", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Pump disconnected")
 
         //PUMP DISCONNECT 30
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PUMP DISCONNECT 200")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("PUMP DISCONNECT 200", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To disconnect pump for"))
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PUMP DISCONNECT 200")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To disconnect pump for")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Pump disconnected", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Pump disconnected")
 
         //HELP
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "HELP")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("HELP", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("PUMP"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("HELP")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("PUMP")
 
         //HELP PUMP
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "HELP PUMP")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("HELP PUMP", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("PUMP"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("HELP PUMP")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("PUMP")
 
         //SMS : wrong format
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "SMS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("SMS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("SMS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //SMS STOP
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "SMS DISABLE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("SMS DISABLE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To disable the SMS Remote Service reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("SMS DISABLE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To disable the SMS Remote Service reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("SMS Remote Service stopped. To reactivate it, use AAPS on master smartphone."))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("SMS Remote Service stopped. To reactivate it, use AAPS on master smartphone.")
 
         //TARGET : wrong format
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "TARGET")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertFalse(sms.ignored)
-        Assertions.assertEquals("TARGET", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(sms.ignored).isFalse()
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("TARGET")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //TARGET MEAL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "TARGET MEAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("TARGET MEAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To set the Temp Target"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("TARGET MEAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To set the Temp Target")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("set successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("set successfully")
 
         //TARGET STOP/CANCEL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "TARGET STOP")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("TARGET STOP", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To cancel Temp Target reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("TARGET STOP")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To cancel Temp Target reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("Temp Target canceled successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("Temp Target canceled successfully")
     }
 
     @Test fun processProfileTest() {
@@ -711,23 +711,23 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "PROFILE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //PROFILE
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PROFILE LIST (no profile defined)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE LIST")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE LIST", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Not configured", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE LIST")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Not configured")
 
         `when`(profileSource.profile).thenReturn(getValidProfileStore())
         `when`(profileFunction.getProfileName()).thenReturn(TESTPROFILENAME)
@@ -736,55 +736,55 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE STATUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE STATUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals(TESTPROFILENAME, smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE STATUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo(TESTPROFILENAME)
 
         //PROFILE LIST
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE LIST")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE LIST", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("1. $TESTPROFILENAME", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE LIST")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("1. $TESTPROFILENAME")
 
         //PROFILE 2 (non existing)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE 2")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE 2", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE 2")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PROFILE 1 0(wrong percentage)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE 1 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE 1 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE 1 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PROFILE 0(wrong index)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //PROFILE 1(OK)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To switch profile to someProfile 100% reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To switch profile to someProfile 100% reply with code")
 
         //PROFILE 1 90(OK)
         `when`(profileFunction.createProfileSwitch(anyObject(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt(), anyLong())).thenReturn(true)
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "PROFILE 1 90")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("PROFILE 1 90", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To switch profile to someProfile 90% reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("PROFILE 1 90")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To switch profile to someProfile 90% reply with code")
         val passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Profile switch created", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Profile switch created")
     }
 
     @Test fun processBasalTest() {
@@ -793,95 +793,95 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "BASAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //BASAL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //BASAL CANCEL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL CANCEL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL CANCEL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To stop temp basal reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL CANCEL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To stop temp basal reply with code")
         var passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("Temp basal canceled"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("Temp basal canceled")
 
         `when`(profileFunction.getProfile()).thenReturn(validProfile)
         //BASAL a%
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL a%")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL a%", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL a%")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //BASAL 10% 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 10% 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 10% 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 10% 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("TBR duration must be a multiple of 30 minutes and greater than 0.")
 
         //BASAL 20% 20
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 20% 20")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 20% 20", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 20% 20")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("TBR duration must be a multiple of 30 minutes and greater than 0.")
         `when`(constraintChecker.applyBasalPercentConstraints(anyObject(), anyObject())).thenReturn(Constraint(20))
 
         //BASAL 20% 30
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 20% 30")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 20% 30", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 20% for 30 min reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 20% 30")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To start basal 20% for 30 min reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Temp basal 20% for 30 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Temp basal 20% for 30 min started successfully\nVirtual Pump")
 
         //BASAL a
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL a")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL a", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL a")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //BASAL 1 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 1 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 1 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 1 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("TBR duration must be a multiple of 30 minutes and greater than 0.")
         `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint(1.0))
 
         //BASAL 1 20
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 1 20")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 1 20", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("TBR duration must be a multiple of 30 minutes and greater than 0.", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 1 20")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("TBR duration must be a multiple of 30 minutes and greater than 0.")
         `when`(constraintChecker.applyBasalConstraints(anyObject(), anyObject())).thenReturn(Constraint(1.0))
 
         //BASAL 1 30
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BASAL 1 30")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BASAL 1 30", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start basal 1.00U/h for 30 min reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BASAL 1 30")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To start basal 1.00U/h for 30 min reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Temp basal 1.00U/h for 30 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Temp basal 1.00U/h for 30 min started successfully\nVirtual Pump")
     }
 
     @Test fun processExtendedTest() {
@@ -890,53 +890,53 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "EXTENDED")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //EXTENDED
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "EXTENDED")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //EXTENDED CANCEL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "EXTENDED CANCEL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED CANCEL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To stop extended bolus reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED CANCEL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To stop extended bolus reply with code")
         var passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("Extended bolus canceled"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("Extended bolus canceled")
 
         //EXTENDED a%
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "EXTENDED a%")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED a%", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED a%")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(constraintChecker.applyExtendedBolusConstraints(anyObject())).thenReturn(Constraint(1.0))
 
         //EXTENDED 1 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "EXTENDED 1 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED 1 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED 1 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //EXTENDED 1 20
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "EXTENDED 1 20")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("EXTENDED 1 20", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To start extended bolus 1.00U for 20 min reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("EXTENDED 1 20")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To start extended bolus 1.00U for 20 min reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Extended bolus 1.00U for 20 min started successfully\nVirtual Pump", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Extended bolus 1.00U for 20 min started successfully\nVirtual Pump")
     }
 
     @Test fun processBolusTest() {
@@ -945,16 +945,16 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "BOLUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //BOLUS
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(constraintChecker.applyBolusConstraints(anyObject())).thenReturn(Constraint(1.0))
         `when`(dateUtilMocked.now()).thenReturn(1000L)
         `when`(sp.getLong(R.string.key_smscommunicator_remote_bolus_min_distance, T.msecs(Constants.remoteBolusMinDistance).mins())).thenReturn(15L)
@@ -962,8 +962,8 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote bolus not available. Try again later.", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote bolus not available. Try again later.")
         `when`(constraintChecker.applyBolusConstraints(anyObject())).thenReturn(Constraint(0.0))
         `when`(dateUtilMocked.now()).thenReturn(Constants.remoteBolusMinDistance + 1002L)
 
@@ -971,15 +971,15 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //BOLUS a
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS a")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS a", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS a")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(constraintChecker.applyExtendedBolusConstraints(anyObject())).thenReturn(Constraint(1.0))
         `when`(constraintChecker.applyBolusConstraints(anyObject())).thenReturn(Constraint(1.0))
 
@@ -987,12 +987,12 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To deliver bolus 1.00U reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To deliver bolus 1.00U reply with code")
         var passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.contains("Bolus 1.00U delivered successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).contains("Bolus 1.00U delivered successfully")
 
         //BOLUS 1 (Suspended pump)
         smsCommunicatorPlugin.lastRemoteBolusTime = 0
@@ -1000,28 +1000,28 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Pump suspended", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Pump suspended")
         testPumpPlugin.pumpSuspended = false
 
         //BOLUS 1 a
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 1 a")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 1 a", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 1 a")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         `when`(profileFunction.getProfile()).thenReturn(validProfile)
         //BOLUS 1 MEAL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "BOLUS 1 MEAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("BOLUS 1 MEAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To deliver meal bolus 1.00U reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("BOLUS 1 MEAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To deliver meal bolus 1.00U reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Meal Bolus 1.00U delivered successfully\nVirtual Pump\nTarget 5.0 for 45 minutes", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Meal Bolus 1.00U delivered successfully\nVirtual Pump\nTarget 5.0 for 45 minutes")
     }
 
     @Test fun processCalTest() {
@@ -1030,34 +1030,34 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "CAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //CAL
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CAL")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CAL", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CAL")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
 
         //CAL 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CAL 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CAL 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CAL 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(xDripBroadcast.sendCalibration(ArgumentMatchers.anyDouble())).thenReturn(true)
         //CAL 1
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CAL 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CAL 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To send calibration 1.00 reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CAL 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To send calibration 1.00 reply with code")
         val passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertEquals("Calibration sent. Receiving must be enabled in xDrip.", smsCommunicatorPlugin.messages[3].text)
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).isEqualTo("Calibration sent. Receiving must be enabled in xDrip.")
     }
 
     @Test fun processCarbsTest() {
@@ -1068,80 +1068,80 @@ class SmsCommunicatorPluginTest : TestBaseWithProfile() {
         smsCommunicatorPlugin.messages = ArrayList()
         var sms = Sms("1234", "CARBS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Remote command is not allowed", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Remote command is not allowed")
         `when`(sp.getBoolean(R.string.key_smscommunicator_remote_commands_allowed, false)).thenReturn(true)
 
         //CARBS
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(constraintChecker.applyCarbsConstraints(anyObject())).thenReturn(Constraint(0))
 
         //CARBS 0
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 0")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 0", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("Wrong format", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 0")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("Wrong format")
         `when`(constraintChecker.applyCarbsConstraints(anyObject())).thenReturn(Constraint(1))
 
         //CARBS 1
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 1")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 1", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To enter 1g at"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 1")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To enter 1g at")
         var passCode: String = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.startsWith("Carbs 1g entered successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).startsWith("Carbs 1g entered successfully")
 
         //CARBS 1 a
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 1 a")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 1 a", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("Wrong format"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 1 a")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("Wrong format")
 
         //CARBS 1 00
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 1 00")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 1 00", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("Wrong format"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 1 00")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("Wrong format")
 
         //CARBS 1 12:01
         `when`(dateUtilMocked.timeString(anyLong())).thenReturn("12:01PM")
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 1 12:01")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 1 12:01", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To enter 1g at 12:01PM reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 1 12:01")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To enter 1g at 12:01PM reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.startsWith("Carbs 1g entered successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).startsWith("Carbs 1g entered successfully")
 
         //CARBS 1 3:01AM
         `when`(dateUtilMocked.timeString(anyLong())).thenReturn("03:01AM")
         smsCommunicatorPlugin.messages = ArrayList()
         sms = Sms("1234", "CARBS 1 3:01AM")
         smsCommunicatorPlugin.processSms(sms)
-        Assertions.assertEquals("CARBS 1 3:01AM", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[1].text.contains("To enter 1g at 03:01AM reply with code"))
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("CARBS 1 3:01AM")
+        assertThat(smsCommunicatorPlugin.messages[1].text).contains("To enter 1g at 03:01AM reply with code")
         passCode = smsCommunicatorPlugin.messageToConfirm?.confirmCode!!
         smsCommunicatorPlugin.processSms(Sms("1234", passCode))
-        Assertions.assertEquals(passCode, smsCommunicatorPlugin.messages[2].text)
-        Assertions.assertTrue(smsCommunicatorPlugin.messages[3].text.startsWith("Carbs 1g entered successfully"))
+        assertThat(smsCommunicatorPlugin.messages[2].text).isEqualTo(passCode)
+        assertThat(smsCommunicatorPlugin.messages[3].text).startsWith("Carbs 1g entered successfully")
     }
 
     @Test fun sendNotificationToAllNumbers() {
         smsCommunicatorPlugin.messages = ArrayList()
         smsCommunicatorPlugin.sendNotificationToAllNumbers("abc")
-        Assertions.assertEquals("abc", smsCommunicatorPlugin.messages[0].text)
-        Assertions.assertEquals("abc", smsCommunicatorPlugin.messages[1].text)
+        assertThat(smsCommunicatorPlugin.messages[0].text).isEqualTo("abc")
+        assertThat(smsCommunicatorPlugin.messages[1].text).isEqualTo("abc")
     }
 }

--- a/pump/dana/src/test/java/info/nightscout/pump/dana/DanaPumpTest.kt
+++ b/pump/dana/src/test/java/info/nightscout/pump/dana/DanaPumpTest.kt
@@ -1,8 +1,8 @@
 package info.nightscout.pump.dana
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.interfaces.profile.Instantiator
 import info.nightscout.sharedtests.TestBaseWithProfile
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
@@ -21,6 +21,6 @@ class DanaPumpTest : TestBaseWithProfile() {
     @Test
     fun detectDanaRS() {
         sut.hwModel = 0x05
-        Assertions.assertTrue(sut.modelFriendlyName().contains("DanaRS"))
+        assertThat(sut.modelFriendlyName()).contains("DanaRS")
     }
 }

--- a/pump/danars/src/test/java/info/nightscout/pump/danars/comm/DanaRsPacketBasalGetBasalRateTest.kt
+++ b/pump/danars/src/test/java/info/nightscout/pump/danars/comm/DanaRsPacketBasalGetBasalRateTest.kt
@@ -1,9 +1,9 @@
 package info.nightscout.pump.danars.comm
 
+import com.google.common.truth.Truth.assertThat
 import dagger.android.AndroidInjector
 import dagger.android.HasAndroidInjector
 import info.nightscout.pump.danars.DanaRSTestBase
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class DanaRsPacketBasalGetBasalRateTest : DanaRSTestBase() {
@@ -28,9 +28,9 @@ class DanaRsPacketBasalGetBasalRateTest : DanaRSTestBase() {
         putIntToArray(array, 0, (1.0 * 100).toInt())
         putByteToArray(array, 2, (0.05 * 100).toInt().toByte())
         packet.handleMessage(array)
-        Assertions.assertEquals(1.0, danaPump.maxBasal, 0.0)
-        Assertions.assertEquals(0.05, danaPump.basalStep, 0.0)
-        Assertions.assertTrue(packet.failed)
-        Assertions.assertEquals("BASAL__GET_BASAL_RATE", packet.friendlyName)
+        assertThat(danaPump.maxBasal).isWithin(0.001).of(1.0)
+        assertThat(danaPump.basalStep).isWithin(0.001).of(0.05)
+        assertThat(packet.failed).isTrue()
+        assertThat(packet.friendlyName).isEqualTo("BASAL__GET_BASAL_RATE")
     }
 }

--- a/pump/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/PayloadSplitterTest.kt
+++ b/pump/omnipod-dash/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/PayloadSplitterTest.kt
@@ -1,9 +1,9 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.message
 
+import com.google.common.truth.Truth.assertThat
 import com.google.crypto.tink.subtle.Hex
 import info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.packet.PayloadSplitter
 import info.nightscout.core.utils.toHex
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class PayloadSplitterTest {
@@ -16,10 +16,10 @@ class PayloadSplitterTest {
         val splitter = PayloadSplitter(payload)
         val packets = splitter.splitInPackets()
 
-        Assertions.assertEquals(packets.size, 2)
-        Assertions.assertEquals(f1, packets[0].toByteArray().toHex())
+        assertThat(packets).hasSize(2)
+        assertThat(packets[0].toByteArray().toHex()).isEqualTo(f1)
         val p2 = packets[1].toByteArray()
-        Assertions.assertTrue(p2.size >= 10)
-        Assertions.assertEquals(f2.subSequence(0, 20), p2.copyOfRange(0, 10).toHex())
+        assertThat(p2.size).isAtLeast(10)
+        assertThat(p2.copyOfRange(0, 10).toHex()).isEqualTo(f2.subSequence(0, 20))
     }
 }

--- a/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/StatusResponseTest.java
+++ b/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/StatusResponseTest.java
@@ -1,14 +1,15 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.communication.message.response;
 
-import org.joda.time.Duration;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.AlertSlot;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.DeliveryStatus;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.OmnipodConstants;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.PodProgressStatus;
 import info.nightscout.pump.core.utils.ByteUtil;
+
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
 
 class StatusResponseTest {
 
@@ -18,7 +19,7 @@ class StatusResponseTest {
 
         StatusResponse statusResponse = new StatusResponse(encodedData);
 
-        Assertions.assertArrayEquals(encodedData, statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(encodedData);
     }
 
     @Test
@@ -28,7 +29,7 @@ class StatusResponseTest {
 
         StatusResponse statusResponse = new StatusResponse(encodedData);
 
-        Assertions.assertArrayEquals(expected, statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(expected);
     }
 
     @Test
@@ -36,17 +37,17 @@ class StatusResponseTest {
         byte[] bytes = ByteUtil.fromHexString("1d180258f80000146fff"); // From https://github.com/openaps/openomni/wiki/Command-1D-Status-response
         StatusResponse statusResponse = new StatusResponse(bytes);
 
-        Assertions.assertEquals(DeliveryStatus.NORMAL, statusResponse.getDeliveryStatus());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, statusResponse.getPodProgressStatus());
-        Assertions.assertNull(statusResponse.getReservoirLevel());
-        Assertions.assertEquals(Duration.standardMinutes(1307).getMillis(), statusResponse.getTimeActive().getMillis());
-        Assertions.assertEquals(1201, statusResponse.getTicksDelivered());
-        Assertions.assertEquals(60.05, statusResponse.getInsulinDelivered(), 0.000001);
-        Assertions.assertEquals(15, statusResponse.getPodMessageCounter());
-        Assertions.assertEquals(0, statusResponse.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0, statusResponse.getUnacknowledgedAlerts().getAlertSlots().size());
+        assertThat(statusResponse.getDeliveryStatus()).isEqualTo(DeliveryStatus.NORMAL);
+        assertThat(statusResponse.getPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(statusResponse.getReservoirLevel()).isNull();
+        assertThat(statusResponse.getTimeActive().getMillis()).isEqualTo(Duration.standardMinutes(1307).getMillis());
+        assertThat(statusResponse.getTicksDelivered()).isEqualTo(1201);
+        assertThat(statusResponse.getInsulinDelivered()).isWithin(0.000001).of(60.05);
+        assertThat(statusResponse.getPodMessageCounter()).isEqualTo(15);
+        assertThat(statusResponse.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(statusResponse.getUnacknowledgedAlerts().getAlertSlots()).isEmpty();
 
-        Assertions.assertArrayEquals(ByteUtil.fromHexString("1d180258f80000146fff"), statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(ByteUtil.fromHexString("1d180258f80000146fff"));
     }
 
     @Test
@@ -54,18 +55,17 @@ class StatusResponseTest {
         byte[] bytes = ByteUtil.fromHexString("1d19061f6800044295e8"); // From https://github.com/openaps/openomni/wiki/Status-Response-1D-long-run-%28Lytrix%29
         StatusResponse statusResponse = new StatusResponse(bytes);
 
-        Assertions.assertEquals(DeliveryStatus.NORMAL, statusResponse.getDeliveryStatus());
-        Assertions.assertEquals(PodProgressStatus.FIFTY_OR_LESS_UNITS, statusResponse.getPodProgressStatus());
-        Assertions.assertEquals(24.4, statusResponse.getReservoirLevel(), 0.000001);
-        Assertions.assertEquals(Duration.standardMinutes(4261).getMillis(), statusResponse.getTimeActive().getMillis());
-        Assertions.assertEquals(3134, statusResponse.getTicksDelivered());
-        Assertions.assertEquals(156.7, statusResponse.getInsulinDelivered(), 0.000001);
-        Assertions.assertEquals(13, statusResponse.getPodMessageCounter());
-        Assertions.assertEquals(0, statusResponse.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(1, statusResponse.getUnacknowledgedAlerts().getAlertSlots().size());
-        Assertions.assertEquals(AlertSlot.SLOT3, statusResponse.getUnacknowledgedAlerts().getAlertSlots().get(0));
+        assertThat(statusResponse.getDeliveryStatus()).isEqualTo(DeliveryStatus.NORMAL);
+        assertThat(statusResponse.getPodProgressStatus()).isEqualTo(PodProgressStatus.FIFTY_OR_LESS_UNITS);
+        assertThat(statusResponse.getReservoirLevel()).isWithin(0.000001).of(24.4);
+        assertThat(statusResponse.getTimeActive().getMillis()).isEqualTo(Duration.standardMinutes(4261).getMillis());
+        assertThat(statusResponse.getTicksDelivered()).isEqualTo(3134);
+        assertThat(statusResponse.getInsulinDelivered()).isWithin(0.000001).of(156.7);
+        assertThat(statusResponse.getPodMessageCounter()).isEqualTo(13);
+        assertThat(statusResponse.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(statusResponse.getUnacknowledgedAlerts().getAlertSlots()).containsExactly(AlertSlot.SLOT3);
 
-        Assertions.assertArrayEquals(ByteUtil.fromHexString("1d19061f6800044295e8"), statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(ByteUtil.fromHexString("1d19061f6800044295e8"));
     }
 
     @Test
@@ -73,16 +73,16 @@ class StatusResponseTest {
         byte[] bytes = ByteUtil.fromHexString("1d11ffffffffffffffff");
         StatusResponse statusResponse = new StatusResponse(bytes);
 
-        Assertions.assertEquals(Duration.standardMinutes(8191).getMillis(), statusResponse.getTimeActive().getMillis());
-        Assertions.assertEquals(OmnipodConstants.POD_PULSE_SIZE * 1023, statusResponse.getBolusNotDelivered(), 0.000001);
-        Assertions.assertNull(statusResponse.getReservoirLevel());
-        Assertions.assertEquals(OmnipodConstants.POD_PULSE_SIZE * 8191, statusResponse.getInsulinDelivered(), 0.0000001);
-        Assertions.assertEquals(8191, statusResponse.getTicksDelivered());
-        Assertions.assertEquals(OmnipodConstants.POD_PULSE_SIZE * 8191, statusResponse.getInsulinDelivered(), 0.0000001);
-        Assertions.assertEquals(15, statusResponse.getPodMessageCounter());
-        Assertions.assertEquals(8, statusResponse.getUnacknowledgedAlerts().getAlertSlots().size());
+        assertThat(statusResponse.getTimeActive().getMillis()).isEqualTo(Duration.standardMinutes(8191).getMillis());
+        assertThat(statusResponse.getBolusNotDelivered()).isWithin(0.000001).of(OmnipodConstants.POD_PULSE_SIZE * 1023);
+        assertThat(statusResponse.getReservoirLevel()).isNull();
+        assertThat(statusResponse.getInsulinDelivered()).isWithin(0.0000001).of(OmnipodConstants.POD_PULSE_SIZE * 8191);
+        assertThat(statusResponse.getTicksDelivered()).isEqualTo(8191);
+        assertThat(statusResponse.getInsulinDelivered()).isWithin(0.0000001).of(OmnipodConstants.POD_PULSE_SIZE * 8191);
+        assertThat(statusResponse.getPodMessageCounter()).isEqualTo(15);
+        assertThat(statusResponse.getUnacknowledgedAlerts().getAlertSlots()).hasSize(8);
 
-        Assertions.assertArrayEquals(ByteUtil.fromHexString("1d11ffffffffffffffff"), statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(ByteUtil.fromHexString("1d11ffffffffffffffff"));
     }
 
     @Test
@@ -90,15 +90,15 @@ class StatusResponseTest {
         byte[] bytes = ByteUtil.fromHexString("1d19050ec82c08376f98");
         StatusResponse statusResponse = new StatusResponse(bytes);
 
-        Assertions.assertTrue(Duration.standardMinutes(3547).isEqual(statusResponse.getTimeActive()));
-        Assertions.assertEquals(DeliveryStatus.NORMAL, statusResponse.getDeliveryStatus());
-        Assertions.assertEquals(PodProgressStatus.FIFTY_OR_LESS_UNITS, statusResponse.getPodProgressStatus());
-        Assertions.assertEquals(2589, statusResponse.getTicksDelivered());
-        Assertions.assertEquals(129.45, statusResponse.getInsulinDelivered(), 0.00001);
-        Assertions.assertEquals(46.00, statusResponse.getReservoirLevel(), 0.00001);
-        Assertions.assertEquals(2.2, statusResponse.getBolusNotDelivered(), 0.0001);
-        Assertions.assertEquals(9, statusResponse.getPodMessageCounter());
+        assertThat(statusResponse.getTimeActive()).isEqualTo(Duration.standardMinutes(3547));
+        assertThat(statusResponse.getDeliveryStatus()).isEqualTo(DeliveryStatus.NORMAL);
+        assertThat(statusResponse.getPodProgressStatus()).isEqualTo(PodProgressStatus.FIFTY_OR_LESS_UNITS);
+        assertThat(statusResponse.getTicksDelivered()).isEqualTo(2589);
+        assertThat(statusResponse.getInsulinDelivered()).isWithin(0.00001).of(129.45);
+        assertThat(statusResponse.getReservoirLevel()).isWithin(0.00001).of(46.00);
+        assertThat(statusResponse.getBolusNotDelivered()).isWithin(0.0001).of(2.2);
+        assertThat(statusResponse.getPodMessageCounter()).isEqualTo(9);
 
-        Assertions.assertArrayEquals(ByteUtil.fromHexString("1d19050ec82c08376f98"), statusResponse.getRawData());
+        assertThat(statusResponse.getRawData()).isEqualTo(ByteUtil.fromHexString("1d19050ec82c08376f98"));
     }
 }

--- a/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoActiveAlertsTest.java
+++ b/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoActiveAlertsTest.java
@@ -1,7 +1,8 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.communication.message.response.podinfo;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.joda.time.Duration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -15,7 +16,7 @@ class PodInfoActiveAlertsTest {
         PodInfoActiveAlerts podInfoActiveAlerts = new PodInfoActiveAlerts(encodedMessage);
 
         List<PodInfoActiveAlerts.AlertActivation> alertActivations = podInfoActiveAlerts.getAlertActivations();
-        Assertions.assertEquals(0, alertActivations.size());
+        assertThat(alertActivations).isEmpty();
     }
 
     @Test
@@ -24,10 +25,10 @@ class PodInfoActiveAlertsTest {
         PodInfoActiveAlerts podInfoActiveAlerts = new PodInfoActiveAlerts(encodedMessage);
 
         List<PodInfoActiveAlerts.AlertActivation> alertActivations = podInfoActiveAlerts.getAlertActivations();
-        Assertions.assertEquals(1, alertActivations.size());
+        assertThat(alertActivations).hasSize(1);
 
         PodInfoActiveAlerts.AlertActivation alertActivation = alertActivations.get(0);
         Duration expectedDuration = Duration.standardHours(72).plus(Duration.standardMinutes(1));
-        Assertions.assertTrue(expectedDuration.isEqual(alertActivation.getValueAsDuration()));
+        assertThat(expectedDuration).isEqualTo(alertActivation.getValueAsDuration());
     }
 }

--- a/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoDataLogTest.java
+++ b/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoDataLogTest.java
@@ -1,9 +1,9 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.communication.message.response.podinfo;
 
-import org.joda.time.Duration;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.FaultEventCode;
 import info.nightscout.pump.core.utils.ByteUtil;
 
@@ -12,10 +12,10 @@ class PodInfoDataLogTest {
     void testDecoding() {
         PodInfoDataLog podInfoDataLog = new PodInfoDataLog(ByteUtil.fromHexString("030100010001043c"), 8); // From https://github.com/ps2/rileylink_ios/blob/omnipod-testing/OmniKitTests/PodInfoTests.swift
 
-        Assertions.assertEquals(FaultEventCode.FAILED_FLASH_ERASE, podInfoDataLog.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardMinutes(1).isEqual(podInfoDataLog.getTimeFaultEvent()));
-        Assertions.assertTrue(Duration.standardMinutes(1).isEqual(podInfoDataLog.getTimeSinceActivation()));
-        Assertions.assertEquals(4, podInfoDataLog.getDataChunkSize());
-        Assertions.assertEquals(60, podInfoDataLog.getMaximumNumberOfDwords());
+        assertThat(podInfoDataLog.getFaultEventCode()).isEqualTo(FaultEventCode.FAILED_FLASH_ERASE);
+        assertThat(podInfoDataLog.getTimeFaultEvent()).isEqualTo(Duration.standardMinutes(1));
+        assertThat(podInfoDataLog.getTimeSinceActivation()).isEqualTo(Duration.standardMinutes(1));
+        assertThat(podInfoDataLog.getDataChunkSize()).isEqualTo(4);
+        assertThat(podInfoDataLog.getMaximumNumberOfDwords()).isEqualTo(60);
     }
 }

--- a/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoDetailedStatusTest.java
+++ b/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoDetailedStatusTest.java
@@ -1,14 +1,14 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.communication.message.response.podinfo;
 
-import org.joda.time.Duration;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.DeliveryStatus;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.ErrorEventInfo;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.FaultEventCode;
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.PodProgressStatus;
 import info.nightscout.pump.core.utils.ByteUtil;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
 
 /**
  * @noinspection SpellCheckingInspection
@@ -18,143 +18,143 @@ class PodInfoDetailedStatusTest {
     void testPodInfoFaultEventNoFaultAlerts() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("02080100000a003800000003ff008700000095ff0000"));
 
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.NORMAL, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0x0a, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertNull(podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.ZERO.isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertTrue(Duration.standardSeconds(8100).isEqual(podInfoDetailedStatus.getTimeActive()));
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.NORMAL);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x0a);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isNull();
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isEqualTo(Duration.ZERO);
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getTimeActive()).isEqualTo(Duration.standardSeconds(8100));
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertNull(errorEventInfo);
-        Assertions.assertNull(podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(2, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(21, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo).isNull();
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isNull();
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(2);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(21);
     }
 
     @Test
     void testPodInfoFaultEventDeliveryErrorDuringPriming() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("020f0000000900345c000103ff0001000005ae056029"));
 
-        Assertions.assertEquals(PodProgressStatus.INACTIVE, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.SUSPENDED, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0x09, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertEquals(FaultEventCode.PRIME_OPEN_COUNT_TOO_LOW, podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardSeconds(60).isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertTrue(Duration.standardSeconds(60).isEqual(podInfoDetailedStatus.getTimeActive()));
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.INACTIVE);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.SUSPENDED);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x09);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isEqualTo(FaultEventCode.PRIME_OPEN_COUNT_TOO_LOW);
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isEqualTo(Duration.standardSeconds(60));
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getTimeActive()).isEqualTo(Duration.standardSeconds(60));
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertFalse(errorEventInfo.isInsulinStateTableCorruption());
-        Assertions.assertEquals(0x00, errorEventInfo.getInternalVariable());
-        Assertions.assertFalse(errorEventInfo.isImmediateBolusInProgress());
-        Assertions.assertEquals(PodProgressStatus.PRIMING_COMPLETED, errorEventInfo.getPodProgressStatus());
-        Assertions.assertEquals(PodProgressStatus.PRIMING_COMPLETED, podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(2, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(46, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo.isInsulinStateTableCorruption()).isFalse();
+        assertThat(errorEventInfo.getInternalVariable()).isEqualTo(0x00);
+        assertThat(errorEventInfo.isImmediateBolusInProgress()).isFalse();
+        assertThat(errorEventInfo.getPodProgressStatus()).isEqualTo(PodProgressStatus.PRIMING_COMPLETED);
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isEqualTo(PodProgressStatus.PRIMING_COMPLETED);
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(2);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(46);
     }
 
     @Test
     void testPodInfoFaultEventErrorShuttingDown() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("020d0000000407f28609ff03ff0a0200000823080000"));
 
-        Assertions.assertEquals(PodProgressStatus.FAULT_EVENT_OCCURRED, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.SUSPENDED, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(2034, podInfoDetailedStatus.getTicksDelivered());
-        Assertions.assertEquals(101.7, podInfoDetailedStatus.getInsulinDelivered(), 0.000001);
-        Assertions.assertEquals(0, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0x04, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertEquals(FaultEventCode.BASAL_OVER_INFUSION_PULSE, podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardMinutes(2559).isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.FAULT_EVENT_OCCURRED);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.SUSPENDED);
+        assertThat(podInfoDetailedStatus.getTicksDelivered()).isEqualTo(2034);
+        assertThat(podInfoDetailedStatus.getInsulinDelivered()).isWithin(0.000001).of(101.7);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x04);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isEqualTo(FaultEventCode.BASAL_OVER_INFUSION_PULSE);
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isEqualTo(Duration.standardMinutes(2559));
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertFalse(errorEventInfo.isInsulinStateTableCorruption());
-        Assertions.assertEquals(0x00, errorEventInfo.getInternalVariable());
-        Assertions.assertFalse(errorEventInfo.isImmediateBolusInProgress());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, errorEventInfo.getPodProgressStatus());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(35, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo.isInsulinStateTableCorruption()).isFalse();
+        assertThat(errorEventInfo.getInternalVariable()).isEqualTo(0x00);
+        assertThat(errorEventInfo.isImmediateBolusInProgress()).isFalse();
+        assertThat(errorEventInfo.getPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(35);
     }
 
     @Test
     void testPodInfoFaultEventInsulinNotDelivered() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("020f0000010200ec6a026803ff026b000028a7082023"));
 
-        Assertions.assertEquals(PodProgressStatus.INACTIVE, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.SUSPENDED, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(236, podInfoDetailedStatus.getTicksDelivered());
-        Assertions.assertEquals(11.8, podInfoDetailedStatus.getInsulinDelivered(), 0.000001);
-        Assertions.assertEquals(0.05, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0x02, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertEquals(FaultEventCode.OCCLUSION_CHECK_ABOVE_THRESHOLD, podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardMinutes(616).isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.INACTIVE);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.SUSPENDED);
+        assertThat(podInfoDetailedStatus.getTicksDelivered()).isEqualTo(236);
+        assertThat(podInfoDetailedStatus.getInsulinDelivered()).isWithin(0.000001).of(11.8);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(0.05);
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x02);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isEqualTo(FaultEventCode.OCCLUSION_CHECK_ABOVE_THRESHOLD);
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isEqualTo(Duration.standardMinutes(616));
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertFalse(errorEventInfo.isInsulinStateTableCorruption());
-        Assertions.assertEquals(0x01, errorEventInfo.getInternalVariable());
-        Assertions.assertFalse(errorEventInfo.isImmediateBolusInProgress());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, errorEventInfo.getPodProgressStatus());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(2, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(39, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo.isInsulinStateTableCorruption()).isFalse();
+        assertThat(errorEventInfo.getInternalVariable()).isEqualTo(0x01);
+        assertThat(errorEventInfo.isImmediateBolusInProgress()).isFalse();
+        assertThat(errorEventInfo.getPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(2);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(39);
     }
 
     @Test
     void testPodInfoFaultEventMaxBolusNotDelivered() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("020f00ffff0200ec6a026803ff026b000028a7082023"));
 
-        Assertions.assertEquals(PodProgressStatus.INACTIVE, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.SUSPENDED, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(236, podInfoDetailedStatus.getTicksDelivered());
-        Assertions.assertEquals(11.8, podInfoDetailedStatus.getInsulinDelivered(), 0.000001);
-        Assertions.assertEquals(3276.75, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001); // Insane and will not happen, but this verifies that we convert it to an unsigned int
-        Assertions.assertEquals(0x02, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertEquals(FaultEventCode.OCCLUSION_CHECK_ABOVE_THRESHOLD, podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardMinutes(616).isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.INACTIVE);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.SUSPENDED);
+        assertThat(podInfoDetailedStatus.getTicksDelivered()).isEqualTo(236);
+        assertThat(podInfoDetailedStatus.getInsulinDelivered()).isWithin(0.000001).of(11.8);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(3276.75); // Insane and will not happen, but this verifies that we convert it to an unsigned int
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x02);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isEqualTo(FaultEventCode.OCCLUSION_CHECK_ABOVE_THRESHOLD);
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isEqualTo(Duration.standardMinutes(616));
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertFalse(errorEventInfo.isInsulinStateTableCorruption());
-        Assertions.assertEquals(0x01, errorEventInfo.getInternalVariable());
-        Assertions.assertFalse(errorEventInfo.isImmediateBolusInProgress());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, errorEventInfo.getPodProgressStatus());
-        Assertions.assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(2, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(39, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo.isInsulinStateTableCorruption()).isFalse();
+        assertThat(errorEventInfo.getInternalVariable()).isEqualTo(0x01);
+        assertThat(errorEventInfo.isImmediateBolusInProgress()).isFalse();
+        assertThat(errorEventInfo.getPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isEqualTo(PodProgressStatus.ABOVE_FIFTY_UNITS);
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(2);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(39);
     }
 
     @Test
     void testPodInfoFaultEventInsulinStateTableCorruptionFoundDuringErrorLogging() {
         PodInfoDetailedStatus podInfoDetailedStatus = new PodInfoDetailedStatus(ByteUtil.fromHexString("020D00000000000012FFFF03FF00160000879A070000"));
 
-        Assertions.assertEquals(PodProgressStatus.FAULT_EVENT_OCCURRED, podInfoDetailedStatus.getPodProgressStatus());
-        Assertions.assertEquals(DeliveryStatus.SUSPENDED, podInfoDetailedStatus.getDeliveryStatus());
-        Assertions.assertEquals(0, podInfoDetailedStatus.getBolusNotDelivered(), 0.000001);
-        Assertions.assertEquals(0x00, podInfoDetailedStatus.getPodMessageCounter());
-        Assertions.assertEquals(FaultEventCode.RESET_DUE_TO_LVD, podInfoDetailedStatus.getFaultEventCode());
-        Assertions.assertTrue(Duration.ZERO.isEqual(podInfoDetailedStatus.getFaultEventTime()));
-        Assertions.assertNull(podInfoDetailedStatus.getReservoirLevel());
-        Assertions.assertTrue(Duration.standardSeconds(1320).isEqual(podInfoDetailedStatus.getTimeActive()));
-        Assertions.assertEquals(0, podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue());
-        Assertions.assertFalse(podInfoDetailedStatus.isFaultAccessingTables());
+        assertThat(podInfoDetailedStatus.getPodProgressStatus()).isEqualTo(PodProgressStatus.FAULT_EVENT_OCCURRED);
+        assertThat(podInfoDetailedStatus.getDeliveryStatus()).isEqualTo(DeliveryStatus.SUSPENDED);
+        assertThat(podInfoDetailedStatus.getBolusNotDelivered()).isWithin(0.000001).of(0);
+        assertThat(podInfoDetailedStatus.getPodMessageCounter()).isEqualTo(0x00);
+        assertThat(podInfoDetailedStatus.getFaultEventCode()).isEqualTo(FaultEventCode.RESET_DUE_TO_LVD);
+        assertThat(podInfoDetailedStatus.getFaultEventTime()).isNull();
+        assertThat(podInfoDetailedStatus.getReservoirLevel()).isNull();
+        assertThat(podInfoDetailedStatus.getTimeActive()).isEqualTo(Duration.standardSeconds(1320));
+        assertThat(podInfoDetailedStatus.getUnacknowledgedAlerts().getRawValue()).isEqualTo(0);
+        assertThat(podInfoDetailedStatus.isFaultAccessingTables()).isFalse();
         ErrorEventInfo errorEventInfo = podInfoDetailedStatus.getErrorEventInfo();
-        Assertions.assertTrue(errorEventInfo.isInsulinStateTableCorruption());
-        Assertions.assertEquals(0x00, errorEventInfo.getInternalVariable());
-        Assertions.assertFalse(errorEventInfo.isImmediateBolusInProgress());
-        Assertions.assertEquals(PodProgressStatus.INSERTING_CANNULA, errorEventInfo.getPodProgressStatus());
-        Assertions.assertEquals(PodProgressStatus.INSERTING_CANNULA, podInfoDetailedStatus.getPreviousPodProgressStatus());
-        Assertions.assertEquals(2, podInfoDetailedStatus.getReceiverLowGain());
-        Assertions.assertEquals(26, podInfoDetailedStatus.getRadioRSSI());
+        assertThat(errorEventInfo.isInsulinStateTableCorruption()).isTrue();
+        assertThat(errorEventInfo.getInternalVariable()).isEqualTo(0x00);
+        assertThat(errorEventInfo.isImmediateBolusInProgress()).isFalse();
+        assertThat(errorEventInfo.getPodProgressStatus()).isEqualTo(PodProgressStatus.INSERTING_CANNULA);
+        assertThat(podInfoDetailedStatus.getPreviousPodProgressStatus()).isEqualTo(PodProgressStatus.INSERTING_CANNULA);
+        assertThat(podInfoDetailedStatus.getReceiverLowGain()).isEqualTo(2);
+        assertThat(podInfoDetailedStatus.getRadioRSSI()).isEqualTo(26);
     }
 }

--- a/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoFaultAndInitializationTimeTest.java
+++ b/pump/omnipod-eros/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/eros/driver/communication/message/response/podinfo/PodInfoFaultAndInitializationTimeTest.java
@@ -1,26 +1,26 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.communication.message.response.podinfo;
 
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static com.google.common.truth.Truth.assertThat;
 
 import info.nightscout.androidaps.plugins.pump.omnipod.eros.driver.definition.FaultEventCode;
 import info.nightscout.pump.core.utils.ByteUtil;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
 
 class PodInfoFaultAndInitializationTimeTest {
     @Test
     void testDecoding() {
         PodInfoFaultAndInitializationTime podInfoFaultAndInitializationTime = new PodInfoFaultAndInitializationTime(ByteUtil.fromHexString("059200010000000000000000091912170e")); // From https://github.com/ps2/rileylink_ios/blob/omnipod-testing/OmniKitTests/PodInfoTests.swift
 
-        Assertions.assertEquals(FaultEventCode.BAD_PUMP_REQ_2_STATE, podInfoFaultAndInitializationTime.getFaultEventCode());
-        Assertions.assertTrue(Duration.standardMinutes(1).isEqual(podInfoFaultAndInitializationTime.getTimeFaultEvent()));
+        assertThat(podInfoFaultAndInitializationTime.getFaultEventCode()).isEqualTo(FaultEventCode.BAD_PUMP_REQ_2_STATE);
+        assertThat(podInfoFaultAndInitializationTime.getTimeFaultEvent()).isEqualTo(Duration.standardMinutes(1));
 
         DateTime dateTime = podInfoFaultAndInitializationTime.getInitializationTime();
-        Assertions.assertEquals(2018, dateTime.getYear());
-        Assertions.assertEquals(9, dateTime.getMonthOfYear());
-        Assertions.assertEquals(25, dateTime.getDayOfMonth());
-        Assertions.assertEquals(23, dateTime.getHourOfDay());
-        Assertions.assertEquals(14, dateTime.getMinuteOfHour());
+        assertThat(dateTime.getYear()).isEqualTo(2018);
+        assertThat(dateTime.getMonthOfYear()).isEqualTo(9);
+        assertThat(dateTime.getDayOfMonth()).isEqualTo(25);
+        assertThat(dateTime.getHourOfDay()).isEqualTo(23);
+        assertThat(dateTime.getMinuteOfHour()).isEqualTo(14);
     }
 }

--- a/wear/src/test/java/info/nightscout/androidaps/interaction/utils/PairTest.kt
+++ b/wear/src/test/java/info/nightscout/androidaps/interaction/utils/PairTest.kt
@@ -1,5 +1,6 @@
 package info.nightscout.androidaps.interaction.utils
 
+import com.google.common.truth.Truth.assertThat
 import org.junit.Assert
 import org.junit.jupiter.api.Test
 
@@ -34,15 +35,15 @@ class PairTest {
         val set: MutableSet<Pair<*, *>> = HashSet()
 
         // THEN
-        Assert.assertFalse(set.contains(inserted))
+        assertThat(set).doesNotContain(inserted)
         set.add(inserted)
-        Assert.assertTrue(set.contains(inserted))
+        assertThat(set).contains(inserted)
     }
 
     @Test fun toStringTest() {
         // GIVEN
         val pair: Pair<*, *> = Pair.create("the-first", "2nd")
-        Assert.assertTrue(pair.toString().contains("the-first"))
-        Assert.assertTrue(pair.toString().contains("2nd"))
+        assertThat(pair.toString()).contains("the-first")
+        assertThat(pair.toString()).contains("2nd")
     }
 }

--- a/wear/src/test/java/info/nightscout/androidaps/interaction/utils/WearUtilTest.kt
+++ b/wear/src/test/java/info/nightscout/androidaps/interaction/utils/WearUtilTest.kt
@@ -1,8 +1,8 @@
 package info.nightscout.androidaps.interaction.utils
 
+import com.google.common.truth.Truth.assertThat
 import info.nightscout.androidaps.WearTestBase
 import info.nightscout.androidaps.testing.mockers.WearUtilMocker
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 /**
@@ -14,21 +14,18 @@ class WearUtilTest : WearTestBase() {
     @Test fun timestampAndTimeDiffsTest() {
 
         // smoke for mocks - since we freeze "now" to get stable tests
-        Assertions.assertEquals(WearUtilMocker.REF_NOW, wearUtil.timestamp())
-        Assertions.assertEquals(0L, wearUtil.msTill(WearUtilMocker.REF_NOW))
-        Assertions.assertEquals(3456L, wearUtil.msTill(WearUtilMocker.REF_NOW + 3456L))
-        Assertions.assertEquals(-6294L, wearUtil.msTill(WearUtilMocker.REF_NOW - 6294L))
-        Assertions.assertEquals(0L, wearUtil.msTill(WearUtilMocker.REF_NOW))
-        Assertions.assertEquals(-3456L, wearUtil.msSince(WearUtilMocker.REF_NOW + 3456L))
-        Assertions.assertEquals(6294L, wearUtil.msSince(WearUtilMocker.REF_NOW - 6294L))
+        assertThat(wearUtil.timestamp()).isEqualTo(WearUtilMocker.REF_NOW)
+        assertThat(wearUtil.msTill(WearUtilMocker.REF_NOW)).isEqualTo(0L)
+        assertThat(wearUtil.msTill(WearUtilMocker.REF_NOW + 3456L)).isEqualTo(3456L)
+        assertThat(wearUtil.msTill(WearUtilMocker.REF_NOW - 6294L)).isEqualTo(-6294L)
+        assertThat(wearUtil.msTill(WearUtilMocker.REF_NOW)).isEqualTo(0L)
+        assertThat(wearUtil.msSince(WearUtilMocker.REF_NOW + 3456L)).isEqualTo(-3456L)
+        assertThat(wearUtil.msSince(WearUtilMocker.REF_NOW - 6294L)).isEqualTo(6294L)
     }
 
     @Test fun joinSetTest() {
         // GIVEN
-        val refSet: MutableSet<String> = HashSet()
-        refSet.add("element1")
-        refSet.add("second-elem")
-        refSet.add("3rd")
+        val refSet = setOf("element1", "second-elem", "3rd")
 
         // WHEN
         val joined = persistence.joinSet(refSet, "|")
@@ -36,10 +33,10 @@ class WearUtilTest : WearTestBase() {
         // THEN
         // we cannot guarantee order of items in joined string
         // but all items have to be there
-        Assertions.assertEquals(joined.length, "element1".length + "second-elem".length + "3rd".length + "|".length * 2)
-        Assertions.assertTrue("|$joined|".contains("|" + "element1" + "|"))
-        Assertions.assertTrue("|$joined|".contains("|" + "second-elem" + "|"))
-        Assertions.assertTrue("|$joined|".contains("|" + "3rd" + "|"))
+        assertThat(joined).hasLength(refSet.sumOf { it.length } + (refSet.size-1))
+        assertThat("|$joined|").contains("|element1|")
+        assertThat("|$joined|").contains("|second-elem|")
+        assertThat("|$joined|").contains("|3rd|")
     }
 
     @Test fun explodeSetTest() {
@@ -50,10 +47,7 @@ class WearUtilTest : WearTestBase() {
         val set = persistence.explodeSet(serializedSet, ":")
 
         // THEN
-        Assertions.assertEquals(set.size, 3)
-        Assertions.assertTrue(set.contains("element1"))
-        Assertions.assertTrue(set.contains("second-elem"))
-        Assertions.assertTrue(set.contains("3rd"))
+        assertThat(set).containsExactly( "element1", "second-elem", "3rd")
     }
 
     @Test fun explodeSetEmptyElemsTest() {
@@ -64,27 +58,25 @@ class WearUtilTest : WearTestBase() {
         val set = persistence.explodeSet(serializedSet, ",")
 
         // THEN
-        Assertions.assertEquals(set.size, 2)
-        Assertions.assertEquals(true, set.contains("real"))
-        Assertions.assertEquals(true, set.contains("another"))
+        assertThat(set).containsExactly("real", "another")
     }
 
     @Test fun joinExplodeStabilityTest() {
         // GIVEN
-        val refSet: MutableSet<String> = HashSet()
-        refSet.add("element1")
-        refSet.add("second-elem")
-        refSet.add("3rd")
-        refSet.add("czwarty")
-        refSet.add("V")
-        refSet.add("6")
+        val refSet = setOf(
+            "element1",
+            "second-elem",
+            "3rd",
+            "czwarty",
+            "V",
+            "6")
 
         // WHEN
         val joinedSet = persistence.joinSet(refSet, "#")
         val explodedSet = persistence.explodeSet(joinedSet, "#")
 
         // THEN
-        Assertions.assertEquals(explodedSet, refSet)
+        assertThat(explodedSet).containsExactlyElementsIn(refSet)
     }
 
     /* Mike: failing with new mockito
@@ -100,8 +92,8 @@ class WearUtilTest : WearTestBase() {
 
             // THEN
             // we cannot guarantee to be exact to the millisecond - we add some margin of error
-            Assertions.assertTrue(60L > measuredSleepDuration)
-            Assertions.assertTrue(requestedSleepDuration + measuringMargin < measuredSleepDuration)
+            assertThat(measuredSleepDuration).isLessThan(60L)
+            assertThat(measuredSleepDuration).isGreaterThan(requestedSleepDuration + measuringMargin)
         }
     */
     @Test fun rateLimitTest() {
@@ -115,9 +107,9 @@ class WearUtilTest : WearTestBase() {
         val callAfterRateLimit = wearUtil.isBelowRateLimit("test-limit", 3)
 
         // THEN
-        Assertions.assertTrue(firstCall)
-        Assertions.assertFalse(callAfterward)
-        Assertions.assertFalse(callTooSoon)
-        Assertions.assertTrue(callAfterRateLimit)
+        assertThat(firstCall).isTrue()
+        assertThat(callAfterward).isFalse()
+        assertThat(callTooSoon).isFalse()
+        assertThat(callAfterRateLimit).isTrue()
     }
 }


### PR DESCRIPTION
In the files I edited, I used `assertThat` and matchers for all assertions for the sake of uniformity. Some types of updates:

Container contents

```
// Before
Assertions.assertEquals(set.size, 3)
Assertions.assertTrue(set.contains("element1"))
Assertions.assertTrue(set.contains("second-elem"))
Assertions.assertTrue(set.contains("3rd"))
        
// After
assertThat(set).containsExactly( "element1", "second-elem", "3rd")
```

Container size

```
// Before
Assertions.assertEquals(true, c.reasonList.size == 2)

// After
assertThat(c.reasonList).hasSize(2) 
```

String contains

```
// Before
Assertions.assertTrue(c.getReasons(aapsLogger).contains("Running dev version. Closed loop is disabled."))

// After
assertThat(c.getReasons(aapsLogger)).contains("Running dev version. Closed loop is disabled.")
```

Float comparison

```
// Before
Assertions.assertEquals(2.0, c.value(), 0.01)

// After
assertThat(c.value()).isWithin(0.01).of(2.0)
```

Ordered comparison

```
// Before
Assertions.assertTrue(bolusForLowBg < bolusForBgInRange)

// After
assertThat(bolusForLowBg).isLessThan(bolusForBgInRange)
```
