### PR TITLE
Improve strings for NSClientV1 and NSClientV3

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/NSClientPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/NSClientPlugin.kt
@@ -76,7 +76,7 @@ class NSClientPlugin @Inject constructor(
         .mainType(PluginType.SYNC)
         .fragmentClass(NSClientFragment::class.java.name)
         .pluginIcon(app.aaps.core.ui.R.drawable.ic_nightscout_syncs)
-        .pluginName(R.string.ns_client)
+        .pluginName(R.string.ns_client_internal_title)
         .shortName(R.string.ns_client_short_name)
         .preferencesId(PluginDescription.PREFERENCE_SCREEN)
         .description(R.string.description_ns_client),
@@ -266,7 +266,7 @@ class NSClientPlugin @Inject constructor(
             )
             addPreference(
                 AdaptiveStringPreference(
-                    ctx = context, stringKey = StringKey.NsClientApiSecret, dialogMessage = R.string.ns_client_secret_dialog_title, title = R.string.ns_client_secret_title,
+                    ctx = context, stringKey = StringKey.NsClientApiSecret, dialogMessage = R.string.ns_client_secret_dialog_message, title = R.string.ns_client_secret_title,
                     validatorParams = DefaultEditTextValidator.Parameters(testType = EditTextValidator.TEST_MIN_LENGTH, minLength = 12)
                 )
             )

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/NSClientV3Plugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/NSClientV3Plugin.kt
@@ -124,7 +124,7 @@ class NSClientV3Plugin @Inject constructor(
         .mainType(PluginType.SYNC)
         .fragmentClass(NSClientFragment::class.java.name)
         .pluginIcon(app.aaps.core.ui.R.drawable.ic_nightscout_syncs)
-        .pluginName(R.string.ns_client_v3)
+        .pluginName(R.string.ns_client_v3_internal_title)
         .shortName(R.string.ns_client_v3_short_name)
         .preferencesId(PluginDescription.PREFERENCE_SCREEN)
         .description(R.string.description_ns_client_v3),
@@ -785,7 +785,7 @@ class NSClientV3Plugin @Inject constructor(
         parent.addPreference(category)
         category.apply {
             key = "ns_client_settings"
-            title = rh.gs(R.string.ns_client_internal_title)
+            title = rh.gs(R.string.ns_client_v3_internal_title)
             initialExpandedChildrenCount = 0
             addPreference(
                 AdaptiveStringPreference(
@@ -795,7 +795,7 @@ class NSClientV3Plugin @Inject constructor(
             )
             addPreference(
                 AdaptiveStringPreference(
-                    ctx = context, stringKey = StringKey.NsClientAccessToken, dialogMessage = R.string.nsclient_token_dialog_title, title = R.string.nsclient_token_title,
+                    ctx = context, stringKey = StringKey.NsClientAccessToken, dialogMessage = R.string.nsclient_token_dialog_message, title = R.string.nsclient_token_title,
                     validatorParams = DefaultEditTextValidator.Parameters(testType = EditTextValidator.TEST_MIN_LENGTH, minLength = 17)
                 )
             )

--- a/plugins/sync/src/main/res/values/strings.xml
+++ b/plugins/sync/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
     <string name="key_ns_offline_event_last_synced_id" translatable="false">ns_offline_event_last_synced_id</string>
     <string name="key_ns_profile_store_last_synced_timestamp" translatable="false">ns_profile_store_last_synced_timestamp</string>
     <string name="key_ns_client_v3_last_modified" translatable="false">key_ns_client_v3_last_modified</string>
-
     <string name="ns_cellular">Use Cellular connection</string>
     <string name="ns_wifi">Use WiFi connection</string>
     <string name="ns_wifi_ssids">WiFi SSID</string>
@@ -29,7 +28,7 @@
     <string name="ns_create_announcements_from_carbs_req_title">Create announcements from carbs required alerts</string>
     <string name="ns_create_announcements_from_errors_summary">Create Nightscout announcement for error dialogs and local alerts (also viewable in Careportal under Treatments)</string>
     <string name="ns_create_announcements_from_carbs_req_summary">Create Nightscout announcements for carbs required alerts</string>
-    <string name="description_ns_client">Synchronizes your data with Nightscout</string>
+    <string name="description_ns_client">Synchronizes your data with Nightscout using v1 API</string>
     <string name="description_ns_client_v3">Synchronizes your data with Nightscout using v3 API</string>
     <string name="blocked_by_charging">Blocked by charging options</string>
     <string name="blocked_by_connectivity">Blocked by connectivity options</string>
@@ -41,23 +40,20 @@
 
     <!-- NSClient -->
     <string name="key_ns_paused" translatable="false">ns_client_paused</string>
-
     <string name="no_write_permission">NSCLIENT has no write permission. Wrong API secret?</string>
-    <string name="ns_client_v3">NSClientV3</string>
     <string name="ns_client_v3_short_name">NSV3</string>
     <string name="ns_client">NSClient</string>
-    <string name="ns_client_short_name">NSCI</string>
+    <string name="ns_client_short_name">NSV1</string>
     <string name="ns_client_url">URL:</string>
     <string name="restart">Restart</string>
-    <string name="ns_client_internal_title">NSClient</string>
+    <string name="ns_client_internal_title">NSClientV1</string>
+    <string name="ns_client_v3_internal_title">NSClientV3</string>
     <string name="ns_client_url_title">Nightscout URL</string>
-    <string name="ns_client_url_dialog_message">Enter Your Nightscout URL</string>
-    <string name="ns_client_secret_title">NS API secret</string>
-    <string name="ns_client_secret_dialog_title">NS API secret</string>
-    <string name="ns_client_secret_dialog_message">Enter NS API secret (min 12 chars)</string>
-    <string name="nsclient_token_title">NS access token</string>
-    <string name="nsclient_token_dialog_title">NS access token</string>
-    <string name="nsclient_token_dialog_message">Access token generated on NS admin page (min 17 chars)</string>
+    <string name="ns_client_url_dialog_message">Enter your Nightscout URL (i.e. https://yoursitename.yourplatform.dom)</string>
+    <string name="ns_client_secret_title">Nightscout API secret</string>
+    <string name="ns_client_secret_dialog_message">Enter your Nightscout API secret (minimum 12 chars password recorded in your Nightscout variables)</string>
+    <string name="nsclient_token_title">Nightscout access token</string>
+    <string name="nsclient_token_dialog_message">Enter your admin level access token generated in Nightscout admin tools (minimum 17 chars, not your API secret!)</string>
     <string name="deliver_now">Deliver now</string>
     <string name="queue">Queue:</string>
     <string name="status">Status:</string>
@@ -98,7 +94,6 @@
 
     <!-- Tidepool -->
     <string name="key_tidepool_last_end" translatable="false">tidepool_last_end</string>
-
     <string name="summary_tidepool_username">Your Tidepool login user name, normally your email address</string>
     <string name="title_tidepool_username">Login User Name</string>
     <string name="summary_tidepool_password">Your Tidepool login password</string>
@@ -111,7 +106,6 @@
     <string name="description_tidepool">Uploads data to Tidepool</string>
     <string name="remove_all">Remove all</string>
     <string name="upload_now">Upload now</string>
-
     <string name="not_connected">Not connected</string>
     <string name="read_only">Read only</string>
     <string name="working">Working</string>
@@ -127,10 +121,8 @@
     <string name="xdrip_status_settings">xDrip+ Status Line Advanced</string>
     <string name="disabled_loop">Loop Disabled</string>
     <string name="xdrip_send_status_title">Send Status line to xDrip+</string>
-
     <string name="xdrip_not_installed">xDrip+ not installed</string>
     <string name="calibration_sent">Calibration sent to xDrip+</string>
-
     <string name="key_xdrip_temporary_target_last_synced_id" translatable="false">xdrip_temporary_target_last_sync</string>
     <string name="key_xdrip_glucose_value_last_synced_id" translatable="false">xdrip_glucose_value_last_sync</string>
     <string name="key_xdrip_food_last_synced_id" translatable="false">xdrip_food_last_sync</string>
@@ -145,10 +137,8 @@
     <string name="key_xdrip_effective_profile_switch_last_synced_id" translatable="false">xdrip_effective_profile_switch_last_synced_id</string>
     <string name="key_xdrip_offline_event_last_synced_id" translatable="false">xdrip_offline_event_last_synced_id</string>
     <string name="key_xdrip_profile_store_last_synced_timestamp" translatable="false">xdrip_profile_store_last_synced_timestamp</string>
-
     <string name="xdrip_local_broadcasts_summary">Send glucose and treatments data to xDrip+. Data Source \"xDrip+ Sync Follower\" must be selected and accepting of data must be enabled in Settings - Inter-app settings - Accept Glucose/Treatments</string>
     <string name="xdrip_local_broadcasts_title">Enable broadcasts to xDrip+.</string>
-
 
     <!--    DataBroadcast-->
     <string name="tizen">Samsung Tizen</string>


### PR DESCRIPTION
It is easy for new users to enter wrong passwords and URL's in NSClientV1 and NSClientV3 due to lack of explanation in dialog boxes. This will improve dialog messages and also distinguish V1 from V3 more clearly in naming so it's easier to know which of the API's users have selected when troubleshooting.