### PR TITLE
Wear Update communication for external data

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -205,7 +205,8 @@ sealed class EventData : Event() {
         val low: Double, // lowLine
         val color: Int = 0,
         val deltaMgdl: Double? = null,
-        val avgDeltaMgdl: Double? = null
+        val avgDeltaMgdl: Double? = null,
+        val id: Int = 0
     ) : EventData(), Comparable<SingleBg> {
 
         override fun equals(other: Any?): Boolean =
@@ -276,7 +277,8 @@ sealed class EventData : Event() {
         val rigBattery: String,
         val openApsStatus: Long,
         val bgi: String,
-        val batteryLevel: Int
+        val batteryLevel: Int,
+        val id: Int = 0
     ) : EventData()
 
     @Serializable

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -1031,6 +1031,58 @@ class DataHandlerMobile @Inject constructor(
         )
     }
 
+    //Both function below can be simplified according to the way external data is built and rules concerning Id between AAPS, AAPSClient, AAPSClient2
+    private fun sendStatusExternal(status: EventData.Status, extId: Int = 1) {
+        rxBus.send(
+            EventMobileToWear(
+                if (status.id != 0)
+                    status
+                else
+                    EventData.Status(
+                        externalStatus = status.externalStatus,
+                        iobSum = status.iobSum,
+                        iobDetail = status.iobDetail,
+                        cob = status.cob,
+                        currentBasal = status.currentBasal,
+                        battery = status.battery,
+                        rigBattery = status.rigBattery,
+                        openApsStatus = status.openApsStatus,
+                        bgi = status.bgi,
+                        batteryLevel = status.batteryLevel,
+                        id = extId
+                    )
+            )
+        )
+    }
+
+    private fun sendSingleBGExternal(singleBG: EventData.SingleBg, extId: Int = 1) {
+        rxBus.send(
+            EventMobileToWear(
+                if (singleBG.id != 0)
+                    singleBG
+                else
+                    EventData.SingleBg(
+                        timeStamp = singleBG.timeStamp,
+                        sgvString = singleBG.sgvString,
+                        glucoseUnits = singleBG.glucoseUnits,
+                        slopeArrow = singleBG.slopeArrow,
+                        delta = singleBG.delta,
+                        deltaDetailed = singleBG.deltaDetailed,
+                        avgDelta = singleBG.avgDelta,
+                        avgDeltaDetailed = singleBG.avgDeltaDetailed,
+                        sgvLevel = singleBG.sgvLevel,
+                        sgv = singleBG.sgv,
+                        high = singleBG.high, // highLine
+                        low = singleBG.low, // lowLine
+                        color = singleBG.color,
+                        deltaMgdl = singleBG.deltaMgdl,
+                        avgDeltaMgdl = singleBG.avgDeltaMgdl,
+                        id = extId
+                    )
+            )
+        )
+    }
+
     private fun deltaString(deltaMGDL: Double, deltaMMOL: Double, units: GlucoseUnit): String {
         var deltaString = if (deltaMGDL >= 0) "+" else "-"
         deltaString += if (units == GlucoseUnit.MGDL) {

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
@@ -125,7 +125,7 @@ class DataHandlerWear @Inject constructor(
             .toObservable(EventData.Status::class.java)
             .observeOn(aapsSchedulers.io)
             .subscribe {
-                aapsLogger.debug(LTag.WEAR, "Status received from ${it.sourceNodeId}")
+                aapsLogger.debug(LTag.WEAR, "Status${if (it.id == 0) "" else it.id} received from ${it.sourceNodeId}")
                 persistence.store(it)
                 LocalBroadcastManager.getInstance(context).sendBroadcast(Intent(DataLayerListenerServiceWear.INTENT_NEW_DATA))
             }
@@ -133,7 +133,7 @@ class DataHandlerWear @Inject constructor(
             .toObservable(EventData.SingleBg::class.java)
             .observeOn(aapsSchedulers.io)
             .subscribe {
-                aapsLogger.debug(LTag.WEAR, "SingleBg received from ${it.sourceNodeId}")
+                aapsLogger.debug(LTag.WEAR, "SingleBg${if (it.id == 0) "" else it.id} received from ${it.sourceNodeId}")
                 persistence.store(it)
             }
         disposable += rxBus

--- a/wear/src/main/kotlin/app/aaps/wear/data/RawDisplayData.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/data/RawDisplayData.kt
@@ -32,6 +32,44 @@ class RawDisplayData {
         avgDeltaMgdl = null
     )
 
+    var singleBg1 = EventData.SingleBg(
+        timeStamp = 0,
+        sgvString = "---",
+        glucoseUnits = "-",
+        slopeArrow = "--",
+        delta = "--",
+        deltaDetailed = "--",
+        avgDelta = "--",
+        avgDeltaDetailed = "--",
+        sgvLevel = 0,
+        sgv = 0.0,
+        high = 0.0,
+        low = 0.0,
+        color = 0,
+        deltaMgdl = null,
+        avgDeltaMgdl = null,
+        id = 1
+    )
+
+    var singleBg2 = EventData.SingleBg(
+        timeStamp = 0,
+        sgvString = "---",
+        glucoseUnits = "-",
+        slopeArrow = "--",
+        delta = "--",
+        deltaDetailed = "--",
+        avgDelta = "--",
+        avgDeltaDetailed = "--",
+        sgvLevel = 0,
+        sgv = 0.0,
+        high = 0.0,
+        low = 0.0,
+        color = 0,
+        deltaMgdl = null,
+        avgDeltaMgdl = null,
+        id = 2
+    )
+
     // status bundle
     var status = EventData.Status(
         externalStatus = "no status",
@@ -44,6 +82,34 @@ class RawDisplayData {
         openApsStatus = -1,
         bgi = "--",
         batteryLevel = 1
+    )
+
+    var status1 = EventData.Status(
+        externalStatus = "no status",
+        iobSum = "IOB",
+        iobDetail = "-.--",
+        cob = "--g",
+        currentBasal = "-.--U/h",
+        battery = "--",
+        rigBattery = "--",
+        openApsStatus = -1,
+        bgi = "--",
+        batteryLevel = 1,
+        id = 1
+    )
+
+    var status2 = EventData.Status(
+        externalStatus = "no status",
+        iobSum = "IOB",
+        iobDetail = "-.--",
+        cob = "--g",
+        currentBasal = "-.--U/h",
+        battery = "--",
+        rigBattery = "--",
+        openApsStatus = -1,
+        bgi = "--",
+        batteryLevel = 1,
+        id = 2
     )
 
     var graphData = EventData.GraphData(
@@ -62,8 +128,12 @@ class RawDisplayData {
 
     fun updateFromPersistence(persistence: Persistence) {
         persistence.readSingleBg()?.let { singleBg = it }
+        persistence.readSingleBg1()?.let { singleBg1 = it }
+        persistence.readSingleBg2()?.let { singleBg2 = it }
         persistence.readGraphData()?.let { graphData = it }
-        persistence.readStatus()?.let { status = it }
+        persistence.readStatus()?.let {  status = it }
+        persistence.readStatus1()?.let {  status1 = it }
+        persistence.readStatus2()?.let {  status2 = it }
         persistence.readTreatments()?.let { treatmentData = it }
     }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/utils/Persistence.kt
@@ -29,9 +29,13 @@ open class Persistence @Inject constructor(
     companion object {
 
         const val BG_DATA_PERSISTENCE_KEY = "bg_data"
+        const val BG1_DATA_PERSISTENCE_KEY = "bg1_data"
+        const val BG2_DATA_PERSISTENCE_KEY = "bg2_data"
         const val GRAPH_DATA_PERSISTENCE_KEY = "graph_data"
         const val TREATMENT_PERSISTENCE_KEY = "treatment_data"
         const val STATUS_PERSISTENCE_KEY = "status_data"
+        const val STATUS1_PERSISTENCE_KEY = "status1_data"
+        const val STATUS2_PERSISTENCE_KEY = "status2_data"
 
         const val KEY_COMPLICATIONS = "complications"
         const val KEY_LAST_SHOWN_SINCE_VALUE = "lastSince"
@@ -95,9 +99,61 @@ open class Persistence @Inject constructor(
         return null
     }
 
+    fun readSingleBg1(): SingleBg? {
+        try {
+            val s = sp.getStringOrNull(BG1_DATA_PERSISTENCE_KEY, null)
+            //aapsLogger.debug(LTag.WEAR, "Loaded BG data: $s")
+            if (s != null) {
+                return deserialize(s) as SingleBg
+            }
+        } catch (exception: Exception) {
+            aapsLogger.error(LTag.WEAR, exception.toString())
+        }
+        return null
+    }
+
+    fun readSingleBg2(): SingleBg? {
+        try {
+            val s = sp.getStringOrNull(BG2_DATA_PERSISTENCE_KEY, null)
+            //aapsLogger.debug(LTag.WEAR, "Loaded BG data: $s")
+            if (s != null) {
+                return deserialize(s) as SingleBg
+            }
+        } catch (exception: Exception) {
+            aapsLogger.error(LTag.WEAR, exception.toString())
+        }
+        return null
+    }
+
     fun readStatus(): EventData.Status? {
         try {
             val s = sp.getStringOrNull(STATUS_PERSISTENCE_KEY, null)
+            //aapsLogger.debug(LTag.WEAR, "Loaded Status data: $s")
+            if (s != null) {
+                return deserialize(s) as EventData.Status
+            }
+        } catch (exception: Exception) {
+            aapsLogger.error(LTag.WEAR, exception.toString())
+        }
+        return null
+    }
+
+    fun readStatus1(): EventData.Status? {
+        try {
+            val s = sp.getStringOrNull(STATUS1_PERSISTENCE_KEY, null)
+            //aapsLogger.debug(LTag.WEAR, "Loaded Status data: $s")
+            if (s != null) {
+                return deserialize(s) as EventData.Status
+            }
+        } catch (exception: Exception) {
+            aapsLogger.error(LTag.WEAR, exception.toString())
+        }
+        return null
+    }
+
+    fun readStatus2(): EventData.Status? {
+        try {
+            val s = sp.getStringOrNull(STATUS2_PERSISTENCE_KEY, null)
             //aapsLogger.debug(LTag.WEAR, "Loaded Status data: $s")
             if (s != null) {
                 return deserialize(s) as EventData.Status
@@ -178,9 +234,23 @@ open class Persistence @Inject constructor(
     }
 
     fun store(singleBg: SingleBg) {
-        putString(BG_DATA_PERSISTENCE_KEY, singleBg.serialize())
-        aapsLogger.debug(LTag.WEAR, "Stored BG data: $singleBg")
-        markDataUpdated()
+        when(singleBg.id) {
+            0 -> {
+                putString(BG_DATA_PERSISTENCE_KEY, singleBg.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored BG data: $singleBg")
+                markDataUpdated()
+            }
+
+            1 -> {
+                putString(BG1_DATA_PERSISTENCE_KEY, singleBg.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored BG1 data: $singleBg")
+            }
+
+            2 -> {
+                putString(BG2_DATA_PERSISTENCE_KEY, singleBg.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored BG2 data: $singleBg")
+            }
+        }
     }
 
     fun store(graphData: EventData.GraphData) {
@@ -194,8 +264,22 @@ open class Persistence @Inject constructor(
     }
 
     fun store(status: EventData.Status) {
-        putString(STATUS_PERSISTENCE_KEY, status.serialize())
-        aapsLogger.debug(LTag.WEAR, "Stored Status data: $status")
+        when (status.id) {
+            0 -> {
+                putString(STATUS_PERSISTENCE_KEY, status.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored Status data: $status")
+            }
+
+            1 -> {
+                putString(STATUS1_PERSISTENCE_KEY, status.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored Status1 data: $status")
+            }
+
+            2 -> {
+                putString(STATUS2_PERSISTENCE_KEY, status.serialize())
+                aapsLogger.debug(LTag.WEAR, "Stored Status2 data: $status")
+            }
+        }
     }
 
     fun store(customWatchface: EventData.ActionSetCustomWatchface, isDefault: Boolean = false) {


### PR DESCRIPTION
Add an `id` property to `SingleBg` and `Status` with 0 as default value (compatibility with previous version checked and ok)
Note that the 2 functions added in `DataHandlerMobile.kt` can probably be simplified according to the way these functions are called.
On wear side I included compatibility with 2 external providers (AAPS + AAPSClient + AAPSClient2)

Next steps will be to update BaseWatchFace to manage these additionnal values, then add new Views within CustomWatchface to manage external values.