### PR TITLE
CWF Communication refactor between phone and Wear

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/PrefFileListProvider.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/PrefFileListProvider.kt
@@ -1,6 +1,7 @@
 package app.aaps.core.interfaces.maintenance
 
 import app.aaps.core.interfaces.rx.weardata.CwfData
+import app.aaps.core.interfaces.rx.weardata.CwfFile
 import java.io.File
 
 interface PrefFileListProvider {
@@ -13,7 +14,7 @@ interface PrefFileListProvider {
     fun newExportCsvFile(): File
     fun newCwfFile(filename: String, withDate: Boolean = true): File
     fun listPreferenceFiles(loadMetadata: Boolean = false): MutableList<PrefsFile>
-    fun listCustomWatchfaceFiles(): MutableList<CwfData>
+    fun listCustomWatchfaceFiles(): MutableList<CwfFile>
     fun checkMetadata(metadata: Map<PrefsMetadataKey, PrefMetadata>): Map<PrefsMetadataKey, PrefMetadata>
     fun formatExportedAgo(utcTime: String): String
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/events/EventMobileDataToWear.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/events/EventMobileDataToWear.kt
@@ -2,4 +2,4 @@ package app.aaps.core.interfaces.rx.events
 
 import app.aaps.core.interfaces.rx.weardata.EventData
 
-class EventMobileDataToWear(val payload: EventData.ActionSetCustomWatchface) : Event()
+class EventMobileDataToWear(val payload: ByteArray) : Event()

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -292,10 +292,9 @@ sealed class EventData : Event() {
     }
 
     @Serializable
-    data class ActionSetCustomWatchface(
-        val customWatchfaceData: CwfData
-    ) : EventData()
-
+    data class ActionSetCustomWatchface(val customWatchfaceData: CwfData) : EventData()
+    @Serializable
+    data class ActionUpdateCustomWatchface(val customWatchfaceData: CwfData) : EventData()
     @Serializable
     data class ActionrequestCustomWatchface(val exportFile: Boolean) : EventData()
 

--- a/core/utils/src/main/res/values/keys.xml
+++ b/core/utils/src/main/res/values/keys.xml
@@ -116,7 +116,9 @@
     <string name="key_wearwizard_cob" translatable="false">wearwizard_cob</string>
     <string name="key_wearwizard_iob" translatable="false">wearwizard_iob</string>
     <string name="key_wear_custom_watchface_autorization" translatable="false">wear_custom_watchface_autorization</string>
-    <string name="key_wear_custom_watchface_save_cwfData" translatable="false">wear_custom_watchface_save_cwfdata</string>
+    <string name="key_wear_cwf_watchface_name" translatable="false">wear_cwf_watchface_name</string>
+    <string name="key_wear_cwf_author_version" translatable="false">wear_cwf_author_version</string>
+    <string name="key_wear_cwf_filename" translatable="false">wear_cwf_filename</string>
     <string name="key_objectives_bg_is_available_in_ns" translatable="false">ObjectivesbgIsAvailableInNS</string>
     <string name="key_objectives_pump_status_is_available_in_ns" translatable="false">ObjectivespumpStatusIsAvailableInNS</string>
     <string name="key_statuslights_cage_warning" translatable="false">statuslights_cage_warning</string>

--- a/core/utils/src/main/res/values/keys.xml
+++ b/core/utils/src/main/res/values/keys.xml
@@ -116,6 +116,7 @@
     <string name="key_wearwizard_cob" translatable="false">wearwizard_cob</string>
     <string name="key_wearwizard_iob" translatable="false">wearwizard_iob</string>
     <string name="key_wear_custom_watchface_autorization" translatable="false">wear_custom_watchface_autorization</string>
+    <string name="key_wear_custom_watchface_save_cwfData" translatable="false">wear_custom_watchface_save_cwfdata</string>
     <string name="key_objectives_bg_is_available_in_ns" translatable="false">ObjectivesbgIsAvailableInNS</string>
     <string name="key_objectives_pump_status_is_available_in_ns" translatable="false">ObjectivespumpStatusIsAvailableInNS</string>
     <string name="key_statuslights_cage_warning" translatable="false">statuslights_cage_warning</string>

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/PrefFileListProviderImpl.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/PrefFileListProviderImpl.kt
@@ -102,7 +102,7 @@ class PrefFileListProviderImpl @Inject constructor(
         val customWatchfaceFiles = mutableListOf<CwfFile>()
         val customWatchfaceAuthorization = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false)
         exportsPath.walk().filter { it.isFile && it.name.endsWith(ZipWatchfaceFormat.CWF_EXTENTION) }.forEach { file ->
-            ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(file.inputStream()), file.name, customWatchfaceAuthorization)?.also { customWatchface ->
+            ZipWatchfaceFormat.loadCustomWatchface(file.readBytes(), file.name, customWatchfaceAuthorization)?.also { customWatchface ->
                 customWatchfaceFiles.add(customWatchface)
             }
         }
@@ -111,12 +111,11 @@ class PrefFileListProviderImpl @Inject constructor(
                 val assetFiles = context.assets.list("") ?: arrayOf()
                 for (assetFileName in assetFiles) {
                     if (assetFileName.endsWith(ZipWatchfaceFormat.CWF_EXTENTION)) {
-                        val assetInputStream = context.assets.open(assetFileName)
-                        ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(assetInputStream), assetFileName, customWatchfaceAuthorization)?.also { customWatchface ->
+                        val assetByteArray = context.assets.open(assetFileName).readBytes()
+                        ZipWatchfaceFormat.loadCustomWatchface(assetByteArray, assetFileName, customWatchfaceAuthorization)?.also { customWatchface ->
                             customWatchfaceFiles.add(customWatchface)
-                            //rxBus.send(EventData.ActionGetCustomWatchface(EventData.ActionSetCustomWatchface(customWatchface.cwfData), exportFile = true, withDate = false))
+                            rxBus.send(EventData.ActionGetCustomWatchface(EventData.ActionSetCustomWatchface(customWatchface.cwfData), exportFile = true, withDate = false))
                         }
-                        assetInputStream.close()
                     }
                 }
             } catch (e: Exception) {

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/PrefFileListProviderImpl.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/PrefFileListProviderImpl.kt
@@ -12,6 +12,7 @@ import app.aaps.core.interfaces.maintenance.PrefsMetadataKey
 import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.weardata.CwfData
+import app.aaps.core.interfaces.rx.weardata.CwfFile
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.rx.weardata.ZipWatchfaceFormat
 import app.aaps.core.interfaces.sharedPreferences.SP
@@ -97,11 +98,11 @@ class PrefFileListProviderImpl @Inject constructor(
         return prefFiles
     }
 
-    override fun listCustomWatchfaceFiles(): MutableList<CwfData> {
-        val customWatchfaceFiles = mutableListOf<CwfData>()
-        val customAwtchfaceAuthorization = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false)
+    override fun listCustomWatchfaceFiles(): MutableList<CwfFile> {
+        val customWatchfaceFiles = mutableListOf<CwfFile>()
+        val customWatchfaceAuthorization = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false)
         exportsPath.walk().filter { it.isFile && it.name.endsWith(ZipWatchfaceFormat.CWF_EXTENTION) }.forEach { file ->
-            ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(file.inputStream()), file.name, customAwtchfaceAuthorization)?.also { customWatchface ->
+            ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(file.inputStream()), file.name, customWatchfaceAuthorization)?.also { customWatchface ->
                 customWatchfaceFiles.add(customWatchface)
             }
         }
@@ -111,9 +112,9 @@ class PrefFileListProviderImpl @Inject constructor(
                 for (assetFileName in assetFiles) {
                     if (assetFileName.endsWith(ZipWatchfaceFormat.CWF_EXTENTION)) {
                         val assetInputStream = context.assets.open(assetFileName)
-                        ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(assetInputStream), assetFileName, customAwtchfaceAuthorization)?.also { customWatchface ->
+                        ZipWatchfaceFormat.loadCustomWatchface(ZipInputStream(assetInputStream), assetFileName, customWatchfaceAuthorization)?.also { customWatchface ->
                             customWatchfaceFiles.add(customWatchface)
-                            rxBus.send(EventData.ActionGetCustomWatchface(EventData.ActionSetCustomWatchface(customWatchface), exportFile = true, withDate = false))
+                            //rxBus.send(EventData.ActionGetCustomWatchface(EventData.ActionSetCustomWatchface(customWatchface.cwfData), exportFile = true, withDate = false))
                         }
                         assetInputStream.close()
                     }

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
@@ -70,13 +70,13 @@ class CustomWatchfaceImportListActivity : TranslatedDaggerAppCompatActivity() {
                     root.isClickable = true
                     customWatchfaceImportListItemBinding.root.setOnClickListener {
                         val customWatchfaceFile = filelistName.tag as CwfFile
-                        val cwfData = CwfData(customWatchfaceFile.cwfData.json, customWatchfaceFile.cwfData.metadata, mutableMapOf())
-                        //Save json and metadata
-                        sp.putString(app.aaps.core.utils.R.string.key_wear_custom_watchface_save_cwfData, EventData.ActionSetCustomWatchface(cwfData).serialize())
+                        sp.putString(app.aaps.core.utils.R.string.key_wear_cwf_watchface_name, customWatchfaceFile.cwfData.metadata[CWF_NAME] ?:"")
+                        sp.putString(app.aaps.core.utils.R.string.key_wear_cwf_author_version, customWatchfaceFile.cwfData.metadata[CWF_AUTHOR_VERSION] ?:"")
+                        sp.putString(app.aaps.core.utils.R.string.key_wear_cwf_filename, customWatchfaceFile.cwfData.metadata[CWF_FILENAME] ?:"")
+
                         val i = Intent()
                         setResult(FragmentActivity.RESULT_OK, i)
                         rxBus.send(EventMobileDataToWear(customWatchfaceFile.zipByteArray))
-                        aapsLogger.debug("XXXXX: ${customWatchfaceFile.zipByteArray.size}")
                         finish()
                     }
                 }

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/activities/CustomWatchfaceImportListActivity.kt
@@ -15,6 +15,7 @@ import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventMobileDataToWear
 import app.aaps.core.interfaces.rx.weardata.CUSTOM_VERSION
 import app.aaps.core.interfaces.rx.weardata.CwfData
+import app.aaps.core.interfaces.rx.weardata.CwfFile
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_AUTHOR
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_AUTHOR_VERSION
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_CREATED_AT
@@ -22,6 +23,7 @@ import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_FILENAME
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_NAME
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey.CWF_VERSION
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataMap
+import app.aaps.core.interfaces.rx.weardata.CwfResDataMap
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.rx.weardata.ResFileMap
 import app.aaps.core.interfaces.rx.weardata.ZipWatchfaceFormat
@@ -56,10 +58,10 @@ class CustomWatchfaceImportListActivity : TranslatedDaggerAppCompatActivity() {
         supportActionBar?.setDisplayShowTitleEnabled(true)
 
         binding.recyclerview.layoutManager = LinearLayoutManager(this)
-        binding.recyclerview.adapter = RecyclerViewAdapter(prefFileListProvider.listCustomWatchfaceFiles().sortedBy { it.metadata[CWF_NAME] })
+        binding.recyclerview.adapter = RecyclerViewAdapter(prefFileListProvider.listCustomWatchfaceFiles().sortedBy { it.cwfData.metadata[CWF_NAME] })
     }
 
-    inner class RecyclerViewAdapter internal constructor(private var customWatchfaceFileList: List<CwfData>) : RecyclerView.Adapter<RecyclerViewAdapter.CwfFileViewHolder>() {
+    inner class RecyclerViewAdapter internal constructor(private var customWatchfaceFileList: List<CwfFile>) : RecyclerView.Adapter<RecyclerViewAdapter.CwfFileViewHolder>() {
 
         inner class CwfFileViewHolder(val customWatchfaceImportListItemBinding: CustomWatchfaceImportListItemBinding) : RecyclerView.ViewHolder(customWatchfaceImportListItemBinding.root) {
 
@@ -67,11 +69,14 @@ class CustomWatchfaceImportListActivity : TranslatedDaggerAppCompatActivity() {
                 with(customWatchfaceImportListItemBinding) {
                     root.isClickable = true
                     customWatchfaceImportListItemBinding.root.setOnClickListener {
-                        val customWatchfaceFile = filelistName.tag as CwfData
-                        val customWF = EventData.ActionSetCustomWatchface(customWatchfaceFile)
+                        val customWatchfaceFile = filelistName.tag as CwfFile
+                        val cwfData = CwfData(customWatchfaceFile.cwfData.json, customWatchfaceFile.cwfData.metadata, mutableMapOf())
+                        //Save json and metadata
+                        sp.putString(app.aaps.core.utils.R.string.key_wear_custom_watchface_save_cwfData, EventData.ActionSetCustomWatchface(cwfData).serialize())
                         val i = Intent()
                         setResult(FragmentActivity.RESULT_OK, i)
-                        rxBus.send(EventMobileDataToWear(customWF))
+                        rxBus.send(EventMobileDataToWear(customWatchfaceFile.zipByteArray))
+                        aapsLogger.debug("XXXXX: ${customWatchfaceFile.zipByteArray.size}")
                         finish()
                     }
                 }
@@ -89,8 +94,8 @@ class CustomWatchfaceImportListActivity : TranslatedDaggerAppCompatActivity() {
 
         override fun onBindViewHolder(holder: CwfFileViewHolder, position: Int) {
             val customWatchfaceFile = customWatchfaceFileList[position]
-            val metadata = customWatchfaceFile.metadata
-            val drawable = customWatchfaceFile.resDatas[ResFileMap.CUSTOM_WATCHFACE.fileName]?.toDrawable(resources)
+            val metadata = customWatchfaceFile.cwfData.metadata
+            val drawable = customWatchfaceFile.cwfData.resDatas[ResFileMap.CUSTOM_WATCHFACE.fileName]?.toDrawable(resources)
             with(holder.customWatchfaceImportListItemBinding) {
                 val fileName = metadata[CWF_FILENAME]?.let { "$it${ZipWatchfaceFormat.CWF_EXTENTION}" } ?: ""
                 filelistName.text = rh.gs(app.aaps.core.interfaces.R.string.metadata_wear_import_filename, fileName)

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/WearPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/WearPlugin.kt
@@ -114,10 +114,12 @@ class WearPlugin @Inject constructor(
         savedCustomWatchface?.let { cwf ->
             val cwf_authorization = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false)
             if (cwf_authorization != cwf.metadata[CwfMetadataKey.CWF_AUTHORIZATION]?.toBooleanStrictOrNull()) {
-                // resend new customWatchface to Watch with updated authorization for preferences update
-                val newCwf = cwf.copy()
-                newCwf.metadata[CwfMetadataKey.CWF_AUTHORIZATION] = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false).toString()
-                rxBus.send(EventMobileDataToWear(EventData.ActionSetCustomWatchface(newCwf)))
+                // update new customWatchface to Watch with updated authorization for preferences update
+                CwfData(cwf.json, cwf.metadata, mutableMapOf()).also {
+                    it.metadata[CwfMetadataKey.CWF_AUTHORIZATION] = sp.getBoolean(app.aaps.core.utils.R.string.key_wear_custom_watchface_autorization, false).toString()
+                    sp.putString(app.aaps.core.utils.R.string.key_wear_custom_watchface_save_cwfData, EventData.ActionSetCustomWatchface(it).serialize())
+                    rxBus.send(EventMobileToWear(EventData.ActionUpdateCustomWatchface(it)))
+                }
             }
         }
     }

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataLayerListenerServiceMobile.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataLayerListenerServiceMobile.kt
@@ -214,7 +214,6 @@ class DataLayerListenerServiceMobile : WearableListenerService() {
 
     private fun sendMessage(path: String, data: ByteArray) {
         aapsLogger.debug(LTag.WEAR, "sendMessage: $path")
-        aapsLogger.debug("XXXXX: $path, ${data.size}")
         transcriptionNodeId?.also { nodeId ->
             messageClient
                 .sendMessage(nodeId, path, data).apply {

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataLayerListenerServiceMobile.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/wear/wearintegration/DataLayerListenerServiceMobile.kt
@@ -93,7 +93,7 @@ class DataLayerListenerServiceMobile : WearableListenerService() {
         disposable += rxBus
             .toObservable(EventMobileDataToWear::class.java)
             .observeOn(aapsSchedulers.io)
-            .subscribe { sendMessage(rxDataPath, it.payload.serializeByte()) }
+            .subscribe { sendMessage(rxDataPath, it.payload) }
     }
 
     override fun onCapabilityChanged(p0: CapabilityInfo) {
@@ -214,6 +214,7 @@ class DataLayerListenerServiceMobile : WearableListenerService() {
 
     private fun sendMessage(path: String, data: ByteArray) {
         aapsLogger.debug(LTag.WEAR, "sendMessage: $path")
+        aapsLogger.debug("XXXXX: $path, ${data.size}")
         transcriptionNodeId?.also { nodeId ->
             messageClient
                 .sendMessage(nodeId, path, data).apply {

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
@@ -186,7 +186,17 @@ class DataHandlerWear @Inject constructor(
             .subscribe {
                 aapsLogger.debug(LTag.WEAR, "Custom Watchface received from ${it.sourceNodeId}")
                 persistence.store(it)
-                persistence.readCustomWatchface()?.let {
+                persistence.readSimplifiedCwf()?.let {
+                    rxBus.send(EventWearDataToMobile(EventData.ActionGetCustomWatchface(it, false)))
+                }
+            }
+        disposable += rxBus
+            .toObservable(EventData.ActionUpdateCustomWatchface::class.java)
+            .observeOn(aapsSchedulers.io)
+            .subscribe {
+                aapsLogger.debug(LTag.WEAR, "Custom Watchface received from ${it.sourceNodeId}")
+                persistence.store(it)
+                persistence.readSimplifiedCwf()?.let {
                     rxBus.send(EventWearDataToMobile(EventData.ActionGetCustomWatchface(it, false)))
                 }
             }
@@ -205,7 +215,7 @@ class DataHandlerWear @Inject constructor(
             .observeOn(aapsSchedulers.io)
             .subscribe { eventData ->
                 aapsLogger.debug(LTag.WEAR, "Custom Watchface requested from ${eventData.sourceNodeId} export ${eventData.exportFile}")
-                persistence.readCustomWatchface(eventData.exportFile)?.let {
+                persistence.readSimplifiedCwf(eventData.exportFile)?.let {
                     rxBus.send(EventWearDataToMobile(EventData.ActionGetCustomWatchface(it, eventData.exportFile)))
                 }
             }

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
@@ -12,6 +12,7 @@ import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventWearDataToMobile
 import app.aaps.core.interfaces.rx.events.EventWearToMobile
 import app.aaps.core.interfaces.rx.weardata.EventData
+import app.aaps.core.interfaces.rx.weardata.ZipWatchfaceFormat
 import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.wear.interaction.utils.Persistence
 import app.aaps.wear.interaction.utils.WearUtil
@@ -127,9 +128,13 @@ class DataLayerListenerServiceWear : WearableListenerService() {
             }
 
             rxDataPath -> {
-                aapsLogger.debug(LTag.WEAR, "onMessageReceived: ${messageEvent.data}")
-                val command = EventData.deserializeByte(messageEvent.data)
-                rxBus.send(command.also { it.sourceNodeId = messageEvent.sourceNodeId })
+                aapsLogger.debug(LTag.WEAR, "onMessageReceived: ${messageEvent.data.size}")
+                ZipWatchfaceFormat.loadCustomWatchface(ZipWatchfaceFormat.byteArrayToZipInputStream(messageEvent.data), "NewWatchface", false)?.let {
+                    val command = EventData.ActionSetCustomWatchface(it.cwfData)
+                    rxBus.send(command.also { it.sourceNodeId = messageEvent.sourceNodeId })
+
+                    aapsLogger.debug("XXXXX: ${it.cwfData.json}")
+                }
                 // Use this sender
                 transcriptionNodeId = messageEvent.sourceNodeId
                 aapsLogger.debug(LTag.WEAR, "Updated node: $transcriptionNodeId")

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
@@ -129,11 +129,9 @@ class DataLayerListenerServiceWear : WearableListenerService() {
 
             rxDataPath -> {
                 aapsLogger.debug(LTag.WEAR, "onMessageReceived: ${messageEvent.data.size}")
-                ZipWatchfaceFormat.loadCustomWatchface(ZipWatchfaceFormat.byteArrayToZipInputStream(messageEvent.data), "NewWatchface", false)?.let {
+                ZipWatchfaceFormat.loadCustomWatchface(messageEvent.data, "", false)?.let {
                     val command = EventData.ActionSetCustomWatchface(it.cwfData)
                     rxBus.send(command.also { it.sourceNodeId = messageEvent.sourceNodeId })
-
-                    aapsLogger.debug("XXXXX: ${it.cwfData.json}")
                 }
                 // Use this sender
                 transcriptionNodeId = messageEvent.sourceNodeId

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
@@ -3,6 +3,9 @@ package app.aaps.wear.interaction.utils
 import app.aaps.annotations.OpenForTesting
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.rx.events.EventMobileToWear
+import app.aaps.core.interfaces.rx.weardata.CwfData
+import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.rx.weardata.EventData.Companion.deserialize
 import app.aaps.core.interfaces.rx.weardata.EventData.SingleBg
@@ -149,6 +152,26 @@ open class Persistence @Inject constructor(
         return null
     }
 
+    fun readSimplifiedCwf(isDefault: Boolean = false): EventData.ActionSetCustomWatchface? {
+        try {
+            var s = sp.getStringOrNull(if (isDefault) CUSTOM_DEFAULT_WATCHFACE else CUSTOM_WATCHFACE, null)
+            if (s != null) {
+                return (deserialize(s) as EventData.ActionSetCustomWatchface).let {
+                    EventData.ActionSetCustomWatchface(it.customWatchfaceData.simplify() ?:it.customWatchfaceData)
+                }
+
+            } else {
+                s = sp.getStringOrNull(CUSTOM_DEFAULT_WATCHFACE, null)
+                if (s != null) {
+                    return deserialize(s) as EventData.ActionSetCustomWatchface
+                }
+            }
+        } catch (exception: Exception) {
+            aapsLogger.error(LTag.WEAR, exception.toString())
+        }
+        return null
+    }
+
     fun store(singleBg: SingleBg) {
         putString(BG_DATA_PERSISTENCE_KEY, singleBg.serialize())
         aapsLogger.debug(LTag.WEAR, "Stored BG data: $singleBg")
@@ -174,6 +197,21 @@ open class Persistence @Inject constructor(
         putString(if (isdefault) CUSTOM_DEFAULT_WATCHFACE else CUSTOM_WATCHFACE, customWatchface.serialize())
         aapsLogger.debug(LTag.WEAR, "Stored Custom Watchface ${customWatchface.customWatchfaceData} ${isdefault}: $customWatchface")
     }
+
+    fun store(customWatchface: EventData.ActionUpdateCustomWatchface) {
+        readCustomWatchface()?.let { savedCwData ->
+            if (customWatchface.customWatchfaceData.metadata[CwfMetadataKey.CWF_NAME] == savedCwData.customWatchfaceData.metadata[CwfMetadataKey.CWF_NAME] &&
+                customWatchface.customWatchfaceData.metadata[CwfMetadataKey.CWF_AUTHOR_VERSION] == savedCwData.customWatchfaceData.metadata[CwfMetadataKey.CWF_AUTHOR_VERSION]
+            ) {
+                // if different json but same name and author version, then resync json and metadata to watch to update filename and authorization
+                val newCwfData = CwfData(customWatchface.customWatchfaceData.json, customWatchface.customWatchfaceData.metadata, savedCwData.customWatchfaceData.resDatas)
+                EventData.ActionSetCustomWatchface(newCwfData).also {
+                    putString(CUSTOM_WATCHFACE, it.serialize())
+                    aapsLogger.debug(LTag.WEAR, "Update Custom Watchface ${it.customWatchfaceData} : $customWatchface")
+            }
+        }
+    }
+}
 
     fun setDefaultWatchface() {
         readCustomWatchface(true)?.let { store(it) }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
@@ -203,8 +203,8 @@ open class Persistence @Inject constructor(
             if (customWatchface.customWatchfaceData.metadata[CwfMetadataKey.CWF_NAME] == savedCwData.customWatchfaceData.metadata[CwfMetadataKey.CWF_NAME] &&
                 customWatchface.customWatchfaceData.metadata[CwfMetadataKey.CWF_AUTHOR_VERSION] == savedCwData.customWatchfaceData.metadata[CwfMetadataKey.CWF_AUTHOR_VERSION]
             ) {
-                // if different json but same name and author version, then resync json and metadata to watch to update filename and authorization
-                val newCwfData = CwfData(customWatchface.customWatchfaceData.json, customWatchface.customWatchfaceData.metadata, savedCwData.customWatchfaceData.resDatas)
+                // if same name and author version, then resync metadata to watch to update filename and authorization
+                val newCwfData = CwfData(savedCwData.customWatchfaceData.json, customWatchface.customWatchfaceData.metadata, savedCwData.customWatchfaceData.resDatas)
                 EventData.ActionSetCustomWatchface(newCwfData).also {
                     putString(CUSTOM_WATCHFACE, it.serialize())
                     aapsLogger.debug(LTag.WEAR, "Update Custom Watchface ${it.customWatchfaceData} : $customWatchface")

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
@@ -44,7 +44,8 @@ import app.aaps.core.interfaces.rx.weardata.ResFileMap
 import app.aaps.core.interfaces.rx.weardata.ResFormat
 import app.aaps.core.interfaces.rx.weardata.ViewKeys
 import app.aaps.core.interfaces.rx.weardata.ZipWatchfaceFormat
-import app.aaps.core.interfaces.rx.weardata.isEquals
+import app.aaps.core.interfaces.rx.weardata.sameMeta
+import app.aaps.core.interfaces.rx.weardata.sameRes
 import app.aaps.wear.R
 import app.aaps.wear.databinding.ActivityCustomBinding
 import app.aaps.wear.watchfaces.utils.BaseWatchFace
@@ -66,6 +67,7 @@ class CustomWatchface : BaseWatchFace() {
     private var lowBatColor = Color.RED
     private var resDataMap: CwfResDataMap = mutableMapOf()
     private var json = JSONObject()
+    private var metadata: CwfMetadataMap = mutableMapOf()
     private var jsonString = ""
     private val bgColor: Int
         get() = when (singleBg.sgvLevel) {
@@ -153,8 +155,9 @@ class CustomWatchface : BaseWatchFace() {
             updatePref(it.customWatchfaceData.metadata)
             try {
                 json = JSONObject(it.customWatchfaceData.json)
-                if (!resDataMap.isEquals(it.customWatchfaceData.resDatas) || jsonString != it.customWatchfaceData.json) {
+                if (!resDataMap.sameRes(it.customWatchfaceData.resDatas) || !metadata.sameMeta(it.customWatchfaceData.metadata) || jsonString != it.customWatchfaceData.json) {
                     resDataMap = it.customWatchfaceData.resDatas
+                    metadata = it.customWatchfaceData.metadata
                     jsonString = it.customWatchfaceData.json
                     FontMap.init(this)
                     ViewMap.init(this)

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
@@ -44,8 +44,7 @@ import app.aaps.core.interfaces.rx.weardata.ResFileMap
 import app.aaps.core.interfaces.rx.weardata.ResFormat
 import app.aaps.core.interfaces.rx.weardata.ViewKeys
 import app.aaps.core.interfaces.rx.weardata.ZipWatchfaceFormat
-import app.aaps.core.interfaces.rx.weardata.sameMeta
-import app.aaps.core.interfaces.rx.weardata.sameRes
+import app.aaps.core.interfaces.rx.weardata.isEquals
 import app.aaps.wear.R
 import app.aaps.wear.databinding.ActivityCustomBinding
 import app.aaps.wear.watchfaces.utils.BaseWatchFace
@@ -67,7 +66,6 @@ class CustomWatchface : BaseWatchFace() {
     private var lowBatColor = Color.RED
     private var resDataMap: CwfResDataMap = mutableMapOf()
     private var json = JSONObject()
-    private var metadata: CwfMetadataMap = mutableMapOf()
     private var jsonString = ""
     private val bgColor: Int
         get() = when (singleBg.sgvLevel) {
@@ -155,9 +153,8 @@ class CustomWatchface : BaseWatchFace() {
             updatePref(it.customWatchfaceData.metadata)
             try {
                 json = JSONObject(it.customWatchfaceData.json)
-                if (!resDataMap.sameRes(it.customWatchfaceData.resDatas) || !metadata.sameMeta(it.customWatchfaceData.metadata) || jsonString != it.customWatchfaceData.json) {
+                if (!resDataMap.isEquals(it.customWatchfaceData.resDatas) || jsonString != it.customWatchfaceData.json) {
                     resDataMap = it.customWatchfaceData.resDatas
-                    metadata = it.customWatchfaceData.metadata
                     jsonString = it.customWatchfaceData.json
                     FontMap.init(this)
                     ViewMap.init(this)


### PR DESCRIPTION
From Phone to Watch
- With previous code, cwfData was embeded into an EventData and serialized, but this increase overall size of sent data by 2 or 3
- Now I directly send zipFile as a ByteArray and after I synchronize metadata to include filename and watch authorization
- Previous size limit of data was about a zip file 320kB (Steampunk wachfaces was very closed to the limit, I had to replace some png by zip to reduce the size)
- new limit is at about 500kb (I expected higher size, but improvement remains important)
- when an update is required (for example to sent authorization, only metadata is sent and not the whole watchface

This divide by about 2 the overall duration to send cwf to the watch and receive confirmation to phone (it takes now about 5 seconds for a full synchro of a big watchface (it was more than 10s previously)

From Watch to phone
- I kept previous communication in the other side (binary serialization), but removed all resources included into watchface to only keep CustomWatchface image (so it reduces a lot the size for complex watchfaces)

I definitively do not understand how the size limit is calculated between phone and watch...
- it was close to 1 Mb with string serialisation when I starter to work on customWF (zip size limit was very low, no more than 150 or 200kb max)
- then it was at about 700 or 800kb (but with the increase of binary serialization zip file limit was at about 320kb/330kb)
- and with this latest refactoring and zip byteArray, it's now at about 500kb...