### PR TITLE
Use word "Recalculate" instead of "Reset" for button in Statistics > TDD

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/activities/StatsActivity.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/activities/StatsActivity.kt
@@ -92,7 +92,7 @@ class StatsActivity : TranslatedDaggerAppCompatActivity() {
             }
         }
         binding.resetTdd.setOnClickListener {
-            OKDialog.showConfirmation(this, rh.gs(R.string.do_you_want_reset_tdd_stats)) {
+            OKDialog.showConfirmation(this, rh.gs(R.string.do_you_want_recalculate_tdd_stats)) {
                 handler.post {
                     uel.log(Action.STAT_RESET, Sources.Stats)
                     persistenceLayer.clearCachedTddData(0)

--- a/ui/src/main/res/layout/activity_stats.xml
+++ b/ui/src/main/res/layout/activity_stats.xml
@@ -51,7 +51,7 @@
                         android:layout_gravity="center"
                         android:paddingStart="10dp"
                         android:paddingEnd="10dp"
-                        android:text="@string/reset"
+                        android:text="@string/recalculate"
                         app:icon="@drawable/ic_local_reset"
                         app:iconTint="@color/ic_local_reset" />
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <!--     Activities-->
     <string name="activity_monitor">Activity monitor</string>
     <string name="do_you_want_reset_stats">Do you want to reset activity stats?</string>
-    <string name="do_you_want_reset_tdd_stats">Do you want to reset TDD stats?</string>
+    <string name="do_you_want_recalculate_tdd_stats">Do you want to recalculate TDD stats?</string>
     <string name="statistics">Statistics</string>
     <string name="calculation_in_progress">Calculation in progress</string>
     <string name="invalid_age">Invalid age entry</string>
@@ -167,6 +167,7 @@
     <string name="constraints_violation">Constraints violation</string>
     <string name="change_your_input">Change your input!</string>
     <string name="confirm_treatment">Please confirm treatment</string>
+    <string name="recalculate">Recalculate</string>
 
     <string-array name="yes_no_positiveonly_negativeonly">
         <item>Both</item>


### PR DESCRIPTION
After discussion in Discord several users agree this is a more precise word for this button. See attached screenhots of how it will look in English. 

When hitting the button AAPS recalculate TDD, it doesn't reset / wipe it. And users may be misled as it stands now. 

If any other phrase or word is more correct, please comment.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/23a227f4-ddc1-4013-a075-91484eedd06b)

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/d3cd0402-8a5c-4246-abd2-fad80dc4bbe9)
