### PR TITLE
Handle unknown DB GlucoseValue SourceSensors

### DIFF
--- a/database/impl/src/main/kotlin/app/aaps/database/Converters.kt
+++ b/database/impl/src/main/kotlin/app/aaps/database/Converters.kt
@@ -60,7 +60,12 @@ class Converters {
     fun fromSourceSensor(sourceSensor: GlucoseValue.SourceSensor?) = sourceSensor?.name
 
     @TypeConverter
-    fun toSourceSensor(sourceSensor: String?) = sourceSensor?.let { GlucoseValue.SourceSensor.valueOf(it) }
+    fun toSourceSensor(sourceSensor: String?): GlucoseValue.SourceSensor? {
+        return sourceSensor?.let {
+            GlucoseValue.SourceSensor.entries.firstOrNull {
+                enumValue -> enumValue.name == it } ?: GlucoseValue.SourceSensor.UNKNOWN
+        }
+    }
 
     @TypeConverter
     fun fromTBRType(tbrType: TemporaryBasal.Type?) = tbrType?.name


### PR DESCRIPTION
Fixes #3466

Updated toSourceSensor to return 'UNKNOWN' SourceSensor for GlucoseValues that have undefined sensor enum values. This change prevents toSourceSensor from raising an exception when the source sensor enum is not found.