### PR TITLE
Auto-add "BG Check" treatment for Contour Link readings

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/PumpSync.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/PumpSync.kt
@@ -1,5 +1,6 @@
 package app.aaps.core.interfaces.pump
 
+import app.aaps.core.interfaces.db.GlucoseUnit
 import app.aaps.core.interfaces.profile.Profile
 import app.aaps.core.interfaces.pump.defs.PumpType
 import app.aaps.core.interfaces.utils.DateUtil
@@ -256,6 +257,26 @@ interface PumpSync {
      * @return true if new record is created
      **/
     fun insertTherapyEventIfNewWithTimestamp(timestamp: Long, type: DetailedBolusInfo.EventType, note: String? = null, pumpId: Long? = null, pumpType: PumpType, pumpSerial: String): Boolean
+
+    /**
+     * Synchronization of FINGER_STICK_BG_VALUE events
+     *
+     * Assuming there will be no clash on timestamp from different pumps
+     * only timestamp and type is compared
+     *
+     * If db record doesn't exist, new record is created.
+     * If exists, data is ignored
+     *
+     * @param timestamp     timestamp of event from pump history
+     * @param glucose       glucose value
+     * @param glucoseUnit   glucose unit
+     * @param note          note
+     * @param pumpId        pump id from history if available
+     * @param pumpType      pump type like PumpType.ACCU_CHEK_COMBO
+     * @param pumpSerial    pump serial number
+     * @return true if new record is created
+     **/
+    fun insertFingerBgIfNewWithTimestamp(timestamp: Long, glucose: Double, glucoseUnit: GlucoseUnit, note: String? = null, pumpId: Long? = null, pumpType: PumpType, pumpSerial: String): Boolean
 
     /**
      * Create an announcement

--- a/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/history/pump/MedtronicPumpHistoryDecoder.kt
+++ b/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/history/pump/MedtronicPumpHistoryDecoder.kt
@@ -153,7 +153,6 @@ class MedtronicPumpHistoryDecoder @Inject constructor(
             PumpHistoryEntryType.ClearAlarm,
             PumpHistoryEntryType.ChangeAlarmNotifyMode,
             PumpHistoryEntryType.EnableDisableRemote,
-            PumpHistoryEntryType.BGReceived,
             PumpHistoryEntryType.SensorAlert,
             PumpHistoryEntryType.ChangeTimeFormat,
             PumpHistoryEntryType.ChangeReservoirWarningTime,
@@ -188,7 +187,6 @@ class MedtronicPumpHistoryDecoder @Inject constructor(
             PumpHistoryEntryType.ChangeWatchdogEnable,
             PumpHistoryEntryType.ChangeOtherDeviceID,
             PumpHistoryEntryType.ReadOtherDevicesIDs,
-            PumpHistoryEntryType.BGReceived512,
             PumpHistoryEntryType.SensorStatus,
             PumpHistoryEntryType.ReadCaptureEventEnabled,
             PumpHistoryEntryType.ChangeCaptureEventEnable,
@@ -205,6 +203,12 @@ class MedtronicPumpHistoryDecoder @Inject constructor(
 
             PumpHistoryEntryType.UnabsorbedInsulin,
             PumpHistoryEntryType.UnabsorbedInsulin512                         -> RecordDecodeStatus.Ignored
+
+            PumpHistoryEntryType.BGReceived,
+            PumpHistoryEntryType.BGReceived512                                -> {
+                decodeBgReceived(entry)
+                RecordDecodeStatus.OK
+            }
 
             PumpHistoryEntryType.DailyTotals522,
             PumpHistoryEntryType.DailyTotals523,
@@ -409,8 +413,11 @@ class MedtronicPumpHistoryDecoder @Inject constructor(
     }
 
     private fun decodeBgReceived(entry: PumpHistoryEntry) {
-        entry.addDecodedData("amount", (ByteUtil.asUINT8(entry.getRawDataByIndex(0)) shl 3) + (ByteUtil.asUINT8(entry.getRawDataByIndex(3)) shr 5))
-        entry.addDecodedData("meter", ByteUtil.substring(entry.rawData, 6, 3)) // index moved from 1 -> 0
+        val glucoseMgdl = (ByteUtil.asUINT8(entry.head[0]) shl 3) + (ByteUtil.asUINT8(entry.datetime[2]) shr 5)
+        val meterSerial = ByteUtil.shortHexStringWithoutSpaces(entry.body)
+        entry.addDecodedData("GlucoseMgdl", glucoseMgdl)
+        entry.addDecodedData("MeterSerial", meterSerial)
+        entry.displayableValue = String.format("Glucose: %d mg/dl, Meter Serial: %s", glucoseMgdl, meterSerial)
     }
 
     private fun decodeCalBGForPH(entry: PumpHistoryEntry) {

--- a/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
+++ b/pump/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/data/MedtronicHistoryData.kt
@@ -4,6 +4,7 @@ import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.notifications.Notification
 import app.aaps.core.interfaces.plugin.ActivePlugin
+import app.aaps.core.interfaces.profile.ProfileUtil
 import app.aaps.core.interfaces.pump.DetailedBolusInfo
 import app.aaps.core.interfaces.pump.PumpSync
 import app.aaps.core.interfaces.pump.defs.PumpType
@@ -67,7 +68,8 @@ class MedtronicHistoryData @Inject constructor(
     val medtronicPumpStatus: MedtronicPumpStatus,
     private val pumpSync: PumpSync,
     private val pumpSyncStorage: PumpSyncStorage,
-    private val uiInteraction: UiInteraction
+    private val uiInteraction: UiInteraction,
+    private val profileUtil: ProfileUtil
 ) {
 
     val allHistory: MutableList<PumpHistoryEntry> = mutableListOf()
@@ -322,6 +324,17 @@ class MedtronicHistoryData @Inject constructor(
      * Process History Data: Boluses(Treatments), TDD, TBRs, Suspend-Resume (or other pump stops: battery, prime)
      */
     fun processNewHistoryData() {
+        // Finger BG (for adding entry to careportal)
+        val bgRecords: MutableList<PumpHistoryEntry> = getFilteredItems(setOf(PumpHistoryEntryType.BGReceived, PumpHistoryEntryType.BGReceived512))
+        aapsLogger.debug(LTag.PUMP, String.format(Locale.ENGLISH, "ProcessHistoryData: BGReceived [count=%d, items=%s]", bgRecords.size, gson.toJson(bgRecords)))
+        if (isCollectionNotEmpty(bgRecords)) {
+            try {
+                processBgReceived(bgRecords)
+            } catch (ex: Exception) {
+                aapsLogger.error(LTag.PUMP, "ProcessHistoryData: Error processing BGReceived entries: " + ex.message, ex)
+                throw ex
+            }
+        }
 
         // Prime (for resetting autosense)
         val primeRecords: MutableList<PumpHistoryEntry> = getFilteredItems(PumpHistoryEntryType.Prime)
@@ -416,6 +429,34 @@ class MedtronicHistoryData @Inject constructor(
                 aapsLogger.error(LTag.PUMP, "ProcessHistoryData: Error processing Suspends entries: " + ex.message, ex)
                 throw ex
             }
+        }
+    }
+
+    private fun processBgReceived(bgRecords: List<PumpHistoryEntry>) {
+        for (bgRecord in bgRecords) {
+            val glucoseMgdl = bgRecord.getDecodedDataEntry("GlucoseMgdl")
+            if (glucoseMgdl == null || glucoseMgdl as Int == 0) {
+                continue
+            }
+
+            val glucose = profileUtil.fromMgdlToUnits(glucoseMgdl.toDouble())
+            val glucoseUnit = profileUtil.units
+
+            val result = pumpSync.insertFingerBgIfNewWithTimestamp(
+                DateTimeUtil.toMillisFromATD(bgRecord.atechDateTime),
+                glucose, glucoseUnit, null,
+                bgRecord.pumpId,
+                medtronicPumpStatus.pumpType,
+                medtronicPumpStatus.serialNumber
+            )
+
+            aapsLogger.debug(
+                LTag.PUMP, String.format(
+                    Locale.ROOT, "insertFingerBgIfNewWithTimestamp [date=%d, glucose=%f, glucoseUnit=%s, pumpId=%d, pumpSerial=%s] - Result: %b",
+                    bgRecord.atechDateTime, glucose, glucoseUnit, bgRecord.pumpId,
+                    medtronicPumpStatus.serialNumber, result
+                )
+            )
         }
     }
 


### PR DESCRIPTION
Adds Contour Link readings received by Medtronic pump as BG check treatments with FINGER as meter type.

**WARNING: I do not have a mmol/l Contour Link meter to test this with, I was only able to validate that it works with mg/dl.** The PR is written to work with mmol/l profiles and the data in pump history *should* be in mg/dl regardless of the meter used but I just want to make it clear that I haven't *actually* tested such a setup.

---

To implement this, I had to add `insertFingerBgIfNewWithTimestamp` to the `PumpSync` interface. The implementation is similar to the existing `insertTherapyEventIfNewWithTimestamp` but accepts additional data about the glucose value and its unit.

---

Originally, I thought I could just use the already implemented `decodeBgReceived()` but it turns out that it was unused for a reason - I found two main problems with it:
- byte indexes used for the glucose were off-by-one (`.rawData[0]` and `.rawData[3]` instead of `.rawData[1]` and `.rawData[4]`) - I decided to replace the usage of them with equivalent `.head[0]` and `.datetime[2]`
- meter variable contained a three-element byte array instead of something useful, such as a string representation of the meter's serial number

While rewriting the decode logic, I figured I'd improve the names to `GlucoseMgdl` and `MeterSerial` *and* set a `displayableValue` as well.

---

Processing BGs is mostly identical to processing primes, rewinds, and battery changes - it uses a slightly different `PumpSync` method and converts mg/dl glucose to the profile's unit before passing it to the treatment. The conversion needs to use the profile's unit as the pump event always stores this data in mg/dl units, no matter what unit the glucometer (or pump's bolus calculator) uses.

Note that the pump's bolus calculator does have a unit setting that determines how the pump's UI shows it but it's irrelevant to the unit that the meter shows it in so I figured it's best to just use the profile's unit here (especially since using pump's unit would require implementing a command for getting that info from bolus calculator settings since iirc it's not part of the output of regular settings command; that would also mean that a full refresh would need to run *another* command as well and generally just complicate this simple change a lot).