### PR TITLE
Add missing permission to the notificationManager

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-feature android:name="android.hardware.type.watch" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.google.android.permission.PROVIDE_BACKGROUND" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />


### PR DESCRIPTION
I found a missing permission needed in the wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear/handleBolusProgress function on line 250.

I added it. 