### PR TITLE
Increase max for canula status lights

### DIFF
--- a/plugins/main/src/main/res/xml/pref_overview.xml
+++ b/plugins/main/src/main/res/xml/pref_overview.xml
@@ -288,7 +288,7 @@
                 android:selectAllOnFocus="true"
                 android:singleLine="true"
                 android:title="@string/statuslights_cage_warning"
-                validate:maxNumber="120"
+                validate:maxNumber="240"
                 validate:minNumber="24"
                 validate:testType="numericRange" />
 
@@ -301,7 +301,7 @@
                 android:selectAllOnFocus="true"
                 android:singleLine="true"
                 android:title="@string/statuslights_cage_critical"
-                validate:maxNumber="120"
+                validate:maxNumber="240"
                 validate:minNumber="24"
                 validate:testType="numericRange" />
 


### PR DESCRIPTION
Current limit to set warning and critical for canula status light is 120 hours (5 days)

However with the Medtronic extended infusion sets max wear time is 7 days as specified by manufacture.
Other infusion sets that have extended wear time are expected as well, for example eopatch 7 day patch.

This PR increases the max for the canula status lights to 240 hours (10 days)