### PR TITLE
Allow for recordOnly bolus when pump is disconnected or suspended

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -583,8 +583,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 && preferences.get(BooleanKey.OverviewShowTreatmentButton)).toVisibility()
             binding.buttonsLayout.wizardButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
                 && preferences.get(BooleanKey.OverviewShowWizardButton)).toVisibility()
-            binding.buttonsLayout.insulinButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
-                && preferences.get(BooleanKey.OverviewShowInsulinButton)).toVisibility()
+            binding.buttonsLayout.insulinButton.visibility = (profile != null && preferences.get(BooleanKey.OverviewShowInsulinButton)).toVisibility()
 
             // **** Calibration & CGM buttons ****
             val xDripIsBgSource = xDripSource.isEnabled()

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -594,7 +594,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             } else {
                 setRibbon(
                     binding.buttonsLayout.insulinButton,
-                    app.aaps.core.ui.R.attr.ribbonTextDefaultColor,
+                    app.aaps.core.ui.R.attr.icBolusColor,
                     app.aaps.core.ui.R.attr.ribbonDefaultColor,
                     rh.gs(app.aaps.core.ui.R.string.overview_insulin_label)
                 )

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -584,6 +584,21 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             binding.buttonsLayout.wizardButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
                 && preferences.get(BooleanKey.OverviewShowWizardButton)).toVisibility()
             binding.buttonsLayout.insulinButton.visibility = (profile != null && preferences.get(BooleanKey.OverviewShowInsulinButton)).toVisibility()
+            if (loop.isDisconnected || !pump.isInitialized() || pump.isSuspended()) {
+                setRibbon(
+                    binding.buttonsLayout.insulinButton,
+                    app.aaps.core.ui.R.attr.ribbonTextWarningColor,
+                    app.aaps.core.ui.R.attr.ribbonWarningColor,
+                    rh.gs(app.aaps.core.ui.R.string.overview_insulin_label)
+                )
+            } else {
+                setRibbon(
+                    binding.buttonsLayout.insulinButton,
+                    app.aaps.core.ui.R.attr.ribbonTextDefaultColor,
+                    app.aaps.core.ui.R.attr.ribbonDefaultColor,
+                    rh.gs(app.aaps.core.ui.R.string.overview_insulin_label)
+                )
+            }
 
             // **** Calibration & CGM buttons ****
             val xDripIsBgSource = xDripSource.isEnabled()

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
@@ -124,11 +124,19 @@ class InsulinDialog : DialogFragmentWithDate() {
         super.onViewCreated(view, savedInstanceState)
 
         val pump = activePlugin.activePump
-        if (config.NSCLIENT || loop.isDisconnected || pump.isSuspended() || !pump.isInitialized()) {
+        if (config.NSCLIENT) {
             binding.recordOnly.isChecked = true
             binding.recordOnly.isEnabled = false
         }
         val maxInsulin = constraintChecker.getMaxBolusAllowed().value()
+
+        if (loop.isDisconnected || pump.isSuspended() || !pump.isInitialized()) {
+            binding.recordOnly.isChecked = true
+            binding.recordOnly.isEnabled = false
+            binding.recordOnly.setTextColor(rh.gac(app.aaps.core.ui.R.attr.warningColor))
+            binding.header.setBackgroundColor(rh.gac(app.aaps.core.ui.R.attr.ribbonWarningColor))
+            binding.headerText.setTextColor(rh.gac(app.aaps.core.ui.R.attr.ribbonTextWarningColor))
+        }
 
         binding.time.setParams(
             savedInstanceState?.getDouble("time")

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
@@ -14,6 +14,7 @@ import app.aaps.core.data.time.T
 import app.aaps.core.data.ue.Action
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.data.ue.ValueWithUnit
+import app.aaps.core.interfaces.aps.Loop
 import app.aaps.core.interfaces.automation.Automation
 import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
@@ -72,6 +73,7 @@ class InsulinDialog : DialogFragmentWithDate() {
     @Inject lateinit var persistenceLayer: PersistenceLayer
     @Inject lateinit var decimalFormatter: DecimalFormatter
     @Inject lateinit var injector: HasAndroidInjector
+    @Inject lateinit var loop: Loop
 
     private var queryingProtection = false
     private val disposable = CompositeDisposable()
@@ -121,7 +123,8 @@ class InsulinDialog : DialogFragmentWithDate() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (config.NSCLIENT) {
+        val pump = activePlugin.activePump
+        if (config.NSCLIENT || loop.isDisconnected || pump.isSuspended() || !pump.isInitialized()) {
             binding.recordOnly.isChecked = true
             binding.recordOnly.isEnabled = false
         }
@@ -162,7 +165,9 @@ class InsulinDialog : DialogFragmentWithDate() {
             binding.amount.announceValue()
         }
 
-        binding.timeLayout.visibility = View.GONE
+        if (!binding.recordOnly.isChecked) {
+            binding.timeLayout.visibility = View.GONE
+        }
         binding.recordOnly.setOnCheckedChangeListener { _, isChecked: Boolean ->
             binding.timeLayout.visibility = isChecked.toVisibility()
         }

--- a/ui/src/main/res/layout/dialog_insulin.xml
+++ b/ui/src/main/res/layout/dialog_insulin.xml
@@ -15,6 +15,7 @@
 
         <RelativeLayout
             style="@style/StyleDialogHeader"
+            android:id="@+id/header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center">
@@ -26,6 +27,7 @@
                 app:srcCompat="@drawable/ic_bolus" />
 
             <TextView
+                android:id="@+id/header_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"


### PR DESCRIPTION
This PR allows to record a bolus using the Insulin button when loop is disconnected or pump is suspended/not active

Have seen this request on discord some time ago, and experienced it myself.

Consider following scenarios:
- You are in a sauna with disconnected/suspended pump, you want to do pen bolus
- You canula is blocked or leaking, you do not trust AAPS to run, so you suspend pump and do manual pen bolus

There are other scenarios as well when you want to do a pen bolus while disconnected.

Tested:
- loop disconnected (medtrum)
- Medtrum Patch not activated
- Dash pod not active
- Insight not initialized

Update:
![Screenshot_20240304-194743_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/d8c433ae-e684-40bf-ae20-9939725b3ab0)

