### PR TITLE
Medtrum: Defaults and notification on warning

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/Notification.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/Notification.kt
@@ -138,6 +138,7 @@ open class Notification {
         const val PUMP_SETTINGS_FAILED = 84
         const val PUMP_TIMEZONE_UPDATE_FAILED = 85
         const val BLUETOOTH_NOT_SUPPORTED = 86
+        const val PUMP_WARNING = 87
 
         const val USER_MESSAGE = 1000
 

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
@@ -71,6 +71,15 @@ class MedtrumPump @Inject constructor(
             _activeAlarms = value
         }
 
+    // New pump warnings
+    private val _pumpWarning = MutableStateFlow(AlarmState.NONE)
+    val pumpWarningFlow: StateFlow<AlarmState> = _pumpWarning
+    var pumpWarning: AlarmState
+        get() = _pumpWarning.value
+        set(value) {
+            _pumpWarning.value = value
+        }
+
     // Prime progress as state flow
     private val _primeProgress = MutableStateFlow(0)
     val primeProgressFlow: StateFlow<Int> = _primeProgress

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/NotificationPacket.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/comm/packets/NotificationPacket.kt
@@ -200,7 +200,11 @@ class NotificationPacket(val injector: HasAndroidInjector) {
                     val alarmState = AlarmState.values()[i]
                     if ((alarmFlags shr i) and 1 != 0) {
                         // If the alarm bit is set, add the corresponding alarm to activeAlarms
-                        medtrumPump.addAlarm(alarmState)
+                        if (!medtrumPump.activeAlarms.contains(alarmState)) {
+                            aapsLogger.debug(LTag.PUMPCOMM, "Adding alarm $alarmState to active alarms")
+                            medtrumPump.addAlarm(alarmState)
+                            medtrumPump.pumpWarning = alarmState
+                        }
                     } else if (medtrumPump.activeAlarms.contains(alarmState)) {
                         // If the alarm bit is not set, and the corresponding alarm is in activeAlarms, remove it
                         medtrumPump.removeAlarm(alarmState)

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
@@ -322,6 +322,7 @@ class MedtrumService : DaggerService(), BLECommCallback {
             }
             // Resume suspended pump
             if (result) result = sendPacketAndGetResponse(ResumePumpPacket(injector))
+            if (result) medtrumPump.clearAlarmState()
         }
         return result
     }
@@ -619,7 +620,6 @@ class MedtrumService : DaggerService(), BLECommCallback {
             MedtrumPumpState.ACTIVE_ALT           -> {
                 rxBus.send(EventDismissNotification(Notification.PATCH_NOT_ACTIVE))
                 rxBus.send(EventDismissNotification(Notification.PUMP_SUSPENDED))
-                medtrumPump.clearAlarmState()
             }
 
             MedtrumPumpState.LOW_BG_SUSPENDED,

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="key_sn_input" translatable="false">sn_input</string>
     <string name="key_alarm_setting" translatable="false">alarm_setting</string>
     <string name="key_patch_expiration" translatable="false">patch_expiration</string>
+    <string name="key_pump_warning_notification" translatable="false">pump_warning_notification</string>
     <string name="key_hourly_max_insulin" translatable="false">hourly_max_insulin</string>
     <string name="key_daily_max_insulin" translatable="false">daily_max_insulin</string>
 
@@ -30,6 +31,7 @@
     <string name="medtrum_pump_description">Pump integration for Medtrum Nano and Medtrum 300U</string>
     <string name="medtrum_pump_setting">Medtrum pump settings</string>
     <string name="pump_error">Pump error: %1$s !! </string>
+    <string name="pump_warning">Pump warning: %1$s </string>
     <string name="pump_is_suspended">Pump is suspended</string>
     <string name="pump_is_suspended_hour_max">Pump is suspended due to hourly max insulin exceeded</string>
     <string name="pump_is_suspended_day_max">Pump is suspended due to daily max insulin exceeded</string>
@@ -138,6 +140,8 @@
     <string name="pump_unsupported">Pump untested: %1$d! Please contact us at discord or github for support</string>
     <string name="alarm_setting_title">Alarm Settings</string>
     <string name="alarm_setting_summary">Select your preferred pump alarm settings.</string>
+    <string name="pump_warning_notification_title">Notification on pump warning</string>
+    <string name="pump_warning_notification_summary">Show notification on non critical pump warnings: low battery, low reservoir (20 units) and expires soon. Recommended to leave enabled when pump alarms are set to silent.</string>
     <string name="patch_expiration_title">Patch Expiration</string>
     <string name="patch_expiration_summary">When enabled, the patch will expire after 3 days, with a grace period of 8 hours after that.</string>
     <string name="hourly_max_insulin_title">Hourly Maximum Insulin</string>

--- a/pump/medtrum/src/main/res/xml/pref_medtrum_pump.xml
+++ b/pump/medtrum/src/main/res/xml/pref_medtrum_pump.xml
@@ -14,7 +14,7 @@
             android:title="@string/sn_input_title" />
 
         <SwitchPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/key_patch_expiration"
             android:title="@string/patch_expiration_title"
             android:summary="@string/patch_expiration_summary" />

--- a/pump/medtrum/src/main/res/xml/pref_medtrum_pump.xml
+++ b/pump/medtrum/src/main/res/xml/pref_medtrum_pump.xml
@@ -27,6 +27,12 @@
             android:entries="@array/alarmSettings"
             android:entryValues="@array/alarmSettingsValues" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_pump_warning_notification"
+            android:title="@string/pump_warning_notification_title"
+            android:summary="@string/pump_warning_notification_summary" />
+
         <app.aaps.core.validators.ValidatingEditTextPreference
             android:defaultValue="25"
             android:inputType="number"


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/2881

- Patch expiration default to true
- Do not spam event bus on bolus progress
- Option to show notification on non critical pump alerts

This adds option to show notification on non critical pump alerts (enabled by default)
![Screenshot_20231008-174736_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/189fc88a-b816-446f-9dd7-b8f94189d9c2)

![Screenshot_20231008-175122_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/797482a9-101b-4595-a1b8-2dc009fef511)
