### PR TITLE
Enable androidTest in CircleCI bulid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,22 @@ jobs:
       tag: 2023.07.1
 
     steps:
-      # Checkout the code as the first step.
       - checkout
+
       - android/change-java-version:
           java-version: 17
-      # The next step will run the unit tests
+
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-29;google_apis;x86
+	  # Compilee while the emulator starts to use the time.
+          post-emulator-launch-assemble-command: ./gradlew compileFullDebugUnitTestSources database:impl:compileFullDebugAndroidTestSources
+          test-command: ./gradlew database:impl:connectedFullDebugAndroidTest
+
       - android/run-tests:
           test-command: ./gradlew testFullDebugUnitTest
 
       - android/run-tests:
           test-command: ./gradlew --stacktrace jacocoAllDebugReport
-
-      # Then start the emulator and run the Instrumentation tests!
-      #      - android/start-emulator-and-run-tests:
-      #          test-command: ./gradlew connectedDebugAndroidTest
-      #          system-image: system-images;android-25;google_apis;x86
 
       # And finally run the release build
       #      - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
 
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-29;google_apis;x86
-	  # Compilee while the emulator starts to use the time.
+          # Compile while the emulator starts to use the time.
           post-emulator-launch-assemble-command: ./gradlew compileFullDebugUnitTestSources database:impl:compileFullDebugAndroidTestSources
           test-command: ./gradlew database:impl:connectedFullDebugAndroidTest
 


### PR DESCRIPTION
For now only for database:impl package. The other androidTests needs some fixes that I'll provide later. This makes the entire run much slower (~ 37min). Seems to be mostly because of compilation. I'm not sure why it's so much slower and so slow in general.