### PR TITLE
Fix Overlapping in Step Graph

### DIFF
--- a/core/graph/src/main/kotlin/app/aaps/core/graph/data/StepsDataPoint.kt
+++ b/core/graph/src/main/kotlin/app/aaps/core/graph/data/StepsDataPoint.kt
@@ -15,7 +15,7 @@ class StepsDataPoint(
     override fun setY(y: Double) {}
 
     override val label: String = ""
-    override val duration = 900000L
+    override val duration = 300000L
     override val shape = Shape.STEPS
     override val size = 10f
     override val paintStyle: Paint.Style = Paint.Style.FILL


### PR DESCRIPTION
Fix #3154
Step duration 5min and graph duration was previously 15min

This PR use same duration for graph
=> Overlapping is not completely removed (within watch we have one measure every 40s but it improves graph readings