### PR TITLE
Improve Data Layer Foreground Service channel notification

### DIFF
--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -271,4 +271,6 @@
     <string name="tile_action_2">Action 2</string>
     <string name="tile_action_3">Action 3</string>
     <string name="tile_action_4">Action 4</string>
+    <string name="datalayer_notification_title">Data Layer Foreground Service</string>
+    <string name="datalayer_notification_text">AAPS is running in the foreground. To hide notification go to Developer options, App notifications, Allowed watch apps, select AAPS, Turn off Data Layer Foreground Service Channel notification.</string>
 </resources>


### PR DESCRIPTION
This will make notification channel less intrusive. It will not pop up, make sound or vibrate when using complications. Also not add a dot on watch screen making you think you have an unread notification.

I've also added text for translation for both title and text describing notification. I'm not entirely sure if it's needed, but I added information about how to hide it, since I believe users may want to do so. As far as I have tested complications work allthough notification channel is hidden.

Improves issue described in https://github.com/nightscout/AndroidAPS/issues/3143

I've tested this on Samsung galaxy watch 4. Would be nice if someone with other type of wear os watches also could test this PR.
