### PR TITLE
Adjust string overview_show_steps to be consistent with rest of strings in overview graph

### DIFF
--- a/plugins/main/src/main/res/values/strings.xml
+++ b/plugins/main/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="ongoingnotificaction" translatable="false">Ongoing Notification</string>
     <string name="description_persistent_notification">Shows an ongoing notification with a short overview of what your loop is doing</string>
     <string name="old_data">OLD DATA</string>
-    <string name="overview_show_steps">steps</string>
+    <string name="overview_show_steps">Steps</string>
     <string name="steps_shortname">STEPS</string>
     <string name="simple_mode_enabled">Simple mode enabled</string>
 


### PR DESCRIPTION
It was missing upper case first letter

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/51fbde9b-3b63-423f-9509-02f2d866f164)
