### PR TITLE
Scale random bg for other than 5 minute interval

### DIFF
--- a/plugins/source/src/main/kotlin/app/aaps/plugins/source/RandomBgPlugin.kt
+++ b/plugins/source/src/main/kotlin/app/aaps/plugins/source/RandomBgPlugin.kt
@@ -121,7 +121,7 @@ class RandomBgPlugin @Inject constructor(
 
         val cal = GregorianCalendar()
         val currentMinute = cal[Calendar.MINUTE] + (cal[Calendar.HOUR_OF_DAY] % 2) * 60
-        val bgMgdl = min + ((max - min) + (max - min) * sin(currentMinute / period * 2 * PI)) / 2 + (SecureRandom().nextDouble() - 0.5) * (max - min) * 0.4
+        val bgMgdl = min + ((max - min) + (max - min) * sin(currentMinute / period * 2 * PI)) / 2 + (SecureRandom().nextDouble() - 0.5) * (max - min) * 0.08 * interval
 
         cal[Calendar.MILLISECOND] = 0
         cal[Calendar.SECOND] = 0


### PR DESCRIPTION
Often I use 1 minute intervals in Random BG for faster test turnaround. However, the scale of the random part itself is tailored to emulate 5 minute CGM. Within 1 minute the change in the underlying sine wave is less and therefore the random addon should be reduced by factor 5 or rather made variable depending on the interval.

Here is an example 

![grafik](https://github.com/nightscout/AndroidAPS/assets/50909826/288c3e33-57f0-46e2-80e6-c8c39c429a24)
