### PR TITLE
Rearrange buttons in actions tab to save screen space 

### DIFF
--- a/plugins/main/src/main/res/layout/actions_fragment.xml
+++ b/plugins/main/src/main/res/layout/actions_fragment.xml
@@ -204,21 +204,6 @@
                     app:layout_row="2" />
 
                 <app.aaps.core.ui.elements.SingleClickButton
-                    android:id="@+id/fill"
-                    style="@style/GrayButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:drawableTop="@drawable/ic_cp_pump_cannula"
-                    android:paddingStart="0dp"
-                    android:paddingEnd="0dp"
-                    android:text="@string/prime_fill"
-                    android:textSize="11sp"
-                    app:layout_column="1"
-                    app:layout_columnWeight="1"
-                    app:layout_gravity="fill"
-                    app:layout_row="2" />
-
-                <app.aaps.core.ui.elements.SingleClickButton
                     android:id="@+id/cgm_sensor_insert"
                     style="@style/GrayButton"
                     android:layout_width="0dp"
@@ -227,6 +212,21 @@
                     android:paddingStart="0dp"
                     android:paddingEnd="0dp"
                     android:text="@string/cgm_sensor_insert"
+                    android:textSize="11sp"
+                    app:layout_column="1"
+                    app:layout_columnWeight="1"
+                    app:layout_gravity="fill"
+                    app:layout_row="2" />
+
+                <app.aaps.core.ui.elements.SingleClickButton
+                    android:id="@+id/fill"
+                    style="@style/GrayButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableTop="@drawable/ic_cp_pump_cannula"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="0dp"
+                    android:text="@string/prime_fill"
                     android:textSize="11sp"
                     app:layout_column="0"
                     app:layout_columnWeight="1"


### PR DESCRIPTION
When using pump Omnipod Dash (without battery/priming need) the action tab look like this now:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/66a77c83-576b-412f-845b-f05d99f90a98)


This PR will change it so that there will be less scrolling in action tab and look like this:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/192076ff-abe4-4b6f-8ca5-3a06f20dce6b)


For pumps with battery/priming it will look like this.
Before:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/79010b8c-c9b2-4209-be07-e6f70391fa9f)

After:
![image](https://github.com/nightscout/AndroidAPS/assets/114103483/abdd812c-1016-48bd-9609-6d45d3ced343)
