### PR TITLE
Medtrum UI improvements

### DIFF
--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPump.kt
@@ -582,6 +582,9 @@ class MedtrumPump @Inject constructor(
         patchId = 0
         syncedSequenceNumber = 1
         currentSequenceNumber = 1
+        reservoir = 0.0
+        batteryVoltage_B = 0.0
+        patchStartTime = 0L
     }
 
     fun handleNewPatch(newPatchId: Long, sequenceNumber: Int, newStartTime: Long) {

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/MedtrumActivateCompleteFragment.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/MedtrumActivateCompleteFragment.kt
@@ -3,8 +3,12 @@ package info.nightscout.pump.medtrum.ui
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.ViewModelProvider
+import app.aaps.core.data.ue.Action
+import app.aaps.core.data.ue.Sources
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.logging.UserEntryLogger
+import app.aaps.core.interfaces.maintenance.ImportExportPrefs
 import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.ui.toast.ToastUtils
 import info.nightscout.pump.medtrum.R
@@ -16,6 +20,8 @@ class MedtrumActivateCompleteFragment : MedtrumBaseFragment<FragmentMedtrumActiv
 
     @Inject lateinit var aapsLogger: AAPSLogger
     @Inject lateinit var rh: ResourceHelper
+    @Inject lateinit var uel: UserEntryLogger
+    @Inject lateinit var importExportPrefs: ImportExportPrefs
 
     companion object {
 
@@ -41,6 +47,13 @@ class MedtrumActivateCompleteFragment : MedtrumBaseFragment<FragmentMedtrumActiv
                         }
                     }
                 }
+            }
+        }
+        binding.navExport.setOnClickListener {
+            uel.log(Action.EXPORT_SETTINGS, Sources.Maintenance)
+            // start activity for checking permissions...
+            importExportPrefs.verifyStoragePermissions(this) {
+                importExportPrefs.exportSharedPreferences(this)
             }
         }
     }

--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -205,8 +205,12 @@ class MedtrumOverviewViewModel @Inject constructor(
         _patchNo.postValue(medtrumPump.patchId.toString())
 
         if (medtrumPump.desiredPatchExpiration) {
-            val expiry = medtrumPump.patchStartTime + T.hours(72).msecs()
-            _patchExpiry.postValue(dateUtil.dateAndTimeString(expiry))
+            if (medtrumPump.patchStartTime == 0L) {
+                _patchExpiry.postValue("")
+            } else {
+                val expiry = medtrumPump.patchStartTime + T.hours(72).msecs()
+                _patchExpiry.postValue(dateUtil.dateAndTimeString(expiry))
+            }
         } else {
             _patchExpiry.postValue(rh.gs(R.string.expiry_not_enabled))
         }

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_activate_complete.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_activate_complete.xml
@@ -40,18 +40,51 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
+                android:id="@+id/text_can_export_settings"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="5dp"
+                android:gravity="center"
+                android:text="@string/can_export_settings"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_activating_complete" />
+
+            <app.aaps.core.ui.elements.SingleClickButton
+                android:id="@+id/nav_export"
+                style="@style/GrayButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="5dp"
+                android:drawableTop="@drawable/ic_export_settings"
+                android:padding="5dp"
+                android:text="@string/nav_export"
+                android:textSize="11sp"
+                app:layout_column="0"
+                app:layout_columnWeight="1"
+                app:layout_gravity="fill"
+                app:layout_constraintTop_toBottomOf="@+id/text_can_export_settings"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <TextView
                 android:id="@+id/text_press_OK_to_return"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
-                android:layout_marginTop="5dp"
+                android:layout_marginTop="20dp"
                 android:layout_marginEnd="5dp"
                 android:gravity="center"
                 android:text="@string/press_OK_to_return"
                 android:textSize="16sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_activating_complete" />
+                app:layout_constraintTop_toBottomOf="@+id/nav_export" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_button"

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch_connect.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_prepare_patch_connect.xml
@@ -54,6 +54,20 @@
                 app:layout_constraintTop_toBottomOf="@+id/text_connect_pump_base" />
 
             <TextView
+                android:id="@+id/text_reservoir_level"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="5dp"
+                android:gravity="center"
+                android:text="@{@string/reservoir_text_and_level(viewModel.medtrumPump.reservoirFlow)}"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_note_min_70" />
+
+            <TextView
                 android:id="@+id/do_not_attach"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="patch_not_active_note">Pump base should not be connected to the patch until the next step!</string>
     <string name="connect_pump_base">Connect pump base to a new patch, remove the residual air and fill with insulin, then press <b>Next</b>.</string>
     <string name="note_min_70_units">Note: A minimum of 70 units is required for activation.</string>
+    <string name="reservoir_text_and_level">Reservoir: %.2f U</string>
     <string name="do_not_attach_to_body">Do not attach the patch to the body yet.</string>
     <string name="half_press_needle">Half-press needle button. Then tap <b>Next</b> to start prime.</string>
     <string name="wait_for_priming">Please wait for the priming to complete.</string>

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="activating_pump">Activating pump and setting initial basal rate. Please Wait.</string>
     <string name="activating_error">Failed to activate, press <b>Retry</b> to try again.</string>
     <string name="activating_complete">New patch activated. %.2f Units remaining.</string>
+    <string name="can_export_settings">You can export the settings to be able to recover this patch session later.</string>
     <string name="press_OK_to_return">Press <b>OK</b> to return to main screen.</string>
 
     <string name="deactivate_sure">Are you sure that you want to deactivate the current patch?</string>


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/3328

- Show reservoir level on filling screen (dynamic), so user can see how much it is filling in the patch
- Reset more parameters so overview screen makes more sense when patch is stopped
- Show export button when activation is complete, allowing users to export their settings without going trough the maintenance menu

![Screenshot_20240510-113744_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/a18b5863-1de5-403a-bfc9-da067718b2c5)
![Screenshot_20240510-114500_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/47c4e6ae-b068-4908-8bda-55ab20fad3b4)
![Screenshot_20240510-114637_AAPS](https://github.com/nightscout/AndroidAPS/assets/60566713/5cec79fb-6f33-44ac-81ef-6c2038899382)
