### PR TITLE
Autotune Fix crashes

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotuneIob.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotuneIob.kt
@@ -76,17 +76,17 @@ open class AutotuneIob @Inject constructor(
 
     @Synchronized
     private fun sortTempBasal() {
-        tempBasals = ArrayList(tempBasals.toList().sortedWith { o1: TB, o2: TB -> (o2.timestamp - o1.timestamp).toInt() })
+        tempBasals = ArrayList(tempBasals.toList().sortedWith { o1: TB, o2: TB -> if (o2.timestamp > o1.timestamp) 1 else -1 })
     }
 
     @Synchronized
     private fun sortNsTreatments() {
-        nsTreatments = ArrayList(nsTreatments.toList().sortedWith { o1: NsTreatment, o2: NsTreatment -> (o2.date - o1.date).toInt() })
+        nsTreatments = ArrayList(nsTreatments.toList().sortedWith { o1: NsTreatment, o2: NsTreatment -> if (o2.date > o1.date) 1 else -1 })
     }
 
     @Synchronized
     private fun sortBoluses() {
-        boluses = ArrayList(boluses.toList().sortedWith { o1: BS, o2: BS -> (o2.timestamp - o1.timestamp).toInt() })
+        boluses = ArrayList(boluses.toList().sortedWith { o1: BS, o2: BS -> if (o2.timestamp > o1.timestamp) 1 else -1 })
     }
 
     private fun initializeBgReadings(from: Long, to: Long) {
@@ -275,7 +275,7 @@ open class AutotuneIob @Inject constructor(
 
     private fun convertToBoluses(eb: EB): MutableList<BS> {
         val result: MutableList<BS> = ArrayList()
-        val aboutFiveMinIntervals = ceil(eb.duration / 5.0).toInt()
+        val aboutFiveMinIntervals = eb.duration / T.mins(5).msecs() + 1
         val spacing = eb.duration / aboutFiveMinIntervals.toDouble()
         for (j in 0L until aboutFiveMinIntervals) {
             // find middle of the interval


### PR DESCRIPTION
Fix OutOfMemoryError due to huge amount of data for eb (wrong unit in aboutFivbeMinuteInterval calculation)
Fix https://console.firebase.google.com/u/0/project/androidaps-c34f8/crashlytics/app/android:info.nightscout.androidaps/issues/1a11117456961599728b9bf51a6bf6da?time=last-seven-days&types=crash&versions=3.2.0.1-dev%20(1500);3.2.0.1%20(1500)&sessionEventKey=654070BE010200013706A85A313370BE_1874401300283590474

Fix #3145