### PR TITLE
Medtrum: Skip record if it fails

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/Notification.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/Notification.kt
@@ -139,6 +139,7 @@ open class Notification {
         const val PUMP_TIMEZONE_UPDATE_FAILED = 85
         const val BLUETOOTH_NOT_SUPPORTED = 86
         const val PUMP_WARNING = 87
+        const val PUMP_SYNC_ERROR = 88
 
         const val USER_MESSAGE = 1000
 

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
@@ -566,7 +566,8 @@ class MedtrumService : DaggerService(), BLECommCallback {
                 result = sendPacketAndGetResponse(packet, COMMAND_SYNC_TIMEOUT_SEC)
                 if (!result && packet.failed) {
                     // Record may be broken for unkown reasons, try the next packet if that fails abort
-                    failureCount++                    
+                    failureCount++
+                    aapsLogger.error(LTag.PUMPCOMM, "Failed to sync record $sequence, failureCount: $failureCount")
                     if (failureCount == 1) {
                         // Show notification to alert user of failure
                         uiInteraction.addNotificationWithSound(

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/MedtrumService.kt
@@ -559,10 +559,29 @@ class MedtrumService : DaggerService(), BLECommCallback {
     private fun syncRecords(): Boolean {
         aapsLogger.debug(LTag.PUMP, "syncRecords: called!, syncedSequenceNumber: ${medtrumPump.syncedSequenceNumber}, currentSequenceNumber: ${medtrumPump.currentSequenceNumber}")
         var result = true
+        var failureCount = 0
         if (medtrumPump.syncedSequenceNumber < medtrumPump.currentSequenceNumber) {
             for (sequence in (medtrumPump.syncedSequenceNumber + 1)..medtrumPump.currentSequenceNumber) {
-                result = sendPacketAndGetResponse(GetRecordPacket(injector, sequence), COMMAND_SYNC_TIMEOUT_SEC)
-                if (!result) break
+                val packet = GetRecordPacket(injector, sequence)
+                result = sendPacketAndGetResponse(packet, COMMAND_SYNC_TIMEOUT_SEC)
+                if (!result && packet.failed) {
+                    // Record may be broken for unkown reasons, try the next packet if that fails abort
+                    failureCount++                    
+                    if (failureCount == 1) {
+                        // Show notification to alert user of failure
+                        uiInteraction.addNotificationWithSound(
+                            Notification.PUMP_SYNC_ERROR,
+                            rh.gs(R.string.pump_sync_error),
+                            Notification.URGENT,
+                            app.aaps.core.ui.R.raw.alarm
+                        )
+                    } else if (failureCount >= 2) {
+                        break
+                    }
+                } else if (!result) {
+                    // Communication timeout, try again
+                    break
+                }
             }
         }
         return result

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="pump_is_suspended_day_max">Pump is suspended due to daily max insulin exceeded</string>
     <string name="patch_not_active">Patch not activated</string>
     <string name="pump_setting_failed">Setting user settings to pump failed!</string>
+    <string name="pump_sync_error">Error while syncing history from pump, a record has been skipped. Check treatment tab to check if bolus is synced correctly. Snooze and if error keep coming back change patch or pumpbase.</string>
 
     <!-- overview fragment -->
     <string name="ble_status_label">BLE Status</string>


### PR DESCRIPTION
Fixes instance where syncing would be blocked by a record that the pump refuses to give.

Has been tested on the pump that gave the error in the first place.