### PR TITLE
UI: Moved bolus result to top in calculator

### DIFF
--- a/ui/src/main/res/layout/dialog_wizard.xml
+++ b/ui/src/main/res/layout/dialog_wizard.xml
@@ -39,6 +39,43 @@
         </RelativeLayout>
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="10dp"
+            android:background="?attr/dialogTitleBackground"
+            android:gravity="center_horizontal"
+            android:orientation="horizontal"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp">
+
+            <TextView
+                android:id="@+id/total"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:text="2.35U 28g"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/percent_used"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:text="50%"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="?attr/bolusColor"
+                tools:ignore="HardcodedText" />
+
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/spacer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -174,43 +211,6 @@
             </TableRow>
 
         </TableLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="10dp"
-            android:background="?attr/dialogTitleBackground"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal"
-            android:paddingTop="5dp"
-            android:paddingBottom="5dp">
-
-            <TextView
-                android:id="@+id/total"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="10dp"
-                android:paddingEnd="10dp"
-                android:text="2.35U 28g"
-                android:textAppearance="?android:attr/textAppearanceLarge"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/percent_used"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:paddingStart="10dp"
-                android:paddingEnd="10dp"
-                android:text="50%"
-                android:textAppearance="?android:attr/textAppearanceLarge"
-                android:textColor="?attr/bolusColor"
-                tools:ignore="HardcodedText" />
-
-        </LinearLayout>
 
         <include
             android:id="@+id/notes_layout"


### PR DESCRIPTION
Solution to https://github.com/nightscout/AndroidAPS/issues/2754

Discussed on Discord - change improves readability. Tested on an external device.

<img width="967" alt="bolus_update" src="https://github.com/nightscout/AndroidAPS/assets/4112129/f30f54b1-6042-4e2e-83e6-4e98026d123a">
