### PR TITLE
Bugfix: Display "50+U" when pod has over 50U

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
@@ -120,7 +120,8 @@ class StatusLightHandler @Inject constructor(
         view: TextView?, criticalSetting: IntKey, warnSetting: IntKey, level: Double, units: String, maxReading: Double
     ) {
         if (level >= maxReading) {
-            view?.text = decimalFormatter.to0Decimal(maxReading, units)
+            @Suppress("SetTextI18n")
+            view?.text = "${decimalFormatter.to0Decimal(maxReading)}+$units"
             view?.setTextColor(rh.gac(view.context, app.aaps.core.ui.R.attr.defaultTextColor))
         } else {
             handleLevel(view, criticalSetting, warnSetting, level, units)


### PR DESCRIPTION
Bugfix https://github.com/nightscout/AndroidAPS/issues/3194

Tested on Omnipod Dash