### PR TITLE
24h sliding average sensitivity for AutoISF plugin

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/OpenAPSAutoISFPlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/OpenAPSAutoISFPlugin.kt
@@ -158,7 +158,6 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
             val key = timestamp - timestamp % T.mins(minutesClass).msecs() + glucose.toLong()
             if (variableSens > 0) autoIsfCache.put(key, variableSens)
             count++
-            count++
         }
         aapsLogger.debug(LTag.APS, "Loaded $count variable sensitivity values from database")
     }

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/OpenAPSAutoISFPlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/OpenAPSAutoISFPlugin.kt
@@ -144,6 +144,8 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
     private val exerciseMode; get() = SMBDefaults.exercise_mode
     private val highTemptargetRaisesSensitivity; get() = preferences.get(BooleanKey.ApsAutoIsfHighTtRaisesSens)
     val normalTarget = 100
+    private val minutesClass; get() = if (preferences.get(IntKey.ApsMaxSmbFrequency) == 1) 6L else 30L  // ga-zelle: later get correct 1 min CGM flag from glucoseStatus ? ... or from apsResults?
+
 
     override fun onStart() {
         super.onStart()
@@ -153,8 +155,9 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
             val glucose = it.glucoseStatus?.glucose ?: return@forEach
             val variableSens = it.variableSens ?: return@forEach
             val timestamp = it.date
-            val key = timestamp - timestamp % T.mins(30).msecs() + glucose.toLong()
-            if (variableSens > 0) dynIsfCache.put(key, variableSens)
+            val key = timestamp - timestamp % T.mins(minutesClass).msecs() + glucose.toLong()
+            if (variableSens > 0) autoIsfCache.put(key, variableSens)
+            count++
             count++
         }
         aapsLogger.debug(LTag.APS, "Loaded $count variable sensitivity values from database")
@@ -166,7 +169,7 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
         val start = dateUtil.now()
         val multiplier = (profile as ProfileSealed.EPS).value.originalPercentage / 100.0
         val sensitivity = calculateVariableIsf(start)
-        if (sensitivity.second == null)
+        if (sensitivity.second == null && caller == "OpenAPSSMBPlugin")
             uiInteraction.addNotificationValidTo(
                 Notification.DYN_ISF_FALLBACK, start,
                 rh.gs(R.string.fallback_to_isf_no_tdd, sensitivity.first), Notification.INFO, dateUtil.now() + T.mins(1).msecs()
@@ -181,7 +184,7 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
         var count = 0
         var sum = 0.0
         val start = timestamp - T.hours(24).msecs()
-        dynIsfCache.forEach { key, value ->
+        autoIsfCache.forEach { key, value ->
             if (key in start..timestamp) {
                 count++
                 sum += value
@@ -216,33 +219,37 @@ open class OpenAPSAutoISFPlugin @Inject constructor(
         preferenceFragment.findPreference<SwitchPreference>(BooleanKey.ApsUseSmbAfterCarbs.key)?.isVisible = !smbAlwaysEnabled || !advancedFiltering
     }
 
-    private val dynIsfCache = LongSparseArray<Double>()
+    private var autoIsfCache = LongSparseArray<Double>()
 
     @Synchronized
     private fun calculateVariableIsf(timestamp: Long): Pair<String, Double?> {
         val profile = profileFunction.getProfile(timestamp)
         if (profile == null) return Pair("OFF", null)
-        if (!preferences.get(BooleanKey.ApsUseDynamicSensitivity)) return Pair("OFF", null)
-        val result = persistenceLayer.getApsResultCloseTo(timestamp)
-        if (result?.variableSens != null && result.variableSens != 0.0) {
-            aapsLogger.debug("calculateVariableIsf DB  ${dateUtil.dateAndTimeAndSecondsString(timestamp)} ${result.variableSens}")
-            return Pair("DB", result.variableSens)
+        val maxIsfCacheAge = T.hours(24).msecs()
+        if (autoIsfCache.size() >0) {
+            if (autoIsfCache.keyAt(autoIsfCache.size() - 1) - autoIsfCache.keyAt(0) > maxIsfCacheAge - 400L ) {
+                val tempIsfCache = autoIsfCache
+                autoIsfCache.forEach { key, value ->
+                    if (key < dateUtil.now() - maxIsfCacheAge - 400L) {
+                        tempIsfCache.remove(key)
+                    }
+                }
+                autoIsfCache.clear()
+                autoIsfCache = tempIsfCache
+            }
         }
         val glucose = glucoseStatusProvider.glucoseStatusData?.glucose ?: return Pair("GLUC", null)
-        // Round down to 30 min and use it as a key for caching
+        // Round down to minutesClass min and use it as a key for caching
         // Add BG to key as it affects calculation
-        val key = timestamp - timestamp % T.mins(30).msecs() + glucose.toLong()
-        val cached = dynIsfCache[key]
-        if (cached != null && timestamp < dateUtil.now()) {
-            aapsLogger.debug("calculateVariableIsf HIT ${dateUtil.dateAndTimeAndSecondsString(timestamp)} $cached")
-            return Pair("HIT", cached)
+        val key = timestamp - timestamp % T.mins(minutesClass).msecs() + glucose.toLong()
+        val sensitivity = autoISF(timestamp, profile)
+        if (sensitivity > 0) {
+            // can default to 0, e.g. for the first 2-3 loops in a virgin setup
+            aapsLogger.debug("calculateVariableIsf CALC ${dateUtil.dateAndTimeAndSecondsString(timestamp)} $sensitivity")
+            autoIsfCache.put(key, sensitivity)
         }
-        // no cached result found, let's calculate the value
-        val autoIsfTimestamp = autoISF(timestamp, profile)
-        val sensitivity = autoIsfTimestamp
-        dynIsfCache.put(key, sensitivity)
-        if (dynIsfCache.size() > 1000) dynIsfCache.clear()
-        return Pair("CALC", sensitivity)
+        // this return is mandatory, otherwise it messed up the AutoISF algo.
+        return Pair("OFF", null)
     }
 
     override fun invoke(initiator: String, tempBasalFallback: Boolean) {


### PR DESCRIPTION
This implements average sensitivity for AutoISF in analogy to DynISF.  It also avoids the message about missing TDDs because they are not used in AutoISF.

Some additional comments:

1. The release notes for 3.3.0 mention a 24h average sensitivity. As I could not immediately find that time window management I kept my solution for a 24 sliding average

2. The key for the dynIsfCache uses BG, probably because it has a very strong correlation with sensitivity. In AutoISF BG has only a very weak correlation with sensitivity. When I checked the calculated averages from AAPS against the theoretical averages I was surprised to see they match, at least after an initial period of 1-2 hours in which they get closer and closer.

3. In case of a 1 minute CGM with loop every minute a 6 minute grouping capability was added as complement to the 30 minute grouping. This is independent of AutoISF and could therefore easily be added to the DynISF variant, too.