### PR TITLE
Adjust DynISF settings

### DIFF
--- a/plugins/aps/src/main/res/values/strings.xml
+++ b/plugins/aps/src/main/res/values/strings.xml
@@ -23,8 +23,8 @@
     <string name="key_DynISFAdjust" translatable="false">DynISFAdjust</string>
     <string name="key_adjust_sensitivity" translatable="false">dynisf_adjust_sensitivity</string>
 
-    <string name="dynisf_adjust_sensitivity">Adjust sensitivity and basal</string>
-    <string name="dynisf_adjust_sensitivity_summary">If activated DynISF uses the last 24h TDD/7D TDD as the basis for adjusting calculated ISF and also for increasing and decreasing basal rate, in the same way that standard Autosens does</string>
+    <string name="dynisf_adjust_sensitivity">Enable TDD based sensitivity ratio for basal and glucose target modification</string>
+    <string name="dynisf_adjust_sensitivity_summary">Uses the last 24h TDD/7D TDD to calculate sensitivity ratio used for increasing or decreasing basal rate, and also adjust glucose target if these options are enabled, in the same way Autosens does. It is recommended to start with this option turned off</string>
     <string name="DynISFAdjust_title" formatted="false">DynamicISF Adjustment Factor %</string>
     <string name="DynISFAdjust_summary" formatted="false">Adjustment factor for DynamicISF. Set more than 100% for more aggressive correction doses, and less than 100% for less aggressive corrections.</string>
     <string name="high_temptarget_raises_sensitivity_title">High temptarget raises sensitivity</string>

--- a/plugins/aps/src/main/res/xml/pref_openapssmbdynamicisf.xml
+++ b/plugins/aps/src/main/res/xml/pref_openapssmbdynamicisf.xml
@@ -56,6 +56,20 @@
             android:title="@string/dynisf_adjust_sensitivity" />
 
         <SwitchPreference
+            android:defaultValue="true"
+            android:dependency="@string/key_adjust_sensitivity"
+            android:key="@string/key_sensitivity_raises_target"
+            android:summary="@string/sensitivity_raises_target_summary"
+            android:title="@string/sensitivity_raises_target_title" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="@string/key_adjust_sensitivity"
+            android:key="@string/key_resistance_lowers_target"
+            android:summary="@string/resistance_lowers_target_summary"
+            android:title="@string/resistance_lowers_target_title" />
+
+        <SwitchPreference
             android:defaultValue="false"
             android:key="@string/key_use_smb"
             android:summary="@string/enable_smb_summary"
@@ -141,16 +155,6 @@
             android:summary="@string/enable_uam_summary"
             android:title="@string/enable_uam" />
 
-        <SwitchPreference
-            android:defaultValue="true"
-            android:key="@string/key_sensitivity_raises_target"
-            android:summary="@string/sensitivity_raises_target_summary"
-            android:title="@string/sensitivity_raises_target_title" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/key_resistance_lowers_target"
-            android:summary="@string/resistance_lowers_target_summary"
-            android:title="@string/resistance_lowers_target_title" />
         <!-- TODO AS-FIX -->
         <!--<SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
After discussion on discord https://discord.com/channels/942372379097698325/943071658481168404/1171511869413015562
And in line with updated AndroidAPS docs: 
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/b7b493fa-bfb3-454a-abc3-9fe2f4525bac)

It is necessary to adjust option text and summary to further specify what this option really does. It's clear that it was partly incorrect as it was.

This will also make sensitivity/resistance altering target options dependent of dynisf_adjust_sensitivity since they don't function unless dynisf_adjust_sensitvity is toggled on anyway. This will make it even easier for user to understand the settings of DynISF.

ON
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/87550d90-cbba-4b72-a569-92f82ad4ab60)

OFF:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/72c874fb-c151-4616-8fe0-cd1c31e73003)
