### PR TITLE
add simple stop SMB button functionality

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -51,6 +51,7 @@ import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.profile.ProfileUtil
 import app.aaps.core.interfaces.protection.ProtectionCheck
 import app.aaps.core.interfaces.pump.defs.determineCorrectBolusStepSize
+import app.aaps.core.interfaces.queue.Command
 import app.aaps.core.interfaces.queue.CommandQueue
 import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.rx.AapsSchedulers
@@ -239,6 +240,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         binding.buttonsLayout.quickWizardButton.setOnLongClickListener(this)
         binding.infoLayout.apsMode.setOnClickListener(this)
         binding.infoLayout.apsMode.setOnLongClickListener(this)
+        binding.stopButton.setOnClickListener(this)
     }
 
     @Synchronized
@@ -470,6 +472,13 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                         if (isAdded) uiInteraction.runLoopDialog(childFragmentManager, 1)
                     })
                 }
+
+                R.id.stop_button         -> {
+                    aapsLogger.debug("Stop SMB delivery button pressed")
+                    binding.pumpStatusLayout.visibility = View.GONE
+                    commandQueue.cancelAllBoluses(null)
+                }
+
             }
         }
     }
@@ -1180,6 +1189,12 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
         val status = overviewData.pumpStatus
         binding.pumpStatus.text = status
         binding.pumpStatusLayout.visibility = (status != "").toVisibility()
+
+        if (commandQueue.performing()?.commandType == Command.CommandType.SMB_BOLUS) {
+            binding.stopButton.visibility = View.VISIBLE
+        } else {
+            binding.stopButton.visibility = View.GONE
+        }
     }
 
     private fun updateNotification() {

--- a/plugins/main/src/main/res/layout/overview_fragment.xml
+++ b/plugins/main/src/main/res/layout/overview_fragment.xml
@@ -207,27 +207,40 @@
 
     </androidx.core.widget.NestedScrollView>
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/pump_status_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
+        android:background="?attr/pumpStatusBackground"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
         android:visibility="gone">
 
         <TextView
             android:id="@+id/pump_status"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
-            android:layout_marginEnd="5dp"
-            android:background="?attr/pumpStatusBackground"
-            android:gravity="center_vertical|center_horizontal"
-            android:paddingTop="6dp"
-            android:paddingBottom="6dp"
+            android:layout_centerInParent="true"
+            android:gravity="center"
             android:text="@string/initializing"
             android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    </LinearLayout>
+        <Button
+            android:id="@+id/stop_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:text="@string/stop"
+            android:backgroundTint="?attr/bolusColor"
+            android:textColor="?attr/defaultTextColor"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:layout_marginEnd="16dp"
+            android:visibility="gone" />
+
+    </RelativeLayout>
 
     <ProgressBar
         android:id="@+id/progress_bar"


### PR DESCRIPTION
Added a Stop button when a SMB is administering like requested in the picture from the issue. 
The LinearLayout was changed to RelativeLayout so that the button doesn't move the text to the left.
When clicking the button the same logic gets executed as when stopping a normal bolus.

Fixes #2572