### PR TITLE
get rid of 30sec extra blockage of SMB after SMBInterval

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/DetermineBasalSMB.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/DetermineBasalSMB.kt
@@ -1034,9 +1034,6 @@ class DetermineBasalSMB @Inject constructor(
             insulinReq = round(insulinReq, 3)
             rT.insulinReq = insulinReq
             //console.error(iob_data.lastBolusTime);
-            // minutes since last bolus
-            val lastBolusAge = round((systemTime - iob_data.lastBolusTime) / 60000.0, 1)
-            //console.error(lastBolusAge);
             //console.error(profile.temptargetSet, target_bg, rT.COB);
             // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
             val maxBolus: Double
@@ -1085,21 +1082,26 @@ class DetermineBasalSMB @Inject constructor(
                 }
                 rT.reason.append(". ")
 
+                // seconds since last bolus
+                val lastBolusAge = (systemTime - iob_data.lastBolusTime) / 1000.0
+                //console.error(lastBolusAge);
                 // allow SMBIntervals between 1 and 10 minutes
-                val SMBInterval = min(10, max(1, profile.SMBInterval))
-                val nextBolusMins = round(SMBInterval - lastBolusAge, 0)
-                val nextBolusSeconds = round((SMBInterval - lastBolusAge) * 60, 0) % 60
+                val SMBInterval = min(10, max(1, profile.SMBInterval)) * 60.0   // in seconds
                 //console.error(naive_eventualBG, insulinReq, worstCaseInsulinReq, durationReq);
-                consoleError.add("naive_eventualBG $naive_eventualBG,${durationReq}m ${smbLowTempReq}U/h temp needed; last bolus ${lastBolusAge}m ago; maxBolus: $maxBolus")
-                if (lastBolusAge > SMBInterval) {
+                consoleError.add("naive_eventualBG $naive_eventualBG,${durationReq}m ${smbLowTempReq}U/h temp needed; last bolus ${round(lastBolusAge/60.0,1)}m ago; maxBolus: $maxBolus")
+                if (lastBolusAge > SMBInterval - 6.0) {   // 6s tolerance
                     if (microBolus > 0) {
                         rT.units = microBolus
                         rT.reason.append("Microbolusing ${microBolus}U. ")
                     }
                 } else {
-                    rT.reason.append("Waiting " + nextBolusMins + "m " + nextBolusSeconds + "s to microbolus again. ")
+                    val nextBolusMins = (SMBInterval-lastBolusAge) / 60.0
+                    val nextBolusSeconds = (SMBInterval - lastBolusAge) % 60
+                    val waitingSeconds = round(nextBolusSeconds,0) % 60
+                    val waitingMins = round(nextBolusMins-waitingSeconds/60.0, 0)
+                    rT.reason.append( "Waiting ${waitingMins.withoutZeros()}m ${waitingSeconds.withoutZeros()}s to microbolus again.")
                 }
-                //rT.reason += ". ";
+               //rT.reason += ". ";
 
                 // if no zero temp is required, don't return yet; allow later code to set a high temp
                 if (durationReq > 0) {


### PR DESCRIPTION
In determinebasal there is a bug regarding SMB intervals. Due to wrong rounding another 0.5 minutes are added on top of the SMBInterval minutes. For example with 1 minute Libre I often saw _waiting 0m 0s to microbolus again_. Here is a screen shot from the SMB plugin after the fix with the default 3 minute interval:
![Screenshot_minAgo_zoomed_20240905_222538](https://github.com/user-attachments/assets/2239bfe0-eb63-48e2-8092-fd493710ff97)

Fix is done for the SMB and AUTOISF plugins in the Kotlin code. The older javascript variants were left as is because they seem doomed and the ReplayApsResultTest still works.