### PR TITLE
Migrate kapt to ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
     id("android-app-dependencies")
@@ -221,13 +222,13 @@ dependencies {
     androidTestImplementation(Libs.jsonAssert)
 
 
-    kaptAndroidTest(Libs.Dagger.androidProcessor)
+    kspAndroidTest(Libs.Dagger.androidProcessor)
 
     /* Dagger2 - We are going to use dagger.android which includes
      * support for Activity and fragment injection so we need to include
      * the following dependencies */
-    kapt(Libs.Dagger.androidProcessor)
-    kapt(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
 
     // MainApp
     api(Libs.Rx.rxDogTag)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ buildscript {
 plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("com.savvasdalkitsis.module-dependency-graph") version "0.12"
+    id("kotlin-kapt")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.25" apply false
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ buildscript {
 plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("com.savvasdalkitsis.module-dependency-graph") version "0.12"
-    id("kotlin-kapt")
     id("com.google.devtools.ksp") version "2.0.21-1.0.25" apply false
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 object KtsBuildVersions {
 
     const val gradle = "8.5.1"
-    const val kotlin = "2.0.0"
+    const val kotlin = "2.0.21"
 }
 
 plugins {

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -3,7 +3,7 @@ object Libs {
 
     object Kotlin {
 
-        const val kotlin = "2.0.0"
+        const val kotlin = "2.0.21"
 
         const val stdlibJdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin"
         const val reflect = "org.jetbrains.kotlin:kotlin-reflect:$kotlin"
@@ -115,7 +115,7 @@ object Libs {
 
     object Dagger {
 
-        private const val version = "2.48.1"
+        private const val version = "2.52"
         const val dagger = "com.google.dagger:dagger:$version"
         const val android = "com.google.dagger:dagger-android:$version"
         const val androidProcessor = "com.google.dagger:dagger-android-processor:$version"

--- a/core/objects/build.gradle.kts
+++ b/core/objects/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("kotlin-parcelize")
     id("android-module-dependencies")
     id("all-open-dependencies")
@@ -35,6 +36,6 @@ dependencies {
     //WorkManager
     api(Libs.AndroidX.Work.runtimeKtx)  // DataWorkerStorage
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/core/validators/build.gradle.kts
+++ b/core/validators/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -21,6 +22,6 @@ dependencies {
     api(Libs.Dagger.androidSupport)
     api(Libs.Google.Android.material)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/database/impl/build.gradle.kts
+++ b/database/impl/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("kotlin-allopen")
     id("android-module-dependencies")
     id("test-module-dependencies")
@@ -12,11 +13,9 @@ android {
     namespace = "app.aaps.database.impl"
 
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
     sourceSets {
@@ -43,6 +42,6 @@ dependencies {
 
     androidTestImplementation(Libs.AndroidX.Room.testing)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.AndroidX.Room.compiler)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.AndroidX.Room.compiler)
 }

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("all-open-dependencies")
     id("test-module-dependencies")
@@ -30,6 +31,6 @@ dependencies {
     api(Libs.Logging.slf4jApi)
     api(Libs.Logging.logbackAndroid)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/aps/build.gradle.kts
+++ b/plugins/aps/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -35,5 +36,5 @@ dependencies {
     //Logger
     api(Libs.Logging.slf4jApi)
 
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/automation/build.gradle.kts
+++ b/plugins/automation/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -30,6 +31,6 @@ dependencies {
     api(Libs.Google.Android.PlayServices.location)
     api(Libs.Kotlin.reflect)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/configuration/build.gradle.kts
+++ b/plugins/configuration/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("kotlin-parcelize")
     id("android-module-dependencies")
     id("test-module-dependencies")
@@ -31,6 +32,6 @@ dependencies {
     // Maintenance
     api(Libs.AndroidX.gridLayout)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/constraints/build.gradle.kts
+++ b/plugins/constraints/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("all-open-dependencies")
     id("test-module-dependencies")
@@ -34,6 +35,6 @@ dependencies {
     // Phone checker
     api(Libs.rootBeer)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/insulin/build.gradle.kts
+++ b/plugins/insulin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -26,6 +27,6 @@ dependencies {
     testImplementation(project(":shared:tests"))
     testImplementation(project(":core:objects"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/main/build.gradle.kts
+++ b/plugins/main/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -45,6 +46,6 @@ dependencies {
     // Food
     api(Libs.AndroidX.Work.runtimeKtx)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/sensitivity/build.gradle.kts
+++ b/plugins/sensitivity/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -23,6 +24,6 @@ dependencies {
 
     testImplementation(project(":shared:tests"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/smoothing/build.gradle.kts
+++ b/plugins/smoothing/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -17,6 +18,6 @@ dependencies {
     implementation(project(":core:interfaces"))
     implementation(project(":core:ui"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/source/build.gradle.kts
+++ b/plugins/source/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -27,6 +28,6 @@ dependencies {
 
     testImplementation(project(":shared:tests"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/plugins/sync/build.gradle.kts
+++ b/plugins/sync/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -53,6 +54,6 @@ dependencies {
     api(Libs.connectiqSdk)
     androidTestImplementation(Libs.connectiqSdk)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/combov2/build.gradle.kts
+++ b/pump/combov2/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -42,6 +43,6 @@ dependencies {
     // TODO: Revisit this when upgrading kotlinx-datetime
     runtimeOnly(Libs.KotlinX.serializationCore)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/dana/build.gradle.kts
+++ b/pump/dana/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -11,11 +12,9 @@ android {
 
     namespace = "app.aaps.pump.dana"
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -31,12 +30,12 @@ dependencies {
     api(Libs.AndroidX.Room.room)
     api(Libs.AndroidX.Room.runtime)
     api(Libs.AndroidX.Room.rxJava3)
-    kapt(Libs.AndroidX.Room.compiler)
+    ksp(Libs.AndroidX.Room.compiler)
 
     testImplementation(project(":shared:tests"))
     testImplementation(project(":core:objects"))
     // create profile from json
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/danar/build.gradle.kts
+++ b/pump/danar/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -26,6 +27,6 @@ dependencies {
     testImplementation(project(":shared:tests"))
     testImplementation(project(":core:objects"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/danars/build.gradle.kts
+++ b/pump/danars/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -29,6 +30,6 @@ dependencies {
     testImplementation(project(":shared:tests"))
     testImplementation(project(":core:objects"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/diaconn/build.gradle.kts
+++ b/pump/diaconn/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -11,11 +12,9 @@ android {
 
     namespace = "info.nightscout.pump.diaconn"
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -32,12 +31,12 @@ dependencies {
     api(Libs.AndroidX.Room.room)
     api(Libs.AndroidX.Room.runtime)
     api(Libs.AndroidX.Room.rxJava3)
-    kapt(Libs.AndroidX.Room.compiler)
+    ksp(Libs.AndroidX.Room.compiler)
 
     api(Libs.Squareup.Okhttp3.okhttp)
     api(Libs.Squareup.Retrofit2.retrofit)
     api(Libs.Squareup.Retrofit2.converterGson)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/eopatch/build.gradle.kts
+++ b/pump/eopatch/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -29,6 +30,6 @@ dependencies {
     api(Libs.rxandroidBle)
     api(Libs.rx3ReplayingShare)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/equil/build.gradle.kts
+++ b/pump/equil/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -12,11 +13,9 @@ android {
 
     namespace = "app.aaps.pump.equil"
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -39,9 +38,9 @@ dependencies {
     api(Libs.AndroidX.Room.room)
     api(Libs.AndroidX.Room.runtime)
     api(Libs.AndroidX.Room.rxJava3)
-    kapt(Libs.AndroidX.Room.compiler)
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.AndroidX.Room.compiler)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 
     implementation("com.github.bumptech.glide:glide:4.16.0")
 }

--- a/pump/insight/build.gradle.kts
+++ b/pump/insight/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -11,11 +12,9 @@ android {
 
     namespace = "info.nightscout.androidaps.insight"
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -34,7 +33,7 @@ dependencies {
     api(Libs.AndroidX.Room.runtime)
     api(Libs.AndroidX.Room.rxJava3)
 
-    kapt(Libs.AndroidX.Room.compiler)
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.AndroidX.Room.compiler)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/medtronic/build.gradle.kts
+++ b/pump/medtronic/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -24,6 +25,6 @@ dependencies {
     testImplementation(project(":core:keys"))
     testImplementation(project(":shared:tests"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/medtrum/build.gradle.kts
+++ b/pump/medtrum/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -28,6 +29,6 @@ dependencies {
     testImplementation(project(":shared:tests"))
     testImplementation(project(":core:objects"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/omnipod-common/build.gradle.kts
+++ b/pump/omnipod-common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -22,6 +23,6 @@ dependencies {
     api(Libs.AndroidX.navigationFragment)
     api(Libs.Google.Android.material)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/omnipod-dash/build.gradle.kts
+++ b/pump/omnipod-dash/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -11,11 +12,9 @@ android {
 
     namespace = "info.nightscout.androidaps.plugins.pump.omnipod.dash"
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -40,7 +39,7 @@ dependencies {
     testImplementation(project(":shared:tests"))
     testImplementation(Libs.commonCodecs)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
-    kapt(Libs.AndroidX.Room.compiler)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
+    ksp(Libs.AndroidX.Room.compiler)
 }

--- a/pump/omnipod-eros/build.gradle.kts
+++ b/pump/omnipod-eros/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -11,11 +12,9 @@ android {
     namespace = "info.nightscout.androidaps.plugins.pump.omnipod.eros"
 
     defaultConfig {
-        kapt {
-            arguments {
-                arg("room.incremental", "true")
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
+        ksp {
+            arg("room.incremental", "true")
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 }
@@ -44,7 +43,7 @@ dependencies {
     testImplementation(project(":shared:tests"))
 
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
-    kapt(Libs.AndroidX.Room.compiler)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
+    ksp(Libs.AndroidX.Room.compiler)
 }

--- a/pump/pump-common/build.gradle.kts
+++ b/pump/pump-common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -20,6 +21,6 @@ dependencies {
     api(Libs.xstream)
     api(Libs.Google.gson)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/rileylink/build.gradle.kts
+++ b/pump/rileylink/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -21,6 +22,6 @@ dependencies {
 
     api(Libs.jodaTimeAndroid)
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/pump/virtual/build.gradle.kts
+++ b/pump/virtual/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -22,6 +23,6 @@ dependencies {
 
     testImplementation(project(":shared:tests"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/shared/impl/build.gradle.kts
+++ b/shared/impl/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -29,6 +30,6 @@ dependencies {
     api(Libs.jodaTimeAndroid)
 
     api(Libs.Dagger.androidSupport)
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/shared/tests/build.gradle.kts
+++ b/shared/tests/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -26,5 +27,5 @@ dependencies {
     api(Libs.Mockito.kotlin)
     api(Libs.JUnit.jupiterApi)
 
-    kapt(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.compiler)
 }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -24,6 +25,6 @@ dependencies {
 
     testImplementation(project(":shared:tests"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-app-dependencies")
     id("test-app-dependencies")
     id("jacoco-app-dependencies")
@@ -127,6 +128,6 @@ dependencies {
     implementation(Libs.KotlinX.datetime)
     implementation(Libs.Kotlin.stdlibJdk8)
 
-    kapt(Libs.Dagger.androidProcessor)
-    kapt(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
 }

--- a/workflow/build.gradle.kts
+++ b/workflow/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("android-module-dependencies")
     id("test-module-dependencies")
     id("jacoco-module-dependencies")
@@ -22,6 +23,6 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:utils"))
 
-    kapt(Libs.Dagger.compiler)
-    kapt(Libs.Dagger.androidProcessor)
+    ksp(Libs.Dagger.compiler)
+    ksp(Libs.Dagger.androidProcessor)
 }


### PR DESCRIPTION
Migrates `kapt` to `ksp` to be able to use `compose` in the future.

# Changes

- [x] replace `kapt` with `ksp` 
- [x] bump kotlin to `2.0.21`
- [x] bump dagger to `2.52`
- [ ] migrate code to use new annotations / fix types
