### PR TITLE
Fix devicestatus history loading

### DIFF
--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/NSAndroidClientImpl.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/NSAndroidClientImpl.kt
@@ -267,9 +267,9 @@ class NSAndroidClientImpl(
             throw UnsuccessfullNightscoutException()
     }
 
-    override suspend fun getDeviceStatusModifiedSince(from: Long): List<NSDeviceStatus> = callWrapper(dispatcher) {
+    override suspend fun getDeviceStatusModifiedSince(from: Long, limit: Int): List<NSDeviceStatus> = callWrapper(dispatcher) {
 
-        val response = api.getDeviceStatusModifiedSince(from)
+        val response = api.getDeviceStatusModifiedSince(from, limit)
         if (response.isSuccessful) {
             return@callWrapper response.body()?.result?.map(RemoteDeviceStatus::toNSDeviceStatus).toNotNull()
         } else if (response.code() in 400..499)

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/interfaces/NSAndroidClient.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/interfaces/NSAndroidClient.kt
@@ -32,7 +32,7 @@ interface NSAndroidClient {
     suspend fun getTreatmentsModifiedSince(from: Long, limit: Int): ReadResponse<List<NSTreatment>>
 
     suspend fun createDeviceStatus(nsDeviceStatus: NSDeviceStatus): CreateUpdateResponse
-    suspend fun getDeviceStatusModifiedSince(from: Long): List<NSDeviceStatus>
+    suspend fun getDeviceStatusModifiedSince(from: Long, limit: Int): List<NSDeviceStatus>
 
     suspend fun createProfileStore(remoteProfileStore: JSONObject): CreateUpdateResponse
     suspend fun getProfileModifiedSince(from: Long): ReadResponse<List<JSONObject>>

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/NightscoutRemoteService.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/NightscoutRemoteService.kt
@@ -75,7 +75,7 @@ internal interface NightscoutRemoteService {
     suspend fun createDeviceStatus(@Body remoteDeviceStatus: RemoteDeviceStatus): Response<RemoteCreateUpdateResponse>
 
     @GET("v3/devicestatus/history/{from}")
-    suspend fun getDeviceStatusModifiedSince(@Path("from") from: Long): Response<NSResponse<List<RemoteDeviceStatus>>>
+    suspend fun getDeviceStatusModifiedSince(@Path("from") from: Long, @Query("limit") limit: Int): Response<NSResponse<List<RemoteDeviceStatus>>>
 
     @GET("v3/food")
     suspend fun getFoods(@Query("limit") limit: Int): Response<NSResponse<List<RemoteFood>>>

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/workers/LoadDeviceStatusWorker.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/workers/LoadDeviceStatusWorker.kt
@@ -34,7 +34,7 @@ class LoadDeviceStatusWorker(
             nsClientV3Plugin.initialLoadFinished = true
 
             val from = dateUtil.now() - T.mins(7).msecs()
-            val deviceStatuses = nsAndroidClient.getDeviceStatusModifiedSince(from)
+            val deviceStatuses = nsAndroidClient.getDeviceStatusModifiedSince(from, NSClientV3Plugin.RECORDS_TO_LOAD)
             aapsLogger.debug("DEVICESTATUSES: $deviceStatuses")
             if (deviceStatuses.isNotEmpty()) {
                 rxBus.send(EventNSClientNewLog("◄ RCV", "${deviceStatuses.size} DSs from ${dateUtil.dateAndTimeAndSecondsString(from)}"))


### PR DESCRIPTION
See NS issue [#8149](https://github.com/nightscout/cgm-remote-monitor/issues/8149): on call to getDeviceStatusModifiedSince always gets HTTP500 on NS 15 because of lack of `limit` argument