### PR TITLE
Medtrum: Remove reset of device address on disconnect during connecting

### DIFF
--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/BLEComm.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/BLEComm.kt
@@ -146,6 +146,7 @@ class BLEComm @Inject internal constructor(
         } else {
             // Scan for device
             aapsLogger.debug(LTag.PUMPBTCOMM, "Scanning for device")
+            mDevice = null
             mDeviceSN = deviceSN
             startScan()
         }

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/BLEComm.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/services/BLEComm.kt
@@ -380,9 +380,7 @@ class BLEComm @Inject internal constructor(
             mBluetoothGatt?.discoverServices()
         } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
             if (isConnecting) {
-                // When we are disconnected during connecting, we reset the device address to force a new scan
-                aapsLogger.warn(LTag.PUMPBTCOMM, "Disconnected while connecting! Reset device address")
-                mDevice = null
+                aapsLogger.warn(LTag.PUMPBTCOMM, "Disconnected while connecting!")
                 // Wait a bit before retrying
                 SystemClock.sleep(2000)
             }


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/3268

Possible that some phones cannot handle scan properly while in background, this reduces scanning.
Needs testing on multiple phones, feel free to do so.

Tested on 4-5 different phones over period of 3 days, no regressions detected