### PR TITLE
Fix light theme in pump drivers

### DIFF
--- a/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Fragment.kt
+++ b/pump/combov2/src/main/kotlin/info/nightscout/pump/combov2/ComboV2Fragment.kt
@@ -1,6 +1,5 @@
 package info.nightscout.pump.combov2
 
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -116,9 +115,9 @@ class ComboV2Fragment : DaggerFragment() {
 
                         binding.combov2DriverState.setTextColor(
                             when (connectionState) {
-                                ComboV2Plugin.DriverState.Error     -> Color.RED
-                                ComboV2Plugin.DriverState.Suspended -> Color.YELLOW
-                                else                                -> Color.WHITE
+                                ComboV2Plugin.DriverState.Error     -> rh.gac(app.aaps.core.ui.R.attr.warningColor)
+                                ComboV2Plugin.DriverState.Suspended -> rh.gac(app.aaps.core.ui.R.attr.urgentColor)
+                                else                                -> rh.gac(app.aaps.core.ui.R.attr.defaultTextColor)
                             }
                         )
                     }
@@ -150,17 +149,17 @@ class ComboV2Fragment : DaggerFragment() {
 
                             BatteryState.NO_BATTERY   -> {
                                 binding.combov2Battery.text = rh.gs(R.string.combov2_battery_empty_indicator)
-                                binding.combov2Battery.setTextColor(Color.RED)
+                                binding.combov2Battery.setTextColor(rh.gac(app.aaps.core.ui.R.attr.warningColor))
                             }
 
                             BatteryState.LOW_BATTERY  -> {
                                 binding.combov2Battery.text = rh.gs(R.string.combov2_battery_low_indicator)
-                                binding.combov2Battery.setTextColor(Color.YELLOW)
+                                binding.combov2Battery.setTextColor(rh.gac(app.aaps.core.ui.R.attr.urgentColor))
                             }
 
                             BatteryState.FULL_BATTERY -> {
                                 binding.combov2Battery.text = rh.gs(R.string.combov2_battery_full_indicator)
-                                binding.combov2Battery.setTextColor(Color.WHITE)
+                                binding.combov2Battery.setTextColor(rh.gac(app.aaps.core.ui.R.attr.defaultTextColor))
                             }
                         }
                     }
@@ -175,10 +174,10 @@ class ComboV2Fragment : DaggerFragment() {
 
                         binding.combov2Reservoir.setTextColor(
                             when (reservoirLevel?.state) {
-                                null                 -> Color.WHITE
-                                ReservoirState.EMPTY -> Color.RED
-                                ReservoirState.LOW   -> Color.YELLOW
-                                ReservoirState.FULL  -> Color.WHITE
+                                null                 -> rh.gac(app.aaps.core.ui.R.attr.defaultTextColor)
+                                ReservoirState.EMPTY -> rh.gac(app.aaps.core.ui.R.attr.warningColor)
+                                ReservoirState.LOW   -> rh.gac(app.aaps.core.ui.R.attr.urgentColor)
+                                ReservoirState.FULL  -> rh.gac(app.aaps.core.ui.R.attr.defaultTextColor)
                             }
                         )
                     }
@@ -249,17 +248,17 @@ class ComboV2Fragment : DaggerFragment() {
 
             in 0..60         -> {
                 binding.combov2LastConnection.text = rh.gs(R.string.combov2_less_than_one_minute_ago)
-                binding.combov2LastConnection.setTextColor(Color.WHITE)
+                binding.combov2LastConnection.setTextColor(rh.gac(app.aaps.core.ui.R.attr.defaultTextColor))
             }
 
             in 60..(30 * 60) -> {
                 binding.combov2LastConnection.text = rh.gs(app.aaps.core.interfaces.R.string.minago, secondsPassed / 60)
-                binding.combov2LastConnection.setTextColor(Color.WHITE)
+                binding.combov2LastConnection.setTextColor(rh.gac(app.aaps.core.ui.R.attr.defaultTextColor))
             }
 
             else             -> {
                 binding.combov2LastConnection.text = rh.gs(R.string.combov2_no_connection_for_n_mins, secondsPassed / 60)
-                binding.combov2LastConnection.setTextColor(Color.RED)
+                binding.combov2LastConnection.setTextColor(rh.gac(app.aaps.core.ui.R.attr.warningColor))
             }
         }
     }

--- a/pump/combov2/src/main/res/layout/combov2_fragment.xml
+++ b/pump/combov2/src/main/res/layout/combov2_fragment.xml
@@ -76,7 +76,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -109,7 +108,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -144,7 +142,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -187,7 +184,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:text=""
                             android:textSize="14sp" />
                     </LinearLayout>
@@ -222,7 +218,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -256,7 +251,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -290,7 +284,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -324,7 +317,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -358,7 +350,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -392,7 +383,6 @@
                             android:layout_weight="1"
                             android:gravity="start"
                             android:paddingLeft="5dp"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 

--- a/pump/eopatch/src/main/res/layout/fragment_eopatch_overview.xml
+++ b/pump/eopatch/src/main/res/layout/fragment_eopatch_overview.xml
@@ -85,7 +85,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.bleStatus}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -134,7 +133,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.patchConfig.patchSerialNumber}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
                 </LinearLayout>
 
@@ -173,7 +171,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.patchConfig.patchLotNumber}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
                 </LinearLayout>
 
@@ -212,7 +209,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{CommonUtils.dateString(viewmodel.patchConfig.patchWakeupTimestamp)}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -252,7 +248,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{CommonUtils.dateString(viewmodel.patchConfig.expireTimestamp)}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -292,7 +287,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.status}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -340,7 +334,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.normalBasal}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -388,7 +381,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.tempBasal}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -436,7 +428,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.patchRemainingInsulin}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>
@@ -484,7 +475,6 @@
                         android:paddingStart="5dp"
                         android:paddingEnd="5dp"
                         android:text="@{viewmodel.patchConfig.insulinInjectionAmountStr}"
-                        android:textColor="@android:color/white"
                         android:textSize="16sp" />
 
                 </LinearLayout>

--- a/pump/eopatch/src/main/res/values/colors.xml
+++ b/pump/eopatch/src/main/res/values/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
-</resources>

--- a/pump/equil/src/main/java/app/aaps/pump/equil/EquilFragment.kt
+++ b/pump/equil/src/main/java/app/aaps/pump/equil/EquilFragment.kt
@@ -2,7 +2,6 @@ package app.aaps.pump.equil
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
@@ -143,7 +142,7 @@ class EquilFragment : DaggerFragment() {
 
             binding.timeDevice.text = dateUtil.dateAndTimeAndSecondsString(equilManager.lastDataTime)
             val runMode = equilManager.runMode
-            binding.mode.setTextColor(Color.WHITE)
+            binding.mode.setTextColor(rh.gac(app.aaps.core.ui.R.attr.defaultTextColor))
             if (equilManager.isActivationCompleted) {
                 when (runMode) {
                     RunMode.RUN     -> {
@@ -174,7 +173,7 @@ class EquilFragment : DaggerFragment() {
                 binding.btnResumeDelivery.visibility = View.GONE
                 binding.btnSuspendDelivery.visibility = View.GONE
                 binding.mode.text = rh.gs(R.string.equil_init_insulin_error)
-                binding.mode.setTextColor(Color.RED)
+                binding.mode.setTextColor(rh.gac(app.aaps.core.ui.R.attr.warningColor))
             }
 
             binding.serialNumber.text = devName

--- a/pump/equil/src/main/res/layout/equil_fra.xml
+++ b/pump/equil/src/main/res/layout/equil_fra.xml
@@ -42,7 +42,6 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:gravity="center"
-                        android:textColor="@android:color/white"
                         android:textSize="14sp" />
 
                     <ProgressBar
@@ -75,7 +74,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -102,7 +100,6 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:gravity="center"
-                        android:textColor="@android:color/white"
                         android:textSize="14sp" />
 
                     <FrameLayout
@@ -146,7 +143,6 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:gravity="center"
-                        android:textColor="@android:color/white"
                         android:textSize="14sp" />
 
                     <FrameLayout
@@ -193,7 +189,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -216,7 +211,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -239,7 +233,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -263,7 +256,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -286,7 +278,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 
@@ -309,7 +300,6 @@
                     android:layout_height="match_parent"
                     android:layout_weight="3"
                     android:gravity="center"
-                    android:textColor="@android:color/white"
                     android:textSize="14sp" />
             </TableRow>
 

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_overview.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_overview.xml
@@ -117,7 +117,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.lastConnectionMinAgo}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -166,7 +165,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.medtrumPump.pumpStateFlow.toString()}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -206,7 +204,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.medtrumPump.lastBasalTypeFlow.toString()}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -246,7 +243,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text='@{@string/current_basal_rate(viewmodel.medtrumPump.lastBasalRateFlow)}'
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -286,7 +282,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text='@{viewmodel.lastBolus}'
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -326,7 +321,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text='@{viewmodel.activeBolusStatus}'
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -375,7 +369,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.activeAlarms}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -424,7 +417,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text='@{@string/reservoir_level(viewmodel.medtrumPump.reservoirFlow)}'
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -464,7 +456,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text='@{@string/battery_voltage(viewmodel.medtrumPump.batteryVoltage_BFlow)}'
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -513,7 +504,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.pumpType}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
                     </LinearLayout>
 
@@ -553,7 +543,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.fwVersion}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
 
                     </LinearLayout>
@@ -594,7 +583,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.patchNo}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
 
                     </LinearLayout>
@@ -634,7 +622,6 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.patchExpiry}"
-                            android:textColor="@android:color/white"
                             android:textSize="14sp" />
 
                     </LinearLayout>

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch.xml
@@ -62,7 +62,7 @@
                 android:layout_marginBottom="40dp"
                 android:gravity="center"
                 android:text="@string/patch_not_active_note"
-                android:textColor="@color/red"
+                android:textColor="@color/warning"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toTopOf="@+id/layout_button"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch_connect.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch_connect.xml
@@ -62,7 +62,7 @@
                 android:layout_marginBottom="40dp"
                 android:gravity="center"
                 android:text="@string/do_not_attach_to_body"
-                android:textColor="@color/red"
+                android:textColor="@color/warning"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toTopOf="@+id/layout_button"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_prime.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_prime.xml
@@ -49,7 +49,7 @@
                 android:layout_marginBottom="40dp"
                 android:gravity="center"
                 android:text="@string/do_not_attach_to_body"
-                android:textColor="@color/red"
+                android:textColor="@color/warning"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toTopOf="@+id/layout_button"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_prime_complete.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_prime_complete.xml
@@ -49,7 +49,7 @@
                 android:layout_marginBottom="40dp"
                 android:gravity="center"
                 android:text="@string/do_not_attach_to_body"
-                android:textColor="@color/red"
+                android:textColor="@color/warning"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toTopOf="@+id/layout_button"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_priming.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_priming.xml
@@ -60,7 +60,7 @@
                 android:layout_marginBottom="40dp"
                 android:gravity="center"
                 android:text="@string/do_not_attach_to_body"
-                android:textColor="@color/red"
+                android:textColor="@color/warning"
                 android:textSize="16sp"
                 app:layout_constraintBottom_toTopOf="@+id/layout_button"
                 app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Various pump drivers had their text colors hardcoded to white.

This PR fixes that.

Medtrum: Fully tested
EOPatch: Overview Tested (nothing else changed)
Equil: Overview tested, Changing of text color not tested as I dont have equil
Combo: Not tested, I dont have a combo

For combo and Equil I have requested a test on the respective channels on discord
