### PR TITLE
Fix Graph Menu in History Browser

### DIFF
--- a/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
@@ -181,6 +181,10 @@ class HistoryBrowseActivity : TranslatedDaggerAppCompatActivity() {
             .observeOn(aapsSchedulers.main)
             .subscribe({ updateGUI("EventRefreshOverview") }, fabricPrivacy::logException)
         disposable += rxBus
+            .toObservable(EventRefreshOverview::class.java)
+            .observeOn(aapsSchedulers.main)
+            .subscribe({ updateGUI("EventRefreshOverview") }, fabricPrivacy::logException)
+        disposable += rxBus
             .toObservable(EventScale::class.java)
             .observeOn(aapsSchedulers.main)
             .subscribe({

--- a/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
@@ -112,6 +112,7 @@ class HistoryBrowseActivity : TranslatedDaggerAppCompatActivity() {
             loadAll("onLongClickZoom")
             true
         }
+        binding.chartMenuButton.visibility = preferences.simpleMode.not().toVisibility()
 
         binding.date.setOnClickListener {
             MaterialDatePicker.Builder.datePicker()


### PR DESCRIPTION
Fix #3341
- Hide Graph menu button in History Browser when SimpleMode is selected (same behaviour than OverView)
- Update Graph Settings within History Browser when modification is done from Graph menu