### PR TITLE
UI: Improved button accessibility in bolus wizard

### DIFF
--- a/core/ui/src/main/res/drawable/toggle_button_selector.xml
+++ b/core/ui/src/main/res/drawable/toggle_button_selector.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true">
-        <shape android:shape="rectangle">
-            <solid android:color="@color/toggle_button_background" />
-            <corners android:radius="10dp" />
-            <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
-        </shape>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
+    <item>
+        <selector>
+            <item android:state_checked="true">
+                <shape android:shape="rectangle">
+                    <corners android:radius="10dp" />
+                    <solid android:color="@color/toggle_button_background" />
+                    <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
+                </shape>
+            </item>
+            <item android:state_checked="false">
+                <shape android:shape="rectangle">
+                    <corners android:radius="10dp" />
+                    <solid android:color="@color/toggle_button_background" />
+                    <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
+                </shape>
+            </item>
+        </selector>
     </item>
-    <item android:state_checked="false">
-        <shape android:shape="rectangle">
-            <solid android:color="@color/toggle_button_background" />
-            <corners android:radius="10dp" />
-            <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
-        </shape>
-    </item>
-</selector>
+</ripple>

--- a/core/ui/src/main/res/drawable/toggle_button_selector.xml
+++ b/core/ui/src/main/res/drawable/toggle_button_selector.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/toggle_button_background" />
+            <corners android:radius="10dp" />
+            <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/toggle_button_background" />
+            <corners android:radius="10dp" />
+            <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
+        </shape>
+    </item>
+</selector>

--- a/core/ui/src/main/res/drawable/toggle_button_selector.xml
+++ b/core/ui/src/main/res/drawable/toggle_button_selector.xml
@@ -14,7 +14,6 @@
                 <shape android:shape="rectangle">
                     <corners android:radius="10dp" />
                     <solid android:color="@color/toggle_button_background" />
-                    <stroke android:width="1dp" android:color="@color/toggle_button_stroke" />
                 </shape>
             </item>
         </selector>

--- a/core/ui/src/main/res/values-night/colors.xml
+++ b/core/ui/src/main/res/values-night/colors.xml
@@ -45,6 +45,10 @@
     <color name="ic_local_reset">#E93057</color>
     <color name="ic_local_save">#67E86A</color>
 
+    <!--    Toggle Buttons-->
+    <color name="toggle_button_background">#303030</color>
+    <color name="toggle_button_stroke">#8A8A8A</color>
+
     <!--    Fragments-->
     <color name="pumpStatusBackground">#505050</color>
 

--- a/core/ui/src/main/res/values/colors.xml
+++ b/core/ui/src/main/res/values/colors.xml
@@ -45,6 +45,10 @@
     <color name="ic_local_reset">#E93057</color>
     <color name="ic_local_save">#67E86A</color>
 
+    <!--    Toggle Buttons-->
+    <color name="toggle_button_background">#E0E0E0</color>
+    <color name="toggle_button_stroke">#8A8A8A</color>
+
     <!--    Fragments-->
     <color name="pumpStatusBackground">#CCCCCC</color>
 

--- a/core/ui/src/main/res/values/styles.xml
+++ b/core/ui/src/main/res/values/styles.xml
@@ -324,6 +324,20 @@
         <item name="android:background">@drawable/dialog_header</item>
     </style>
 
+    <style name="ToggleBtnStyle">
+        <item name="android:background">@drawable/toggle_button_selector</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">match_parent</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:checked">true</item>
+        <item name="android:padding">7dp</item>
+        <item name="android:textOn"></item>
+        <item name="android:textOff"></item>
+        <item name="android:layout_marginEnd">2dp</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+    </style>
+
     <style name="OkCancelButton.Text" ns2:ignore="NewApi">
         <item name="android:textSize">@dimen/material_button_text_size</item>
         <item name="android:singleLine">true</item>

--- a/core/ui/src/main/res/values/styles.xml
+++ b/core/ui/src/main/res/values/styles.xml
@@ -330,12 +330,10 @@
         <item name="android:layout_height">match_parent</item>
         <item name="android:layout_weight">1</item>
         <item name="android:checked">true</item>
-        <item name="android:padding">7dp</item>
+        <item name="android:paddingTop">7dp</item>
         <item name="android:textOn"></item>
         <item name="android:textOff"></item>
         <item name="android:layout_marginEnd">2dp</item>
-        <item name="android:clickable">true</item>
-        <item name="android:focusable">true</item>
     </style>
 
     <style name="OkCancelButton.Text" ns2:ignore="NewApi">

--- a/ui/src/main/res/layout/dialog_wizard.xml
+++ b/ui/src/main/res/layout/dialog_wizard.xml
@@ -272,69 +272,43 @@
         <LinearLayout
             android:id="@+id/checkbox_row"
             android:layout_width="match_parent"
-            android:layout_height="55dp"
-            android:paddingHorizontal="5dp"
-            android:layout_marginBottom="15dp">
+            android:layout_height="40dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginBottom="15dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
             <ToggleButton
                 android:id="@+id/bg_checkbox_icon"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:checked="true"
+                style="@style/ToggleBtnStyle"
                 android:contentDescription="@string/bg_label"
-                android:drawableTop="@drawable/checkbox_bg_icon"
-                android:padding="13dp"
-                android:textOn=""
-                android:textOff="" />
+                android:drawableTop="@drawable/checkbox_bg_icon" />
 
             <ToggleButton
                 android:id="@+id/tt_checkbox_icon"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:checked="true"
+                style="@style/ToggleBtnStyle"
                 android:contentDescription="@string/tt_label"
-                android:drawableTop="@drawable/checkbox_tt_icon"
-                android:padding="13dp"
-                android:textOn=""
-                android:textOff="" />
+                android:drawableTop="@drawable/checkbox_tt_icon" />
 
             <ToggleButton
                 android:id="@+id/trend_checkbox_icon"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:checked="true"
+                style="@style/ToggleBtnStyle"
                 android:contentDescription="@string/bg_trend_label"
-                android:drawableTop="@drawable/checkbox_trend_icon"
-                android:padding="13dp"
-                android:textOn=""
-                android:textOff="" />
+                android:drawableTop="@drawable/checkbox_trend_icon" />
 
             <ToggleButton
                 android:id="@+id/iob_checkbox_icon"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:checked="true"
+                style="@style/ToggleBtnStyle"
                 android:contentDescription="@string/iob"
-                android:drawableTop="@drawable/checkbox_iob_icon"
-                android:padding="13dp"
-                android:textOn=""
-                android:textOff="" />
+                android:drawableTop="@drawable/checkbox_iob_icon" />
 
             <ToggleButton
                 android:id="@+id/cob_checkbox_icon"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:checked="true"
+                style="@style/ToggleBtnStyle"
                 android:contentDescription="@string/treatments_wizard_cob_label"
-                android:drawableTop="@drawable/checkbox_cob_icon"
-                android:padding="13dp"
-                android:textOn=""
-                android:textOff="" />
+                android:drawableTop="@drawable/checkbox_cob_icon" />
 
         </LinearLayout>
 

--- a/ui/src/main/res/layout/dialog_wizard.xml
+++ b/ui/src/main/res/layout/dialog_wizard.xml
@@ -272,68 +272,69 @@
         <LinearLayout
             android:id="@+id/checkbox_row"
             android:layout_width="match_parent"
-            android:layout_height="45dp"
-            android:paddingHorizontal="10dp">
+            android:layout_height="55dp"
+            android:paddingHorizontal="5dp"
+            android:layout_marginBottom="15dp">
 
             <ToggleButton
                 android:id="@+id/bg_checkbox_icon"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/bg_label"
                 android:drawableTop="@drawable/checkbox_bg_icon"
-                android:scaleX="1.4"
-                android:scaleY="1.4" />
+                android:padding="13dp"
+                android:textOn=""
+                android:textOff="" />
 
             <ToggleButton
                 android:id="@+id/tt_checkbox_icon"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/tt_label"
                 android:drawableTop="@drawable/checkbox_tt_icon"
-                android:scaleX="1.6"
-                android:scaleY="1.6" />
+                android:padding="13dp"
+                android:textOn=""
+                android:textOff="" />
 
             <ToggleButton
                 android:id="@+id/trend_checkbox_icon"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/bg_trend_label"
                 android:drawableTop="@drawable/checkbox_trend_icon"
-                android:scaleX="1.4"
-                android:scaleY="1.4" />
+                android:padding="13dp"
+                android:textOn=""
+                android:textOff="" />
 
             <ToggleButton
                 android:id="@+id/iob_checkbox_icon"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/iob"
                 android:drawableTop="@drawable/checkbox_iob_icon"
-                android:scaleX="1.4"
-                android:scaleY="1.4" />
+                android:padding="13dp"
+                android:textOn=""
+                android:textOff="" />
 
             <ToggleButton
                 android:id="@+id/cob_checkbox_icon"
-                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:checked="true"
                 android:contentDescription="@string/treatments_wizard_cob_label"
                 android:drawableTop="@drawable/checkbox_cob_icon"
-                android:scaleX="1.6"
-                android:scaleY="1.6" />
+                android:padding="13dp"
+                android:textOn=""
+                android:textOff="" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Solution https://github.com/nightscout/AndroidAPS/issues/3210

- Enabled/disabled state is obvious
- Added spacing between buttons and cancel button to prevent accidental taps

<img src="https://github.com/nightscout/AndroidAPS/assets/4112129/932ccf00-23f6-44da-b097-412249017ed9" width="350">