### PR TITLE
Add string for notification shown when changing profile with Dash/Eros

### DIFF
--- a/pump/omnipod-common/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/common/queue/command/CommandDisableSuspendAlerts.kt
+++ b/pump/omnipod-common/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/common/queue/command/CommandDisableSuspendAlerts.kt
@@ -1,9 +1,11 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.common.queue.command
 
 import app.aaps.core.interfaces.queue.CustomCommand
+import app.aaps.core.interfaces.resources.ResourceHelper
+import info.nightscout.androidaps.plugins.pump.omnipod.common.R
 
-class CommandDisableSuspendAlerts : CustomCommand {
+class CommandDisableSuspendAlerts(private val rh: ResourceHelper) : CustomCommand {
 
     override val statusDescription: String
-        get() = "DISABLE SUSPEND ALERTS"
+        get() = rh.gs(R.string.omnipod_common_disable_suspend_alerts)
 }

--- a/pump/omnipod-common/src/main/res/values/strings.xml
+++ b/pump/omnipod-common/src/main/res/values/strings.xml
@@ -211,6 +211,7 @@
     <string name="omnipod_common_cancel">Cancel</string>
     <string name="omnipod_common_warning">Warning</string>
     <string name="omnipod_common_two_strings_concatenated_by_colon" translatable="false">%1$s: %2$s</string>
+    <string name="omnipod_common_disable_suspend_alerts">DISABLE SUSPEND ALERTS</string>
 
     <!-- Omnipod - Times -->
     <string name="omnipod_common_time_with_timezone" translatable="false">%1$s (%2$s)</string>

--- a/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -1417,7 +1417,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     rxBus.send(EventDismissNotification(Notification.FAILED_UPDATE_PROFILE))
                     rxBus.send(EventDismissNotification(Notification.OMNIPOD_TBR_ALERTS))
                     rxBus.send(EventDismissNotification(Notification.OMNIPOD_TIME_OUT_OF_SYNC))
-                    commandQueue.customCommand(CommandDisableSuspendAlerts(), null)
+                    commandQueue.customCommand(CommandDisableSuspendAlerts(rh), null)
                 }
             }
 
@@ -1441,7 +1441,7 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     rxBus.send(EventDismissNotification(Notification.FAILED_UPDATE_PROFILE))
                     rxBus.send(EventDismissNotification(Notification.OMNIPOD_TBR_ALERTS))
                     rxBus.send(EventDismissNotification(Notification.OMNIPOD_TIME_OUT_OF_SYNC))
-                    commandQueue.customCommand(CommandDisableSuspendAlerts(), null)
+                    commandQueue.customCommand(CommandDisableSuspendAlerts(rh), null)
                 }
             }
 


### PR DESCRIPTION
Appears briefly at bottom of screen when changing profile or setting temporary profile.

Built and ran tests ok.