### PR TITLE
Fixed boken regexp in allCommitted()

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,9 +85,9 @@ fun allCommitted(): Boolean {
             standardOutput = stdout
         }
         // ignore all changes done in .idea/codeStyles
-        val cleanedList: String = stdout.toString().replace("/(?m)^\\s*(M|A|D|\\?\\?)\\s*.*?\\.idea\\/codeStyles\\/.*?\\s*\$/", "")
+        val cleanedList: String = stdout.toString().replace(Regex("""(?m)^\s*(M|A|D|\?\?)\s*.*?\.idea\/codeStyles\/.*?\s*$"""), "")
             // ignore all files added to project dir but not staged/known to GIT
-            .replace("/(?m)^\\s*(\\?\\?)\\s*.*?\\s*\$/", "")
+            .replace(Regex("""(?m)^\s*(\?\?)\s*.*?\s*$"""), "")
         stringBuilder.append(cleanedList.trim())
     } catch (ignored: Exception) {
         return false // NoGitSystemAvailable


### PR DESCRIPTION
The Regexp used to allow changes in various files was broken as regexp syntax has to be casted explicitly when using string.replace() function. 

Steps to reproduce:
* Change file within `.idea/codeStyles/`
* Try to build
* FAIL due to uncommited changes