### PR TITLE
PR3296 auto export (DRAFT)

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -43,6 +43,7 @@ import app.aaps.core.interfaces.notifications.Notification
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.plugin.PluginDescription
 import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.protection.ProtectionCheck
 import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.interfaces.rx.events.EventAppExit
@@ -108,6 +109,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var fileListProvider: FileListProvider
     @Inject lateinit var cryptoUtil: CryptoUtil
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
+
 
     private lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
     private var pluginPreferencesMenuItem: MenuItem? = null
@@ -298,6 +301,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
             androidPermission.notifyForBtConnectPermission(this)
         }
         passwordResetCheck(this)
+        exportPasswordResetCheck(this)
+
         if (preferences.get(StringKey.ProtectionMasterPassword) == "")
             rxBus.send(EventNewNotification(Notification(Notification.MASTER_PASSWORD_NOT_SET, rh.gs(R.string.master_password_not_set), Notification.NORMAL)))
     }
@@ -481,12 +486,28 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
      * reset password to SN of active pump if file exists
      */
     private fun passwordResetCheck(context: Context) {
-        val passwordReset = File(fileListProvider.ensureExtraDirExists(), "PasswordReset")
-        if (passwordReset.exists()) {
+        val fh = File(fileListProvider.ensureExtraDirExists(), "PasswordReset")
+        if (fh.exists()) {
             val sn = activePlugin.activePump.serialNumber()
             preferences.put(StringKey.ProtectionMasterPassword, cryptoUtil.hashPassword(sn))
-            passwordReset.delete()
+            fh.delete()
+            // Also clear any stored password
+            exportPasswordDataStore.clearPasswordDataStore(context)
             ToastUtils.okToast(context, context.getString(app.aaps.core.ui.R.string.password_set))
         }
     }
+
+    /**
+     * Check for existing ExportPasswordReset file and
+     * clear password stored in datastore if file exists
+     */
+        private fun exportPasswordResetCheck(context: Context) {
+        val exportPasswordReset = File(fileListProvider.ensureExtraDirExists(), "ExportPasswordReset")
+        if (exportPasswordReset.exists()) {
+            exportPasswordDataStore.clearPasswordDataStore(context)
+            exportPasswordReset.delete()
+            ToastUtils.okToast(context, context.getString(app.aaps.core.ui.R.string.datastore_password_cleared))
+        }
+    }
+
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/ImportExportPrefs.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/ImportExportPrefs.kt
@@ -1,5 +1,6 @@
 package app.aaps.core.interfaces.maintenance
 
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import app.aaps.core.interfaces.rx.weardata.CwfData
@@ -16,6 +17,7 @@ interface ImportExportPrefs {
     fun prefsFileExists(): Boolean
     fun verifyStoragePermissions(fragment: Fragment, onGranted: Runnable)
     fun exportSharedPreferences(f: Fragment)
+    fun exportSharedPreferencesNonInteractive(context: Context, password: String): Boolean
     fun exportUserEntriesCsv(activity: FragmentActivity)
     fun exportApsResult(algorithm: String?, input: JSONObject, output: JSONObject?)
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/NotificationUserMessage.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/NotificationUserMessage.kt
@@ -11,3 +11,15 @@ class NotificationUserMessage(text: String) : Notification() {
         level = URGENT
     }
 }
+
+class NotificationInfoMessage(text: String) : Notification() {
+
+    init {
+        var hash = text.hashCode()
+        if (hash < USER_MESSAGE) hash += USER_MESSAGE
+        id = hash
+        date = System.currentTimeMillis()
+        this.text = text
+        level = INFO
+    }
+}

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/ExportPasswordDataStore.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/ExportPasswordDataStore.kt
@@ -1,0 +1,30 @@
+package app.aaps.core.interfaces.protection
+
+import android.content.Context
+
+interface ExportPasswordDataStore {
+
+    /***
+     * TODO: While in dev only (delete when implementation is excepted):
+     * Check Export password functionality
+     * Returns true when Export password store is enabled.
+     */
+    fun exportPasswordStoreEnabled() : Boolean
+
+    /***
+     * Clear password currently stored.
+     */
+    fun clearPasswordDataStore(context: Context): String
+
+    /***
+     * Put password to local phone's datastore.
+     */
+    fun putPasswordToDataStore(context: Context, password: String): String
+
+    /***
+     * Get password from local phone's data store.
+     * Return pair (true,<password>) or (false,"")
+     */
+    fun getPasswordFromDataStore(context: Context): Pair<Boolean, String>
+
+}

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/PasswordCheck.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/PasswordCheck.kt
@@ -37,4 +37,5 @@ interface PasswordCheck {
         context: Context, @StringRes labelId: Int, preference: String, @StringRes passwordExplanation: Int?,
         @StringRes passwordWarning: Int?, ok: ((String) -> Unit)?, cancel: (() -> Unit)? = null
     )
+
 }

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -62,6 +62,8 @@ enum class BooleanKey(
 
     MaintenanceEnableFabric("enable_fabric2", true, defaultedBySM = true, hideParentScreenIfHidden = true),
 
+    MaintenanceEnableExportSettingsAutomation("enable_export_settings_automation", true, defaultedBySM = true, hideParentScreenIfHidden = true),
+
     AutotuneAutoSwitchProfile("autotune_auto", false),
     AutotuneCategorizeUamAsBasal("categorize_uam_as_basal", false),
     AutotuneTuneInsulinCurve("autotune_tune_insulin_curve", false),

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
@@ -59,6 +59,8 @@ enum class IntKey(
 
     AutotuneDefaultTuneDays("autotune_default_tune_days", 5, 1, 30),
 
+    AutoExportPasswordExpiryDays("auto_export_password_expiry_days", 7, 1, 90),
+
     SmsRemoteBolusDistance("smscommunicator_remotebolusmindistance", 15, 3, 60),
 
     BgSourceRandomInterval("randombg_interval_min", 5, 1, 15, defaultedBySM = true),

--- a/core/objects/src/main/res/drawable/ic_export_settings_24dp.xml
+++ b/core/objects/src/main/res/drawable/ic_export_settings_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    android:tint="#58BA2E">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2,20h20v-4L2,16v4zM4,17h2v2L4,19v-2zM2,4v4h20L22,4L2,4zM6,7L4,7L4,5h2v2zM2,14h20v-4L2,10v4zM4,11h2v2L4,13v-2z"/>
+
+</vector>

--- a/core/ui/src/main/res/values/protection.xml
+++ b/core/ui/src/main/res/values/protection.xml
@@ -21,6 +21,7 @@
     <string name="unsecure_fallback_descriotion_biometric">In order to be effective, biometric protection needs a master password set for fallback.\n\nPlease set a master password!</string>
 
     <string name="password_set">Password set!</string>
+    <string name="datastore_password_cleared">Stored Export Password cleared!</string>
     <string name="pin_set">PIN set!</string>
     <string name="password_not_set">Password not set</string>
     <string name="pin_not_set">PIN not set</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="removerecord">Remove record</string>
     <string name="loopisdisabled">Loop is disabled</string>
     <string name="alarm">Alarm</string>
+    <string name="exportsettings">Export Settings</string>
     <string name="disableloop">Disable loop</string>
     <string name="enableloop">Enable loop</string>
     <string name="resumeloop">Resume loop</string>

--- a/implementation/src/main/kotlin/app/aaps/implementation/di/ImplementationModule.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/di/ImplementationModule.kt
@@ -12,6 +12,7 @@ import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.profile.ProfileUtil
 import app.aaps.core.interfaces.profiling.Profiler
 import app.aaps.core.interfaces.protection.PasswordCheck
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.protection.ProtectionCheck
 import app.aaps.core.interfaces.pump.BlePreCheck
 import app.aaps.core.interfaces.pump.DetailedBolusInfoStorage
@@ -46,6 +47,7 @@ import app.aaps.implementation.profile.ProfileFunctionImpl
 import app.aaps.implementation.profile.ProfileStoreObject
 import app.aaps.implementation.profile.ProfileUtilImpl
 import app.aaps.implementation.profiling.ProfilerImpl
+import app.aaps.implementation.protection.ExportPasswordDataStoreImpl
 import app.aaps.implementation.protection.PasswordCheckImpl
 import app.aaps.implementation.protection.ProtectionCheckImpl
 import app.aaps.implementation.pump.BlePreCheckImpl
@@ -101,6 +103,7 @@ abstract class ImplementationModule {
         @Binds fun bindTranslator(translatorImpl: TranslatorImpl): Translator
         @Binds fun bindProtectionCheck(protectionCheckImpl: ProtectionCheckImpl): ProtectionCheck
         @Binds fun bindPasswordCheck(passwordCheckImpl: PasswordCheckImpl): PasswordCheck
+        @Binds fun bindExportPasswordCheck(exportPasswordDataStoreImpl: ExportPasswordDataStoreImpl): ExportPasswordDataStore
         @Binds fun bindLoggerUtils(loggerUtilsImpl: LoggerUtilsImpl): LoggerUtils
         @Binds fun bindProfiler(profilerImpl: ProfilerImpl): Profiler
         @Binds fun bindWarnColors(warnColorsImpl: WarnColorsImpl): WarnColors

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
@@ -1,0 +1,168 @@
+package app.aaps.implementation.protection
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
+import app.aaps.core.interfaces.sharedPreferences.SP
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.keys.IntKey
+import dagger.Reusable
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+// Internal constant stings
+const val datastoreName : String = "app.aaps.plugins.configuration.maintenance.ImportExport.datastore"
+const val passwordPreferenceName = "$datastoreName.password_value"
+
+@Reusable
+class ExportPasswordDataStoreImpl @Inject constructor(
+    private var log: AAPSLogger,
+    private val sp: SP
+    ) : ExportPasswordDataStore {
+
+    @Inject lateinit var dateUtil: DateUtil
+
+    // TODO: Review security aspects on temporarily storing password in phone's local data store
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = datastoreName
+    )
+
+    private var exportPasswordStoreIsEnabled = false
+    private var passwordValidityWindowSeconds: Long = 0
+
+    /***
+     * Check Export password functionality
+     * Returns true when Export password store is enabled.
+     */
+    override fun exportPasswordStoreEnabled() : Boolean {
+        // Is password storing enabled?
+        exportPasswordStoreIsEnabled = sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)
+        // Password validity window
+        passwordValidityWindowSeconds = sp.getLong(IntKey.AutoExportPasswordExpiryDays.key, 7) * 24 * 3600 * 1000
+        log.debug(LTag.CORE, "ExportPassword Store Supported: $exportPasswordStoreIsEnabled, expiry days=$passwordValidityWindowSeconds")
+        return exportPasswordStoreIsEnabled
+    }
+
+    /***
+     * Clear password currently stored to "empty"
+     */
+    override fun clearPasswordDataStore(context: Context): String {
+        // TODO: For now always clear - also when general functionality is disabled?
+        // if (!exportPasswordStoreEnabled()) return ""
+
+        log.debug(LTag.CORE, "clearPasswordDataStore")
+        // Store & update to empty password and return
+        return this.storePassword(context, "")
+    }
+
+    /***
+     * Put password to local phone's datastore
+     */
+    override fun putPasswordToDataStore(context: Context, password: String): String {
+        if (!exportPasswordStoreEnabled()) return ""
+
+        log.debug(LTag.CORE, "putPasswordToDataStore")
+        return this.storePassword(context, password)
+    }
+
+    /***
+     * Get password from local phone's data store
+     * Return pair (true,<password>) or (false,"")
+     */
+    override fun getPasswordFromDataStore(context: Context): Pair<Boolean, String> {
+        if (!exportPasswordStoreEnabled()) return Pair (false, "")
+
+        val password = this.retrievePassword(context)
+        if (password.isNotEmpty()) {  // And not expired
+            log.debug(LTag.CORE, "getPasswordFromDataStore")
+            return Pair(true, password)
+        }
+        return Pair (false, "")
+    }
+
+    /*************************************************************************
+     * Private functions
+    *************************************************************************/
+
+    /***
+     * Check if timestamp is in validity window T...T+duration
+     */
+    private fun isInValidityWindow(timestamp: Long, @Suppress("SameParameterValue") duration: Long?): Boolean {
+        return dateUtil.now() in timestamp..timestamp + (duration ?: 0L)
+    }
+
+    /***
+     * Store password and set timestamp to current
+     */
+    private fun storePassword(context: Context, password: String): String {
+
+        // Write setting to android datastore and return password
+        fun updatePrefString(name: String, str: String)  = runBlocking {
+            val preferencesKeyPassword = stringPreferencesKey("$name.key")
+            val preferencesKeyTimestamp = stringPreferencesKey("$name.ts")
+            context.dataStore.edit { settings ->
+                // Update password and timestamp to "now" as string value
+                settings[preferencesKeyPassword] = str
+                settings[preferencesKeyTimestamp] = dateUtil.now().toString()
+            }[preferencesKeyPassword].toString()
+        }
+
+        // Update & return password string
+        return updatePrefString(passwordPreferenceName, encrypt(password))
+    }
+
+    /***
+     * Retrieve password from local phone's data store.
+     * Reset password when validity expired
+    ***/
+    private fun retrievePassword(context: Context): String {
+
+        // Read string value from phone's local datastore using key name
+        var passwordStr = ""
+        var timestampStr = ""
+
+        runBlocking {
+            val keyName = passwordPreferenceName
+            val preferencesKeyVal = stringPreferencesKey("$keyName.key")
+            val preferencesKeyTs = stringPreferencesKey("$keyName.ts")
+            context.dataStore.edit { settings ->
+                passwordStr = settings[preferencesKeyVal] ?:""
+                timestampStr = (settings[preferencesKeyTs] ?:"")
+            }
+        }
+
+        // Get the password value stored
+        if (passwordStr.isEmpty())
+            return ""
+
+        // Password is defined: Check for password expiry:
+        val timestamp = if (timestampStr.isEmpty()) 0L else timestampStr.toLong()
+        if (!isInValidityWindow(timestamp, passwordValidityWindowSeconds))
+            // Password validity ended - need to renew:
+            // Clear/update password in data store
+            return this.clearPasswordDataStore(context)
+
+        // Store/update password and return
+        return this.storePassword(context, decrypt(passwordStr))
+    }
+
+    /***
+     * Preparing for encryption/decryption (needs additional research)
+     */
+    private fun encrypt(str: String): String {
+        return str
+    }
+
+    private fun decrypt(str: String): String {
+        return str
+    }
+
+}

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/PasswordCheckImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/PasswordCheckImpl.kt
@@ -11,7 +11,9 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.StringRes
+import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.protection.PasswordCheck
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.core.objects.R
 import app.aaps.core.objects.crypto.CryptoUtil
@@ -23,6 +25,7 @@ import javax.inject.Inject
 
 @Reusable
 class PasswordCheckImpl @Inject constructor(
+    private var log: AAPSLogger,
     private val sp: SP,
     private val cryptoUtil: CryptoUtil
 ) : PasswordCheck {
@@ -30,6 +33,8 @@ class PasswordCheckImpl @Inject constructor(
     // since androidx.autofill.HintConstants are not available
     @Suppress("PrivatePropertyName")
     private val AUTOFILL_HINT_NEW_PASSWORD = "newPassword"
+
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
 
     /**
     Asks for "managed" kind of password, checking if it is valid.
@@ -123,6 +128,7 @@ class PasswordCheckImpl @Inject constructor(
                     ToastUtils.errorToast(context, context.getString(msg))
                 } else if (enteredPassword.isNotEmpty()) {
                     sp.putString(preference, cryptoUtil.hashPassword(enteredPassword))
+                    exportPasswordDataStore.clearPasswordDataStore(context)
                     val msg = if (pinInput) app.aaps.core.ui.R.string.pin_set else app.aaps.core.ui.R.string.password_set
                     ToastUtils.okToast(context, context.getString(msg))
                     ok?.invoke(enteredPassword)
@@ -213,4 +219,5 @@ class PasswordCheckImpl @Inject constructor(
             }
         }
     }
+
 }

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
@@ -42,6 +42,7 @@ import app.aaps.plugins.automation.actions.ActionProfileSwitch
 import app.aaps.plugins.automation.actions.ActionProfileSwitchPercent
 import app.aaps.plugins.automation.actions.ActionRunAutotune
 import app.aaps.plugins.automation.actions.ActionSendSMS
+import app.aaps.plugins.automation.actions.ActionSettingsExport
 import app.aaps.plugins.automation.actions.ActionStartTempTarget
 import app.aaps.plugins.automation.actions.ActionStopProcessing
 import app.aaps.plugins.automation.actions.ActionStopTempTarget
@@ -382,6 +383,7 @@ class AutomationPlugin @Inject constructor(
             ActionStopTempTarget(injector),
             ActionNotification(injector),
             ActionAlarm(injector),
+            ActionSettingsExport(injector),
             ActionCarePortalEvent(injector),
             ActionProfileSwitchPercent(injector),
             ActionProfileSwitch(injector),

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/Action.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/Action.kt
@@ -58,6 +58,7 @@ abstract class Action(val injector: HasAndroidInjector) {
             if (dotIndex > 0) type = type.substring(dotIndex + 1)
             return when (type) {
                 ActionAlarm::class.java.simpleName                -> ActionAlarm(injector).fromJSON(data.toString())
+                ActionSettingsExport::class.java.simpleName       -> ActionSettingsExport(injector).fromJSON(data.toString())
                 ActionCarePortalEvent::class.java.simpleName      -> ActionCarePortalEvent(injector).fromJSON(data.toString())
                 ActionDummy::class.java.simpleName                -> ActionDummy(injector).fromJSON(data.toString())
                 ActionLoopDisable::class.java.simpleName          -> ActionLoopDisable(injector).fromJSON(data.toString())

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
@@ -1,0 +1,117 @@
+package app.aaps.plugins.automation.actions
+
+import android.content.Context
+import android.widget.LinearLayout
+import androidx.annotation.DrawableRes
+import app.aaps.core.data.model.TE
+import app.aaps.core.data.ue.Sources
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.db.PersistenceLayer
+import app.aaps.core.interfaces.maintenance.ImportExportPrefs
+import app.aaps.core.interfaces.notifications.NotificationInfoMessage
+import app.aaps.core.interfaces.notifications.NotificationUserMessage
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
+import app.aaps.core.interfaces.queue.Callback
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventNewNotification
+import app.aaps.core.interfaces.rx.events.EventRefreshOverview
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.objects.extensions.asAnnouncement
+import app.aaps.core.utils.JsonHelper
+import app.aaps.plugins.automation.R
+import app.aaps.plugins.automation.elements.InputString
+import app.aaps.plugins.automation.elements.LabelWithElement
+import app.aaps.plugins.automation.elements.LayoutBuilder
+import app.aaps.plugins.automation.ui.TimerUtil
+import dagger.android.HasAndroidInjector
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.kotlin.plusAssign
+import org.json.JSONObject
+import javax.inject.Inject
+
+class ActionSettingsExport(injector: HasAndroidInjector) : Action(injector) {
+
+    @Inject lateinit var rxBus: RxBus
+    @Inject lateinit var context: Context
+    @Inject lateinit var dateUtil: DateUtil
+    @Inject lateinit var timerUtil: TimerUtil
+    @Inject lateinit var config: Config
+    @Inject lateinit var persistenceLayer: PersistenceLayer
+    @Inject lateinit var importExportPrefs: ImportExportPrefs
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
+
+    private val disposable = CompositeDisposable()
+
+    var text = InputString()
+
+    constructor(injector: HasAndroidInjector, text: String) : this(injector) {
+        this.text = InputString(text)
+    }
+
+    override fun friendlyName(): Int = app.aaps.core.ui.R.string.exportsettings
+    override fun shortDescription(): String = rh.gs(R.string.exportsettings_message, text.value)
+    @DrawableRes override fun icon(): Int = app.aaps.core.objects.R.drawable.ic_export_settings_24dp
+
+    override fun isValid(): Boolean = true
+
+    override fun doAction(callback: Callback) {
+        val message: String
+
+        if (exportPasswordDataStore.exportPasswordStoreEnabled()) {
+            val storedPassword = exportPasswordDataStore.getPasswordFromDataStore(context)
+            if (storedPassword.first) {
+                // We have a password: start exporting & notify info
+                importExportPrefs.exportSharedPreferencesNonInteractive(context, storedPassword.second)
+                message = "Settings exported"
+                val notification = NotificationInfoMessage(message)
+                rxBus.send(EventNewNotification(notification))
+            } else {
+                // No password, was expired and needs re-entering by user, notify user
+                exportPasswordDataStore.clearPasswordDataStore(context)
+                message = "Settings export canceled: Export manually and (re)enter password!"
+                val notification = NotificationUserMessage(message)
+                rxBus.send(EventNewNotification(notification))
+            }
+        }
+        else {
+            message = "Warning (automation): Settings export not enabled!"
+            val notification = NotificationUserMessage(message)
+            rxBus.send(EventNewNotification(notification))
+        }
+
+        disposable += persistenceLayer.insertPumpTherapyEventIfNewByTimestamp(
+            therapyEvent = TE.asAnnouncement(text.value),
+            timestamp = dateUtil.now(),
+            action = app.aaps.core.data.ue.Action.EXPORT_SETTINGS,
+            source = Sources.Automation,
+            note = message,
+            listValues = listOf()
+        ).subscribe()
+        rxBus.send(EventRefreshOverview("ActionSettingsExport"))
+        callback.result(instantiator.providePumpEnactResult().success(true).comment(app.aaps.core.ui.R.string.ok)).run()
+
+    }
+
+
+    override fun toJSON(): String {
+        val data = JSONObject().put("text", text.value)
+        return JSONObject()
+            .put("type", this.javaClass.simpleName)
+            .put("data", data)
+            .toString()
+    }
+
+    override fun fromJSON(data: String): Action {
+        val o = JSONObject(data)
+        text.value = JsonHelper.safeGetString(o, "text", "")
+        return this
+    }
+
+    override fun hasDialog(): Boolean = true
+
+    override fun generateDialog(root: LinearLayout) {
+        LayoutBuilder()
+            .add(LabelWithElement(rh, rh.gs(R.string.export_settings_short), "", text))
+            .build(root)
+    }
+}

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
@@ -6,6 +6,7 @@ import app.aaps.plugins.automation.AutomationFragment
 import app.aaps.plugins.automation.AutomationPlugin
 import app.aaps.plugins.automation.actions.Action
 import app.aaps.plugins.automation.actions.ActionAlarm
+import app.aaps.plugins.automation.actions.ActionSettingsExport
 import app.aaps.plugins.automation.actions.ActionCarePortalEvent
 import app.aaps.plugins.automation.actions.ActionDummy
 import app.aaps.plugins.automation.actions.ActionLoopDisable
@@ -109,6 +110,7 @@ abstract class AutomationModule {
     @ContributesAndroidInjector abstract fun actionLoopSuspendInjector(): ActionLoopSuspend
     @ContributesAndroidInjector abstract fun actionNotificationInjector(): ActionNotification
     @ContributesAndroidInjector abstract fun actionAlarmInjector(): ActionAlarm
+    @ContributesAndroidInjector abstract fun actionSettingsExportInjector(): ActionSettingsExport
     @ContributesAndroidInjector abstract fun actionCarePortalEventInjector(): ActionCarePortalEvent
     @ContributesAndroidInjector abstract fun actionProfileSwitchInjector(): ActionProfileSwitch
     @ContributesAndroidInjector abstract fun actionProfileSwitchPercentInjector(): ActionProfileSwitchPercent

--- a/plugins/automation/src/main/res/values/strings.xml
+++ b/plugins/automation/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="automation_missing_task_name">Please enter a task name.</string>
     <string name="automation_missing_trigger">Please specify at least one trigger.</string>
     <string name="automation_missing_action">Please specify at least one action.</string>
+    <string name="exportsettings_message">Settings Export: %1$s</string>
+    <string name="export_settings_short">Export:</string>
     <string name="alarm_message">Alarm: %1$s</string>
     <string name="alarm_short">Alarm:</string>
     <string name="message_short">Msg:</string>

--- a/plugins/automation/src/main/res/values/strings.xml
+++ b/plugins/automation/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="automation_missing_trigger">Please specify at least one trigger.</string>
     <string name="automation_missing_action">Please specify at least one action.</string>
     <string name="exportsettings_message">Settings Export: %1$s</string>
-    <string name="export_settings_short">Export:</string>
+    <string name="export_settings_short">Text in treatments:</string>
     <string name="alarm_message">Alarm: %1$s</string>
     <string name="alarm_short">Alarm:</string>
     <string name="message_short">Msg:</string>

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/MaintenancePlugin.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/MaintenancePlugin.kt
@@ -235,7 +235,7 @@ class MaintenancePlugin @Inject constructor(
     }
 
     override fun addPreferenceScreen(preferenceManager: PreferenceManager, parent: PreferenceScreen, context: Context, requiredKey: String?) {
-        if (requiredKey != null && requiredKey != "data_choice_setting") return
+        if (requiredKey != null && !(requiredKey == "data_choice_setting" || requiredKey == "export_settings_automation")) return
         val category = PreferenceCategory(context)
         parent.addPreference(category)
         category.apply {
@@ -253,7 +253,22 @@ class MaintenancePlugin @Inject constructor(
                 key = "data_choice_setting"
                 title = rh.gs(R.string.data_choices)
                 addPreference(AdaptiveSwitchPreference(ctx = context, booleanKey = BooleanKey.MaintenanceEnableFabric, title = R.string.fabric_upload))
-                addPreference(AdaptiveStringPreference(ctx = context, stringKey = StringKey.MaintenanceIdentification, summary = R.string.summary_email_for_crash_report, title = R.string.identification))
+                addPreference(AdaptiveStringPreference(ctx = context, stringKey = StringKey.MaintenanceIdentification, title = R.string.identification))
+            })
+
+            addPreference(preferenceManager.createPreferenceScreen(context).apply {
+                key = "export_settings_automation"
+                title = rh.gs(R.string.export_settings_automation)
+                addPreference(AdaptiveSwitchPreference(ctx = context, booleanKey = BooleanKey.MaintenanceEnableExportSettingsAutomation,
+                    title = R.string.export_settings_automation,
+                    summary = R.string.export_settings_automation_summary
+                    )
+                )
+                addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.AutoExportPasswordExpiryDays,
+                    title = R.string.export_settings_automation_password_expiry,
+                    summary = R.string.export_settings_automation_password_expiry_summary
+                    )
+                )
             })
         }
     }

--- a/plugins/configuration/src/main/res/values/strings.xml
+++ b/plugins/configuration/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="readstatus">Read status</string>
     <string name="data_choices">Data Choices</string>
     <string name="fabric_upload">Fabric Upload</string>
+    <string name="export_settings_automation">Export Settings Automation</string>
+    <string name="export_settings_automation_summary">Enable this will store your password in the app store on your phone</string>
+    <string name="export_settings_automation_password_expiry">Password expiry</string>
+    <string name="export_settings_automation_password_expiry_summary">Number of days after which the password will expire when not used:\n</string>
     <string name="allow_automated_crash_reporting">Allow automated crash reporting and feature usage data to be sent to the developers via the fabric.io service.</string>
     <string name="summary_email_for_crash_report">This identification will attached to crash reports so we can contact you in urgent cases. It\'s optional.</string>
     <string name="identification">Identification (email, FB or Discord nick etc)</string>

--- a/plugins/configuration/src/main/res/values/strings.xml
+++ b/plugins/configuration/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="fabric_upload">Fabric Upload</string>
     <string name="export_settings_automation">Export Settings Automation</string>
     <string name="export_settings_automation_summary">Enable this will store your password in the app store on your phone</string>
-    <string name="export_settings_automation_password_expiry">Password expiry</string>
+    <string name="export_settings_automation_password_expiry">Password expiry (days)</string>
     <string name="export_settings_automation_password_expiry_summary">Number of days after which the password will expire when not used:\n</string>
     <string name="allow_automated_crash_reporting">Allow automated crash reporting and feature usage data to be sent to the developers via the fabric.io service.</string>
     <string name="summary_email_for_crash_report">This identification will attached to crash reports so we can contact you in urgent cases. It\'s optional.</string>


### PR DESCRIPTION
**This PR#3451 enables automated settings export.**
As settings export needs the master password for encryption the password is stored on the local phone's app datastore on manually exporting settings from the maintenance menu. Password will expire/wipe when not used for the number of days set.
Stored password wil be wiped on settings master password (or forced with file 'ExportPasswordReset' in /AAPS/extra)

Functionality is enabled through a new setting in Maintenance preferences.
Once enabled (and password set through manual export) user can define the automatic settings export from automation.

Actions also wil be in registered to "Treatments" (careportal/User entry)

_TODO_: Review/determine if storing the master password unencrypted local phone's app storage is acceptable.
See also issue https://github.com/nightscout/AndroidAPS/issues/3296

**Additional note**:
This PR implementation should enable implementation for auto exporting to alternate storage locations (like the Downloads folder or Cloud). But this will be subject for another PR.