### PR TITLE
Night mode

### DIFF
--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -522,6 +522,18 @@
     <string name="max_carbs_title">Max allowed carbs [g]</string>
     <string name="patient_type">Patient type</string>
 
+    <!-- Night mode -->
+    <string name="treatment_safety_night_mode">Night mode</string>
+    <string name="treatment_safety_night_mode_enabled">Use night mode</string>
+    <string name="treatment_safety_night_mode_bg_offset_title">BG offset</string>
+    <string name="treatment_safety_night_mode_bg_offset_description">There will be no SMB when below this BG offset from profile target at night unless COB or a low TT is active\ne.g. if normalTarget is 5.5 (99) and this setting is 1.5 (27) there will be no SMB below 7.0 (126)</string>
+    <string name="treatment_safety_night_mode_start_title">Start time (24h format)</string>
+    <string name="treatment_safety_night_mode_end_title">End time (24h format)</string>
+    <string name="treatment_safety_night_mode_disable_with_cob_title">Disable night mode when COB > 0</string>
+    <string name="treatment_safety_night_mode_disable_with_low_temp_target_title">Disable night mode when Temporary Target below Profile Target is set</string>
+    <string name="treatment_safety_night_mode_smb_disabled">SMB disabled by Night mode</string>
+    <!-- /Night mode -->
+
     <!--    Protection-->
     <string name="unlock_settings">Unlock settings</string>
 

--- a/core/utils/src/main/res/values/keys.xml
+++ b/core/utils/src/main/res/values/keys.xml
@@ -37,6 +37,15 @@
     <string name="key_smscommunicator_settings" translatable="false">smscommunicator_settings</string>
     <string name="key_openapssmb_settings" translatable="false">openapssmb_settings</string>
     <string name="key_treatmentssafety_settings" translatable="false">treatmentssafety_settings</string>
+    <!-- Night mode -->
+    <string name="key_treatment_safety_night_mode_enabled" translatable="false">treatment_safety_night_mode_enabled</string>
+    <string name="key_treatment_safety_night_mode_bg_offset" translatable="false">treatment_safety_night_mode_bg_offset</string>
+    <string name="key_treatment_safety_night_mode_start" translatable="false">treatment_safety_night_mode_start</string>
+    <string name="key_treatment_safety_night_mode_end" translatable="false">treatment_safety_night_mode_end</string>
+    <string name="key_treatment_safety_night_mode_disable_with_cob" translatable="false">treatment_safety_night_mode_disable_with_cob</string>
+    <string name="key_treatment_safety_night_mode_disable_with_low_temp_target" translatable="false">treatment_safety_night_mode_disable_with_low_temp_target</string>
+
+    <!-- /Night mode -->
     <string name="key_loop_settings" translatable="false">loop_settings</string>
     <string name="key_virtualpump_settings" translatable="false">virtualpump_settings</string>
     <string name="key_pump_settings" translatable="false">pump_settings</string>

--- a/core/validators/src/main/res/values/validator.xml
+++ b/core/validators/src/main/res/values/validator.xml
@@ -19,6 +19,7 @@
     <string name="error_mustbe12hexadidits">Must be 12 characters of ABCDEF0123456789</string>
     <string name="error_mustbe8hexadidits">Must be 8 characters of ABCDEF0123456789</string>
     <string name="error_mustbe4hexadidits">Must be 4 characters of ABCDEF0123456789</string>
+    <string name="error_invalid_time">Must be time value in hh:mm (24h) format</string>
     <string name="error_not_a_minimum_length">Not a minimum length</string>
     <string name="error_pin_not_valid">Pin should be 3 to 6 digits, not same or in series</string>
 
@@ -26,5 +27,7 @@
     <string name="twelvehexanumber" translatable="false">^[A-F0-9]{12}$</string>
     <string name="eighthexanumber" translatable="false">^[A-F0-9]{8}$</string>
     <string name="fourhexanumber" translatable="false">^[A-F0-9]{4}$</string>
+
+    <string name="time" translatable="false">^\\d{1,2}:\\d{1,2}$</string>
 
 </resources>

--- a/plugins/constraints/src/main/res/xml/pref_safety.xml
+++ b/plugins/constraints/src/main/res/xml/pref_safety.xml
@@ -34,6 +34,60 @@
             validate:floatminNumber="1"
             validate:testType="numericRange" />
 
+        <androidx.preference.PreferenceScreen
+            android:key="safety_night_mode"
+            android:title="@string/treatment_safety_night_mode">
+
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="@string/key_treatment_safety_night_mode_enabled"
+                android:title="@string/treatment_safety_night_mode_enabled" />
+
+            <info.nightscout.core.validators.ValidatingEditTextPreference
+                android:dependency="@string/key_treatment_safety_night_mode_enabled"
+                android:defaultValue="27"
+                android:inputType="numberDecimal"
+                android:title="@string/treatment_safety_night_mode_bg_offset_title"
+                android:key="@string/key_treatment_safety_night_mode_bg_offset"
+                android:dialogMessage="@string/treatment_safety_night_mode_bg_offset_description"
+                validate:floatmaxNumber="270.0"
+                validate:floatminNumber="0"
+                validate:testType="bgRange" />
+
+            <info.nightscout.core.validators.ValidatingEditTextPreference
+                android:dependency="@string/key_treatment_safety_night_mode_enabled"
+                android:defaultValue="23:00"
+                android:inputType="text"
+                android:key="@string/key_treatment_safety_night_mode_start"
+                android:title="@string/treatment_safety_night_mode_start_title"
+                validate:customRegexp="@string/time"
+                validate:testErrorString="@string/error_invalid_time"
+                validate:testType="regexp" />
+
+            <info.nightscout.core.validators.ValidatingEditTextPreference
+                android:dependency="@string/key_treatment_safety_night_mode_enabled"
+                android:defaultValue="07:00"
+                android:inputType="text"
+                android:key="@string/key_treatment_safety_night_mode_end"
+                android:title="@string/treatment_safety_night_mode_end_title"
+                validate:customRegexp="@string/time"
+                validate:testErrorString="@string/error_invalid_time"
+                validate:testType="regexp" />
+
+            <SwitchPreference
+                android:dependency="@string/key_treatment_safety_night_mode_enabled"
+                android:defaultValue="false"
+                android:key="@string/key_treatment_safety_night_mode_disable_with_cob"
+                android:title="@string/treatment_safety_night_mode_disable_with_cob_title" />
+
+            <SwitchPreference
+                android:dependency="@string/key_treatment_safety_night_mode_enabled"
+                android:defaultValue="false"
+                android:key="@string/key_treatment_safety_night_mode_disable_with_low_temp_target"
+                android:title="@string/treatment_safety_night_mode_disable_with_low_temp_target_title" />
+
+        </androidx.preference.PreferenceScreen>
+
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This PR adds overnight SMB restriction mode (inspired by Eating Now @dicko72).
- You set up the time interval for 'Night mode' to be active
- Set the BG offset (from profile target) in which Night mode will be active during time from step 1

So during night while your BG is below `profileTarget` + `BG offset` - SMB will be disabled and only TBR will be active for plugins.
When BG escalates higher than `profileTarget` + `BG offset` - SMB overnight restriction falls off.

You can also set up Night mode to be disabled if COB > 0.
Or when Temp Target is set lower than profile target.

![telegram-cloud-photo-size-2-5228906977193741105-y](https://github.com/nightscout/AndroidAPS/assets/4157587/65aaa195-6307-46d4-8186-9048110bcd40)
![telegram-cloud-photo-size-2-5228906977193741106-y](https://github.com/nightscout/AndroidAPS/assets/4157587/ebb8fc22-ac21-41c4-91f5-f12ed4a5f252)
![telegram-cloud-photo-size-2-5228906977193741104-x](https://github.com/nightscout/AndroidAPS/assets/4157587/2974d936-5b5b-47e6-abf7-2f8711a2933d)

The idea of this mode itself is to add some security mode against overnight sensor pressures. Here is my daughter's BG this night - these fast drops are sensor pressures, and quick rises - BG comes back to real after pressure released.
![telegram-cloud-photo-size-2-5228833984224546746-y](https://github.com/nightscout/AndroidAPS/assets/4157587/a69b9942-5f57-47fb-953a-13f59500bcb1)

Usually AAPS acts like this for these quick rises (see many SMBs here)
![telegram-cloud-photo-size-2-5228833984224546748-y](https://github.com/nightscout/AndroidAPS/assets/4157587/7b88361b-ab05-421e-a6af-483ece7b8fd4)

But frankly thats a graph from my test phone connected to virtual pump, because in reality MUCH lower amount of insulin were required to deal with that:
![telegram-cloud-photo-size-2-5228833984224546747-y](https://github.com/nightscout/AndroidAPS/assets/4157587/2eec3a13-667d-4f16-a793-634e6516bb64)

TBS is way more safe for such beaviour