### PR TITLE
Set testCoverageEnabled=false in wear.

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -50,6 +50,18 @@ android {
         buildConfigField("String", "BUILDVERSION", "\"${generateGitBuild()}-${generateDate()}\"")
     }
 
+    android {
+        buildTypes {
+            debug {
+                enableUnitTestCoverage = true
+                // Disable androidTest coverage, since it performs offline coverage
+                // instrumentation and that causes online (JavaAgent) instrumentation
+                // to fail in this project.
+                enableAndroidTestCoverage = false
+            }
+        }
+    }
+
     flavorDimensions.add("standard")
     productFlavors {
         create("full") {


### PR DESCRIPTION
Setting this to true conflicts with the jacoco plugin and causes no coverage reporting. Not sure why this is only a problem in the wear subproj.