### PR TITLE
Add iob, cob, tbr to GARMIN sgv.json endpoint

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
@@ -327,6 +327,9 @@ class GarminPlugin @Inject constructor(
                     GlucoseUnit.MGDL -> jo.addProperty("units_hint", "mgdl")
                     GlucoseUnit.MMOL -> jo.addProperty("units_hint", "mmol")
                 }
+                jo.addProperty("iob", loopHub.insulinTotalOnboard)
+                jo.addProperty("tbr", loopHub.temporaryBasalPercent)
+                jo.addProperty("cob", loopHub.carbsOnboard)
             }
             joa.add(jo)
         }

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/LoopHub.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/LoopHub.kt
@@ -20,6 +20,12 @@ interface LoopHub {
     /** Returns the remaining bolus insulin on board. */
     val insulinOnboard: Double
 
+    /** Returns the remaining bolus and basal insulin on board. */
+    val insulinTotalOnboard: Double
+
+    /** Returns the remaining carbs on board. */
+    val carbsOnboard: Double?
+
     /** Returns true if the pump is connected. */
     val isConnected: Boolean
 
@@ -28,6 +34,9 @@ interface LoopHub {
 
     /** Returns the factor by which the basal rate is currently raised (> 1) or lowered (< 1). */
     val temporaryBasal: Double
+
+    /** Returns the temporary basal rate in percent */
+    val temporaryBasalPercent: String
 
     /** Tells the loop algorithm that the pump is physically connected. */
     fun connectPump()


### PR DESCRIPTION
First of all, a big thank you to Robert Buessow for adding an sgv.json endpoint to the Garmin interface!

In this PR there is an addition of the values iob and cob (these can also be found in the pepple endpoint of Nightscout) and additionally tbr.
In contrast to the other endpoint, iob is calculated here as total IOB (bolus + basal instead of only bolus) and therefore a second iob variable (val insulinTotalOnboard: Double) was introduced. cob and tbr were previously not available.