### PR TITLE
Steampunk Watchface simplification

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -186,7 +186,9 @@ sealed class EventData : Event() {
         val sgv: Double,
         val high: Double, // highLine
         val low: Double, // lowLine
-        val color: Int = 0
+        val color: Int = 0,
+        val deltaMgdl: Double? = null,
+        val avgDeltaMgdl: Double? = null
     ) : EventData(), Comparable<SingleBg> {
 
         override fun equals(other: Any?): Boolean =

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataHandlerMobile.kt
@@ -986,7 +986,9 @@ class DataHandlerMobile @Inject constructor(
             sgv = glucoseValue.recalculated,
             high = highLine,
             low = lowLine,
-            color = 0
+            color = 0,
+            deltaMgdl = glucoseStatus?.delta,
+            avgDeltaMgdl = glucoseStatus?.shortAvgDelta
         )
     }
 

--- a/wear/src/main/kotlin/app/aaps/wear/data/RawDisplayData.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/data/RawDisplayData.kt
@@ -27,7 +27,9 @@ class RawDisplayData {
         sgv = 0.0,
         high = 0.0,
         low = 0.0,
-        color = 0
+        color = 0,
+        deltaMgdl = null,
+        avgDeltaMgdl = null
     )
 
     // status bundle


### PR DESCRIPTION
Adding double values for delta and avgDelta within SingleBg allow an important simplification of Steampunk watchface (Cognitive Complexity divided by 2 from 80 to 43 according to SonarLint)