### PR TITLE
Auto-add Medtronic battery changes to careportal

### DIFF
--- a/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/history/pump/MedtronicPumpHistoryDecoder.kt
+++ b/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/history/pump/MedtronicPumpHistoryDecoder.kt
@@ -297,7 +297,9 @@ class MedtronicPumpHistoryDecoder @Inject constructor(
     }
 
     private fun decodeBatteryActivity(entry: PumpHistoryEntry) {
-        entry.displayableValue = if (entry.head[0] == 0.toByte()) "Battery Removed" else "Battery Replaced"
+        val isRemoved = entry.head[0] == 0.toByte()
+        entry.addDecodedData("isRemoved", isRemoved)
+        entry.displayableValue = if (isRemoved) "Battery Removed" else "Battery Replaced"
     }
 
     private fun decodeBasalProfileStart(entry: PumpHistoryEntry): RecordDecodeStatus {

--- a/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/util/MedtronicConst.kt
+++ b/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/util/MedtronicConst.kt
@@ -30,5 +30,6 @@ object MedtronicConst {
         const val LastPumpHistoryEntry = StatsPrefix + "pump_history_entry"
         const val LastPrime = StatsPrefix + "last_sent_prime"
         const val LastRewind = StatsPrefix + "last_sent_rewind"
+        const val LastBatteryChange = StatsPrefix + "last_sent_battery_change"
     }
 }


### PR DESCRIPTION
Analogous to the existing handling of insulin and cannula changes *as well as* the existing handling of pump battery change events in some other drivers (combov2, insight, diaconn).

Works as expected in my testing with Paradigm 715 (Worldwide region) pump.