### PR TITLE
UI: Graph Scale Buttons instead of Dropdown

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -16,12 +16,15 @@ import android.os.HandlerThread
 import android.util.DisplayMetrics
 import android.util.TypedValue
 import android.view.LayoutInflater
+import android.view.Menu
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
+import android.graphics.Typeface
 import android.widget.TextView
+import androidx.appcompat.widget.PopupMenu
 import androidx.core.text.toSpanned
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.aaps.core.data.configuration.Constants
@@ -220,6 +223,54 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             sp.putBoolean(app.aaps.core.utils.R.string.key_objectiveusescale, true)
             false
         }
+
+        val selectedScale = sp.getInt(app.aaps.core.utils.R.string.key_rangetodisplay, 6)
+        when (selectedScale) {
+            6   -> binding.graphsLayout.graphScale6h.isChecked = true
+            12  -> binding.graphsLayout.graphScale12h.isChecked = true
+            18  -> binding.graphsLayout.graphScale18h.isChecked = true
+            24  -> binding.graphsLayout.graphScale24h.isChecked = true
+        }
+
+        binding.graphsLayout.chartMenuButton.setOnLongClickListener { v: View ->
+            val popup = PopupMenu(v.context, v)
+            popup.menu.add(Menu.NONE, 6, Menu.NONE, rh.gq(app.aaps.core.ui.R.plurals.hours, 6, 6))
+            popup.menu.add(Menu.NONE, 12, Menu.NONE, rh.gq(app.aaps.core.ui.R.plurals.hours, 12, 12))
+            popup.menu.add(Menu.NONE, 18, Menu.NONE, rh.gq(app.aaps.core.ui.R.plurals.hours, 18, 18))
+            popup.menu.add(Menu.NONE, 24, Menu.NONE, rh.gq(app.aaps.core.ui.R.plurals.hours, 24, 24))
+            popup.setOnMenuItemClickListener {
+                // id == Range to display ...
+                sp.putInt(app.aaps.core.utils.R.string.key_rangetodisplay, it.itemId)
+                rxBus.send(EventPreferenceChange(rh.gs(app.aaps.core.utils.R.string.key_rangetodisplay)))
+                return@setOnMenuItemClickListener true
+            }
+            binding.graphsLayout.chartMenuButton.setImageResource(R.drawable.ic_arrow_drop_up_white_24dp)
+            popup.setOnDismissListener { binding.graphsLayout.chartMenuButton.setImageResource(R.drawable.ic_arrow_drop_down_white_24dp) }
+            popup.show()
+            false
+        }
+
+        binding.graphsLayout.graphScale6h.setOnClickListener {
+            sp.putInt(app.aaps.core.utils.R.string.key_rangetodisplay, 6)
+            resetScaleText()
+            rxBus.send(EventPreferenceChange(rh.gs(app.aaps.core.utils.R.string.key_rangetodisplay)))
+        }
+        binding.graphsLayout.graphScale12h.setOnClickListener {
+            sp.putInt(app.aaps.core.utils.R.string.key_rangetodisplay, 12)
+            resetScaleText()
+            rxBus.send(EventPreferenceChange(rh.gs(app.aaps.core.utils.R.string.key_rangetodisplay)))
+        }
+        binding.graphsLayout.graphScale18h.setOnClickListener {
+            sp.putInt(app.aaps.core.utils.R.string.key_rangetodisplay, 18)
+            resetScaleText()
+            rxBus.send(EventPreferenceChange(rh.gs(app.aaps.core.utils.R.string.key_rangetodisplay)))
+        }
+        binding.graphsLayout.graphScale24h.setOnClickListener {
+            sp.putInt(app.aaps.core.utils.R.string.key_rangetodisplay, 24)
+            resetScaleText()
+            rxBus.send(EventPreferenceChange(rh.gs(app.aaps.core.utils.R.string.key_rangetodisplay)))
+        }
+
         prepareGraphsIfNeeded(overviewMenus.setting.size)
         context?.let { overviewMenus.setupChartMenu(it, binding.graphsLayout.chartMenuButton) }
         binding.graphsLayout.chartMenuButton.visibility = preferences.simpleMode.not().toVisibility()
@@ -239,6 +290,20 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         binding.buttonsLayout.quickWizardButton.setOnLongClickListener(this)
         binding.infoLayout.apsMode.setOnClickListener(this)
         binding.infoLayout.apsMode.setOnLongClickListener(this)
+    }
+
+    fun resetScaleText() {
+        binding.graphsLayout.graphScale6h.setTypeface(null, Typeface.NORMAL)
+        binding.graphsLayout.graphScale12h.setTypeface(null, Typeface.NORMAL)
+        binding.graphsLayout.graphScale18h.setTypeface(null, Typeface.NORMAL)
+        binding.graphsLayout.graphScale24h.setTypeface(null, Typeface.NORMAL)
+
+        when (sp.getInt(app.aaps.core.utils.R.string.key_rangetodisplay,6)) {
+            6   -> binding.graphsLayout.graphScale6h.setTypeface(null, Typeface.BOLD)
+            12  -> binding.graphsLayout.graphScale12h.setTypeface(null, Typeface.BOLD)
+            18  -> binding.graphsLayout.graphScale18h.setTypeface(null, Typeface.BOLD)
+            24  -> binding.graphsLayout.graphScale24h.setTypeface(null, Typeface.BOLD)
+        }
     }
 
     @Synchronized
@@ -351,6 +416,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         if (!config.appInitialized) return
         runOnUiThread {
             _binding ?: return@runOnUiThread
+            resetScaleText()
             updateTime()
             updateSensitivity()
             updateGraph()

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewMenusImpl.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewMenusImpl.kt
@@ -175,6 +175,7 @@ class OverviewMenusImpl @Inject constructor(
             }
 
             popup.setOnMenuItemClickListener {
+                var keepMenu = false
                 synchronized(this) {
                     try {
                         // id < 100 graph header - divider 1, 2, 3 .....
@@ -191,17 +192,20 @@ class OverviewMenusImpl @Inject constructor(
                             it.itemId == numOfGraphs                           -> {
                                 // add new empty
                                 _setting.add(Array(CharTypeData.entries.size) { false })
+                                keepMenu = true
                             }
 
                             it.itemId < 100                                    -> {
                                 // remove graph
                                 _setting.removeAt(it.itemId)
+                                keepMenu = true
                             }
 
                             else                                               -> {
                                 val graphNumber = it.itemId / 100 - 1
                                 val item = it.itemId % 100
                                 _setting[graphNumber][item] = !it.isChecked
+                                keepMenu = true
                             }
                         }
                     } catch (exception: Exception) {
@@ -210,6 +214,8 @@ class OverviewMenusImpl @Inject constructor(
                 }
                 storeGraphConfig()
                 setupChartMenu(context, chartButton)
+                if (keepMenu)
+                    chartButton.performClick()
                 rxBus.send(EventRefreshOverview("OnMenuItemClickListener", now = true))
                 return@setOnMenuItemClickListener true
             }

--- a/plugins/main/src/main/res/layout/overview_graphs_layout.xml
+++ b/plugins/main/src/main/res/layout/overview_graphs_layout.xml
@@ -6,6 +6,63 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <LinearLayout
+        android:id="@+id/graph_scale"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.google.android.material.chip.ChipGroup
+            android:layout_width="0dp"
+            android:layout_height="35dp"
+            android:layout_weight="1"
+            app:singleSelection="true"
+            app:chipSpacing="10dp">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/graph_scale_6h"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/graph_scale_6h"
+                android:contentDescription="@string/a11y_graph_scale_6h"
+                style="@style/Widget.MaterialComponents.Chip.Choice" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/graph_scale_12h"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/graph_scale_12h"
+                android:contentDescription="@string/a11y_graph_scale_12h"
+                style="@style/Widget.MaterialComponents.Chip.Choice" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/graph_scale_18h"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/graph_scale_18h"
+                android:contentDescription="@string/a11y_graph_scale_18h"
+                style="@style/Widget.MaterialComponents.Chip.Choice" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/graph_scale_24h"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/graph_scale_24h"
+                android:contentDescription="@string/a11y_graph_scale_24h"
+                style="@style/Widget.MaterialComponents.Chip.Choice" />
+
+        </com.google.android.material.chip.ChipGroup>
+
+        <ImageButton
+            android:id="@+id/chart_menu_button"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_gravity="end"
+            android:contentDescription="@string/chart_menu"
+            app:srcCompat="@drawable/ic_arrow_drop_down_white_24dp" />
+
+    </LinearLayout>
+
     <RelativeLayout
         android:layout_width="wrap_content"
         android:layout_height="0dp"
@@ -16,17 +73,6 @@
             android:layout_width="wrap_content"
             android:layout_height="200dp"
             android:contentDescription="@string/a11y_graph" />
-
-        <ImageButton
-            android:id="@+id/chart_menu_button"
-            android:layout_width="30dp"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginEnd="3dp"
-            android:contentDescription="@string/chart_menu"
-            android:paddingTop="5dp"
-            app:srcCompat="@drawable/ic_arrow_drop_down_white_24dp" />
 
     </RelativeLayout>
 

--- a/plugins/main/src/main/res/values/strings.xml
+++ b/plugins/main/src/main/res/values/strings.xml
@@ -203,7 +203,15 @@
     <string name="statuslights_bat_warning">Threshold warning pump battery level [%]</string>
     <string name="statuslights_bat_critical">Threshold critical pump battery level [%]</string>
     <string name="statuslights_copy_ns">Copy settings from NS</string>
+    <string name="graph_scale_6h">6h</string>
+    <string name="graph_scale_12h">12h</string>
+    <string name="graph_scale_18h">18h</string>
+    <string name="graph_scale_24h">24h</string>
     <string name="a11y_graph">graph</string>
+    <string name="a11y_graph_scale_6h">graph scale 6 hours</string>
+    <string name="a11y_graph_scale_12h">graph scale 12 hours</string>
+    <string name="a11y_graph_scale_18h">graph scale 18 hours</string>
+    <string name="a11y_graph_scale_24h">graph scale 24 hours</string>
     <string name="a11y_insulin_label">insulin</string>
     <string name="chart_menu">Chart menu</string>
     <string name="a11y_bg_quality">blood glucose quality</string>


### PR DESCRIPTION
An alternative solution to https://github.com/nightscout/AndroidAPS/pull/3306 - instead of having text overlayed on the graph, added buttons to switch between scales.

Users can tap on buttons to quickly switch between graph scales instead of doing it with 3 actions. This will also make the dropdown exclusively for graph data management.

Todo:
- Remove graph scale from the dropdown menu
- Remove long tap on graph to switch between graph scales

<img src="https://github.com/nightscout/AndroidAPS/assets/4112129/0ec076fc-545f-42bc-8c8a-fee54454efbf" width="350">