### PR TITLE
Remove TDD capability from Insight Pump

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/pump/defs/PumpCapability.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/pump/defs/PumpCapability.kt
@@ -22,7 +22,7 @@ enum class PumpCapability {
 
     //DanaWithHistoryCapabilities(arrayOf(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, StoreCarbInfo, TDD, ManualTDDLoad)),
     DanaWithHistoryCapabilities(arrayOf(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD, ManualTDDLoad)),
-    InsightCapabilities(arrayOf(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD, BasalRate30min)),
+    InsightCapabilities(arrayOf(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, BasalRate30min)),
     MedtronicCapabilities(arrayOf(Bolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD)),
     OmnipodCapabilities(arrayOf(Bolus, TempBasal, BasalProfileSet, BasalRate30min)),
     YpsomedCapabilities(arrayOf(Bolus, ExtendedBolus, TempBasal, BasalProfileSet, Refill, ReplaceBattery, TDD, ManualTDDLoad)),  // BasalRates (separately grouped)


### PR DESCRIPTION
Got several times issues on informations provided by TDD button for Insight pump
=> I think this tab is not relevant for Insight pump (Prime from AAPS included into Bolus, Basal/Bolus not correct due to TBR emulation, manual Bolus with Pen not included...)

I think it's better to remove this capability for Insight pump...