### PR TITLE
Add translated strings for U/h and U in Persistent Notification

### DIFF
--- a/core/objects/src/main/kotlin/app/aaps/core/objects/extensions/TemporaryBasalExtension.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/extensions/TemporaryBasalExtension.kt
@@ -7,6 +7,7 @@ import app.aaps.core.data.model.TB
 import app.aaps.core.data.time.T
 import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.profile.Profile
+import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
 import kotlin.math.ceil
@@ -55,9 +56,9 @@ fun TB.toStringFull(profile: Profile, dateUtil: DateUtil, decimalFormatter: Deci
     }
 }
 
-fun TB.toStringShort(decimalFormatter: DecimalFormatter): String =
-    if (isAbsolute || type == TB.Type.FAKE_EXTENDED) decimalFormatter.to2Decimal(rate) + "U/h"
-    else "${decimalFormatter.to0Decimal(rate)}%"
+fun TB.toStringShort(rh: ResourceHelper): String =
+    if (isAbsolute || type == TB.Type.FAKE_EXTENDED) rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, rate)
+    else rh.gs(app.aaps.core.ui.R.string.formatPercent, rate)
 
 fun TB.iobCalc(time: Long, profile: Profile, insulinInterface: Insulin): IobTotal {
     if (!isValid) return IobTotal(time)

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
@@ -262,7 +262,7 @@ class ActionsFragment : DaggerFragment() {
                 binding.setTempBasal.visibility = View.GONE
                 binding.cancelTempBasal.visibility = View.VISIBLE
                 @Suppress("SetTextI18n")
-                binding.cancelTempBasal.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeTemp.toStringShort(decimalFormatter)
+                binding.cancelTempBasal.text = rh.gs(app.aaps.core.ui.R.string.cancel) + " " + activeTemp.toStringShort(rh)
             } else {
                 binding.setTempBasal.visibility = View.VISIBLE
                 binding.cancelTempBasal.visibility = View.GONE

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewDataImpl.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewDataImpl.kt
@@ -133,7 +133,7 @@ class OverviewDataImpl @Inject constructor(
         profileFunction.getProfile()?.let { profile ->
             var temporaryBasal = processedTbrEbData.getTempBasalIncludingConvertedExtended(dateUtil.now())
             if (temporaryBasal?.isInProgress == false) temporaryBasal = null
-            temporaryBasal?.let { "T:" + it.toStringShort(decimalFormatter) }
+            temporaryBasal?.let { "T:" + it.toStringShort(rh) }
                 ?: rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, profile.getBasal())
         } ?: rh.gs(app.aaps.core.ui.R.string.value_unavailable_short)
 

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -142,28 +142,28 @@ class PersistentNotificationPlugin @Inject constructor(
             }
             val activeTemp = processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())
             if (activeTemp != null) {
-                line1 += "  " + activeTemp.toStringShort(decimalFormatter)
-                line1aa += "  " + activeTemp.toStringShort(decimalFormatter) + "."
+                line1 += "  " + activeTemp.toStringShort(rh)
+                line1aa += "  " + activeTemp.toStringShort(rh) + "."
             }
             //IOB
             val bolusIob = iobCobCalculator.calculateIobFromBolus().round()
             val basalIob = iobCobCalculator.calculateIobFromTempBasalsIncludingConvertedExtended().round()
             line2 =
-                rh.gs(app.aaps.core.ui.R.string.treatments_iob_label_string) + " " + decimalFormatter.to2Decimal(bolusIob.iob + basalIob.basaliob) + "U " + rh.gs(
+                rh.gs(app.aaps.core.ui.R.string.treatments_iob_label_string) + " " + rh.gs(app.aaps.core.ui.R.string.format_insulin_units,(bolusIob.iob + basalIob.basaliob)) + " " + rh.gs(
                     app.aaps.core.ui.R
                         .string.cob
                 ) + ": " + iobCobCalculator.getCobInfo(
                     "PersistentNotificationPlugin"
                 ).generateCOBString(decimalFormatter)
             val line2aa =
-                rh.gs(app.aaps.core.ui.R.string.treatments_iob_label_string) + " " + decimalFormatter.to2Decimal(bolusIob.iob + basalIob.basaliob) + "U. " + rh.gs(
+                rh.gs(app.aaps.core.ui.R.string.treatments_iob_label_string) + " " + rh.gs(app.aaps.core.ui.R.string.format_insulin_units,(bolusIob.iob + basalIob.basaliob)) + ". " + rh.gs(
                     app.aaps.core.ui.R
                         .string.cob
                 ) + ": " + iobCobCalculator.getCobInfo(
                     "PersistentNotificationPlugin"
                 ).generateCOBString(decimalFormatter) + "."
-            line3 = decimalFormatter.to2Decimal(pump.baseBasalRate) + " U/h"
-            var line3aa = decimalFormatter.to2Decimal(pump.baseBasalRate) + " U/h."
+            line3 = rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, pump.baseBasalRate)
+            var line3aa = rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, pump.baseBasalRate) + "."
             line3 += " - " + profileFunction.getProfileName()
             line3aa += " - " + profileFunction.getProfileName() + "."
             /// For Android Auto

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -912,7 +912,7 @@ class DataHandlerMobile @Inject constructor(
             iobDetail = "(${decimalFormatter.to2Decimal(bolusIob.iob)}|${decimalFormatter.to2Decimal(basalIob.basaliob)})"
             cobString = iobCobCalculator.getCobInfo("WatcherUpdaterService").generateCOBString(decimalFormatter)
             currentBasal =
-                processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.toStringShort(decimalFormatter) ?: rh.gs(
+                processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.toStringShort(rh) ?: rh.gs(
                     app.aaps.core.ui.R.string.pump_base_basal_rate, profile
                         .getBasal()
                 )

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripPlugin.kt
@@ -240,7 +240,7 @@ class XdripPlugin @Inject constructor(
 
         //Temp basal
         processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.let {
-            status.append(it.toStringShort(decimalFormatter)).append(" ")
+            status.append(it.toStringShort(rh)).append(" ")
         }
         //IOB
         val bolusIob = iobCobCalculator.calculateIobFromBolus().round()


### PR DESCRIPTION
By doing this also improves some other places missing translated strings for function `toStringShort`

Built locally and testet OK, also ran all Tests in AS OK.

A screenshot of noticeable differences:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/dac5831f-00e7-4b57-b4b0-0147ac704585)
