### PR TITLE
Change visibility of Boluswizard and Insulin button in AAPSClient

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -583,10 +583,14 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 (profile != null && preferences.get(BooleanKey.OverviewShowCarbsButton)).toVisibility()
             binding.buttonsLayout.treatmentButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
                 && preferences.get(BooleanKey.OverviewShowTreatmentButton)).toVisibility()
-            binding.buttonsLayout.wizardButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
+            if (config.APS) { binding.buttonsLayout.wizardButton.visibility = (!loop.isDisconnected && pump.isInitialized() && !pump.isSuspended() && profile != null
                 && preferences.get(BooleanKey.OverviewShowWizardButton)).toVisibility()
+            } else {
+                binding.buttonsLayout.wizardButton.visibility =
+                    (profile != null && preferences.get(BooleanKey.OverviewShowWizardButton)).toVisibility()
+            }
             binding.buttonsLayout.insulinButton.visibility = (profile != null && preferences.get(BooleanKey.OverviewShowInsulinButton)).toVisibility()
-            if (loop.isDisconnected || !pump.isInitialized() || pump.isSuspended()) {
+            if (config.APS && (loop.isDisconnected || !pump.isInitialized() || pump.isSuspended())) {
                 setRibbon(
                     binding.buttonsLayout.insulinButton,
                     app.aaps.core.ui.R.attr.ribbonTextWarningColor,


### PR DESCRIPTION
You can't bolus via pump from AAPSClient, thus it makes no sense to hide Insulin and Boluswizard button in AAPSClient when pump is disconnected from AAPS. This change will make visibility to these buttons to be similar to that of Carbs button.

We disconnect pump in AAPS when our son goes swimming, and it would be useful to check Bolus wizard for missing carbs for example in AAPSClient.

| AAPS (Pump connected) | AAPSClient (Pump connected) |
|--------|--------|
| ![image](https://github.com/nightscout/AndroidAPS/assets/114103483/4e3048ed-5d84-43fa-8d40-6cc6bbc9e7ab) | ![image](https://github.com/nightscout/AndroidAPS/assets/114103483/b4839a04-1dc8-4244-adec-f41a503a580b) |
| AAPS (Pump disconnected) | AAPSClient (Pump disconnected) |
| ![image](https://github.com/nightscout/AndroidAPS/assets/114103483/17b7a023-f928-4294-ba83-83d31e6603a5) | ![image](https://github.com/nightscout/AndroidAPS/assets/114103483/97360143-2e82-47a9-9994-cb4817c822ff) | 