### PR TITLE
Fix HR and Step with third party watchfaces

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
@@ -93,7 +93,6 @@ class DataLayerListenerServiceWear : WearableListenerService() {
             .toObservable(EventWearPreferenceChange::class.java)
             .observeOn(aapsSchedulers.main)
             .subscribe { event: EventWearPreferenceChange ->
-                if (event.changedKey != null && event.changedKey == "delta_granularity") rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace:onSharedPreferenceChanged")))
                 if (event.changedKey == getString(R.string.key_heart_rate_sampling)) updateHeartRateListener()
                 if (event.changedKey == getString(R.string.key_steps_sampling)) updatestepsCountListener()
             }

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
@@ -15,11 +15,15 @@ import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventWearDataToMobile
 import app.aaps.core.interfaces.rx.events.EventWearToMobile
 import app.aaps.core.interfaces.rx.weardata.EventData
+import app.aaps.core.interfaces.rx.weardata.EventData.ActionResendData
 import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.shared.impl.weardata.ZipWatchfaceFormat
 import app.aaps.wear.R
+import app.aaps.wear.events.EventWearPreferenceChange
+import app.aaps.wear.heartrate.HeartRateListener
 import app.aaps.wear.interaction.ConfigurationActivity
 import app.aaps.wear.interaction.utils.Persistence
+import app.aaps.wear.wearStepCount.StepCountListener
 import com.google.android.gms.tasks.Tasks
 import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.CapabilityInfo
@@ -61,6 +65,8 @@ class DataLayerListenerServiceWear : WearableListenerService() {
     private var handler = Handler(HandlerThread(this::class.simpleName + "Handler").also { it.start() }.looper)
 
     private val disposable = CompositeDisposable()
+    private var heartRateListener: HeartRateListener? = null
+    private var stepCountListener: StepCountListener? = null
 
     private val rxPath get() = getString(app.aaps.core.interfaces.R.string.path_rx_bridge)
     private val rxDataPath get() = getString(app.aaps.core.interfaces.R.string.path_rx_data_bridge)
@@ -83,6 +89,17 @@ class DataLayerListenerServiceWear : WearableListenerService() {
             .subscribe {
                 sendMessage(rxDataPath, it.payload.serializeByte())
             }
+        disposable += rxBus
+            .toObservable(EventWearPreferenceChange::class.java)
+            .observeOn(aapsSchedulers.main)
+            .subscribe { event: EventWearPreferenceChange ->
+                if (event.changedKey != null && event.changedKey == "delta_granularity") rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace:onSharedPreferenceChanged")))
+                if (event.changedKey == getString(R.string.key_heart_rate_sampling)) updateHeartRateListener()
+                if (event.changedKey == getString(R.string.key_steps_sampling)) updatestepsCountListener()
+            }
+
+        updateHeartRateListener()
+        updatestepsCountListener()
     }
 
     override fun onCapabilityChanged(p0: CapabilityInfo) {
@@ -172,6 +189,37 @@ class DataLayerListenerServiceWear : WearableListenerService() {
             .setContentIntent(pendingIntent)
             .build()
         startForeground(FOREGROUND_NOTIF_ID, notification)
+    }
+
+
+    private fun updateHeartRateListener() {
+        if (sp.getBoolean(R.string.key_heart_rate_sampling, false)) {
+            if (heartRateListener == null) {
+                heartRateListener = HeartRateListener(
+                    this, aapsLogger, aapsSchedulers
+                ).also { hrl -> disposable += hrl }
+            }
+        } else {
+            heartRateListener?.let { hrl ->
+                disposable.remove(hrl)
+                heartRateListener = null
+            }
+        }
+    }
+
+    private fun updatestepsCountListener() {
+        if (sp.getBoolean(R.string.key_steps_sampling, false)) {
+            if (stepCountListener == null) {
+                stepCountListener = StepCountListener(
+                    this, aapsLogger, aapsSchedulers
+                ).also { scl -> disposable += scl }
+            }
+        } else {
+            stepCountListener?.let { scl ->
+                disposable.remove(scl)
+                stepCountListener = null
+            }
+        }
     }
 
     @Suppress("PrivatePropertyName")

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/BaseWatchFace.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/BaseWatchFace.kt
@@ -109,8 +109,6 @@ abstract class BaseWatchFace : WatchFace() {
 
     private var mLastSvg = ""
     private var mLastDirection = ""
-    //private var heartRateListener: HeartRateListener? = null
-    //private var stepCountListener: StepCountListener? = null
 
     override fun onCreate() {
         // Not derived from DaggerService, do injection here
@@ -127,8 +125,6 @@ abstract class BaseWatchFace : WatchFace() {
             .subscribe { event: EventWearPreferenceChange ->
                 simpleUi.updatePreferences()
                 if (event.changedKey != null && event.changedKey == "delta_granularity") rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace:onSharedPreferenceChanged")))
-                //if (event.changedKey == getString(R.string.key_heart_rate_sampling)) updateHeartRateListener()
-                //if (event.changedKey == getString(R.string.key_steps_sampling)) updatestepsCountListener()
                 if (layoutSet) setDataFields()
                 invalidate()
             }
@@ -153,45 +149,13 @@ abstract class BaseWatchFace : WatchFace() {
         layoutView = binding.root
         performViewSetup()
         rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace::onCreate")))
-        //updateHeartRateListener()
-        //updatestepsCountListener()
     }
 
     private fun forceUpdate() {
         setDataFields()
         invalidate()
     }
-/*
-    private fun updateHeartRateListener() {
-        if (sp.getBoolean(R.string.key_heart_rate_sampling, false)) {
-            if (heartRateListener == null) {
-                heartRateListener = HeartRateListener(
-                    this, aapsLogger, aapsSchedulers
-                ).also { hrl -> disposable += hrl }
-            }
-        } else {
-            heartRateListener?.let { hrl ->
-                disposable.remove(hrl)
-                heartRateListener = null
-            }
-        }
-    }
 
-    private fun updatestepsCountListener() {
-        if (sp.getBoolean(R.string.key_steps_sampling, false)) {
-            if (stepCountListener == null) {
-                stepCountListener = StepCountListener(
-                    this, aapsLogger, aapsSchedulers
-                ).also { scl -> disposable += scl }
-            }
-        } else {
-            stepCountListener?.let { scl ->
-                disposable.remove(scl)
-                stepCountListener = null
-            }
-        }
-    }
-*/
     override fun onTapCommand(tapType: Int, x: Int, y: Int, eventTime: Long) {
         binding.chart?.let { chart ->
             if (tapType == TAP_TYPE_TAP && x >= chart.left && x <= chart.right && y >= chart.top && y <= chart.bottom) {

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/BaseWatchFace.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/BaseWatchFace.kt
@@ -109,8 +109,8 @@ abstract class BaseWatchFace : WatchFace() {
 
     private var mLastSvg = ""
     private var mLastDirection = ""
-    private var heartRateListener: HeartRateListener? = null
-    private var stepCountListener: StepCountListener? = null
+    //private var heartRateListener: HeartRateListener? = null
+    //private var stepCountListener: StepCountListener? = null
 
     override fun onCreate() {
         // Not derived from DaggerService, do injection here
@@ -127,8 +127,8 @@ abstract class BaseWatchFace : WatchFace() {
             .subscribe { event: EventWearPreferenceChange ->
                 simpleUi.updatePreferences()
                 if (event.changedKey != null && event.changedKey == "delta_granularity") rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace:onSharedPreferenceChanged")))
-                if (event.changedKey == getString(R.string.key_heart_rate_sampling)) updateHeartRateListener()
-                if (event.changedKey == getString(R.string.key_steps_sampling)) updatestepsCountListener()
+                //if (event.changedKey == getString(R.string.key_heart_rate_sampling)) updateHeartRateListener()
+                //if (event.changedKey == getString(R.string.key_steps_sampling)) updatestepsCountListener()
                 if (layoutSet) setDataFields()
                 invalidate()
             }
@@ -153,15 +153,15 @@ abstract class BaseWatchFace : WatchFace() {
         layoutView = binding.root
         performViewSetup()
         rxBus.send(EventWearToMobile(ActionResendData("BaseWatchFace::onCreate")))
-        updateHeartRateListener()
-        updatestepsCountListener()
+        //updateHeartRateListener()
+        //updatestepsCountListener()
     }
 
     private fun forceUpdate() {
         setDataFields()
         invalidate()
     }
-
+/*
     private fun updateHeartRateListener() {
         if (sp.getBoolean(R.string.key_heart_rate_sampling, false)) {
             if (heartRateListener == null) {
@@ -191,7 +191,7 @@ abstract class BaseWatchFace : WatchFace() {
             }
         }
     }
-
+*/
     override fun onTapCommand(tapType: Int, x: Int, y: Int, eventTime: Long) {
         binding.chart?.let { chart ->
             if (tapType == TAP_TYPE_TAP && x >= chart.left && x <= chart.right && y >= chart.top && y <= chart.bottom) {


### PR DESCRIPTION
HR and steps stop to be sent to AAPS when a third party watchface is selected...
=> I moved the launch of Steps and HR listeners from BaseWatchFace to DataLayerListenerServiceWear to fix it
I don't know if it's the best architecture but with this modif it works on my side...