### PR TITLE
Unify default temp target value and duration in phone/wear.

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/TempTargetDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/TempTargetDialog.kt
@@ -74,19 +74,19 @@ class TempTargetDialog : DialogFragmentWithDate() {
 
         binding.duration.setParams(
             savedInstanceState?.getDouble("duration")
-                ?: 0.0, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, binding.okcancel.ok
+                ?: 60.0, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, binding.okcancel.ok
         )
 
         if (profileUtil.units == GlucoseUnit.MMOL)
             binding.temptarget.setParams(
                 savedInstanceState?.getDouble("tempTarget")
-                    ?: 8.0,
+                    ?: 5.6,
                 Constants.MIN_TT_MMOL, Constants.MAX_TT_MMOL, 0.1, DecimalFormat("0.0"), false, binding.okcancel.ok
             )
         else
             binding.temptarget.setParams(
                 savedInstanceState?.getDouble("tempTarget")
-                    ?: 144.0,
+                    ?: 101.0,
                 Constants.MIN_TT_MGDL, Constants.MAX_TT_MGDL, 1.0, DecimalFormat("0"), false, binding.okcancel.ok
             )
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
@@ -62,10 +62,10 @@ class TempTargetActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 val title = if (isSingleTarget) getString(R.string.action_target) else getString(R.string.action_low)
                 if (isMGDL) {
-                    var initValue = SafeParse.stringToDouble(lowRange?.editText?.text.toString(), 100.0)
+                    var initValue = SafeParse.stringToDouble(lowRange?.editText?.text.toString(), 101.0)
                     lowRange = PlusMinusEditText(viewAdapter, initValue, 72.0, 180.0, 1.0, DecimalFormat("0"), false, title)
                 } else {
-                    var initValue = SafeParse.stringToDouble(lowRange?.editText?.text.toString(), 5.5)
+                    var initValue = SafeParse.stringToDouble(lowRange?.editText?.text.toString(), 5.6)
                     lowRange = PlusMinusEditText(viewAdapter, initValue, 4.0, 10.0, 0.1, DecimalFormat("#0.0"), false, title)
                 }
                 container.addView(view)


### PR DESCRIPTION
Discussed at Discord. https://discord.com/channels/629952586895851530/801760569342165004/1240017765318918164
Feel free to comment if you mean there are better default values than what PR suggest. :)

Today in AAPS wear when you use the Temp Target button default values are 5,5 mmol/l and 60 minutes duration. When hitting temp target button in AAPS phone app default values are 8,0 mmol/l and 0 minutes duration. When needing a custom TT both of these default values requires some clicking.

This PR will unify default TT value to 5.6 mmol/l or 101 mg/dl and 60 min duration in phone/wear. Activating this custom TT will disable SMBs in most setups of AAPS both for mmol/l and mg/dl. (Enable SMB when High TT is recommended OFF)
 
 This will in turn lead to fewer clicks for most users when activating custom TT's.

![image](https://github.com/nightscout/AndroidAPS/assets/114103483/a527f9a9-aa79-4d06-a5b2-25c5ffa549f4)
