### PR TITLE
Add missing translated strings for Temp basal and EB rates and for Dash pump status

### DIFF
--- a/core/main/src/main/kotlin/app/aaps/core/main/extensions/ExtendedBolusExtension.kt
+++ b/core/main/src/main/kotlin/app/aaps/core/main/extensions/ExtendedBolusExtension.kt
@@ -4,8 +4,8 @@ import app.aaps.core.interfaces.aps.AutosensResult
 import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.iob.IobTotal
 import app.aaps.core.interfaces.profile.Profile
+import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.utils.DateUtil
-import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.core.interfaces.utils.T
 import app.aaps.database.entities.Bolus
 import app.aaps.database.entities.ExtendedBolus
@@ -23,12 +23,12 @@ fun ExtendedBolus.isInProgress(dateUtil: DateUtil): Boolean =
 val ExtendedBolus.plannedRemainingMinutes: Int
     get() = max(round((end - System.currentTimeMillis()) / 1000.0 / 60).toInt(), 0)
 
-fun ExtendedBolus.toStringFull(dateUtil: DateUtil, decimalFormatter: DecimalFormatter): String =
-    "E " + decimalFormatter.to2Decimal(rate) + "U/h @" + dateUtil.timeString(timestamp) +
+fun ExtendedBolus.toStringFull(dateUtil: DateUtil, rh: ResourceHelper): String =
+    "E " + rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate) + " @" + dateUtil.timeString(timestamp) +
         " " + getPassedDurationToTimeInMinutes(dateUtil.now()) + "/" + T.msecs(duration).mins() + "min"
 
-fun ExtendedBolus.toStringMedium(dateUtil: DateUtil, decimalFormatter: DecimalFormatter): String =
-    decimalFormatter.to2Decimal(rate) + "U/h " + getPassedDurationToTimeInMinutes(dateUtil.now()) + "/" + T.msecs(duration).mins() + "'"
+fun ExtendedBolus.toStringMedium(dateUtil: DateUtil, rh: ResourceHelper): String =
+    rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate) + " " + getPassedDurationToTimeInMinutes(dateUtil.now()) + "/" + T.msecs(duration).mins() + "'"
 
 fun ExtendedBolus.getPassedDurationToTimeInMinutes(time: Long): Int =
     ((min(time, end) - timestamp) / 60.0 / 1000).roundToInt()

--- a/core/main/src/main/kotlin/app/aaps/core/main/extensions/TemporaryBasalExtension.kt
+++ b/core/main/src/main/kotlin/app/aaps/core/main/extensions/TemporaryBasalExtension.kt
@@ -4,6 +4,7 @@ import app.aaps.core.interfaces.aps.AutosensResult
 import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.iob.IobTotal
 import app.aaps.core.interfaces.profile.Profile
+import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.core.interfaces.utils.T
@@ -34,16 +35,16 @@ private fun TemporaryBasal.netExtendedRate(profile: Profile) = rate - profile.ge
 val TemporaryBasal.durationInMinutes
     get() = T.msecs(duration).mins()
 
-fun TemporaryBasal.toStringFull(profile: Profile, dateUtil: DateUtil, decimalFormatter: DecimalFormatter): String {
+fun TemporaryBasal.toStringFull(profile: Profile, dateUtil: DateUtil, decimalFormatter: DecimalFormatter, rh: ResourceHelper): String {
     return when {
         type == TemporaryBasal.Type.FAKE_EXTENDED -> {
-            decimalFormatter.to2Decimal(rate) + "U/h (" + decimalFormatter.to2Decimal(netExtendedRate(profile)) + "E) @" +
+            rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate) + "(" + decimalFormatter.to2Decimal(netExtendedRate(profile)) + "E) @" +
                 dateUtil.timeString(timestamp) +
                 " " + getPassedDurationToTimeInMinutes(dateUtil.now()) + "/" + durationInMinutes + "'"
         }
 
         isAbsolute                                -> {
-            decimalFormatter.to2Decimal(rate) + "U/h @" +
+            rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate) + " @" +
                 dateUtil.timeString(timestamp) +
                 " " + getPassedDurationToTimeInMinutes(dateUtil.now()) + "/" + durationInMinutes + "'"
         }
@@ -56,9 +57,9 @@ fun TemporaryBasal.toStringFull(profile: Profile, dateUtil: DateUtil, decimalFor
     }
 }
 
-fun TemporaryBasal.toStringShort(decimalFormatter: DecimalFormatter): String =
-    if (isAbsolute || type == TemporaryBasal.Type.FAKE_EXTENDED) decimalFormatter.to2Decimal(rate) + "U/h"
-    else "${decimalFormatter.to0Decimal(rate)}%"
+fun TemporaryBasal.toStringShort(rh: ResourceHelper): String =
+    if (isAbsolute || type == TemporaryBasal.Type.FAKE_EXTENDED) rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate)
+    else rh.gs(app.aaps.core.ui.R.string.formatPercent, rate)
 
 fun TemporaryBasal.iobCalc(time: Long, profile: Profile, insulinInterface: Insulin): IobTotal {
     if (!isValid) return IobTotal(time)

--- a/core/main/src/main/kotlin/app/aaps/core/main/graph/data/ExtendedBolusDataPoint.kt
+++ b/core/main/src/main/kotlin/app/aaps/core/main/graph/data/ExtendedBolusDataPoint.kt
@@ -3,13 +3,11 @@ package app.aaps.core.main.graph.data
 import android.content.Context
 import android.graphics.Paint
 import app.aaps.core.interfaces.resources.ResourceHelper
-import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.database.entities.ExtendedBolus
 
 class ExtendedBolusDataPoint(
     val data: ExtendedBolus,
     private val rh: ResourceHelper,
-    private val decimalFormatter: DecimalFormatter
 ) : DataPointWithLabelInterface {
 
     private var yValue = 0.0
@@ -29,5 +27,5 @@ class ExtendedBolusDataPoint(
         yValue = y
     }
 
-    private fun ExtendedBolus.toStringTotal(): String = "${decimalFormatter.to2Decimal(amount)}U ( ${decimalFormatter.to2Decimal(rate)} U/h )"
+    private fun ExtendedBolus.toStringTotal(): String = "${rh.gs(app.aaps.core.ui.R.string.format_insulin_units, amount)} ( ${rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate)} )"
 }

--- a/implementation/src/main/kotlin/app/aaps/implementation/overview/OverviewDataImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/overview/OverviewDataImpl.kt
@@ -184,7 +184,7 @@ class OverviewDataImpl @Inject constructor(
         profileFunction.getProfile()?.let { profile ->
             var temporaryBasal = iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())
             if (temporaryBasal?.isInProgress == false) temporaryBasal = null
-            temporaryBasal?.let { "T:" + it.toStringShort(decimalFormatter) }
+            temporaryBasal?.let { "T:" + it.toStringShort(rh) }
                 ?: rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, profile.getBasal())
         } ?: rh.gs(app.aaps.core.ui.R.string.value_unavailable_short)
 
@@ -192,7 +192,7 @@ class OverviewDataImpl @Inject constructor(
         profileFunction.getProfile()?.let { profile ->
             iobCobCalculator.getTempBasalIncludingConvertedExtended(dateUtil.now())?.let { temporaryBasal ->
                 "${rh.gs(app.aaps.core.ui.R.string.base_basal_rate_label)}: ${rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, profile.getBasal())}" +
-                    "\n" + rh.gs(app.aaps.core.ui.R.string.tempbasal_label) + ": " + temporaryBasal.toStringFull(profile, dateUtil, decimalFormatter)
+                    "\n" + rh.gs(app.aaps.core.ui.R.string.tempbasal_label) + ": " + temporaryBasal.toStringFull(profile, dateUtil, decimalFormatter, rh)
             }
                 ?: "${rh.gs(app.aaps.core.ui.R.string.base_basal_rate_label)}: ${rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, profile.getBasal())}"
         } ?: rh.gs(app.aaps.core.ui.R.string.value_unavailable_short)
@@ -229,7 +229,7 @@ class OverviewDataImpl @Inject constructor(
         } ?: ""
 
     override fun extendedBolusDialogText(iobCobCalculator: IobCobCalculator): String =
-        iobCobCalculator.getExtendedBolus(dateUtil.now())?.toStringFull(dateUtil, decimalFormatter) ?: ""
+        iobCobCalculator.getExtendedBolus(dateUtil.now())?.toStringFull(dateUtil, rh) ?: ""
 
     /*
      * IOB, COB

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
@@ -245,7 +245,7 @@ class ActionsFragment : DaggerFragment() {
                 binding.extendedBolus.visibility = View.GONE
                 binding.extendedBolusCancel.visibility = View.VISIBLE
                 @Suppress("SetTextI18n")
-                binding.extendedBolusCancel.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeExtendedBolus.value.toStringMedium(dateUtil, decimalFormatter)
+                binding.extendedBolusCancel.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeExtendedBolus.value.toStringMedium(dateUtil, rh)
             } else {
                 binding.extendedBolus.visibility = View.VISIBLE
                 binding.extendedBolusCancel.visibility = View.GONE
@@ -261,7 +261,7 @@ class ActionsFragment : DaggerFragment() {
                 binding.setTempBasal.visibility = View.GONE
                 binding.cancelTempBasal.visibility = View.VISIBLE
                 @Suppress("SetTextI18n")
-                binding.cancelTempBasal.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeTemp.toStringShort(decimalFormatter)
+                binding.cancelTempBasal.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeTemp.toStringShort(rh)
             } else {
                 binding.setTempBasal.visibility = View.VISIBLE
                 binding.cancelTempBasal.visibility = View.GONE

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -142,8 +142,8 @@ class PersistentNotificationPlugin @Inject constructor(
             }
             val activeTemp = iobCobCalculator.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())
             if (activeTemp != null) {
-                line1 += "  " + activeTemp.toStringShort(decimalFormatter)
-                line1aa += "  " + activeTemp.toStringShort(decimalFormatter) + "."
+                line1 += "  " + activeTemp.toStringShort(rh)
+                line1aa += "  " + activeTemp.toStringShort(rh) + "."
             }
             //IOB
             val bolusIob = iobCobCalculator.calculateIobFromBolus().round()

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/dataBroadcaster/DataBroadcastPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/dataBroadcaster/DataBroadcastPlugin.kt
@@ -179,7 +179,7 @@ class DataBroadcastPlugin @Inject constructor(
             bundle.putLong("tempBasalDurationInMinutes", it.durationInMinutes)
             if (it.isAbsolute) bundle.putDouble("tempBasalAbsolute", it.rate) // U/h for absolute TBR
             else bundle.putInt("tempBasalPercent", it.rate.toInt()) // % for percent type TBR
-            bundle.putString("tempBasalString", it.toStringFull(profile, dateUtil, decimalFormatter)) // user friendly string
+            bundle.putString("tempBasalString", it.toStringFull(profile, dateUtil, decimalFormatter, rh)) // user friendly string
         }
     }
 

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -913,7 +913,7 @@ class DataHandlerMobile @Inject constructor(
             iobDetail = "(${decimalFormatter.to2Decimal(bolusIob.iob)}|${decimalFormatter.to2Decimal(basalIob.basaliob)})"
             cobString = iobCobCalculator.getCobInfo("WatcherUpdaterService").generateCOBString(decimalFormatter)
             currentBasal =
-                iobCobCalculator.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.toStringShort(decimalFormatter) ?: rh.gs(
+                iobCobCalculator.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.toStringShort(rh) ?: rh.gs(
                     app.aaps.core.ui.R.string.pump_base_basal_rate, profile
                         .getBasal()
                 )

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripPlugin.kt
@@ -240,7 +240,7 @@ class XdripPlugin @Inject constructor(
 
         //Temp basal
         iobCobCalculator.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.let {
-            status.append(it.toStringShort(decimalFormatter)).append(" ")
+            status.append(it.toStringShort(rh)).append(" ")
         }
         //IOB
         val bolusIob = iobCobCalculator.calculateIobFromBolus().round()

--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="omnipod_common_pod_status_waiting_for_cannula_insertion">Setup in progress (waiting for cannula insertion)</string>
     <string name="omnipod_common_pod_status_running">Running</string>
     <string name="omnipod_common_pod_status_suspended">Suspended</string>
+    <string name="omnipod_common_pod_status_normal">Normal</string>
     <string name="omnipod_common_pod_status_pod_fault">Pod Fault</string>
     <string name="omnipod_common_pod_status_activation_time_exceeded">Activation time exceeded</string>
     <string name="omnipod_common_pod_status_inactive">Inactive</string>

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -991,9 +991,9 @@ class OmnipodDashPumpPlugin @Inject constructor(
         val extended = JSONObject()
         try {
             val podStatus = when {
-                podStateManager.isPodRunning && podStateManager.isSuspended -> "suspended"
-                podStateManager.isPodRunning                                -> "normal"
-                else                                                        -> "no active Pod"
+                podStateManager.isPodRunning && podStateManager.isSuspended -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_suspended).lowercase()
+                podStateManager.isPodRunning                                -> rh.gs(R.string.omnipod_common_pod_status_normal)
+                else                                                        -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_short_status_no_active_pod).lowercase()
             }
             status.put("status", podStatus)
             status.put("timestamp", dateUtil.toISOString(podStateManager.lastUpdatedSystem))

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -992,7 +992,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
         try {
             val podStatus = when {
                 podStateManager.isPodRunning && podStateManager.isSuspended -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_suspended).lowercase()
-                podStateManager.isPodRunning                                -> rh.gs(R.string.omnipod_common_pod_status_normal)
+                podStateManager.isPodRunning                                -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_normal).lowercase()
                 else                                                        -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_short_status_no_active_pod).lowercase()
             }
             status.put("status", podStatus)

--- a/pump/omnipod-dash/src/main/res/values/strings.xml
+++ b/pump/omnipod-dash/src/main/res/values/strings.xml
@@ -67,6 +67,5 @@
     <string name="cancel_temp_basal_result_is_uncertain">Cancel temp basal result is uncertain</string>
     <string name="unconfirmed_resumedelivery_command_please_refresh_pod_status">Unconfirmed resumeDelivery command. Please refresh pod status</string>
     <string name="cancelling_temp_basal_might_have_failed">Cancelling temp basal might have failed. If a temp basal was previously running, it might have been cancelled. Please manually refresh the Pod status from the Omnipod tab.</string>
-    <string name="omnipod_common_pod_status_normal">normal</string>
 
 </resources>

--- a/pump/omnipod-dash/src/main/res/values/strings.xml
+++ b/pump/omnipod-dash/src/main/res/values/strings.xml
@@ -67,5 +67,6 @@
     <string name="cancel_temp_basal_result_is_uncertain">Cancel temp basal result is uncertain</string>
     <string name="unconfirmed_resumedelivery_command_please_refresh_pod_status">Unconfirmed resumeDelivery command. Please refresh pod status</string>
     <string name="cancelling_temp_basal_might_have_failed">Cancelling temp basal might have failed. If a temp basal was previously running, it might have been cancelled. Please manually refresh the Pod status from the Omnipod tab.</string>
+    <string name="omnipod_common_pod_status_normal">normal</string>
 
 </resources>

--- a/pump/virtual/src/main/kotlin/app/aaps/pump/virtual/VirtualPumpFragment.kt
+++ b/pump/virtual/src/main/kotlin/app/aaps/pump/virtual/VirtualPumpFragment.kt
@@ -95,9 +95,9 @@ class VirtualPumpFragment : DaggerFragment() {
         if (_binding == null) return
         val profile = profileFunction.getProfile() ?: return
         binding.baseBasalRate.text = rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, virtualPumpPlugin.baseBasalRate)
-        binding.tempbasal.text = iobCobCalculator.getTempBasal(dateUtil.now())?.toStringFull(profile, dateUtil, decimalFormatter)
+        binding.tempbasal.text = iobCobCalculator.getTempBasal(dateUtil.now())?.toStringFull(profile, dateUtil, decimalFormatter, rh)
             ?: ""
-        binding.extendedbolus.text = iobCobCalculator.getExtendedBolus(dateUtil.now())?.toStringFull(dateUtil, decimalFormatter)
+        binding.extendedbolus.text = iobCobCalculator.getExtendedBolus(dateUtil.now())?.toStringFull(dateUtil, rh)
             ?: ""
         binding.battery.text = rh.gs(app.aaps.core.ui.R.string.format_percent, virtualPumpPlugin.batteryPercent)
         binding.reservoir.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, virtualPumpPlugin.reservoirInUnits.toDouble())

--- a/ui/src/main/kotlin/app/aaps/ui/activities/fragments/TreatmentsTemporaryBasalsFragment.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/activities/fragments/TreatmentsTemporaryBasalsFragment.kt
@@ -274,7 +274,8 @@ class TreatmentsTemporaryBasalsFragment : DaggerFragment(), MenuProvider {
                     tempBasal.toStringFull(
                         profile,
                         dateUtil,
-                        decimalFormatter
+                        decimalFormatter,
+                        rh
                     )
                 }\n" +
                     "${rh.gs(app.aaps.core.ui.R.string.date)}: ${dateUtil.dateAndTimeString(tempBasal.timestamp)}"

--- a/workflow/src/main/kotlin/app/aaps/workflow/PrepareTreatmentsDataWorker.kt
+++ b/workflow/src/main/kotlin/app/aaps/workflow/PrepareTreatmentsDataWorker.kt
@@ -102,7 +102,7 @@ class PrepareTreatmentsDataWorker(
         // Extended bolus
         if (!activePlugin.activePump.isFakingTempsByExtendedBoluses) {
             repository.getExtendedBolusDataFromTimeToTime(fromTime, endTime, true).blockingGet()
-                .map { ExtendedBolusDataPoint(it, rh, decimalFormatter) }
+                .map { ExtendedBolusDataPoint(it, rh) }
                 .filter { it.duration != 0L }
                 .forEach {
                     it.y = getNearestBg(data.overviewData, it.x.toLong())


### PR DESCRIPTION
When Temp basal is enacted "U/h" now get's translated in overview screen and when you click on temp basal to show more info.
When EB is used "U/h" and "U" now get's translated in overview screen, also in graph. Also added translation in careportal for Cancel EB "U/h" .

Also added translations for Dash pump status most visible in AAPSClient.

