### PR TITLE
Improve error message in Loop-plugin during DST.

### DIFF
--- a/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/dstHelper/DstHelperPlugin.kt
+++ b/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/dstHelper/DstHelperPlugin.kt
@@ -72,7 +72,7 @@ class DstHelperPlugin @Inject constructor(
             } else {
                 aapsLogger.debug(LTag.CONSTRAINTS, "Loop already suspended")
             }
-            value.set(false, "DST in last 3 hours.", this)
+            value.set(false, rh.gs(R.string.dst_loop_disabled_error), this)
         }
         return value
     }

--- a/plugins/constraints/src/main/res/values/strings.xml
+++ b/plugins/constraints/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="dst_plugin_name" translatable="false">Daylight Saving time</string>
     <string name="dst_in_24h_warning">Daylight Saving time change in 24h or less</string>
     <string name="dst_loop_disabled_warning">Daylight Saving time change less than 3 hours ago - Closed loop disabled</string>
+    <string name="dst_loop_disabled_error">Daylight Saving Time (DST) change occurred less than 3 hours ago. Closed loop disabled temporarily, will automatically re-enable 3 hours after DST change</string>
 
     <!-- Storage constraint -->
     <string name="storage" translatable="false">Storage constraint</string>


### PR DESCRIPTION
During DST the current error message in Loop plugin is a bit short. I've noticed some confusion regarding this. This will improve it so users will easier understand that closed loop will return 3 hours after DST.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/11246b64-3696-446b-b51f-3647b442a003)
