### PR TITLE
Fix for a misleading string (Garmin -> Samsung)

### DIFF
--- a/plugins/sync/src/main/res/values/strings.xml
+++ b/plugins/sync/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@
     <!--    DataBroadcast-->
     <string name="data_broadcaster">Data Broadcaster</string>
     <string name="data_broadcaster_short">DBRO</string>
-    <string name="data_broadcaster_description">Broadcast data to Samsung\'s G-Watch Wear App</string>
+    <string name="data_broadcaster_description">Broadcast data to Samsung\'s G-Watch Wear App (Tizen OS)</string>
 
     <!-- GarminPlugin -->
     <string name="garmin">Garmin</string>

--- a/plugins/sync/src/main/res/values/strings.xml
+++ b/plugins/sync/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@
     <!--    DataBroadcast-->
     <string name="data_broadcaster">Data Broadcaster</string>
     <string name="data_broadcaster_short">DBRO</string>
-    <string name="data_broadcaster_description">Broadcast data to Garmin\'s G-Watch Wear App</string>
+    <string name="data_broadcaster_description">Broadcast data to Samsung\'s G-Watch Wear App</string>
 
     <!-- GarminPlugin -->
     <string name="garmin">Garmin</string>


### PR DESCRIPTION
This explanation has puzzled me for years, because the broadcaster has nothing to do with Garmin. Rather, it refers to this Samsung related app:
https://github.com/trupici/G-Watch-Wear