### PR TITLE
Add dash pod status translation strings in AAPSClient Overview

### DIFF
--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
     <string name="omnipod_common_pod_status_activation_time_exceeded">Activation time exceeded</string>
     <string name="omnipod_common_pod_status_inactive">Inactive</string>
     <string name="omnipod_common_pod_status_pod_fault_description">Pod Fault: %1$03d %2$s</string>
+    <string name="omnipod_common_pod_status_normal">Normal</string>
 
     <!-- Omnipod - Commands -->
     <string name="omnipod_common_cmd_deactivate_pod">Deactivate Pod</string>

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -991,9 +991,9 @@ class OmnipodDashPumpPlugin @Inject constructor(
         val extended = JSONObject()
         try {
             val podStatus = when {
-                podStateManager.isPodRunning && podStateManager.isSuspended -> "suspended"
-                podStateManager.isPodRunning                                -> "normal"
-                else                                                        -> "no active Pod"
+                podStateManager.isPodRunning && podStateManager.isSuspended -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_suspended).lowercase()
+                podStateManager.isPodRunning                                -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_normal).lowercase()
+                else                                                        -> rh.gs(info.nightscout.androidaps.plugins.pump.omnipod.common.R.string.omnipod_common_pod_status_no_active_pod).lowercase()
             }
             status.put("status", podStatus)
             status.put("timestamp", dateUtil.toISOString(podStateManager.lastUpdatedSystem))


### PR DESCRIPTION
This adds translation strings for Dash pod statuses shown in AAPSClient overview-screen. Also make sure they are lowercase to fit with the rest of the text.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/1b0e83c1-7a30-4cdd-b704-895491096cee)
