### PR TITLE
Wear CWF Fix Invalid keys for TopOffset, LeftOffset and RotationOffset steps

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/CustomWatchfaceFormat.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/CustomWatchfaceFormat.kt
@@ -268,6 +268,9 @@ enum class JsonKeys(val key: String) {
     DYNPREF("dynPref"),
     DYNPREFCOLOR("dynPrefColor"),
     PREFKEY("prefKey"),
+    INVALIDTOPOFFSET("invalidTopOffset"),
+    INVALIDLEFTOFFSET("invalidLeftOffset"),
+    INVALIDROTATIONOFFSET("invalidRotationOffset"),
     DEFAULT("default")
 }
 

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
@@ -819,9 +819,9 @@ class CustomWatchface : BaseWatchFace() {
             getColorSteps(dynColor, COLOR.key, INVALIDCOLOR.key)
             getColorSteps(dynFontColor, FONTCOLOR.key, INVALIDFONTCOLOR.key)
             getIntSteps(dynTextSize, TEXTSIZE.key, INVALIDTEXTSIZE.key)
-            getIntSteps(dynLeftOffset, LEFTOFFSET.key, INVALIDTEXTSIZE.key)
-            getIntSteps(dynTopOffset, TOPOFFSET.key, INVALIDTEXTSIZE.key)
-            getIntSteps(dynRotationOffset, ROTATIONOFFSET.key, INVALIDTEXTSIZE.key)
+            getIntSteps(dynLeftOffset, LEFTOFFSET.key, INVALIDLEFTOFFSET.key)
+            getIntSteps(dynTopOffset, TOPOFFSET.key, INVALIDTOPOFFSET.key)
+            getIntSteps(dynRotationOffset, ROTATIONOFFSET.key, INVALIDROTATIONOFFSET.key)
         }
 
         private fun getDrawableSteps(dynMap: MutableMap<Int, Drawable?>, key: String, invalidKey: String) {


### PR DESCRIPTION
Hopefully no CWF currently uses these keys (I will use them for the remaining AAPS watchfaces (AAPS NoChart and AAPS Large)...

@milos, do you want me to do a dedicated PR for refactor branch (I saw you have reorganized CustomWatchfaceFormat file...) ?