### PR TITLE
Improve/Fix SMB options when advancedFiltering is false and adjust related strings

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.kt
@@ -182,28 +182,20 @@ open class OpenAPSSMBPlugin @Inject constructor(
 
     override fun preprocessPreferences(preferenceFragment: PreferenceFragmentCompat) {
         super.preprocessPreferences(preferenceFragment)
-        val uamEnabled = if (preferences.get(BooleanKey.ApsUseSmb)) {
-            preferences.get(BooleanKey.ApsUseUam)
-        } else {
-            preferences.get(BooleanKey.ApsUseSmb)
-        }
-        val smbAlwaysEnabled = if (preferences.get(BooleanKey.ApsUseSmb)) {
-            preferences.get(BooleanKey.ApsUseSmbAlways)
-        } else {
-            !preferences.get(BooleanKey.ApsUseSmb)
-        }
+
+        val smbEnabled = preferences.get(BooleanKey.ApsUseSmb)
+        val smbAlwaysEnabled = preferences.get(BooleanKey.ApsUseSmbAlways)
+        val uamEnabled = preferences.get(BooleanKey.ApsUseUam)
         val advancedFiltering = activePlugin.activeBgSource.advancedFilteringSupported()
-        val autoSensOrDynIsfSensEnabled = if (preferences.get(BooleanKey.ApsUseDynamicSensitivity)) {
-            preferences.get(BooleanKey.ApsDynIsfAdjustSensitivity)
-        } else {
-            preferences.get(BooleanKey.ApsUseAutosens)
-        }
-        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbWithCob.key)?.isVisible = !smbAlwaysEnabled || !advancedFiltering
-        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbWithLowTt.key)?.isVisible = !smbAlwaysEnabled || !advancedFiltering
-        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbAfterCarbs.key)?.isVisible = !smbAlwaysEnabled || !advancedFiltering
+        val autoSensOrDynIsfSensEnabled = preferences.get(BooleanKey.ApsUseDynamicSensitivity) && preferences.get(BooleanKey.ApsDynIsfAdjustSensitivity) || preferences.get(BooleanKey.ApsUseAutosens)
+
+        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbAlways.key)?.isVisible = smbEnabled && advancedFiltering
+        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbWithCob.key)?.isVisible = smbEnabled && !smbAlwaysEnabled && advancedFiltering || smbEnabled && !advancedFiltering
+        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbWithLowTt.key)?.isVisible = smbEnabled && !smbAlwaysEnabled && advancedFiltering || smbEnabled && !advancedFiltering
+        preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbAfterCarbs.key)?.isVisible = smbEnabled && !smbAlwaysEnabled && advancedFiltering
         preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsResistanceLowersTarget.key)?.isVisible = autoSensOrDynIsfSensEnabled
         preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsSensitivityRaisesTarget.key)?.isVisible = autoSensOrDynIsfSensEnabled
-        preferenceFragment.findPreference<AdaptiveIntPreference>(IntKey.ApsUamMaxMinutesOfBasalToLimitSmb.key)?.isVisible = uamEnabled
+        preferenceFragment.findPreference<AdaptiveIntPreference>(IntKey.ApsUamMaxMinutesOfBasalToLimitSmb.key)?.isVisible = smbEnabled && uamEnabled
     }
 
     private val dynIsfCache = LongSparseArray<Double>()

--- a/plugins/aps/src/main/res/values/strings.xml
+++ b/plugins/aps/src/main/res/values/strings.xml
@@ -71,9 +71,9 @@
     <string name="enable_smb_summary">Use Super Micro Boluses instead of temp basal for faster action</string>
     <string name="enable_uam_summary">Detection of Unannounced meals</string>
     <string name="enable_smb_always">Enable SMB always</string>
-    <string name="enable_smb_always_summary">Enable SMB always independently to boluses. Possible only with BG source with nice filtering of data like G5</string>
+    <string name="enable_smb_always_summary">Enable SMB always independently to COB, temp targets or boluses. Possible only with BG sources with advanced filtering of data</string>
     <string name="enable_smb_after_carbs">Enable SMB after carbs</string>
-    <string name="enable_smb_after_carbs_summary">Enable SMB for 6h after carbs, even with 0 COB. Possible only with BG source with nice filtering of data like G5</string>
+    <string name="enable_smb_after_carbs_summary">Enable SMB for 6h after carbs, even with 0 COB. Possible only with BG sources with advanced filtering of data</string>
     <string name="enable_smb_with_cob">Enable SMB with COB</string>
     <string name="enable_smb_with_cob_summary">Enable SMB when there is COB active.</string>
     <string name="enable_smb_with_temp_target">Enable SMB with temp targets</string>


### PR DESCRIPTION
The filtering of SMB options doesn't work quite right now when `advancedFiltering` = false. This will address that and:

* Improves UX when `advancedFiltering` = false, hides SMB options that is not possible to use.
* Adjust strings to reflect the wider array of supported CGM's for `enable_smb_always` and `enable_smb_after_carbs`
* Cleaned up code abit

SMB-tab will still display constraint when advanced filtering is false:
![image](https://github.com/user-attachments/assets/f2c3dd99-bf89-43d6-bbcd-3c0f0e4643e0)

Example of how it looks with this PR:
| SMB Enabled `advancedFiltering` = TRUE | SMB Enabled `advancedFiltering` = FALSE |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/30aee5e5-f885-46ec-93e1-555c1d12feff)| ![image](https://github.com/user-attachments/assets/ed9e5442-fb62-458f-81e5-0ec0011aa37e)|
| SMB disabled `advancedFiltering` = TRUE | SMB disabled `advancedFiltering` = FALSE |
| ![image](https://github.com/user-attachments/assets/9c1316f2-8ecf-4fe2-b740-cc1d34787eac)|![image](https://github.com/user-attachments/assets/78140ee6-4d7f-4950-b484-06447f9341f2)|

