### PR TITLE
Fix wrong translation of german string shorthour for next master release

### DIFF
--- a/core/interfaces/src/main/res/values-de-rDE/strings.xml
+++ b/core/interfaces/src/main/res/values-de-rDE/strings.xml
@@ -10,7 +10,7 @@
     <string name="days_ago_round">vor %1$.0f Tagen</string>
     <string name="in_days">in %1$.0f Tagen</string>
     <string name="in_days_round">in %1$.0f Tagen</string>
-    <string name="shorthour">s</string>
+    <string name="shorthour">h</string>
     <string name="days">Tage</string>
     <string name="hours">Stunden</string>
     <string name="unit_second">Sekunde</string>


### PR DESCRIPTION
Fixes issue https://github.com/nightscout/AndroidAPS/issues/3172 for 3.2.0.4

It's been fixed in crowdin for dev https://github.com/nightscout/AndroidAPS/commit/00ae71e8149d47c134c9eca7902530d59080956d, but this PR will add fix for wrong translation for next 3.2 master release