### PR TITLE
Fix typo of DynISF setting "Adjust sensitivity and BG" and add summary

### DIFF
--- a/plugins/aps/src/main/res/values/strings.xml
+++ b/plugins/aps/src/main/res/values/strings.xml
@@ -23,7 +23,8 @@
     <string name="key_DynISFAdjust" translatable="false">DynISFAdjust</string>
     <string name="key_adjust_sensitivity" translatable="false">dynisf_adjust_sensitivity</string>
 
-    <string name="dynisf_adjust_sensitivity">Adjust sensitivity and BG</string>
+    <string name="dynisf_adjust_sensitivity">Adjust sensitivity and basal</string>
+    <string name="dynisf_adjust_sensitivity_summary">If activated this replaces Autosens, and uses the last 24h TDD/7D TDD as the basis for adjusting calculated ISF and also for increasing and decreasing basal rate, in the same way that standard Autosens does</string>
     <string name="DynISFAdjust_title" formatted="false">DynamicISF Adjustment Factor %</string>
     <string name="DynISFAdjust_summary" formatted="false">Adjustment factor for DynamicISF. Set more than 100% for more aggressive correction doses, and less than 100% for less aggressive corrections.</string>
     <string name="high_temptarget_raises_sensitivity_title">High temptarget raises sensitivity</string>
@@ -148,6 +149,7 @@
     <string name="loop_open_mode_min_change">Minimal request change [%]</string>
     <string name="loop_open_mode_min_change_summary" formatted="false">Open Loop will popup new change request only if change is bigger than this value in %. Default value is 20%</string>
     <string name="fallback_smb_no_tdd">Fallback to SMB. Not enough TDD data.</string>
+
 
 
 </resources>

--- a/plugins/aps/src/main/res/values/strings.xml
+++ b/plugins/aps/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="key_adjust_sensitivity" translatable="false">dynisf_adjust_sensitivity</string>
 
     <string name="dynisf_adjust_sensitivity">Adjust sensitivity and basal</string>
-    <string name="dynisf_adjust_sensitivity_summary">If activated this replaces Autosens, and uses the last 24h TDD/7D TDD as the basis for adjusting calculated ISF and also for increasing and decreasing basal rate, in the same way that standard Autosens does</string>
+    <string name="dynisf_adjust_sensitivity_summary">If activated DynISF uses the last 24h TDD/7D TDD as the basis for adjusting calculated ISF and also for increasing and decreasing basal rate, in the same way that standard Autosens does</string>
     <string name="DynISFAdjust_title" formatted="false">DynamicISF Adjustment Factor %</string>
     <string name="DynISFAdjust_summary" formatted="false">Adjustment factor for DynamicISF. Set more than 100% for more aggressive correction doses, and less than 100% for less aggressive corrections.</string>
     <string name="high_temptarget_raises_sensitivity_title">High temptarget raises sensitivity</string>

--- a/plugins/aps/src/main/res/xml/pref_openapssmbdynamicisf.xml
+++ b/plugins/aps/src/main/res/xml/pref_openapssmbdynamicisf.xml
@@ -52,6 +52,7 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/key_adjust_sensitivity"
+            android:summary="@string/dynisf_adjust_sensitivity_summary"
             android:title="@string/dynisf_adjust_sensitivity" />
 
         <SwitchPreference


### PR DESCRIPTION
Tim has approved text in summary, taken from docs and fix'd typo.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/a981aed7-ede6-45d4-bf51-9146d2ef9c67)
