### PR TITLE
Fix flaky GarminSimulatorClientTest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.warning.mode=all
-org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 
 android.enableJetifier=false
 android.useAndroidX=true

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminSimulatorClient.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminSimulatorClient.kt
@@ -13,6 +13,7 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
 import java.time.Duration
+import java.time.Instant
 import java.util.Collections
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -142,10 +143,10 @@ class GarminSimulatorClient(
 
     /** Wait for the server to start listing to requests. */
     fun awaitReady(wait: Duration): Boolean {
-        var waitNanos = wait.toNanos()
+        val waitUntil = Instant.now() + wait
         readyLock.withLock {
-            while (!serverSocket.isBound && waitNanos > 0L) {
-                waitNanos = readyCond.awaitNanos(waitNanos)
+            while (!serverSocket.isBound && Instant.now() < waitUntil) {
+                readyCond.await(20, TimeUnit.MILLISECONDS)
             }
         }
         return serverSocket.isBound

--- a/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminSimulatorClientTest.kt
+++ b/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminSimulatorClientTest.kt
@@ -1,11 +1,9 @@
 package app.aaps.plugins.sync.garmin
 
 import app.aaps.shared.tests.TestBase
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
@@ -19,6 +17,14 @@ class GarminSimulatorClientTest: TestBase() {
 
     private lateinit var client: GarminSimulatorClient
     private val receiver: GarminReceiver = mock()
+
+    private fun <T> waitForOrFail(c: ()->T?): T {
+        for (i in 0 until 10) {
+            c()?.let { return it }
+            Thread.sleep(1)
+        }
+        throw AssertionError("wait timed out")
+    }
 
     @BeforeEach
     fun setup() {
@@ -36,8 +42,9 @@ class GarminSimulatorClientTest: TestBase() {
             assertTrue(socket.isConnected)
             socket.getOutputStream().write(payload)
             socket.getOutputStream().flush()
+            val device = waitForOrFail { client.connectedDevices.firstOrNull() }
             verify(receiver, timeout(1_000))
-                .onReceiveMessage(eq(client), any(), eq("SIMAPP"), eq(payload))
+                .onReceiveMessage(eq(client), eq(device.id), eq("SIMAPP"), eq(payload))
         }
     }
 
@@ -45,15 +52,14 @@ class GarminSimulatorClientTest: TestBase() {
     fun sendMessage() {
         val payload = "foo".toByteArray()
         assertTrue(client.awaitReady(Duration.ofSeconds(10)))
+        verify(receiver, timeout(100)).onConnect(client)
         val port = client.port
         val ip = Inet4Address.getByAddress(byteArrayOf(127, 0, 0, 1))
         val device: GarminDevice
         val app: GarminApplication
         Socket(ip, port).use { socket ->
             assertTrue(socket.isConnected)
-            verify(receiver).onConnect(client)
-            assertEquals(1, client.connectedDevices.size)
-            device = client.connectedDevices.first()
+            device = waitForOrFail { client.connectedDevices.firstOrNull() }
             app = GarminApplication(device, "SIMAPP", "T")
             client.sendMessage(app, payload)
         }


### PR DESCRIPTION
I hope that helps. May ci setup fails with some other error, so cannot really validate but I did see these tests failed ~1% of time on my machine before.
I also increase the gradle jvm memory from 3 to 4g since that sometime causes problems during build.