### PR TITLE
Wear CWF Refactoring and cleanup

### DIFF
--- a/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
+++ b/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
@@ -63,7 +63,8 @@ enum class ResFormat(val extension: String) {
     SVG("svg"),
     JPG("jpg"),
     PNG("png"),
-    TTF("ttf");
+    TTF("ttf"),
+    OTF("otf");
 
     companion object {
 
@@ -102,7 +103,7 @@ data class ResData(val value: ByteArray, val format: ResFormat) {
     fun toTypeface(): Typeface? {
         try {
             return when (format) {
-                ResFormat.TTF -> {
+                ResFormat.TTF, ResFormat.OTF -> {
                     // Workaround with temporary File, Typeface.createFromFileDescriptor(null, value, 0, value.size) more simple not available
                     File.createTempFile("temp", format.extension).let { tempFile ->
                         FileOutputStream(tempFile).let { fileOutputStream ->

--- a/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
+++ b/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
@@ -104,7 +104,7 @@ data class ResData(val value: ByteArray, val format: ResFormat) {
             return when (format) {
                 ResFormat.TTF -> {
                     // Workaround with temporary File, Typeface.createFromFileDescriptor(null, value, 0, value.size) more simple not available
-                    File.createTempFile("temp", ".ttf").let { tempFile ->
+                    File.createTempFile("temp", format.extension).let { tempFile ->
                         FileOutputStream(tempFile).let { fileOutputStream ->
                             fileOutputStream.write(value)
                             fileOutputStream.close()

--- a/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
+++ b/app-wear-shared/shared/src/main/java/info/nightscout/rx/weardata/CustomWatchfaceFormat.kt
@@ -202,67 +202,60 @@ enum class ViewKeys(val key: String, @StringRes val comment: Int) {
     COVER_PLATE("cover_plate", R.string.cwf_comment_cover_plate),
     HOUR_HAND("hour_hand", R.string.cwf_comment_hour_hand),
     MINUTE_HAND("minute_hand", R.string.cwf_comment_minute_hand),
-    SECOND_HAND("second_hand", R.string.cwf_comment_second_hand);
+    SECOND_HAND("second_hand", R.string.cwf_comment_second_hand)
 }
 
-enum class JsonKeys(val key: String, val viewType: ViewType, @StringRes val comment: Int?) {
-    METADATA("metadata", ViewType.NONE, null),
-    ENABLESECOND("enableSecond", ViewType.NONE, null),
-    HIGHCOLOR("highColor", ViewType.NONE, null),
-    MIDCOLOR("midColor", ViewType.NONE, null),
-    LOWCOLOR("lowColor", ViewType.NONE, null),
-    LOWBATCOLOR("lowBatColor", ViewType.NONE, null),
-    CARBCOLOR("carbColor", ViewType.NONE, null),
-    BASALBACKGROUNDCOLOR("basalBackgroundColor", ViewType.NONE, null),
-    BASALCENTERCOLOR("basalCenterColor", ViewType.NONE, null),
-    GRIDCOLOR("gridColor", ViewType.NONE, null),
-    POINTSIZE("pointSize", ViewType.NONE, null),
-    WIDTH("width", ViewType.ALLVIEWS, null),
-    HEIGHT("height", ViewType.ALLVIEWS, null),
-    TOPMARGIN("topmargin", ViewType.ALLVIEWS, null),
-    LEFTMARGIN("leftmargin", ViewType.ALLVIEWS, null),
-    ROTATION("rotation", ViewType.TEXTVIEW, null),
-    VISIBILITY("visibility", ViewType.ALLVIEWS, null),
-    TEXTSIZE("textsize", ViewType.TEXTVIEW, null),
-    TEXTVALUE("textvalue", ViewType.TEXTVIEW, null),
-    GRAVITY("gravity", ViewType.TEXTVIEW, null),
-    FONT("font", ViewType.TEXTVIEW, null),
-    FONTSTYLE("fontStyle", ViewType.TEXTVIEW, null),
-    FONTCOLOR("fontColor", ViewType.TEXTVIEW, null),
-    COLOR("color", ViewType.IMAGEVIEW, null),
-    ALLCAPS("allCaps", ViewType.TEXTVIEW, null),
-    DAYNAMEFORMAT("dayNameFormat", ViewType.NONE, null),
-    MONTHFORMAT("monthFormat", ViewType.NONE, null)
+enum class JsonKeys(val key: String) {
+    METADATA("metadata"),
+    ENABLESECOND("enableSecond"),
+    HIGHCOLOR("highColor"),
+    MIDCOLOR("midColor"),
+    LOWCOLOR("lowColor"),
+    LOWBATCOLOR("lowBatColor"),
+    CARBCOLOR("carbColor"),
+    BASALBACKGROUNDCOLOR("basalBackgroundColor"),
+    BASALCENTERCOLOR("basalCenterColor"),
+    GRIDCOLOR("gridColor"),
+    POINTSIZE("pointSize"),
+    WIDTH("width"),
+    HEIGHT("height"),
+    TOPMARGIN("topmargin"),
+    LEFTMARGIN("leftmargin"),
+    ROTATION("rotation"),
+    VISIBILITY("visibility"),
+    TEXTSIZE("textsize"),
+    TEXTVALUE("textvalue"),
+    GRAVITY("gravity"),
+    FONT("font"),
+    FONTSTYLE("fontStyle"),
+    FONTCOLOR("fontColor"),
+    COLOR("color"),
+    ALLCAPS("allCaps"),
+    DAYNAMEFORMAT("dayNameFormat"),
+    MONTHFORMAT("monthFormat")
 }
 
-enum class JsonKeyValues(val key: String, val jsonKey: JsonKeys) {
-    GONE("gone", JsonKeys.VISIBILITY),
-    VISIBLE("visible", JsonKeys.VISIBILITY),
-    INVISIBLE("invisible", JsonKeys.VISIBILITY),
-    CENTER("center", JsonKeys.GRAVITY),
-    LEFT("left", JsonKeys.GRAVITY),
-    RIGHT("right", JsonKeys.GRAVITY),
-    SANS_SERIF("sans_serif", JsonKeys.FONT),
-    DEFAULT("default", JsonKeys.FONT),
-    DEFAULT_BOLD("default_bold", JsonKeys.FONT),
-    MONOSPACE("monospace", JsonKeys.FONT),
-    SERIF("serif", JsonKeys.FONT),
-    ROBOTO_CONDENSED_BOLD("roboto_condensed_bold", JsonKeys.FONT),
-    ROBOTO_CONDENSED_LIGHT("roboto_condensed_light", JsonKeys.FONT),
-    ROBOTO_CONDENSED_REGULAR("roboto_condensed_regular", JsonKeys.FONT),
-    ROBOTO_SLAB_LIGHT("roboto_slab_light", JsonKeys.FONT),
-    NORMAL("normal", JsonKeys.FONTSTYLE),
-    BOLD("bold", JsonKeys.FONTSTYLE),
-    BOLD_ITALIC("bold_italic", JsonKeys.FONTSTYLE),
-    ITALIC("italic", JsonKeys.FONTSTYLE),
-    BGCOLOR("bgColor", JsonKeys.COLOR)
-}
-
-enum class ViewType(@StringRes val comment: Int?) {
-    NONE(null),
-    TEXTVIEW(null),
-    IMAGEVIEW(null),
-    ALLVIEWS(null)
+enum class JsonKeyValues(val key: String) {
+    GONE("gone"),
+    VISIBLE("visible"),
+    INVISIBLE("invisible"),
+    CENTER("center"),
+    LEFT("left"),
+    RIGHT("right"),
+    SANS_SERIF("sans_serif"),
+    DEFAULT("default"),
+    DEFAULT_BOLD("default_bold"),
+    MONOSPACE("monospace"),
+    SERIF("serif"),
+    ROBOTO_CONDENSED_BOLD("roboto_condensed_bold"),
+    ROBOTO_CONDENSED_LIGHT("roboto_condensed_light"),
+    ROBOTO_CONDENSED_REGULAR("roboto_condensed_regular"),
+    ROBOTO_SLAB_LIGHT("roboto_slab_light"),
+    NORMAL("normal"),
+    BOLD("bold"),
+    BOLD_ITALIC("bold_italic"),
+    ITALIC("italic"),
+    BGCOLOR("bgColor")
 }
 
 class ZipWatchfaceFormat {
@@ -324,7 +317,7 @@ class ZipWatchfaceFormat {
             try {
                 val outputStream = FileOutputStream(file)
                 val zipOutputStream = ZipOutputStream(BufferedOutputStream(outputStream))
-                
+
                 val jsonEntry = ZipEntry(CWF_JSON_FILE)
                 zipOutputStream.putNextEntry(jsonEntry)
                 zipOutputStream.write(customWatchface.json.toByteArray())
@@ -355,5 +348,4 @@ class ZipWatchfaceFormat {
             return metadata
         }
     }
-
 }

--- a/plugins/configuration/src/main/java/info/nightscout/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
+++ b/plugins/configuration/src/main/java/info/nightscout/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
@@ -89,7 +89,7 @@ class CustomWatchfaceImportListActivity: TranslatedDaggerAppCompatActivity()  {
         override fun onBindViewHolder(holder: CwfFileViewHolder, position: Int) {
             val customWatchfaceFile = customWatchfaceFileList[position]
             val metadata = customWatchfaceFile.metadata
-            val drawable = customWatchfaceFile.resDatas[ResFileMap.CUSTOM_WATCHFACE]?.toDrawable(resources)
+            val drawable = customWatchfaceFile.resDatas[ResFileMap.CUSTOM_WATCHFACE.fileName]?.toDrawable(resources)
             with(holder.customWatchfaceImportListItemBinding) {
                 filelistName.text = rh.gs(info.nightscout.shared.R.string.metadata_wear_import_filename, metadata[CWF_FILENAME])
                 filelistName.tag = customWatchfaceFile

--- a/plugins/main/src/main/java/info/nightscout/plugins/general/wear/WearFragment.kt
+++ b/plugins/main/src/main/java/info/nightscout/plugins/general/wear/WearFragment.kt
@@ -111,7 +111,7 @@ class WearFragment : DaggerFragment() {
         wearPlugin.savedCustomWatchface?.let {
             wearPlugin.checkCustomWatchfacePreferences()
             binding.customName.text = rh.gs(R.string.wear_custom_watchface, it.metadata[CwfMetadataKey.CWF_NAME])
-            binding.coverChart.setImageDrawable(it.resDatas[ResFileMap.CUSTOM_WATCHFACE]?.toDrawable(resources))
+            binding.coverChart.setImageDrawable(it.resDatas[ResFileMap.CUSTOM_WATCHFACE.fileName]?.toDrawable(resources))
             binding.infosCustom.visibility = View.VISIBLE
         } ?:apply {
             binding.customName.text = rh.gs(R.string.wear_custom_watchface, "")

--- a/plugins/main/src/main/java/info/nightscout/plugins/general/wear/activities/CwfInfosActivity.kt
+++ b/plugins/main/src/main/java/info/nightscout/plugins/general/wear/activities/CwfInfosActivity.kt
@@ -86,7 +86,7 @@ class CwfInfosActivity : TranslatedDaggerAppCompatActivity() {
         wearPlugin.savedCustomWatchface?.let {
             val cwfAuthorization = sp.getBoolean(info.nightscout.core.utils.R.string.key_wear_custom_watchface_autorization, false)
             val metadata = it.metadata
-            val drawable = it.resDatas[ResFileMap.CUSTOM_WATCHFACE]?.toDrawable(resources)
+            val drawable = it.resDatas[ResFileMap.CUSTOM_WATCHFACE.fileName]?.toDrawable(resources)
             binding.customWatchface.setImageDrawable(drawable)
             title = rh.gs(CwfMetadataKey.CWF_NAME.label, metadata[CwfMetadataKey.CWF_NAME])
             metadata[CwfMetadataKey.CWF_AUTHOR_VERSION]?.let { authorVersion ->

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
@@ -554,7 +554,7 @@ private enum class FontMap(val key: String, var font: Typeface, @FontRes val fon
                 } ?: fontMap.font
             }
             resDataMap.filter { (_, resData) ->
-                resData.format == ResFormat.TTF
+                resData.format == ResFormat.TTF || resData.format == ResFormat.OTF
             }.forEach { (key, resData) ->
                 customFonts[key.lowercase()] = resData.toTypeface() ?:Typeface.DEFAULT
             }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
@@ -301,7 +301,7 @@ class CustomWatchface : BaseWatchFace() {
         val metadataMap = ZipWatchfaceFormat.loadMetadata(json)
         val drawableDataMap: CwfResDataMap = mutableMapOf()
         getResourceByteArray(info.nightscout.shared.R.drawable.watchface_custom)?.let {
-            drawableDataMap[ResFileMap.CUSTOM_WATCHFACE] = ResData(it, ResFormat.PNG)
+            drawableDataMap[ResFileMap.CUSTOM_WATCHFACE.fileName] = ResData(it, ResFormat.PNG)
         }
         return EventData.ActionSetCustomWatchface(CwfData(json.toString(4), metadataMap, drawableDataMap))
     }
@@ -489,10 +489,10 @@ class CustomWatchface : BaseWatchFace() {
 
         fun drawable(resources: Resources, drawableDataMap: CwfResDataMap, sgvLevel: Long): Drawable? = customDrawable?.let { cd ->
             when (sgvLevel) {
-                1L   -> { drawableDataMap[customHigh]?.toDrawable(resources) ?: drawableDataMap[cd]?.toDrawable(resources) }
-                0L   -> { drawableDataMap[cd]?.toDrawable(resources) }
-                -1L  -> { drawableDataMap[customLow]?.toDrawable(resources) ?: drawableDataMap[cd]?.toDrawable(resources) }
-                else -> drawableDataMap[cd]?.toDrawable(resources)
+                1L   -> { customHigh?.let {drawableDataMap[customHigh.fileName]}?.toDrawable(resources) ?: drawableDataMap[cd.fileName]?.toDrawable(resources) }
+                0L   -> { drawableDataMap[cd.fileName]?.toDrawable(resources) }
+                -1L  -> { customLow?.let {drawableDataMap[customLow.fileName]}?.toDrawable(resources) ?: drawableDataMap[cd.fileName]?.toDrawable(resources) }
+                else -> drawableDataMap[cd.fileName]?.toDrawable(resources)
             }
         }
     }
@@ -514,7 +514,7 @@ private enum class TrendArrowMap(val symbol: String, @DrawableRes val icon: Int,
 
         fun drawable(direction: String?, resources: Resources, drawableDataMap: CwfResDataMap): Drawable {
             val arrow = values().firstOrNull { it.symbol == direction } ?:NONE
-            return drawableDataMap[arrow.customDrawable]?.toDrawable(resources)  ?:resources.getDrawable(arrow.icon)
+            return arrow.customDrawable?. let {drawableDataMap[arrow.customDrawable.fileName]}?.toDrawable(resources)  ?:resources.getDrawable(arrow.icon)
         }
 
     }
@@ -532,36 +532,34 @@ private enum class GravityMap(val key: String, val gravity: Int) {
     }
 }
 
-private enum class FontMap(val key: String, var font: Typeface, @FontRes val fontRessources: Int?, val customFont: ResFileMap?) {
-    SANS_SERIF(JsonKeyValues.SANS_SERIF.key, Typeface.SANS_SERIF, null, null),
-    DEFAULT(JsonKeyValues.DEFAULT.key, Typeface.DEFAULT, null, null),
-    DEFAULT_BOLD(JsonKeyValues.DEFAULT_BOLD.key, Typeface.DEFAULT_BOLD, null, null),
-    MONOSPACE(JsonKeyValues.MONOSPACE.key, Typeface.MONOSPACE, null, null),
-    SERIF(JsonKeyValues.SERIF.key, Typeface.SERIF, null, null),
-    ROBOTO_CONDENSED_BOLD(JsonKeyValues.ROBOTO_CONDENSED_BOLD.key, Typeface.DEFAULT, R.font.roboto_condensed_bold, null),
-    ROBOTO_CONDENSED_LIGHT(JsonKeyValues.ROBOTO_CONDENSED_LIGHT.key, Typeface.DEFAULT, R.font.roboto_condensed_light, null),
-    ROBOTO_CONDENSED_REGULAR(JsonKeyValues.ROBOTO_CONDENSED_REGULAR.key, Typeface.DEFAULT, R.font.roboto_condensed_regular, null),
-    ROBOTO_SLAB_LIGHT(JsonKeyValues.ROBOTO_SLAB_LIGHT.key, Typeface.DEFAULT, R.font.roboto_slab_light, null),
-    FONT1(JsonKeyValues.FONT1.key, Typeface.DEFAULT, null, ResFileMap.FONT1),
-    FONT2(JsonKeyValues.FONT2.key, Typeface.DEFAULT, null, ResFileMap.FONT2),
-    FONT3(JsonKeyValues.FONT3.key, Typeface.DEFAULT, null, ResFileMap.FONT3),
-    FONT4(JsonKeyValues.FONT4.key, Typeface.DEFAULT, null, ResFileMap.FONT4);
+private enum class FontMap(val key: String, var font: Typeface, @FontRes val fontRessources: Int?) {
+    SANS_SERIF(JsonKeyValues.SANS_SERIF.key, Typeface.SANS_SERIF, null),
+    DEFAULT(JsonKeyValues.DEFAULT.key, Typeface.DEFAULT, null),
+    DEFAULT_BOLD(JsonKeyValues.DEFAULT_BOLD.key, Typeface.DEFAULT_BOLD, null),
+    MONOSPACE(JsonKeyValues.MONOSPACE.key, Typeface.MONOSPACE, null),
+    SERIF(JsonKeyValues.SERIF.key, Typeface.SERIF, null),
+    ROBOTO_CONDENSED_BOLD(JsonKeyValues.ROBOTO_CONDENSED_BOLD.key, Typeface.DEFAULT, R.font.roboto_condensed_bold),
+    ROBOTO_CONDENSED_LIGHT(JsonKeyValues.ROBOTO_CONDENSED_LIGHT.key, Typeface.DEFAULT, R.font.roboto_condensed_light),
+    ROBOTO_CONDENSED_REGULAR(JsonKeyValues.ROBOTO_CONDENSED_REGULAR.key, Typeface.DEFAULT, R.font.roboto_condensed_regular),
+    ROBOTO_SLAB_LIGHT(JsonKeyValues.ROBOTO_SLAB_LIGHT.key, Typeface.DEFAULT, R.font.roboto_slab_light);
 
     companion object {
 
-        fun init(context: Context, resDataMap: CwfResDataMap) = values().forEach { fontMap ->
-            fontMap.customFont?.let { customFont ->
-                fontMap.font = Typeface.DEFAULT
-                resDataMap[customFont]?.toTypeface()?.let { resData ->
-                    fontMap.font = resData
-                }
-            } ?: run {
-                fontMap.font = fontMap.fontRessources?.let { fontResource ->
+        private val customFonts = mutableMapOf<String, Typeface>()
+        fun init(context: Context, resDataMap: CwfResDataMap) {
+            values().forEach { fontMap ->
+                customFonts[fontMap.key.lowercase()] = fontMap.fontRessources?.let { fontResource ->
                     ResourcesCompat.getFont(context, fontResource)
                 } ?: fontMap.font
             }
+            resDataMap.filter { (_, resData) ->
+                resData.format == ResFormat.TTF
+            }.forEach { (key, resData) ->
+                customFonts[key.lowercase()] = resData.toTypeface() ?:Typeface.DEFAULT
+            }
         }
-        fun font(key: String) = values().firstOrNull { it.key == key }?.font ?: DEFAULT.font
+
+        fun font(key: String) = customFonts[key.lowercase()] ?: DEFAULT.font
         fun key() = DEFAULT.key
     }
 }

--- a/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/java/info/nightscout/androidaps/watchfaces/CustomWatchface.kt
@@ -547,6 +547,7 @@ private enum class FontMap(val key: String, var font: Typeface, @FontRes val fon
 
         private val customFonts = mutableMapOf<String, Typeface>()
         fun init(context: Context, resDataMap: CwfResDataMap) {
+            customFonts.clear()
             values().forEach { fontMap ->
                 customFonts[fontMap.key.lowercase()] = fontMap.fontRessources?.let { fontResource ->
                     ResourcesCompat.getFont(context, fontResource)


### PR DESCRIPTION
With refactoring, CwfResDataMap is no more limited to files "harcoded" within ResFileMap, all resources are included with FileName as key within json file (for all other resources)
=> This remove the limitation of 4 external Fonts possible (only limitation is zip file size), and within json, just put font filename (not case sensitive) to use the font
=> This will allow any other files (bitmap, vector) to be loaded and accessible in future version
=> include compatibility with otf format for external fonts

I also cleaned the code with all unused properties