### PR TITLE
Bugfix objective 1 not completing "BG available in NS or Tidepool" when NSClientV3 is used

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/services/NSClientV3Service.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/services/NSClientV3Service.kt
@@ -222,6 +222,7 @@ class NSClientV3Service : DaggerService() {
         when (collection) {
             "devicestatus" -> docString.toNSDeviceStatus().let { nsDeviceStatusHandler.handleNewData(arrayOf(it)) }
             "entries"      -> docString.toNSSgvV3()?.let {
+                sp.putBoolean(app.aaps.core.utils.R.string.key_objectives_bg_is_available_in_ns, true)
                 nsIncomingDataProcessor.processSgvs(listOf(it))
                 storeDataForDb.storeGlucoseValuesToDb()
             }


### PR DESCRIPTION
Tested locally and it solves the issue below. Let me know if it's more complicated than so. Could this also be merged to dev32 for 3.2.0.4, since I've seen quite a few new users having problems with this.

https://github.com/nightscout/AndroidAPS/issues/3148