### PR TITLE
RestoreSMBAlways for G7 xDrip direct sources

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
@@ -16,6 +16,7 @@ enum class SourceSensor(val text: String) {
     DEXCOM_G6_NATIVE_XDRIP("G6 Native"),
     DEXCOM_G5_NATIVE_XDRIP("G5 Native"),
     DEXCOM_G7_NATIVE_XDRIP("G7 Native"),
+    DEXCOM_G7_XDRIP("G7"),
     LIBRE_1_OTHER("Other App"),
     LIBRE_1_NET("Network libre"),
     LIBRE_1_BLUE("BlueReader"),

--- a/database/impl/src/main/kotlin/app/aaps/database/entities/GlucoseValue.kt
+++ b/database/impl/src/main/kotlin/app/aaps/database/entities/GlucoseValue.kt
@@ -83,6 +83,7 @@ data class GlucoseValue(
         DEXCOM_G5_NATIVE_XDRIP,
         DEXCOM_G6_NATIVE_XDRIP,
         DEXCOM_G7_NATIVE_XDRIP,
+        DEXCOM_G7_XDRIP,
         LIBRE_1_OTHER,
         LIBRE_1_NET,
         LIBRE_1_BLUE,

--- a/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourceSensorExtension.kt
+++ b/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourceSensorExtension.kt
@@ -67,6 +67,7 @@ fun SourceSensor.toDb(): GlucoseValue.SourceSensor =
         SourceSensor.DEXCOM_G5_NATIVE_XDRIP    -> GlucoseValue.SourceSensor.DEXCOM_G5_NATIVE_XDRIP
         SourceSensor.DEXCOM_G6_NATIVE_XDRIP    -> GlucoseValue.SourceSensor.DEXCOM_G6_NATIVE_XDRIP
         SourceSensor.DEXCOM_G7_NATIVE_XDRIP    -> GlucoseValue.SourceSensor.DEXCOM_G7_NATIVE_XDRIP
+        SourceSensor.DEXCOM_G7_XDRIP           -> GlucoseValue.SourceSensor.DEXCOM_G7_XDRIP
         SourceSensor.LIBRE_1_OTHER             -> GlucoseValue.SourceSensor.LIBRE_1_OTHER
         SourceSensor.LIBRE_1_NET               -> GlucoseValue.SourceSensor.LIBRE_1_NET
         SourceSensor.LIBRE_1_BLUE              -> GlucoseValue.SourceSensor.LIBRE_1_BLUE

--- a/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
+++ b/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
@@ -60,7 +60,8 @@ class XdripSourcePlugin @Inject constructor(
             SourceSensor.DEXCOM_G7_NATIVE,
             SourceSensor.DEXCOM_G5_NATIVE_XDRIP,
             SourceSensor.DEXCOM_G6_NATIVE_XDRIP,
-            SourceSensor.DEXCOM_G7_NATIVE_XDRIP
+            SourceSensor.DEXCOM_G7_NATIVE_XDRIP,
+            SourceSensor.DEXCOM_G7_XDRIP
         ).any { it == glucoseValue.sourceSensor }
     }
 


### PR DESCRIPTION
Fixes #3499 

xDrip sends 'G7' when running as a collector, erraneously removed in #3411:
https://github.com/NightscoutFoundation/xDrip/blob/9f769df176112b92aaaaa42f717cdfea44605708/app/src/main/java/com/eveningoutpost/dexdrip/utils/DexCollectionType.java#L280

 
