### PR TITLE
Add missing dash notification string when there is no active pod

### DIFF
--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -183,7 +183,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
             if (!podStateManager.isPodRunning) {
                 uiInteraction.addNotification(
                     Notification.OMNIPOD_POD_NOT_ATTACHED,
-                    "Pod not activated",
+                    rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_no_active_pod),
                     Notification.NORMAL
                 )
             } else {


### PR DESCRIPTION
When there is no active pod we now in master/dev get a non-translated notification. This adds a string that's already translated to properly notify in local language setting.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/c5a0badb-b214-4152-bbac-f3d25150e620)
