### PR TITLE
PR3487 unattended settings export (final)

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -502,10 +502,10 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
      * clear password stored in datastore if file exists
      */
         private fun exportPasswordResetCheck(context: Context) {
-        val exportPasswordReset = File(fileListProvider.ensureExtraDirExists(), "ExportPasswordReset")
-        if (exportPasswordReset.exists()) {
+        val fh = File(fileListProvider.ensureExtraDirExists(), "ExportPasswordReset")
+        if (fh.exists()) {
             exportPasswordDataStore.clearPasswordDataStore(context)
-            exportPasswordReset.delete()
+            fh.delete()
             ToastUtils.okToast(context, context.getString(app.aaps.core.ui.R.string.datastore_password_cleared))
         }
     }

--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -43,6 +43,7 @@ import app.aaps.core.interfaces.notifications.Notification
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.plugin.PluginDescription
 import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.protection.ProtectionCheck
 import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.interfaces.rx.events.EventAppExit
@@ -108,6 +109,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
     @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var fileListProvider: FileListProvider
     @Inject lateinit var cryptoUtil: CryptoUtil
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
+
 
     private lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
     private var pluginPreferencesMenuItem: MenuItem? = null
@@ -298,6 +301,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
             androidPermission.notifyForBtConnectPermission(this)
         }
         passwordResetCheck(this)
+        exportPasswordResetCheck(this)
+
         if (preferences.get(StringKey.ProtectionMasterPassword) == "")
             rxBus.send(EventNewNotification(Notification(Notification.MASTER_PASSWORD_NOT_SET, rh.gs(app.aaps.core.ui.R.string.master_password_not_set), Notification.NORMAL)))
     }
@@ -481,12 +486,28 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
      * reset password to SN of active pump if file exists
      */
     private fun passwordResetCheck(context: Context) {
-        val passwordReset = File(fileListProvider.ensureExtraDirExists(), "PasswordReset")
-        if (passwordReset.exists()) {
+        val fh = File(fileListProvider.ensureExtraDirExists(), "PasswordReset")
+        if (fh.exists()) {
             val sn = activePlugin.activePump.serialNumber()
             preferences.put(StringKey.ProtectionMasterPassword, cryptoUtil.hashPassword(sn))
-            passwordReset.delete()
+            fh.delete()
+            // Also clear any stored password
+            exportPasswordDataStore.clearPasswordDataStore(context)
             ToastUtils.okToast(context, context.getString(app.aaps.core.ui.R.string.password_set))
         }
     }
+
+    /**
+     * Check for existing ExportPasswordReset file and
+     * clear password stored in datastore if file exists
+     */
+        private fun exportPasswordResetCheck(context: Context) {
+        val exportPasswordReset = File(fileListProvider.ensureExtraDirExists(), "ExportPasswordReset")
+        if (exportPasswordReset.exists()) {
+            exportPasswordDataStore.clearPasswordDataStore(context)
+            exportPasswordReset.delete()
+            ToastUtils.okToast(context, context.getString(app.aaps.core.ui.R.string.datastore_password_cleared))
+        }
+    }
+
 }

--- a/core/data/src/main/kotlin/app/aaps/core/data/model/TE.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/model/TE.kt
@@ -91,6 +91,7 @@ data class TE(
         PUMP_STOPPED("Pump Stopped"),
         PUMP_STARTED("Pump Started"),
         PUMP_PAUSED("Pump Paused"),
+        SETTINGS_EXPORT("Settings Export"),
         WAKING_UP("Waking Up"),
         SICKNESS("Sickness"),
         STRESS("Stress"),

--- a/core/data/src/main/kotlin/app/aaps/core/data/ue/Sources.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/ue/Sources.kt
@@ -20,6 +20,7 @@ enum class Sources {
     Exercise,
     Question,
     Announcement,
+    SettingsExport,
     Actions,            //From Actions plugin
     Automation,         //From Automation plugin
     Autotune,           //From Autotune plugin

--- a/core/graph/src/main/kotlin/app/aaps/core/graph/data/Shape.kt
+++ b/core/graph/src/main/kotlin/app/aaps/core/graph/data/Shape.kt
@@ -19,6 +19,7 @@ enum class Shape {
     MBG,
     BGCHECK,
     ANNOUNCEMENT,
+    SETTINGS_EXPORT,
     OPENAPS_OFFLINE,
     EXERCISE,
     GENERAL,

--- a/core/graph/src/main/kotlin/app/aaps/core/graph/data/TherapyEventDataPoint.kt
+++ b/core/graph/src/main/kotlin/app/aaps/core/graph/data/TherapyEventDataPoint.kt
@@ -44,6 +44,7 @@ class TherapyEventDataPoint(
                 data.type == TE.Type.NS_MBG                -> Shape.MBG
                 data.type == TE.Type.FINGER_STICK_BG_VALUE -> Shape.BGCHECK
                 data.type == TE.Type.ANNOUNCEMENT          -> Shape.ANNOUNCEMENT
+                data.type == TE.Type.SETTINGS_EXPORT       -> Shape.SETTINGS_EXPORT
                 data.type == TE.Type.APS_OFFLINE           -> Shape.OPENAPS_OFFLINE
                 data.type == TE.Type.EXERCISE              -> Shape.EXERCISE
                 duration > 0                               -> Shape.GENERAL_WITH_DURATION
@@ -55,6 +56,7 @@ class TherapyEventDataPoint(
     override fun color(context: Context?): Int {
         return when (data.type) {
             TE.Type.ANNOUNCEMENT          -> rh.gac(context, app.aaps.core.ui.R.attr.notificationAnnouncement)
+            TE.Type.SETTINGS_EXPORT       -> rh.gac(context, app.aaps.core.ui.R.attr.notificationSettingsExport)
             TE.Type.NS_MBG                -> rh.gac(context, app.aaps.core.ui.R.attr.therapyEvent_NS_MBG)
             TE.Type.FINGER_STICK_BG_VALUE -> rh.gac(context, app.aaps.core.ui.R.attr.therapyEvent_FINGER_STICK_BG_VALUE)
             TE.Type.EXERCISE              -> rh.gac(context, app.aaps.core.ui.R.attr.therapyEvent_EXERCISE)

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/ImportExportPrefs.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/ImportExportPrefs.kt
@@ -1,5 +1,6 @@
 package app.aaps.core.interfaces.maintenance
 
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import app.aaps.core.interfaces.rx.weardata.CwfData
@@ -16,6 +17,7 @@ interface ImportExportPrefs {
     fun prefsFileExists(): Boolean
     fun verifyStoragePermissions(fragment: Fragment, onGranted: Runnable)
     fun exportSharedPreferences(f: Fragment)
+    fun exportSharedPreferencesNonInteractive(context: Context, password: String): Boolean
     fun exportUserEntriesCsv(activity: FragmentActivity)
     fun exportApsResult(algorithm: String?, input: JSONObject, output: JSONObject?)
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/NotificationUserMessage.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/notifications/NotificationUserMessage.kt
@@ -1,6 +1,6 @@
 package app.aaps.core.interfaces.notifications
 
-class NotificationUserMessage(text: String) : Notification() {
+class NotificationUserMessage(text: String, notifyLevel:Int = Notification.URGENT) : Notification() {
 
     init {
         var hash = text.hashCode()
@@ -8,6 +8,6 @@ class NotificationUserMessage(text: String) : Notification() {
         id = hash
         date = System.currentTimeMillis()
         this.text = text
-        level = URGENT
+        level = notifyLevel // URGENT
     }
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/ExportPasswordDataStore.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/ExportPasswordDataStore.kt
@@ -1,0 +1,29 @@
+package app.aaps.core.interfaces.protection
+
+import android.content.Context
+
+interface ExportPasswordDataStore {
+
+    /***
+     * Check Export password functionality
+     * Returns true when Export password store is enabled.
+     */
+    fun exportPasswordStoreEnabled() : Boolean
+
+    /***
+     * Clear password currently stored.
+     */
+    fun clearPasswordDataStore(context: Context): String
+
+    /***
+     * Put password to local phone's datastore.
+     */
+    fun putPasswordToDataStore(context: Context, password: String): String
+
+    /***
+     * Get password from local phone's data store.
+     * Return pair (true,<password>) or (false,"")
+     */
+    fun getPasswordFromDataStore(context: Context): Triple<String, Boolean, Boolean>
+
+    }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/PasswordCheck.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/PasswordCheck.kt
@@ -37,4 +37,5 @@ interface PasswordCheck {
         context: Context, @StringRes labelId: Int, preference: String, @StringRes passwordExplanation: Int?,
         @StringRes passwordWarning: Int?, ok: ((String) -> Unit)?, cancel: (() -> Unit)? = null
     )
+
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/SecureEncrypt.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/protection/SecureEncrypt.kt
@@ -1,0 +1,25 @@
+package app.aaps.core.interfaces.protection
+
+interface SecureEncrypt {
+
+    /***
+     * Encrypt plaintext secret
+     * - plaintextSecret: Plain text string to be encrypted
+     * - keystoreAlias: KeyStore alias name for encryption/decryption
+     * Returns: encrypted or empty string
+     */
+    fun encrypt(plaintextSecret: String, keystoreAlias: String): String
+
+    /***
+     * Decrypt plaintext string
+     * - encryptedSecret: encrypted text string
+     * Returns: decrypted text string
+     */
+    fun decrypt(encryptedSecret: String): String
+
+    /**
+     * Check if header part of the data string is valid hash
+     */
+    fun isValidDataString(data: String?): Boolean
+
+}

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -62,6 +62,8 @@ enum class BooleanKey(
 
     MaintenanceEnableFabric("enable_fabric2", true, defaultedBySM = true, hideParentScreenIfHidden = true),
 
+    MaintenanceEnableExportSettingsAutomation("enable_unattended_export", false, defaultedBySM = false),
+
     AutotuneAutoSwitchProfile("autotune_auto", false),
     AutotuneCategorizeUamAsBasal("categorize_uam_as_basal", false),
     AutotuneTuneInsulinCurve("autotune_tune_insulin_curve", false),

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
@@ -59,6 +59,8 @@ enum class IntKey(
 
     AutotuneDefaultTuneDays("autotune_default_tune_days", 5, 1, 30),
 
+    // AutoExportPasswordExpiryDays("auto_export_password_expiry_days", 28, 7, 28),
+
     SmsRemoteBolusDistance("smscommunicator_remotebolusmindistance", 15, 3, 60),
 
     BgSourceRandomInterval("randombg_interval_min", 5, 1, 15, defaultedBySM = true),

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/treatment/EventType.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/treatment/EventType.kt
@@ -14,6 +14,7 @@ enum class EventType(val text: String) {
     @SerializedName("BG Check") FINGER_STICK_BG_VALUE("BG Check"),
     @SerializedName("Exercise") EXERCISE("Exercise"),
     @SerializedName("Announcement") ANNOUNCEMENT("Announcement"),
+    @SerializedName("SettingsExport") SETTINGS_EXPORT("Settings Export"),
     @SerializedName("Question") QUESTION("Question"),
     @SerializedName("Note") NOTE("Note"),
     @SerializedName("OpenAPS Offline") APS_OFFLINE("OpenAPS Offline"),
@@ -38,7 +39,6 @@ enum class EventType(val text: String) {
     @SerializedName("<none>") NONE("<none>");
 
     companion object {
-
-        fun fromString(text: String?) = values().firstOrNull { it.text == text } ?: NONE
+        fun fromString(text: String?) = entries.firstOrNull { it.text == text } ?: NONE
     }
 }

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/extensions/TherapyEventExtension.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/extensions/TherapyEventExtension.kt
@@ -20,3 +20,19 @@ fun TE.Companion.asAnnouncement(error: String, pumpId: Long? = null, pumpType: P
             pumpSerial = pumpSerial
         )
     )
+
+fun TE.Companion.asSettingsExport(error: String, pumpId: Long? = null, pumpType: PumpType? = null, pumpSerial: String? = null): TE =
+    TE(
+        timestamp = System.currentTimeMillis(),
+        type = TE.Type.SETTINGS_EXPORT,
+        duration = 0, note = error,
+        enteredBy = "AAPS",
+        glucose = null,
+        glucoseType = null,
+        glucoseUnit = GlucoseUnit.MGDL,
+        ids = IDs(
+            pumpId = pumpId,
+            pumpType = pumpType,
+            pumpSerial = pumpSerial
+        )
+    )

--- a/core/objects/src/main/res/drawable/ic_export_settings_24dp.xml
+++ b/core/objects/src/main/res/drawable/ic_export_settings_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    android:tint="#58BA2E">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2,20h20v-4L2,16v4zM4,17h2v2L4,19v-2zM2,4v4h20L22,4L2,4zM6,7L4,7L4,5h2v2zM2,14h20v-4L2,10v4zM4,11h2v2L4,13v-2z"/>
+
+</vector>

--- a/core/ui/src/main/res/values/attrs.xml
+++ b/core/ui/src/main/res/values/attrs.xml
@@ -76,6 +76,7 @@
     <attr name="notificationLow" format="reference|color" />
     <attr name="notificationInfo" format="reference|color" />
     <attr name="notificationAnnouncement" format="reference|color" />
+    <attr name="notificationSettingsExport" format="reference|color" />
     <!---Disabled Text Color  -->
     <attr name="disabledTextColor" format="reference|color" />
     <!---Overview and History browser  -->

--- a/core/ui/src/main/res/values/protection.xml
+++ b/core/ui/src/main/res/values/protection.xml
@@ -21,6 +21,7 @@
     <string name="unsecure_fallback_descriotion_biometric">In order to be effective, biometric protection needs a master password set for fallback.\n\nPlease set a master password!</string>
 
     <string name="password_set">Password set!</string>
+    <string name="datastore_password_cleared">Stored Export Password cleared!</string>
     <string name="pin_set">PIN set!</string>
     <string name="password_not_set">Password not set</string>
     <string name="pin_not_set">PIN not set</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="removerecord">Remove record</string>
     <string name="loopisdisabled">Loop is disabled</string>
     <string name="alarm">Alarm</string>
+    <string name="exportsettings">Export Settings</string>
     <string name="disableloop">Disable loop</string>
     <string name="enableloop">Enable loop</string>
     <string name="resumeloop">Resume loop</string>
@@ -536,6 +537,13 @@
 
     <!-- TwoMessagesDialog -->
     <string name="password_preferences_decrypt_prompt">You will be asked for master password, which is needed to decrypt imported preferences.</string>
+
+    <!-- <unattende_export> -->
+    <string name="export_ok">OK</string>
+    <string name="export_warning">Warning</string>
+    <string name="export_expired">Expired</string>
+    <string name="export_disabled">Disabled</string>
+    <string name="export_failed">Failed</string>
 
     <!-- NumberPicker -->
     <string name="a11y_min_button_description">decrement %1$s by %2$s</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -216,10 +216,12 @@
     <string name="careportal_bgcheck">BG Check</string>
     <string name="careportal_mbg">Manual BG or Calibration</string>
     <string name="careportal_announcement">Announcement</string>
+    <string name="careportal_settings_export">Settings Export</string>
     <string name="careportal_note">Note</string>
     <string name="careportal_question">Question</string>
     <string name="careportal_exercise">Exercise</string>
     <string name="careportal_announcement_message">Announcement : %1$s</string>
+    <string name="careportal_settings_export_message">Settings Export : %1$s</string>
     <string name="careportal_note_message">Note : %1$s</string>
     <string name="careportal_question_message">Question : %1$s</string>
     <string name="careportal_exercise_message">Exercise : %1$s</string>
@@ -252,6 +254,7 @@
     <string name="activity">Activity</string>
     <string name="wear">Wear</string>
     <string name="automation">Automation</string>
+    <string name="settingsexport">Settings Export</string>
     <string name="custom">Custom</string>
     <string name="loop">Loop</string>
     <string name="ns">NS</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -541,12 +541,20 @@
     <!-- TwoMessagesDialog -->
     <string name="password_preferences_decrypt_prompt">You will be asked for master password, which is needed to decrypt imported preferences.</string>
 
-    <!-- <unattende_export> -->
+    <!-- <unattended_export> -->
     <string name="export_ok">OK</string>
     <string name="export_warning">Warning</string>
     <string name="export_expired">Expired</string>
     <string name="export_disabled">Disabled</string>
     <string name="export_failed">Failed</string>
+    <string name="export_alert">ALERT</string>
+
+    <!-- <unattended_export result messages> -->
+    <string name="export_result_message_exported">Settings exported</string>
+    <string name="export_result_message_failed">Settings export FAILED!</string>
+    <string name="export_result_message_about_to_expire">Settings exported: password about to expire soon. Export manually and (re)enter password.</string>
+    <string name="export_result_message_expired">Settings export canceled: password expired. Export manually and (re)enter!</string>
+    <string name="export_result_message_disabled">Warning (automation): Settings export not enabled!</string>
 
     <!-- NumberPicker -->
     <string name="a11y_min_button_description">decrement %1$s by %2$s</string>

--- a/database/impl/src/main/kotlin/app/aaps/database/entities/TherapyEvent.kt
+++ b/database/impl/src/main/kotlin/app/aaps/database/entities/TherapyEvent.kt
@@ -87,6 +87,7 @@ data class TherapyEvent(
         TEMPORARY_BASAL_END,
 
         // Not supported by NS
+        SETTINGS_EXPORT,
         TUBE_CHANGE,
         FALLING_ASLEEP,
         BATTERY_EMPTY,

--- a/database/impl/src/main/kotlin/app/aaps/database/entities/UserEntry.kt
+++ b/database/impl/src/main/kotlin/app/aaps/database/entities/UserEntry.kt
@@ -136,6 +136,7 @@ data class UserEntry(
         Exercise,
         Question,
         Announcement,
+        SettingsExport,
         Actions,            //From Actions plugin
         Automation,         //From Automation plugin
         Autotune,           //From Autotune plugin

--- a/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourcesExtension.kt
+++ b/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourcesExtension.kt
@@ -26,6 +26,7 @@ fun UserEntry.Sources.fromDb(): Sources =
         UserEntry.Sources.Announcement        -> Sources.Announcement
         UserEntry.Sources.Actions             -> Sources.Actions
         UserEntry.Sources.Automation          -> Sources.Automation
+        UserEntry.Sources.SettingsExport      -> Sources.SettingsExport
         UserEntry.Sources.Autotune            -> Sources.Autotune
         UserEntry.Sources.BG                  -> Sources.BG
         UserEntry.Sources.Aidex               -> Sources.Aidex
@@ -102,6 +103,7 @@ fun Sources.toDb(): UserEntry.Sources =
         Sources.Exercise            -> UserEntry.Sources.Exercise
         Sources.Question            -> UserEntry.Sources.Question
         Sources.Announcement        -> UserEntry.Sources.Announcement
+        Sources.SettingsExport      -> UserEntry.Sources.SettingsExport
         Sources.Actions             -> UserEntry.Sources.Actions
         Sources.Automation          -> UserEntry.Sources.Automation
         Sources.Autotune            -> UserEntry.Sources.Autotune

--- a/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/TherapyEventExtension.kt
+++ b/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/TherapyEventExtension.kt
@@ -6,6 +6,7 @@ import app.aaps.database.entities.TherapyEvent
 fun TherapyEvent.Type.fromDb(): TE.Type = when (this) {
     TherapyEvent.Type.CANNULA_CHANGE          -> TE.Type.CANNULA_CHANGE
     TherapyEvent.Type.INSULIN_CHANGE          -> TE.Type.INSULIN_CHANGE
+    TherapyEvent.Type.SETTINGS_EXPORT         -> TE.Type.SETTINGS_EXPORT
     TherapyEvent.Type.PUMP_BATTERY_CHANGE     -> TE.Type.PUMP_BATTERY_CHANGE
     TherapyEvent.Type.SENSOR_CHANGE           -> TE.Type.SENSOR_CHANGE
     TherapyEvent.Type.SENSOR_STARTED          -> TE.Type.SENSOR_STARTED
@@ -53,6 +54,7 @@ fun TherapyEvent.Type.fromDb(): TE.Type = when (this) {
 fun TE.Type.toDb(): TherapyEvent.Type = when (this) {
     TE.Type.CANNULA_CHANGE          -> TherapyEvent.Type.CANNULA_CHANGE
     TE.Type.INSULIN_CHANGE          -> TherapyEvent.Type.INSULIN_CHANGE
+    TE.Type.SETTINGS_EXPORT         -> TherapyEvent.Type.SETTINGS_EXPORT
     TE.Type.PUMP_BATTERY_CHANGE     -> TherapyEvent.Type.PUMP_BATTERY_CHANGE
     TE.Type.SENSOR_CHANGE           -> TherapyEvent.Type.SENSOR_CHANGE
     TE.Type.SENSOR_STARTED          -> TherapyEvent.Type.SENSOR_STARTED

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ retrofit = "2.11.0"
 kotlinx-serialization = "1.7.3"
 kotlinx-coroutines = "1.9.0"
 work = "2.10.0"
+datastorePreferences = "1.1.1"
 
 [plugins]
 android-library = { id = "com.android.library" }
@@ -79,6 +80,7 @@ androidx-biometric = { group = "androidx.biometric", name = "biometric", version
 androidx-browser = { group = "androidx.browser", name = "browser", version = "1.8.0" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.2.0" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.15.0" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version = "1.8.5" }
 androidx-gridlayout = { group = "androidx.gridlayout", name = "gridlayout", version = "1.0.0" }
 androidx-legacy-support = { group = "androidx.legacy", name = "legacy-support-v13", version = "1.0.0" }

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(project(":core:objects"))
     implementation(project(":core:ui"))
     implementation(project(":core:utils"))
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(project(":shared:tests"))
     testImplementation(project(":plugins:aps"))

--- a/implementation/src/main/kotlin/app/aaps/implementation/di/ImplementationModule.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/di/ImplementationModule.kt
@@ -12,7 +12,9 @@ import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.profile.ProfileUtil
 import app.aaps.core.interfaces.profiling.Profiler
 import app.aaps.core.interfaces.protection.PasswordCheck
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.protection.ProtectionCheck
+import app.aaps.core.interfaces.protection.SecureEncrypt
 import app.aaps.core.interfaces.pump.BlePreCheck
 import app.aaps.core.interfaces.pump.DetailedBolusInfoStorage
 import app.aaps.core.interfaces.pump.PumpSync
@@ -46,8 +48,10 @@ import app.aaps.implementation.profile.ProfileFunctionImpl
 import app.aaps.implementation.profile.ProfileStoreObject
 import app.aaps.implementation.profile.ProfileUtilImpl
 import app.aaps.implementation.profiling.ProfilerImpl
+import app.aaps.implementation.protection.ExportPasswordDataStoreImpl
 import app.aaps.implementation.protection.PasswordCheckImpl
 import app.aaps.implementation.protection.ProtectionCheckImpl
+import app.aaps.implementation.protection.SecureEncryptImpl
 import app.aaps.implementation.pump.BlePreCheckImpl
 import app.aaps.implementation.pump.DetailedBolusInfoStorageImpl
 import app.aaps.implementation.pump.PumpSyncImplementation
@@ -101,6 +105,8 @@ abstract class ImplementationModule {
         @Binds fun bindTranslator(translatorImpl: TranslatorImpl): Translator
         @Binds fun bindProtectionCheck(protectionCheckImpl: ProtectionCheckImpl): ProtectionCheck
         @Binds fun bindPasswordCheck(passwordCheckImpl: PasswordCheckImpl): PasswordCheck
+        @Binds fun bindExportPasswordCheck(exportPasswordDataStoreImpl: ExportPasswordDataStoreImpl): ExportPasswordDataStore
+        @Binds fun bindSecureEncrypt(secureEncryptImpl: SecureEncryptImpl): SecureEncrypt
         @Binds fun bindLoggerUtils(loggerUtilsImpl: LoggerUtilsImpl): LoggerUtils
         @Binds fun bindProfiler(profilerImpl: ProfilerImpl): Profiler
         @Binds fun bindWarnColors(warnColorsImpl: WarnColorsImpl): WarnColors

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
@@ -47,7 +47,7 @@ class ExportPasswordDataStoreImpl @Inject constructor(
     @Inject lateinit var dateUtil: DateUtil
     @Inject lateinit var secureEncrypt: SecureEncrypt
 
-    // TODO: Remove for release (Debug only!)
+    // Remove for release? (Debug only!)
     @Inject lateinit var fileListProvider: FileListProvider
 
     companion object {
@@ -96,7 +96,7 @@ class ExportPasswordDataStoreImpl @Inject constructor(
         // Use fixed defaults for password validity window, optional overrule defaults from prefs:
         // passwordValidityWindow = (sp.getLong(IntKey.AutoExportPasswordExpiryDays.key.....
 
-        // TODO: To be removed for final PR/release?
+        // To be removed for final PR/release...
         // START
         if (config.isEngineeringMode() && config.isDev()) {
             // Enable debug mode when file 'DebugUnattendedExport' exists
@@ -153,7 +153,6 @@ class ExportPasswordDataStoreImpl @Inject constructor(
         with(passwordData) {
             if (password.isNotEmpty()) {  // And not expired
                 log.debug(LTag.CORE, "$MODULE: getPasswordFromDataStore")
-                // return Triple(true, passwordData.password, passwordData.isAboutToExpire)
                 return Triple(password, isExpired, isAboutToExpire)
             }
         }
@@ -180,13 +179,11 @@ class ExportPasswordDataStoreImpl @Inject constructor(
 
         // Write setting to android datastore and return password
         fun updatePrefString(name: String)  = runBlocking {
-            val preferencesKeyPassword = stringPreferencesKey("$name.key")
-            val preferencesKeyTimestamp = stringPreferencesKey("$name.ts")
             context.dataStore.edit { settings ->
                 // Clear password as string value
-                settings[preferencesKeyPassword] = ""
-                settings[preferencesKeyTimestamp] = "0"
-            }[preferencesKeyPassword].toString()
+                settings[stringPreferencesKey("$name.key")] = ""    // Password
+                settings[stringPreferencesKey("$name.ts")] = "0"    // Timestamp
+            }[stringPreferencesKey("$name.key")].toString()         // Return updated password
         }
 
         // Clear password stored in DataStore

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
@@ -198,14 +198,12 @@ class ExportPasswordDataStoreImpl @Inject constructor(
 
         // Write encrypted password key and timestamp to the local phone's android datastore and return password
         fun updatePrefString(name: String, str: String)  = runBlocking {
-            val preferencesKeyPassword = stringPreferencesKey("$name.key")
-            val preferencesKeyTimestamp = stringPreferencesKey("$name.ts")
             context.dataStore.edit { settings ->
                 // If current password is empty, update to new timestamp "now" or else leave it
-                settings[preferencesKeyTimestamp] = dateUtil.now().toString()
+                settings[stringPreferencesKey("$name.ts")] = dateUtil.now().toString()
                 // Update password as string value
-                settings[preferencesKeyPassword] = str
-            }[preferencesKeyPassword].toString()
+                settings[stringPreferencesKey("$name.key")] = str
+            }[stringPreferencesKey("$name.key")].toString()
         }
 
         // Update DataStore & return password string
@@ -224,11 +222,9 @@ class ExportPasswordDataStoreImpl @Inject constructor(
 
         runBlocking {
             val keyName = PASSWORD_PREFERENCE_NAME
-            val preferencesKeyVal = stringPreferencesKey("$keyName.key")
-            val preferencesKeyTs = stringPreferencesKey("$keyName.ts")
             context.dataStore.edit { settings ->
-                passwordStr = settings[preferencesKeyVal] ?:""
-                timestampStr = (settings[preferencesKeyTs] ?:"")
+                passwordStr = settings[stringPreferencesKey("$keyName.key")] ?:""
+                timestampStr = (settings[stringPreferencesKey("$keyName.ts")] ?:"")
             }
         }
 

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImpl.kt
@@ -1,0 +1,261 @@
+package app.aaps.implementation.protection
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.maintenance.FileListProvider
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
+import app.aaps.core.interfaces.protection.SecureEncrypt
+import app.aaps.core.interfaces.sharedPreferences.SP
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.keys.BooleanKey
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Class ExportPasswordDataStore (interface + implementation)
+ *
+ * This class is used to keep/store password state in the phones DataStore, that is:
+ * Password (encryption key) and creation timestamp are stored, "expiry" state and "about to expire"
+ * are calculated based on timestamp and the validity window defined.
+ *
+ * Note:
+ * - Password secret and state are stored on the phone's "Android DataStore", not in AAPS preferences.
+ * - Password encryption and decryption uses encryption keys securely stored in the phone's "Android KeyStore".
+ * - The actual password is not stored, only a secret "key" containing encrypted data and parameters.
+ * - The secret "key" is used for secure access to the password in the "Android KeyStore"
+ *
+ * Dependancy: Class SecureEncrypt
+ *
+ */
+
+@Singleton
+class ExportPasswordDataStoreImpl @Inject constructor(
+    private var log: AAPSLogger,
+    private var sp: SP,
+    private var config: Config
+    ) : ExportPasswordDataStore {
+
+    @Inject lateinit var dateUtil: DateUtil
+    @Inject lateinit var secureEncrypt: SecureEncrypt
+
+    // TODO: Remove for release (Debug only!)
+    @Inject lateinit var fileListProvider: FileListProvider
+
+    companion object {
+        // Internal constant stings
+        const val MODULE = "ExportPasswordDataStore"
+        // KeyStore alias name to use for encrypting
+        const val KEYSTORE_ALIAS = "UnattendedExportAlias"
+
+        // Android DataStore: used for keeping password state on local phone storage
+        const val DATASTORE_NAME: String = "app.aaps.plugins.configuration.maintenance.ImportExport.datastore"
+        const val PASSWORD_PREFERENCE_NAME = "$DATASTORE_NAME.unattended_export"
+
+        // On enabling & password expiry (fixed defaults)
+        private var exportPasswordStoreIsEnabled    = false                   // Set from prefs, disabled by default
+        private var passwordValidityWindow: Long    = 35 * 24 * 3600 * 1000L  // 5 weeks (including grace period)
+        private var passwordExpiryGracePeriod: Long =  7 * 24 * 3600 * 1000L  // 1 week
+    }
+
+    // Declare DataStore
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = DATASTORE_NAME
+    )
+
+    /***
+     * Data class holding password status
+     */
+    data class ClassPasswordData(
+        var password: String,
+        var timestamp: Long,
+        var isExpired: Boolean,
+        var isAboutToExpire: Boolean
+    )
+
+    /***
+     * Check if ExportPasswordDataStore is enabled
+     * Returns true when Export password store is enabled.
+     * see also:
+     * - var passwordValidityWindow
+     * - var passwordExpiryGracePeriod
+     */
+    override fun exportPasswordStoreEnabled() : Boolean {
+        // Is password storing enabled?
+        exportPasswordStoreIsEnabled  = sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)
+        if (!exportPasswordStoreIsEnabled) return false // Easy, done!
+
+        // Use fixed defaults for password validity window, optional overrule defaults from prefs:
+        // passwordValidityWindow = (sp.getLong(IntKey.AutoExportPasswordExpiryDays.key.....
+
+        // TODO: To be removed for final PR/release?
+        // START
+        if (config.isEngineeringMode() && config.isDev()) {
+            // Enable debug mode when file 'DebugUnattendedExport' exists
+            val debug = File(fileListProvider.ensureExtraDirExists(), "DebugUnattendedExport").exists()
+            val debugDev = File(fileListProvider.ensureExtraDirExists(), "DebugUnattendedExportDev").exists()
+            if (debugDev) {
+                log.warn(LTag.CORE, "$MODULE: ExportPasswordDataStore running DEBUG(DEV) mode!")
+                /*** Debug/testing mode ***/
+                passwordValidityWindow = 20 * 60 * 1000L                // Valid for 20 min
+                passwordExpiryGracePeriod = passwordValidityWindow/2    // Grace period 10 min
+            }
+            else if (debug) {
+                log.warn(LTag.CORE, "$MODULE: ExportPasswordDataStore running DEBUG mode!")
+                /*** Debug mode ***/
+                passwordValidityWindow = 2 * 24 * 3600 * 1000L           // 2 Days (including grace periodee)
+                passwordExpiryGracePeriod     = passwordValidityWindow/2 // Grace period 1 days
+            }
+        }
+        // END
+
+        log.info(LTag.CORE, "$MODULE: ExportPasswordDataStore is enabled: $exportPasswordStoreIsEnabled, expiry msecs=$passwordValidityWindow")
+        return exportPasswordStoreIsEnabled
+    }
+
+    /***
+     * Clear password currently stored in DataStore to "empty"
+     */
+    override fun clearPasswordDataStore(context: Context): String {
+        if (!exportPasswordStoreEnabled()) return "" // Do nothing, return empty
+
+        // Store & update to empty password and return
+        log.debug(LTag.CORE, "$MODULE: clearPasswordDataStore")
+        return this.clearPassword(context)
+    }
+
+    /***
+     * Store password in local phone's DataStore
+     * Return: password
+     */
+    override fun putPasswordToDataStore(context: Context, password: String): String {
+        if (!exportPasswordStoreEnabled()) return password // Just return the password
+        log.debug(LTag.CORE, "$MODULE: putPasswordToDataStore")
+        return this.storePassword(context, password)
+    }
+
+    /***
+     * Get password from local phone's DataStore
+     * Return Triple (ok, password string, isExpired, isAboutToExpire)
+     */
+    override fun getPasswordFromDataStore(context: Context): Triple<String, Boolean, Boolean> {
+        if (!exportPasswordStoreEnabled()) return Triple ("", true, true)
+
+        val passwordData = this.retrievePassword(context)
+        with(passwordData) {
+            if (password.isNotEmpty()) {  // And not expired
+                log.debug(LTag.CORE, "$MODULE: getPasswordFromDataStore")
+                // return Triple(true, passwordData.password, passwordData.isAboutToExpire)
+                return Triple(password, isExpired, isAboutToExpire)
+            }
+        }
+        return Triple ("", true, true)
+    }
+
+    /*************************************************************************
+     * Private functions
+    *************************************************************************/
+
+    /***
+     * Check if timestamp is in validity window T...T+duration
+     */
+    private fun isInValidityWindow(timestamp: Long, duration: Long?, gracePeriod: Long?):Pair<Boolean, Boolean> {
+        val expired = dateUtil.now() !in timestamp..timestamp + (duration ?: 0L)
+        val expires = dateUtil.now() !in timestamp..timestamp + (duration ?: 0L) - (gracePeriod ?: 0L)
+        return Pair (expired, expires)
+    }
+
+    /***
+     * Clear password and timestamp
+     */
+    private fun clearPassword(context: Context): String {
+
+        // Write setting to android datastore and return password
+        fun updatePrefString(name: String)  = runBlocking {
+            val preferencesKeyPassword = stringPreferencesKey("$name.key")
+            val preferencesKeyTimestamp = stringPreferencesKey("$name.ts")
+            context.dataStore.edit { settings ->
+                // Clear password as string value
+                settings[preferencesKeyPassword] = ""
+                settings[preferencesKeyTimestamp] = "0"
+            }[preferencesKeyPassword].toString()
+        }
+
+        // Clear password stored in DataStore
+        return updatePrefString(PASSWORD_PREFERENCE_NAME)
+    }
+
+
+    /***
+     * Store password and set timestamp to current
+     */
+    private fun storePassword(context: Context, password: String): String {
+
+        // Write encrypted password key and timestamp to the local phone's android datastore and return password
+        fun updatePrefString(name: String, str: String)  = runBlocking {
+            val preferencesKeyPassword = stringPreferencesKey("$name.key")
+            val preferencesKeyTimestamp = stringPreferencesKey("$name.ts")
+            context.dataStore.edit { settings ->
+                // If current password is empty, update to new timestamp "now" or else leave it
+                settings[preferencesKeyTimestamp] = dateUtil.now().toString()
+                // Update password as string value
+                settings[preferencesKeyPassword] = str
+            }[preferencesKeyPassword].toString()
+        }
+
+        // Update DataStore & return password string
+        return updatePrefString(PASSWORD_PREFERENCE_NAME, secureEncrypt.encrypt(password, KEYSTORE_ALIAS))
+    }
+
+    /***
+     * Retrieve password from local phone's data store.
+     * Reset password when validity expired
+    ***/
+    private fun retrievePassword(context: Context): ClassPasswordData {
+
+        // Read encrypted password key and timestamp from the local phone's android datastore and return password
+        var passwordStr = ""
+        var timestampStr = ""
+
+        runBlocking {
+            val keyName = PASSWORD_PREFERENCE_NAME
+            val preferencesKeyVal = stringPreferencesKey("$keyName.key")
+            val preferencesKeyTs = stringPreferencesKey("$keyName.ts")
+            context.dataStore.edit { settings ->
+                passwordStr = settings[preferencesKeyVal] ?:""
+                timestampStr = (settings[preferencesKeyTs] ?:"")
+            }
+        }
+
+        val classPasswordData = ClassPasswordData(
+            password = passwordStr,
+            timestamp = if (timestampStr.isEmpty()) 0L else timestampStr.toLong(),
+            isExpired = true,
+            isAboutToExpire =  true
+        )
+
+        // Get the password value stored
+        with(classPasswordData) {
+            if (password.isEmpty()) return classPasswordData
+
+            // Password is defined: Check for password expiry:
+            val (expired, expires) = isInValidityWindow(timestamp, passwordValidityWindow, passwordExpiryGracePeriod)
+            isExpired = expired
+            isAboutToExpire = expires
+
+            // When expired, need to renew: clear/update password in data store
+            if (isExpired) password = clearPasswordDataStore(context)
+        }
+        // Store/update password and return
+        return classPasswordData
+    }
+
+}

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/PasswordCheckImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/PasswordCheckImpl.kt
@@ -11,7 +11,9 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.StringRes
+import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.protection.PasswordCheck
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
 import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.core.objects.R
 import app.aaps.core.objects.crypto.CryptoUtil
@@ -23,6 +25,7 @@ import javax.inject.Inject
 
 @Reusable
 class PasswordCheckImpl @Inject constructor(
+    private var log: AAPSLogger,
     private val sp: SP,
     private val cryptoUtil: CryptoUtil
 ) : PasswordCheck {
@@ -30,6 +33,8 @@ class PasswordCheckImpl @Inject constructor(
     // since androidx.autofill.HintConstants are not available
     @Suppress("PrivatePropertyName")
     private val AUTOFILL_HINT_NEW_PASSWORD = "newPassword"
+
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
 
     /**
     Asks for "managed" kind of password, checking if it is valid.
@@ -123,6 +128,7 @@ class PasswordCheckImpl @Inject constructor(
                     ToastUtils.errorToast(context, context.getString(msg))
                 } else if (enteredPassword.isNotEmpty()) {
                     sp.putString(preference, cryptoUtil.hashPassword(enteredPassword))
+                    exportPasswordDataStore.clearPasswordDataStore(context)
                     val msg = if (pinInput) app.aaps.core.ui.R.string.pin_set else app.aaps.core.ui.R.string.password_set
                     ToastUtils.okToast(context, context.getString(msg))
                     ok?.invoke(enteredPassword)
@@ -213,4 +219,5 @@ class PasswordCheckImpl @Inject constructor(
             }
         }
     }
+
 }

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/SecureEncryptImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/SecureEncryptImpl.kt
@@ -135,11 +135,11 @@ class SecureEncryptImpl @Inject constructor(
                 .build()
             val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
             keyGenerator.init(keyGenParameterSpec)
+            // Return newly generated key
             return keyGenerator.generateKey()
-        } else {
-            // Alias exists in KeyStore: retrieve key
-            return retrieveSecretKeyFromKeyStore(keyAlias)
         }
+        // Else: Alias exists in KeyStore: retrieve existing key
+        return retrieveSecretKeyFromKeyStore(keyAlias)
     }
 
     /***
@@ -210,15 +210,13 @@ class SecureEncryptImpl @Inject constructor(
      */
     private fun stringToClassEncryptedData(dataString: String): ClassEncryptedData
     {
+        var classEncryptedData = ClassEncryptedData(isValid = false, keyStoreAlias = "", ivHexString = "", encryptedDataHexString = "")
         if (isValidDataString(dataString)) {
             val data = dataString.split(HEX_STRING_SEPARATOR)
-            return if (data.size == 4)
-                ClassEncryptedData(isValid = true, keyStoreAlias = data[1], ivHexString = data[2], encryptedDataHexString = data[3])
-            else
-                ClassEncryptedData(isValid = false, keyStoreAlias = "", ivHexString = "", encryptedDataHexString = "")
+            if (data.size == 4)
+                classEncryptedData = ClassEncryptedData(isValid = true, keyStoreAlias = data[1], ivHexString = data[2], encryptedDataHexString = data[3])
         }
-        else
-            return ClassEncryptedData(isValid = false, keyStoreAlias = "", ivHexString = "", encryptedDataHexString = "")
+        return classEncryptedData
     }
 
     /***

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/SecureEncryptImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/SecureEncryptImpl.kt
@@ -1,0 +1,362 @@
+package app.aaps.implementation.protection
+
+// Core
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.protection.SecureEncrypt
+import javax.inject.Inject
+
+// Android KeyStore
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import app.aaps.core.objects.crypto.CryptoUtil
+import app.aaps.core.utils.hexStringToByteArray
+import java.io.IOException
+import java.security.InvalidKeyException
+import java.security.KeyStore
+import java.security.KeyStoreException
+import java.security.NoSuchAlgorithmException
+import java.security.NoSuchProviderException
+import java.security.UnrecoverableKeyException
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Singleton
+
+/***
+ * Implementation for class SecureEncrypt
+ *
+ * This provides functions for encrypting/decrypting plain text strings using the Android KeyStore.
+ * The Android Keystore system stores cryptographic keys in a container to make them more difficult to extract
+ * from the device. Once keys are in the keystore, they can be used cryptographic operations, with the key material
+ * remaining non-exportable.
+ */
+
+@Singleton
+class SecureEncryptImpl @Inject constructor(
+    private var log: AAPSLogger,
+    private var cryptoUtil: CryptoUtil
+    ) : SecureEncrypt {
+
+    companion object {
+        // Internal "constant" stings
+        const val MODULE = "ENCRYPT"
+        const val HEX_STRING_SEPARATOR = ":"
+    }
+
+    /***
+     * Encrypt plaintext secret
+     * - plaintextSecret: Plain text string to be encrypted
+     * - keystoreAlias: KeyStore alias name for encryption/decryption
+     * Returns: encrypted or empty string
+     */
+    override fun encrypt(plaintextSecret: String, keystoreAlias: String): String {
+        //
+        if (!plaintextSecret.isEmpty()) {
+            // Encrypt plaintextSecret string
+            val classEncryptedData = keyStoreEncrypt(keystoreAlias, plaintextSecret)
+            val secret = classEncryptedDataToString(classEncryptedData)
+            log.info(LTag.CORE, "$MODULE: encrypt() stored encryption secret.")
+            return secret
+        }
+        else {
+            log.debug(LTag.CORE, "$MODULE: encrypt() not encrypting empty secret.")
+        }
+        return ""
+    }
+
+    /***
+     * Decrypt plaintext string
+     * - encryptedSecret: encrypted text string
+     * Returns: decrypted text string
+     */
+    override fun decrypt(encryptedSecret: String): String {
+        if (!encryptedSecret.isEmpty()) {
+            // Prepare for decryption
+            val classEncryptedData = stringToClassEncryptedData(encryptedSecret)
+            // Decrypt string
+            val decryptedSecret = keyStoreDecrypt(classEncryptedData)
+            log.info(LTag.CORE, "$MODULE: decrypt() secret decrypted.")
+            return decryptedSecret
+        }
+        else
+            log.debug(LTag.CORE, "$MODULE: decrypt() empty not decrypting empty secret.")
+
+        return ""
+    }
+
+    /**
+     * Check if header part of the DataString is valid hash
+     */
+    override fun isValidDataString(data: String?): Boolean {
+        with(data) {
+            if (!isNullOrEmpty() && split(HEX_STRING_SEPARATOR).size > 1) {
+                val dataContent = substringAfter(HEX_STRING_SEPARATOR)
+                return (substringBefore(HEX_STRING_SEPARATOR) == cryptoUtil.sha256(dataContent))
+            }
+        }
+        return false
+    }
+
+    /*************************************************************************
+     * Private functions
+    *************************************************************************/
+
+    /***
+     * getKeyFromKeyStore() generates new or gets existing alias key from local phones KeyStore
+     * - keyAlias: KeyStore alias name to use
+     * - forceNew: Force generate new key
+     * Returns: New or existing KeyStore key for alias
+     *
+     * Note getKeyFromKeyStore runtime can throw the following exceptions:
+     *  is KeyStoreException,
+     *  is NoSuchAlgorithmException,
+     *  is InvalidKeyException
+     *  is UnrecoverableKeyException
+     *  is NoSuchProviderException
+     *  is IOException
+     *
+     */
+    private fun getKeyFromKeyStore(keyAlias: String, forceNew: Boolean = false): SecretKey {
+        // Get KeyStore instance
+        val keyStore = KeyStore.getInstance("AndroidKeyStore")
+        keyStore.load(null)
+        val keyStoreIsAvailable = keyStore.containsAlias(keyAlias)
+
+        // Create new KeyStore alias or reuse existing key generation or retrieval
+        if (!keyStoreIsAvailable || forceNew) {
+            // Keystore alias does not exist in KeyStore: generate new key
+            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+                keyAlias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build()
+            val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+            keyGenerator.init(keyGenParameterSpec)
+            return keyGenerator.generateKey()
+        } else {
+            // Alias exists in KeyStore: retrieve key
+            return retrieveSecretKeyFromKeyStore(keyAlias)
+        }
+    }
+
+    /***
+     * Get secret key from local phones alias KeyStore
+     * - keyAlias: KeyStore alias name to use
+     * Returns: Existing KeyStore key for alias
+     */
+    private fun retrieveSecretKeyFromKeyStore(keyAlias: String): SecretKey {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore")
+        keyStore.load(null)
+        val secretKeyEntry = keyStore.getEntry(keyAlias, null) as KeyStore.SecretKeyEntry
+        val secretKey = secretKeyEntry.secretKey
+        return secretKey
+    }
+
+    /***
+     * Convert hex string to ByteArray
+     * - Hex formatted string
+     * Returns ByteArray
+     */
+    private fun hexStringToByteArray(hexString: String): ByteArray {
+        val len = hexString.length
+        val data = ByteArray(len / 2)
+        for (i in 0 until len step 2) {
+            data[i / 2] = ((Character.digit(hexString[i], 16) shl 4) + Character.digit(hexString[i + 1], 16)).toByte()
+        }
+        return data
+    }
+
+    /***
+     * Data class holding encryption attributes
+     * - ivHexString: Hex formatted KeyStore iv parameter
+     * - encryptedDataHexString: Hex formatted, encrypted data string
+     */
+    data class ClassEncryptedData (
+        var isValid: Boolean,
+        var keyStoreAlias: String,
+        var ivHexString: String,
+        var encryptedDataHexString: String
+    )
+
+    /**
+     * Get classEncryptedData into one single String formatted "<keyStoreAlis><separator><ivHexString><separator><encryptedDataHexString>" for easy storing.
+     * - ClassEncryptedData object containing encryption data
+     * Returns: plaintext String formatted "<hash><separator><keyStoreAlias><separator><ivHexString><separator><encryptedDataHexString>"
+     */
+    private fun classEncryptedDataToString(classEncryptedData: ClassEncryptedData): String
+    {
+        // Construct data string
+        val data = buildString {
+            append(classEncryptedData.keyStoreAlias)
+            append(HEX_STRING_SEPARATOR)
+            append(classEncryptedData.ivHexString)
+            append(HEX_STRING_SEPARATOR)
+            append(classEncryptedData.encryptedDataHexString)
+        }
+        // Return data string with header hash value
+        return buildString {
+            append(cryptoUtil.sha256(data)) // Hash to be able to validate
+            append(HEX_STRING_SEPARATOR)    // <separator>
+            append(data)                    // Data...
+        }
+    }
+
+    /**
+     * Input plaintext string formatted "<ivHexString><separator><encryptedDataHexString>"
+     * Returns initialized ClassEncryptedData object
+     */
+    private fun stringToClassEncryptedData(dataString: String): ClassEncryptedData
+    {
+        if (isValidDataString(dataString)) {
+            val data = dataString.split(HEX_STRING_SEPARATOR)
+            return if (data.size == 4)
+                ClassEncryptedData(isValid = true, keyStoreAlias = data[1], ivHexString = data[2], encryptedDataHexString = data[3])
+            else
+                ClassEncryptedData(isValid = false, keyStoreAlias = "", ivHexString = "", encryptedDataHexString = "")
+        }
+        else
+            return ClassEncryptedData(isValid = false, keyStoreAlias = "", ivHexString = "", encryptedDataHexString = "")
+    }
+
+    /***
+     * Encrypt plaintext data string using KeyStore alias
+     * Returns: ClassEncryptedData
+     */
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun keyStoreEncrypt(keyAlias: String, originalDataString: String): ClassEncryptedData {
+        // Initialize data class
+        var classEncryptedData = ClassEncryptedData(isValid = false, keyStoreAlias = keyAlias, ivHexString = "", encryptedDataHexString = "")
+
+        try {
+            // Get secret key
+            val secretKey = getKeyFromKeyStore(keyAlias)
+
+            // Initialize Cipher for encryption & get iv
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+            val ivHex = cipher.iv.toHexString()
+
+            // Encrypt Data
+            val originalData = originalDataString.toByteArray()
+            val encryptedData = cipher.doFinal(originalData)
+
+            classEncryptedData = ClassEncryptedData (
+                isValid = true,
+                keyStoreAlias = keyAlias,
+                ivHexString = ivHex,
+                encryptedDataHexString = encryptedData.toHexString()
+            )
+            println("Encryption, isValid      : $classEncryptedData.isValid")
+            println("Encryption, keyStoreAlias: $classEncryptedData.keyStoreAlias")
+            println("Encryption, iv(hex)      : $classEncryptedData.ivHex")
+            println("Encryption, Text(hex)    : $classEncryptedData.encryptedDataHexString")
+        }
+        catch (e: Exception) {
+            when (e) {
+                is KeyStoreException,
+                is NoSuchAlgorithmException,
+                is InvalidKeyException,
+                is UnrecoverableKeyException,
+                is NoSuchProviderException,
+                is IOException -> {
+                    log.error(LTag.CORE, "$MODULE: keyStoreEncrypt, msg=${e.message}, $e")
+                }
+            }
+        }
+        return classEncryptedData
+    }
+
+    /***
+     * Decrypt plaintext data string using KeyStore alias
+     * - keyAlias: KeyStore alias to use
+     * - classEncryptedData: initialized ClassEncryptedData object
+     * Returns: Decrypted plaintext string or empty string when error or no encrypted data
+     */
+    private fun keyStoreDecrypt(classEncryptedData: ClassEncryptedData): String {
+        with (classEncryptedData) {
+            if (!isValid || encryptedDataHexString.isEmpty()) {
+                // There is no valid or encrypted data: return empty string
+                return ""
+            }
+        }
+
+        // Initialise
+        var decryptedDataString = ""
+
+        try {
+            // Get decryption parameters
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            val iv: ByteArray = classEncryptedData.ivHexString.hexStringToByteArray()
+            val secretKey: SecretKey = retrieveSecretKeyFromKeyStore(classEncryptedData.keyStoreAlias)
+
+            // Initialize Cipher instance we already have?
+            val ivParameterSpec = GCMParameterSpec(128, iv) // Use GCMParameterSpec
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec)
+
+            // Decrypt
+            val dataToDecrypt = hexStringToByteArray(classEncryptedData.encryptedDataHexString)
+            val decryptedData = cipher.doFinal(dataToDecrypt)
+            decryptedDataString = String(decryptedData)
+
+            // Check the result:
+            println("Encryption, decrypted text OK")
+        }
+        catch (e: Exception) {
+            when (e) {
+                is KeyStoreException,
+                is NoSuchAlgorithmException,
+                is InvalidKeyException,
+                is UnrecoverableKeyException,
+                is NoSuchProviderException,
+                is IOException -> {
+                    log.error(LTag.CORE, "$MODULE: keyStoreDecrypt, msg: ${e.message}, $e")
+                }
+            }
+        }
+        return decryptedDataString
+    }
+
+    /***
+    * TESTING: Test/Debyg example code using Android KeyStore
+    private fun doTest(): Boolean {
+        val originalDataString = "My sensitive data"
+
+        // Encrypt original data string
+        var classEncryptedData = keyStoreEncrypt(keyAlias, originalDataString)
+        /**
+        Data class classEncryptedData object now holds keystore parameter iv (bytes) and encrypted data (bytes) as Hex String
+        Function keyStoreDecrypt uses the key alias to retrieve the secret key and decipher the encrypted data using
+        the secret key and iv
+        **/
+        // Make it one string for easy storing
+        var testdata:String = getDataStringFromClassEncryptedData(classEncryptedData)
+
+        // Try to get some encrypted data from elsewhere
+        val decryptDebug = false
+        if (decryptDebug) {
+            // Debug: using fixed iv and encrypted string from previous encryption run (see logcat?)
+            val testDataClass = ClassEncryptedData (
+                ivHexString = "833fb80226e34b7289b3cad5",
+                encryptedDataHexString = "f81583199a30642ec9c32ca2fd1d6e23ed15c874c42f2acde9b2b6774b1175fad6"
+            )
+            testdata = getDataStringFromClassEncryptedData(testDataClass)
+        }
+
+        // Now decrypt encryption result in decrypted data to original data string
+        classEncryptedData = putDataStringToClassEncryptedData(testdata)
+        val decryptedDataString = keyStoreDecrypt(keyAlias, classEncryptedData)
+
+        if (originalDataString == decryptedDataString) {
+            println("Encryption, OK!")
+            return true
+        } else {
+            println("EncryptionERROR!")
+            return false
+        }
+    }
+    */
+
+}

--- a/implementation/src/main/kotlin/app/aaps/implementation/userEntry/UserEntryPresentationHelperImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/userEntry/UserEntryPresentationHelperImpl.kt
@@ -60,6 +60,7 @@ class UserEntryPresentationHelperImpl @Inject constructor(
         Sources.Exercise            -> R.drawable.ic_cp_exercise
         Sources.Question            -> R.drawable.ic_cp_question
         Sources.Announcement        -> R.drawable.ic_cp_announcement
+        Sources.SettingsExport      -> R.drawable.ic_automation
         Sources.Actions             -> R.drawable.ic_action
         Sources.Automation          -> R.drawable.ic_automation
         Sources.Autotune            -> R.drawable.ic_autotune

--- a/implementation/src/main/kotlin/app/aaps/implementation/utils/TranslatorImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/utils/TranslatorImpl.kt
@@ -136,6 +136,7 @@ class TranslatorImpl @Inject internal constructor(
         TE.Type.BOLUS_WIZARD            -> rh.gs(app.aaps.core.ui.R.string.boluswizard)
         TE.Type.COMBO_BOLUS             -> rh.gs(app.aaps.core.ui.R.string.careportal_combobolus)
         TE.Type.ANNOUNCEMENT            -> rh.gs(app.aaps.core.ui.R.string.careportal_announcement)
+        TE.Type.SETTINGS_EXPORT         -> rh.gs(app.aaps.core.ui.R.string.careportal_settings_export)
         TE.Type.NOTE                    -> rh.gs(app.aaps.core.ui.R.string.careportal_note)
         TE.Type.QUESTION                -> rh.gs(app.aaps.core.ui.R.string.careportal_question)
         TE.Type.EXERCISE                -> rh.gs(app.aaps.core.ui.R.string.careportal_exercise)
@@ -288,6 +289,7 @@ class TranslatorImpl @Inject internal constructor(
         Sources.Aaps                               -> TODO()
         */
         Sources.Automation -> rh.gs(app.aaps.core.ui.R.string.automation)
+        Sources.SettingsExport -> rh.gs(app.aaps.core.ui.R.string.settingsexport)
         Sources.Autotune   -> rh.gs(app.aaps.core.ui.R.string.autotune)
         Sources.Loop       -> rh.gs(app.aaps.core.ui.R.string.loop)
         Sources.NSClient   -> rh.gs(app.aaps.core.ui.R.string.ns)

--- a/implementation/src/test/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImplTest.kt
+++ b/implementation/src/test/kotlin/app/aaps/implementation/protection/ExportPasswordDataStoreImplTest.kt
@@ -1,0 +1,67 @@
+package app.aaps.implementation.protection
+
+import android.content.Context
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
+import app.aaps.core.interfaces.protection.SecureEncrypt
+import app.aaps.core.interfaces.sharedPreferences.SP
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.objects.aps.DetermineBasalResult
+import app.aaps.core.objects.crypto.CryptoUtil
+import app.aaps.shared.tests.AAPSLoggerTest
+import app.aaps.shared.tests.TestBase
+import app.aaps.shared.tests.TestBaseWithProfile
+import dagger.android.AndroidInjector
+import dagger.android.DaggerApplication
+import dagger.android.HasAndroidInjector
+
+
+import org.junit.BeforeClass
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+class ExportPasswordDataStoreImplTest: TestBaseWithProfile() {
+
+    private val somePassword = "somePassword"
+
+    val sut: ExportPasswordDataStoreImpl by lazy {
+        ExportPasswordDataStoreImpl(aapsLogger, sp, config)
+    }
+
+    @Test
+    fun exportPasswordStoreEnabled() {
+        // When disabled
+        `when`(sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)).thenReturn(false)
+        assertFalse(sut.exportPasswordStoreEnabled())
+
+        // When enabled
+        `when`(sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)).thenReturn(true)
+        assertTrue(sut.exportPasswordStoreEnabled())
+        assertTrue(sut.clearPasswordDataStore(context).isEmpty())
+
+        // These will fail to run (can not instantiate secure encrypt?)
+        // assertTrue(sut.putPasswordToDataStore(context, somePassword) == somePassword)
+        // assertTrue(sut.getPasswordFromDataStore(context) == Triple ("", true, true))
+    }
+
+    @Test
+    fun clearPasswordDataStore() {
+        `when`(sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)).thenReturn(false)
+        assertTrue(sut.clearPasswordDataStore(context).isEmpty())
+    }
+
+    @Test
+    fun putPasswordToDataStore() {
+        `when`(sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)).thenReturn(false)
+        assertTrue(sut.putPasswordToDataStore(context, somePassword) == somePassword)
+    }
+
+    @Test
+    fun getPasswordFromDataStore() {
+        `when`(sp.getBoolean(BooleanKey.MaintenanceEnableExportSettingsAutomation.key, false)).thenReturn(false)
+        assertTrue(sut.getPasswordFromDataStore(context) == Triple ("", true, true))
+    }
+}

--- a/implementation/src/test/kotlin/app/aaps/implementation/protection/SecureEncryptImplTest.kt
+++ b/implementation/src/test/kotlin/app/aaps/implementation/protection/SecureEncryptImplTest.kt
@@ -1,0 +1,49 @@
+package app.aaps.implementation.protection
+
+import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.interfaces.sharedPreferences.SP
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+import app.aaps.core.objects.crypto.CryptoUtil
+import app.aaps.shared.tests.TestBase
+import org.mockito.Mock
+
+class SecureEncryptImplTest: TestBase() {
+
+    private val cryptoUtil = CryptoUtil(aapsLogger)
+    private val sut = SecureEncryptImpl(aapsLogger, cryptoUtil)
+
+    private val testData = "My secret data"
+    private val secretData = "6072f90e56e607f8e54fa5f434d149b5e84b2813ff13be1691f9819f5d04a7f9:UnattendedExportAlias:17fafca82f1c8e58b4b78eb6:335573ff96c60dc7b1766b49c0c0fd57276d2f"
+
+    /***
+    Test general interface only (as the Android KeyStore is not available or mocked)
+    */
+
+    @Test
+    fun encrypt() {
+        // Partial test: KeyStore is not available on test platform
+        // Expect secret wil contain empty password
+        val testSecret = sut.encrypt(plaintextSecret = testData, keystoreAlias = "TestAlias")
+        assertThat(testSecret).isNotEmpty()
+        assertThat(sut.isValidDataString(testSecret)).isTrue()
+    }
+
+    @Test
+    fun decrypt() {
+        // Partial test: KeyStore is not available on test platform
+        // Expect secret is not empty and contains empty password
+        val testSecret = sut.encrypt(plaintextSecret = testData, keystoreAlias = "TestAlias")
+        assertThat(testSecret).isNotEmpty()
+        assertThat(sut.isValidDataString(testSecret)).isTrue()
+        val result = sut.decrypt(encryptedSecret = testSecret)
+        assertThat(result).isEqualTo("")
+    }
+
+    //@org.junit.jupiter.api.Test
+    @Test fun isValidDataString() {
+        // Expect test/sample string has valid data
+        assertThat(sut.isValidDataString(secretData)).isTrue()
+    }
+}

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
@@ -58,6 +58,7 @@ import app.aaps.plugins.automation.triggers.TriggerBTDevice
 import app.aaps.plugins.automation.triggers.TriggerBg
 import app.aaps.plugins.automation.triggers.TriggerBolusAgo
 import app.aaps.plugins.automation.triggers.TriggerCOB
+import app.aaps.plugins.automation.triggers.TriggerPodChange
 import app.aaps.plugins.automation.triggers.TriggerCannulaAge
 import app.aaps.plugins.automation.triggers.TriggerConnector
 import app.aaps.plugins.automation.triggers.TriggerDelta
@@ -415,10 +416,14 @@ class AutomationPlugin @Inject constructor(
             TriggerSensorAge(injector),
             TriggerCannulaAge(injector),
             TriggerReservoirLevel(injector)
-        )
+            )
 
         val pump = activePlugin.activePump
-        if (!pump.pumpDescription.isPatchPump) {
+
+        if (pump.pumpDescription.isPatchPump) {
+            triggers.add(TriggerPodChange(injector))
+        }
+        else {
             triggers.add(TriggerInsulinAge(injector))
         }
         if (pump.pumpDescription.isBatteryReplaceable || pump.isBatteryChangeLoggingEnabled()) {

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/AutomationPlugin.kt
@@ -42,6 +42,7 @@ import app.aaps.plugins.automation.actions.ActionProfileSwitch
 import app.aaps.plugins.automation.actions.ActionProfileSwitchPercent
 import app.aaps.plugins.automation.actions.ActionRunAutotune
 import app.aaps.plugins.automation.actions.ActionSendSMS
+import app.aaps.plugins.automation.actions.ActionSettingsExport
 import app.aaps.plugins.automation.actions.ActionStartTempTarget
 import app.aaps.plugins.automation.actions.ActionStopProcessing
 import app.aaps.plugins.automation.actions.ActionStopTempTarget
@@ -382,6 +383,7 @@ class AutomationPlugin @Inject constructor(
             ActionStopTempTarget(injector),
             ActionNotification(injector),
             ActionAlarm(injector),
+            ActionSettingsExport(injector),
             ActionCarePortalEvent(injector),
             ActionProfileSwitchPercent(injector),
             ActionProfileSwitch(injector),

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/Action.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/Action.kt
@@ -58,6 +58,7 @@ abstract class Action(val injector: HasAndroidInjector) {
             if (dotIndex > 0) type = type.substring(dotIndex + 1)
             return when (type) {
                 ActionAlarm::class.java.simpleName                -> ActionAlarm(injector).fromJSON(data.toString())
+                ActionSettingsExport::class.java.simpleName       -> ActionSettingsExport(injector).fromJSON(data.toString())
                 ActionCarePortalEvent::class.java.simpleName      -> ActionCarePortalEvent(injector).fromJSON(data.toString())
                 ActionDummy::class.java.simpleName                -> ActionDummy(injector).fromJSON(data.toString())
                 ActionLoopDisable::class.java.simpleName          -> ActionLoopDisable(injector).fromJSON(data.toString())

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionNotification.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionNotification.kt
@@ -5,6 +5,7 @@ import androidx.annotation.DrawableRes
 import app.aaps.core.data.model.TE
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.interfaces.db.PersistenceLayer
+import app.aaps.core.interfaces.notifications.Notification
 import app.aaps.core.interfaces.notifications.NotificationUserMessage
 import app.aaps.core.interfaces.queue.Callback
 import app.aaps.core.interfaces.rx.bus.RxBus
@@ -38,7 +39,7 @@ class ActionNotification(injector: HasAndroidInjector) : Action(injector) {
     @DrawableRes override fun icon(): Int = R.drawable.ic_notifications
 
     override fun doAction(callback: Callback) {
-        val notification = NotificationUserMessage(text.value)
+        val notification = NotificationUserMessage(text.value, Notification.URGENT)
         rxBus.send(EventNewNotification(notification))
         disposable += persistenceLayer.insertPumpTherapyEventIfNewByTimestamp(
             therapyEvent = TE.asAnnouncement(text.value),

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
@@ -16,7 +16,7 @@ import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventNewNotification
 import app.aaps.core.interfaces.rx.events.EventRefreshOverview
 import app.aaps.core.interfaces.utils.DateUtil
-import app.aaps.core.objects.extensions.asAnnouncement
+import app.aaps.core.objects.extensions.asSettingsExport
 import app.aaps.core.utils.JsonHelper
 import app.aaps.plugins.automation.R
 import app.aaps.plugins.automation.elements.InputString
@@ -100,7 +100,8 @@ class ActionSettingsExport(injector: HasAndroidInjector) : Action(injector) {
         }
 
         disposable += persistenceLayer.insertPumpTherapyEventIfNewByTimestamp(
-            therapyEvent = TE.asAnnouncement(text.value),
+            // therapyEvent = TE.asAnnouncement(text.value),
+            therapyEvent = TE.asSettingsExport(text.value),
             timestamp = dateUtil.now(),
             action = app.aaps.core.data.ue.Action.EXPORT_SETTINGS,
             source = Sources.Automation,

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/actions/ActionSettingsExport.kt
@@ -1,0 +1,135 @@
+package app.aaps.plugins.automation.actions
+
+import android.content.Context
+import android.widget.LinearLayout
+import androidx.annotation.DrawableRes
+import app.aaps.core.data.model.TE
+import app.aaps.core.data.ue.Sources
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.db.PersistenceLayer
+import app.aaps.core.interfaces.maintenance.ImportExportPrefs
+import app.aaps.core.interfaces.notifications.Notification
+import app.aaps.core.interfaces.notifications.NotificationUserMessage
+import app.aaps.core.interfaces.protection.ExportPasswordDataStore
+import app.aaps.core.interfaces.queue.Callback
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventNewNotification
+import app.aaps.core.interfaces.rx.events.EventRefreshOverview
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.objects.extensions.asAnnouncement
+import app.aaps.core.utils.JsonHelper
+import app.aaps.plugins.automation.R
+import app.aaps.plugins.automation.elements.InputString
+import app.aaps.plugins.automation.elements.LabelWithElement
+import app.aaps.plugins.automation.elements.LayoutBuilder
+import dagger.android.HasAndroidInjector
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.kotlin.plusAssign
+import org.json.JSONObject
+import javax.inject.Inject
+
+class ActionSettingsExport(injector: HasAndroidInjector) : Action(injector) {
+
+    @Inject lateinit var rxBus: RxBus
+    @Inject lateinit var context: Context
+    @Inject lateinit var dateUtil: DateUtil
+    @Inject lateinit var config: Config
+    @Inject lateinit var persistenceLayer: PersistenceLayer
+    @Inject lateinit var importExportPrefs: ImportExportPrefs
+    @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
+
+    private val disposable = CompositeDisposable()
+    private val text = InputString()
+
+    override fun friendlyName(): Int = app.aaps.core.ui.R.string.exportsettings
+    override fun shortDescription(): String = rh.gs(R.string.exportsettings_message, text.value)
+    @DrawableRes override fun icon(): Int = app.aaps.core.objects.R.drawable.ic_export_settings_24dp
+
+    override fun isValid(): Boolean = true
+
+    override fun doAction(callback: Callback) {
+        val message: String
+
+        // Feedback on result
+        var exportResultComment: Int        // Comment string ID set in code
+
+        if (exportPasswordDataStore.exportPasswordStoreEnabled()) {
+            // Send user notification when done
+            val notification: Notification
+
+            // Get the (encrypted) password and status from the DataStore
+            val (password, isExpired, isAboutToExpire) = exportPasswordDataStore.getPasswordFromDataStore(context)
+            // An do according to password state
+            if (password.isNotEmpty() && !isExpired) { // Password is not empty and not isExpired
+                // Password is not empty and not expired
+                if (isAboutToExpire) {
+                    // Password is about to expire and needs re-entering by user soon: notify user
+                    // Note: we are allowed to export!
+                    message = "Settings exported: password about to expire soon. Export manually and (re)enter password."
+                    notification = NotificationUserMessage(message, Notification.LOW)  // LOW -> e.g. color ORANGE
+                    exportResultComment = app.aaps.core.ui.R.string.export_warning
+                } else {
+                    // We have a valid password: start exporting, then notify
+                    message = "Settings exported"
+                    notification = NotificationUserMessage(message, Notification.INFO) // INFO -> e.g. color GREEN
+                    exportResultComment = app.aaps.core.ui.R.string.export_ok
+                }
+                // Execute settings export, then notify user
+                if (!importExportPrefs.exportSharedPreferencesNonInteractive(context, password)) {
+                    exportResultComment = app.aaps.core.ui.R.string.export_failed
+                }
+
+            }
+            else {
+                // No password or was expired and needs re-entering by user
+                message = "Settings export canceled: password expired. Export manually and (re)enter!"
+                notification = NotificationUserMessage(message, Notification.URGENT)  // Urgent -> e.g. color RED
+                exportResultComment = app.aaps.core.ui.R.string.export_expired
+                // Clear password in datastore, then notify user
+                exportPasswordDataStore.clearPasswordDataStore(context)
+            }
+            // send notification
+            rxBus.send(EventNewNotification(notification))
+        }
+        else {
+            // Not enabled, do nothing and notify user
+            message = "Warning (automation): Settings export not enabled!"
+            exportResultComment = app.aaps.core.ui.R.string.export_disabled
+            val notification = NotificationUserMessage(message, Notification.URGENT)
+            rxBus.send(EventNewNotification(notification))
+        }
+
+        disposable += persistenceLayer.insertPumpTherapyEventIfNewByTimestamp(
+            therapyEvent = TE.asAnnouncement(text.value),
+            timestamp = dateUtil.now(),
+            action = app.aaps.core.data.ue.Action.EXPORT_SETTINGS,
+            source = Sources.Automation,
+            note = message,
+            listValues = listOf()
+        ).subscribe()
+        rxBus.send(EventRefreshOverview("ActionSettingsExport"))
+        callback.result(instantiator.providePumpEnactResult().success(true).comment(exportResultComment)).run()
+    }
+
+    override fun toJSON(): String {
+        val data = JSONObject().put("text", text.value)
+        return JSONObject()
+            .put("type", this.javaClass.simpleName)
+            .put("data", data)
+            .toString()
+    }
+
+    override fun fromJSON(data: String): Action {
+        val o = JSONObject(data)
+        text.value = JsonHelper.safeGetString(o, "text", "")
+        return this
+    }
+
+    override fun hasDialog(): Boolean = true
+
+    override fun generateDialog(root: LinearLayout) {
+        LayoutBuilder()
+            .add(LabelWithElement(rh, rh.gs(R.string.export_settings_short), "", text))
+            .build(root)
+    }
+}

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
@@ -42,6 +42,7 @@ import app.aaps.plugins.automation.triggers.TriggerHeartRate
 import app.aaps.plugins.automation.triggers.TriggerInsulinAge
 import app.aaps.plugins.automation.triggers.TriggerIob
 import app.aaps.plugins.automation.triggers.TriggerLocation
+import app.aaps.plugins.automation.triggers.TriggerPodChange
 import app.aaps.plugins.automation.triggers.TriggerProfilePercent
 import app.aaps.plugins.automation.triggers.TriggerPumpBatteryAge
 import app.aaps.plugins.automation.triggers.TriggerPumpBatteryLevel
@@ -80,6 +81,7 @@ abstract class AutomationModule {
     @ContributesAndroidInjector abstract fun triggerBgInjector(): TriggerBg
     @ContributesAndroidInjector abstract fun triggerBolusAgoInjector(): TriggerBolusAgo
     @ContributesAndroidInjector abstract fun triggerSensorAgeInjector(): TriggerSensorAge
+    @ContributesAndroidInjector abstract fun triggerPadChangeInjector(): TriggerPodChange
     @ContributesAndroidInjector abstract fun triggerCanulaAgeInjector(): TriggerCannulaAge
     @ContributesAndroidInjector abstract fun triggerInsulinAgeInjector(): TriggerInsulinAge
     @ContributesAndroidInjector abstract fun triggerReservoirLevelInjector(): TriggerReservoirLevel

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/di/AutomationModule.kt
@@ -6,6 +6,7 @@ import app.aaps.plugins.automation.AutomationFragment
 import app.aaps.plugins.automation.AutomationPlugin
 import app.aaps.plugins.automation.actions.Action
 import app.aaps.plugins.automation.actions.ActionAlarm
+import app.aaps.plugins.automation.actions.ActionSettingsExport
 import app.aaps.plugins.automation.actions.ActionCarePortalEvent
 import app.aaps.plugins.automation.actions.ActionDummy
 import app.aaps.plugins.automation.actions.ActionLoopDisable
@@ -109,6 +110,7 @@ abstract class AutomationModule {
     @ContributesAndroidInjector abstract fun actionLoopSuspendInjector(): ActionLoopSuspend
     @ContributesAndroidInjector abstract fun actionNotificationInjector(): ActionNotification
     @ContributesAndroidInjector abstract fun actionAlarmInjector(): ActionAlarm
+    @ContributesAndroidInjector abstract fun actionSettingsExportInjector(): ActionSettingsExport
     @ContributesAndroidInjector abstract fun actionCarePortalEventInjector(): ActionCarePortalEvent
     @ContributesAndroidInjector abstract fun actionProfileSwitchInjector(): ActionProfileSwitch
     @ContributesAndroidInjector abstract fun actionProfileSwitchPercentInjector(): ActionProfileSwitchPercent

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/Trigger.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/Trigger.kt
@@ -96,6 +96,7 @@ abstract class Trigger(val injector: HasAndroidInjector) {
                 TriggerBTDevice::class.java.simpleName           -> TriggerBTDevice(injector).fromJSON(data.toString())
                 TriggerSensorAge::class.java.simpleName          -> TriggerSensorAge(injector).fromJSON(data.toString())
                 TriggerCannulaAge::class.java.simpleName         -> TriggerCannulaAge(injector).fromJSON(data.toString())
+                TriggerPodChange::class.java.simpleName          -> TriggerPodChange(injector).fromJSON(data.toString())
                 TriggerInsulinAge::class.java.simpleName         -> TriggerInsulinAge(injector).fromJSON(data.toString())
                 TriggerReservoirLevel::class.java.simpleName     -> TriggerReservoirLevel(injector).fromJSON(data.toString())
                 TriggerPumpBatteryAge::class.java.simpleName     -> TriggerPumpBatteryAge(injector).fromJSON(data.toString())

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
@@ -1,0 +1,72 @@
+package app.aaps.plugins.automation.triggers
+
+import android.widget.LinearLayout
+import app.aaps.core.data.model.TE
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.plugins.automation.R
+import app.aaps.plugins.automation.elements.Comparator
+import app.aaps.plugins.automation.elements.LabelWithElement
+import app.aaps.plugins.automation.elements.LayoutBuilder
+import app.aaps.plugins.automation.elements.StaticLabel
+import dagger.android.HasAndroidInjector
+import org.json.JSONObject
+import java.util.Optional
+
+class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
+
+    private constructor(injector: HasAndroidInjector, triggerPodChange: TriggerPodChange) : this(injector) {
+    }
+
+    override fun shouldRun(): Boolean {
+        val maxMinutesSinceCannulaChange: Double = 6.0
+
+        val therapyEventPodChange = persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)
+        if (therapyEventPodChange == null) {
+            aapsLogger.debug(LTag.AUTOMATION, "NOT ready for execution (1): " + friendlyDescription())
+            return false
+        }
+
+        val currentPodChangeMinutes = therapyEventPodChange?.timestamp?.let { timestamp ->
+            (dateUtil.now() - timestamp) / (60 * 1000.0)
+        }?.toDouble() ?: 0.0
+
+        if (Comparator.Compare.IS_LESSER.check(currentPodChangeMinutes, maxMinutesSinceCannulaChange)) {
+            aapsLogger.debug(LTag.AUTOMATION, "Ready for execution: " + friendlyDescription())
+            return true
+        }
+
+        aapsLogger.debug(LTag.AUTOMATION, "NOT ready for execution (2): " + friendlyDescription())
+        return false
+    }
+
+    override fun dataJSON(): JSONObject =
+        JSONObject()
+
+    override fun fromJSON(data: String): Trigger {
+        val d = JSONObject(data)
+        return this
+    }
+
+    override fun friendlyName(): Int = R.string.triggerPodChangeLabel
+
+    override fun friendlyDescription(): String =
+        rh.gs(R.string.triggerPodChangeDesc)
+
+    override fun icon(): Optional<Int> {
+        val isPatchPump = activePlugin.activePump.pumpDescription.isPatchPump
+        return if (isPatchPump) {
+            Optional.of(app.aaps.core.objects.R.drawable.ic_patch_pump_outline)
+        } else {
+            Optional.of(app.aaps.core.objects.R.drawable.ic_cp_age_cannula)
+        }
+    }
+
+    override fun duplicate(): Trigger = TriggerPodChange(injector, this)
+
+    override fun generateDialog(root: LinearLayout) {
+        LayoutBuilder()
+            .add(StaticLabel(rh, R.string.triggerPodChangeLabel, this))
+            .add(LabelWithElement(rh, rh.gs(R.string.triggerPodChangeLabel)))
+            .build(root)
+    }
+}

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
@@ -14,11 +14,8 @@ import java.util.Optional
 
 class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
 
-    private constructor(injector: HasAndroidInjector, triggerPodChange: TriggerPodChange) : this(injector) {
-    }
-
     override fun shouldRun(): Boolean {
-        val maxMinutesSinceCannulaChange: Double = 6.0
+        val maxMinutesSinceCannulaChange = 6.0
 
         val therapyEventPodChange = persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)
         if (therapyEventPodChange == null) {
@@ -26,7 +23,7 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
             return false
         }
 
-        val currentPodChangeMinutes = therapyEventPodChange?.timestamp?.let { timestamp ->
+        val currentPodChangeMinutes = therapyEventPodChange.timestamp?.let { timestamp ->
             (dateUtil.now() - timestamp) / (60 * 1000.0)
         }?.toDouble() ?: 0.0
 
@@ -43,7 +40,6 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
         JSONObject()
 
     override fun fromJSON(data: String): Trigger {
-        val d = JSONObject(data)
         return this
     }
 
@@ -61,7 +57,7 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
         }
     }
 
-    override fun duplicate(): Trigger = TriggerPodChange(injector, this)
+    override fun duplicate(): Trigger = TriggerPodChange(injector)
 
     override fun generateDialog(root: LinearLayout) {
         LayoutBuilder()

--- a/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
+++ b/plugins/automation/src/main/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChange.kt
@@ -14,8 +14,11 @@ import java.util.Optional
 
 class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
 
+    private constructor(injector: HasAndroidInjector, triggerPodChange: TriggerPodChange) : this(injector) {
+    }
+
     override fun shouldRun(): Boolean {
-        val maxMinutesSinceCannulaChange = 6.0
+        val maxMinutesSinceCannulaChange: Double = 6.0
 
         val therapyEventPodChange = persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)
         if (therapyEventPodChange == null) {
@@ -23,7 +26,7 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
             return false
         }
 
-        val currentPodChangeMinutes = therapyEventPodChange.timestamp?.let { timestamp ->
+        val currentPodChangeMinutes = therapyEventPodChange?.timestamp?.let { timestamp ->
             (dateUtil.now() - timestamp) / (60 * 1000.0)
         }?.toDouble() ?: 0.0
 
@@ -40,6 +43,7 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
         JSONObject()
 
     override fun fromJSON(data: String): Trigger {
+        val d = JSONObject(data)
         return this
     }
 
@@ -57,7 +61,7 @@ class TriggerPodChange(injector: HasAndroidInjector) : Trigger(injector) {
         }
     }
 
-    override fun duplicate(): Trigger = TriggerPodChange(injector)
+    override fun duplicate(): Trigger = TriggerPodChange(injector, this)
 
     override fun generateDialog(root: LinearLayout) {
         LayoutBuilder()

--- a/plugins/automation/src/main/res/values/strings.xml
+++ b/plugins/automation/src/main/res/values/strings.xml
@@ -92,7 +92,9 @@
     <string name="triggerSensorAgeLabel">Sensor age</string>
     <string name="triggerSensorAgeDesc">Sensor age %1$s %2$.1f hour</string>
     <string name="triggerCannulaAgeLabel">Cannula age</string>
-    <string name="triggerCannulaAgeDesc">Cannula age %1$s %2$.1f hour</string>    
+    <string name="triggerCannulaAgeDesc">Cannula age %1$s %2$.1f hour</string>
+    <string name="triggerPodChangeLabel">Pod activation</string>
+    <string name="triggerPodChangeDesc">Pod activated</string>
     <string name="triggerInsulinAgeLabel">Insulin age</string>
     <string name="triggerInsulinAgeDesc">Insulin age %1$s %2$.1f hour</string>
     <string name="triggerPumpBatteryAgeLabel">Pump battery age</string>

--- a/plugins/automation/src/main/res/values/strings.xml
+++ b/plugins/automation/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="automation_missing_task_name">Please enter a task name.</string>
     <string name="automation_missing_trigger">Please specify at least one trigger.</string>
     <string name="automation_missing_action">Please specify at least one action.</string>
+    <string name="exportsettings_message">Settings Export: %1$s</string>
+    <string name="export_settings_short">Text in treatments:</string>
     <string name="alarm_message">Alarm: %1$s</string>
     <string name="alarm_short">Alarm:</string>
     <string name="message_short">Msg:</string>

--- a/plugins/automation/src/test/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChangeTest.kt
+++ b/plugins/automation/src/test/kotlin/app/aaps/plugins/automation/triggers/TriggerPodChangeTest.kt
@@ -1,0 +1,78 @@
+package app.aaps.plugins.automation.triggers
+
+import app.aaps.core.data.model.GlucoseUnit
+import app.aaps.core.data.model.TE
+import app.aaps.core.data.pump.defs.PumpDescription
+import app.aaps.core.data.time.T
+import app.aaps.pump.virtual.VirtualPumpPlugin
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.skyscreamer.jsonassert.JSONAssert
+import java.util.Optional
+
+class TriggerPodChangeTest : TriggerTestBase() {
+
+    @Mock lateinit var virtualPumpPlugin: VirtualPumpPlugin
+
+    @Test fun shouldRunTest() {
+        // Cannula change is "now"
+        val cannulaChangeEvent = TE(glucoseUnit = GlucoseUnit.MGDL, timestamp = now, type = TE.Type.CANNULA_CHANGE)
+        // Test settings export was 1 minute before or after Cannula change
+        val settingsExportEventIsBefore =
+            TE(glucoseUnit = GlucoseUnit.MGDL, timestamp = now - T.mins(1).msecs(), type = TE.Type.SETTINGS_EXPORT)
+        val settingsExportEventIsAfter =
+            TE(glucoseUnit = GlucoseUnit.MGDL, timestamp = now + T.mins(1).msecs(), type = TE.Type.SETTINGS_EXPORT)
+        val t = TriggerPodChange(injector)
+
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)).thenReturn(cannulaChangeEvent)
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.SETTINGS_EXPORT)).thenReturn(settingsExportEventIsBefore)
+        assertThat(t.shouldRun()).isTrue()
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)).thenReturn(cannulaChangeEvent)
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.SETTINGS_EXPORT)).thenReturn(settingsExportEventIsAfter)
+        assertThat(t.shouldRun()).isFalse()
+    }
+
+    @Test fun shouldRunNotAvailable() {
+        val t = TriggerPodChange(injector)
+        // No cannula change and no export events
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)).thenReturn(null)
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.SETTINGS_EXPORT)).thenReturn(null)
+        assertThat(t.shouldRun()).isFalse()
+
+        // No cannula change events
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.CANNULA_CHANGE)).thenReturn(null)
+        assertThat(t.shouldRun()).isFalse()
+
+        // No settings export events
+        `when`(persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.SETTINGS_EXPORT)).thenReturn(null)
+        assertThat(t.shouldRun()).isFalse()
+    }
+
+    @Test fun toJSONTest() {
+        // JSON not relevant...
+        val podChangeJson = "{}"
+        val t = TriggerPodChange(injector)
+        JSONAssert.assertEquals(podChangeJson, t.dataJSON().toString(), true)
+    }
+
+    @Test fun fromJSONTest() {
+        // JSON not relevant...
+        val podChangeJson = "{}"
+        val t = TriggerPodChange(injector)
+        JSONAssert.assertEquals(podChangeJson, t.fromJSON("").dataJSON(), true)
+    }
+
+    @Test fun iconTest() {
+        val t = TriggerPodChange(injector)
+        `when`(activePlugin.activePump).thenReturn(virtualPumpPlugin)
+        val pumpDescription = PumpDescription()
+        pumpDescription.isPatchPump = false
+        `when`(virtualPumpPlugin.pumpDescription).thenReturn(pumpDescription)
+        assertThat(t.icon()).isEqualTo(Optional.of(app.aaps.core.objects.R.drawable.ic_cp_age_cannula))
+        pumpDescription.isPatchPump = true
+        assertThat(t.icon()).isEqualTo(Optional.of(app.aaps.core.objects.R.drawable.ic_patch_pump_outline))
+        assertThat(true).isTrue()
+    }
+}

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/MaintenancePlugin.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/MaintenancePlugin.kt
@@ -235,7 +235,7 @@ class MaintenancePlugin @Inject constructor(
     }
 
     override fun addPreferenceScreen(preferenceManager: PreferenceManager, parent: PreferenceScreen, context: Context, requiredKey: String?) {
-        if (requiredKey != null && requiredKey != "data_choice_setting") return
+        if (requiredKey != null && !(requiredKey == "data_choice_setting" || requiredKey == "enable_unattended_export")) return
         val category = PreferenceCategory(context)
         parent.addPreference(category)
         category.apply {
@@ -253,7 +253,22 @@ class MaintenancePlugin @Inject constructor(
                 key = "data_choice_setting"
                 title = rh.gs(R.string.data_choices)
                 addPreference(AdaptiveSwitchPreference(ctx = context, booleanKey = BooleanKey.MaintenanceEnableFabric, title = R.string.fabric_upload))
-                addPreference(AdaptiveStringPreference(ctx = context, stringKey = StringKey.MaintenanceIdentification, summary = R.string.summary_email_for_crash_report, title = R.string.identification))
+                addPreference(AdaptiveStringPreference(ctx = context, stringKey = StringKey.MaintenanceIdentification, title = R.string.identification))
+            })
+
+            addPreference(preferenceManager.createPreferenceScreen(context).apply {
+                key = "enable_unattended_export"
+                title = rh.gs(R.string.unattended_settings_export)
+                addPreference(AdaptiveSwitchPreference(ctx = context, booleanKey = BooleanKey.MaintenanceEnableExportSettingsAutomation,
+                    title = R.string.unattended_settings_export,
+                    summary = R.string.unattended_settings_export_summary
+                    )
+                )
+                // addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.AutoExportPasswordExpiryDays,
+                //     title = R.string.unattended_settings_export_password_expiry,
+                //     summary = R.string.unattended_settings_export_password_expiry_summary
+                //     )
+                // )
             })
         }
     }

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/formats/EncryptedPrefsFormat.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/formats/EncryptedPrefsFormat.kt
@@ -89,7 +89,6 @@ class EncryptedPrefsFormat @Inject constructor(
             if (encrypted) {
                 val salt = cryptoUtil.mineSalt()
                 val rawContent = content.toString()
-                //val contentAttempt = cryptoUtil.encrypt(masterPassword!!, salt, rawContent)
 
                 var masterPasswordUnencrypted = masterPassword
                 if (secureEncrypt.isValidDataString(masterPassword)) {

--- a/plugins/configuration/src/main/res/values/strings.xml
+++ b/plugins/configuration/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="readstatus">Read status</string>
     <string name="data_choices">Data Choices</string>
     <string name="fabric_upload">Fabric Upload</string>
+    <string name="unattended_settings_export">Unattended Settings Export</string>
+    <string name="unattended_settings_export_summary">Enabling this will securely store your password on your phone</string>
     <string name="allow_automated_crash_reporting">Allow automated crash reporting and feature usage data to be sent to the developers via the fabric.io service.</string>
     <string name="summary_email_for_crash_report">This identification will attached to crash reports so we can contact you in urgent cases. It\'s optional.</string>
     <string name="identification">Identification (email, FB or Discord nick etc)</string>
@@ -105,6 +107,7 @@
     <string name="different_password_used">This file was exported and encrypted with different master password. Provide old master password to decrypt file.</string>
     <string name="master_password_will_be_replaced">As a result of successful import current master password WILL BE REPLACED with that old master password!</string>
     <string name="exported">Preferences exported</string>
+    <string name="exported_failed">Preferences export failed!</string>
     <string name="filenotfound">File not found</string>
     <string name="goto_main_try_again">Please go back to main screen and try again.</string>
     <string name="restartingapp">Exiting application to apply settings.</string>


### PR DESCRIPTION
This PR enables unattended exports
(see also issue #https://github.com/nightscout/AndroidAPS/issues/3296)

**Functional short description:**

The master password should be entered as usual when manually exporting settings from the AAPS maintenance menu.
When the "unattended exports" option is enabled in maintenance preferences the password entered is encrypted and securely stored on the user's phone (not in AAPS).

Subsequent exports will no longer require the user to enter the master password until it expires or is reset.
- A new Pod Activation automation is added for automating settings export.
- A new Trigger is added for triggering an action on Pod Activation

When active, the new "Export settings" automation will alert in AAPS overview on exporting and (when relevant) not being enabled or password expiry. The user can (grace period) or is required (expired) to reenter the password executing a manual export.

**Choice:**

User has a choice to enable/disable unattended exports through the maintenance settings.
When disabled, no password is stored and unattended exports are unavailable.

**When enabled:**

Password will be securely stored encrypted on the local phone's Android DataStore (1).
Encryption key needed for decrypting is generated and protected by the local phone's Android KeyStore (2).
To ensure user needs to "maintain" the master password it will expire after 4 weeks with a grace periode of 1 week (non-configurable)
Stored password will be removed on changing the master password or AAPS password reset.
Importing setting or other functionality that needs entering the master password/PIN/Biometrics are not affected.

_Ad1) Android DataStore:_
_This system provides a robust and flexible way of storing key-value pairs on the phones storage._

_Ad2) Android Keystore:_
_This system allows to store cryptographic keys in a secure container, making them difficult to extract from the device._

**Testing:**

- Password expiry/grace period (it is set fixed at 4 weeks+1 week grace):
For testing purposes, placing a semaphore file named `DebugUnattendedExport` (no extension!) will set expiry to 1 day with a grace periode of 1 day.