### PR TITLE
Wear Fix WearOS 5.0 missing Watchface parameter

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/events/EventUpdateSelectedWatchface.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/events/EventUpdateSelectedWatchface.kt
@@ -1,0 +1,3 @@
+package app.aaps.core.interfaces.rx.events
+
+class EventUpdateSelectedWatchface() : Event()

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
@@ -5,9 +5,10 @@ import android.os.Bundle
 import app.aaps.wear.R
 import app.aaps.wear.interaction.WatchfaceConfigurationActivity
 import app.aaps.wear.interaction.utils.MenuListActivity
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 
 class PreferenceMenuActivity : MenuListActivity() {
-
+    private var lastWatchface = SelectedWatchFace.NONE
     override fun onCreate(savedInstanceState: Bundle?) {
         setTitle(R.string.menu_settings)
         super.onCreate(savedInstanceState)
@@ -20,6 +21,13 @@ class PreferenceMenuActivity : MenuListActivity() {
             add(MenuItem(R.drawable.ic_interface, getString(R.string.pref_interface_settings)))
             add(MenuItem(R.drawable.ic_complication, getString(R.string.pref_complication_settings)))
             add(MenuItem(R.drawable.ic_others, getString(R.string.pref_others_settings)))
+            lastWatchface = SelectedWatchFace.fromId(sp.getInt(R.string.key_last_selected_watchface, SelectedWatchFace.NONE.ordinal))
+            when(lastWatchface) {
+                SelectedWatchFace.NONE -> Unit
+                SelectedWatchFace.CUSTOM -> add(MenuItem(R.drawable.watchface_custom, getString(R.string.label_watchface_custom)))
+                SelectedWatchFace.DIGITAL -> add(MenuItem(R.drawable.watchface_digitalstyle, getString(R.string.label_watchface_digital_style)))
+                SelectedWatchFace.CIRCLE -> add(MenuItem(R.drawable.watchface_circle, getString(R.string.label_watchface_circle)))
+            }
         }
 
     override fun doAction(position: String) {
@@ -47,6 +55,18 @@ class PreferenceMenuActivity : MenuListActivity() {
             getString(R.string.pref_others_settings)       -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 putExtra(getString(R.string.key_preference_id), R.xml.others_preferences)
+            })
+
+            getString(R.string.label_watchface_custom),
+            getString(R.string.label_watchface_digital_style),
+            getString(R.string.label_watchface_circle)     -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                when (lastWatchface) {
+                    SelectedWatchFace.NONE    -> Unit
+                    SelectedWatchFace.CUSTOM  -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_custom)
+                    SelectedWatchFace.DIGITAL -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_digitalstyle)
+                    SelectedWatchFace.CIRCLE  -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_circle)
+                }
             })
         }
     }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/utils/MenuListActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/utils/MenuListActivity.kt
@@ -12,12 +12,16 @@ import androidx.wear.widget.CurvedTextView
 import androidx.wear.widget.WearableLinearLayoutManager
 import androidx.wear.widget.WearableLinearLayoutManager.LayoutCallback
 import androidx.wear.widget.WearableRecyclerView
+import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventUpdateSelectedWatchface
 import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.core.keys.Preferences
 import app.aaps.wear.R
 import app.aaps.wear.interaction.utils.MenuListActivity.MenuAdapter.ItemViewHolder
 import dagger.android.DaggerActivity
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.kotlin.plusAssign
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.math.min
@@ -30,8 +34,10 @@ abstract class MenuListActivity : DaggerActivity() {
     @Inject lateinit var sp: SP
     @Inject lateinit var preferences: Preferences
     @Inject lateinit var rxBus: RxBus
+    @Inject lateinit var aapsSchedulers: AapsSchedulers
 
     private var elements: List<MenuItem> = listOf()
+    private var disposable = CompositeDisposable()
     protected abstract fun provideElements(): List<MenuItem>
     protected abstract fun doAction(position: String)
 
@@ -39,6 +45,21 @@ abstract class MenuListActivity : DaggerActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.actions_list_activity)
         setTitleBasedOnScreenShape(title.toString())
+        disposable += rxBus
+            .toObservable(EventUpdateSelectedWatchface::class.java)
+            .observeOn(aapsSchedulers.main)
+            .subscribe { event: EventUpdateSelectedWatchface ->
+                updateMenu()
+            }
+        updateMenu()
+    }
+
+    override fun onDestroy() {
+        disposable.clear()
+        super.onDestroy()
+    }
+
+    private fun updateMenu() {
         elements = provideElements()
         val customScrollingLayoutCallback = CustomScrollingLayoutCallback()
         val layoutManager = WearableLinearLayoutManager(this)
@@ -48,7 +69,7 @@ abstract class MenuListActivity : DaggerActivity() {
             layoutManager.layoutCallback = customScrollingLayoutCallback
             listView.isEdgeItemsCenteringEnabled = true
         } else {
-            // Bug in androidx.wear:wear:1.2.0 
+            // Bug in androidx.wear:wear:1.2.0
             // WearableRecyclerView setEdgeItemsCenteringEnabled requires fix for square screen
             listView.setPadding(0, 50, 0, 0)
         }

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CircleWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CircleWatchface.kt
@@ -20,6 +20,7 @@ import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventUpdateSelectedWatchface
 import app.aaps.core.interfaces.rx.events.EventWearToMobile
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.rx.weardata.EventData.ActionResendData
@@ -29,6 +30,7 @@ import app.aaps.wear.R
 import app.aaps.wear.data.RawDisplayData
 import app.aaps.wear.interaction.menus.MainMenuActivity
 import app.aaps.wear.interaction.utils.Persistence
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 import com.ustwo.clockwise.common.WatchFaceTime
 import com.ustwo.clockwise.wearable.WatchFace
 import dagger.android.AndroidInjection
@@ -89,6 +91,8 @@ class CircleWatchface : WatchFace() {
     override fun onCreate() {
         AndroidInjection.inject(this)
         super.onCreate()
+        sp.putInt(R.string.key_last_selected_watchface, SelectedWatchFace.CIRCLE.ordinal)
+        rxBus.send(EventUpdateSelectedWatchface())
         val powerManager = getSystemService(POWER_SERVICE) as PowerManager
         val wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "AndroidAPS:CircleWatchface")
         wakeLock.acquire(30000)

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
@@ -29,6 +29,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.forEach
 import androidx.viewbinding.ViewBinding
 import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.rx.events.EventUpdateSelectedWatchface
 import app.aaps.core.interfaces.rx.weardata.CUSTOM_VERSION
 import app.aaps.core.interfaces.rx.weardata.CwfData
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey
@@ -49,6 +50,7 @@ import app.aaps.shared.impl.weardata.toTypeface
 import app.aaps.wear.R
 import app.aaps.wear.databinding.ActivityCustomBinding
 import app.aaps.wear.watchfaces.utils.BaseWatchFace
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 import org.joda.time.DateTime
 import org.joda.time.TimeOfDay
 import org.json.JSONObject
@@ -92,6 +94,8 @@ class CustomWatchface : BaseWatchFace() {
 
     @Suppress("DEPRECATION")
     override fun inflateLayout(inflater: LayoutInflater): ViewBinding {
+        sp.putInt(R.string.key_last_selected_watchface, SelectedWatchFace.CUSTOM.ordinal)
+        rxBus.send(EventUpdateSelectedWatchface())
         binding = ActivityCustomBinding.inflate(inflater)
         setDefaultColors()
         persistence.store(defaultWatchface(false), defaultWatchface(true), true)

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/DigitalStyleWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/DigitalStyleWatchface.kt
@@ -10,9 +10,11 @@ import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.viewbinding.ViewBinding
 import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.rx.events.EventUpdateSelectedWatchface
 import app.aaps.wear.R
 import app.aaps.wear.databinding.ActivityDigitalstyleBinding
 import app.aaps.wear.watchfaces.utils.BaseWatchFace
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 
 class DigitalStyleWatchface : BaseWatchFace() {
 
@@ -20,6 +22,8 @@ class DigitalStyleWatchface : BaseWatchFace() {
 
     override fun inflateLayout(inflater: LayoutInflater): ViewBinding {
         binding = ActivityDigitalstyleBinding.inflate(inflater)
+        sp.putInt(R.string.key_last_selected_watchface, SelectedWatchFace.DIGITAL.ordinal)
+        rxBus.send(EventUpdateSelectedWatchface())
         return binding
     }
 

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/WatchfaceViewAdapter.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/utils/WatchfaceViewAdapter.kt
@@ -109,6 +109,18 @@ class WatchfaceViewAdapter(
                 else                           -> throw IllegalArgumentException("ViewBinding is not implement in WatchfaceViewAdapter")
             }
         }
+
+        enum class SelectedWatchFace() {
+            NONE,
+            CUSTOM,
+            DIGITAL,
+            CIRCLE;
+
+            companion object {
+
+                fun fromId(ordinal: Int): SelectedWatchFace = SelectedWatchFace.entries[ordinal]
+            }
+        }
     }
 
 }

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -232,6 +232,7 @@
     <string name="key_show_seconds" translatable="false">show_second</string>
     <string name="key_include_external" translatable="false">include_external</string>
     <string name="key_switch_external" translatable="false">switch_external</string>
+    <string name="key_last_selected_watchface" translatable="false">last_selected_watchface</string>
     <string name="increment">increment</string>
     <string name="decrement">decrement</string>
     <string name="abbreviation_average">avg</string>

--- a/wear/src/main/res/xml/interface_preferences.xml
+++ b/wear/src/main/res/xml/interface_preferences.xml
@@ -31,6 +31,15 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:key="@string/key_vibrate_hourly"
+        android:summaryOn="@string/on"
+        android:summaryOff="@string/off"
+        android:title="@string/pref_vibrate_hourly"
+        app:wear_iconOff="@drawable/settings_off"
+        app:wear_iconOn="@drawable/settings_on" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="primefill"
         android:summary="Prime/Fill from watch possible"
         android:summaryOn="@string/on"

--- a/wear/src/main/res/xml/watch_face_configuration_circle.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_circle.xml
@@ -51,13 +51,4 @@
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
 
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="@string/key_vibrate_hourly"
-        android:summaryOn="@string/on"
-        android:summaryOff="@string/off"
-        android:title="@string/pref_vibrate_hourly"
-        app:wear_iconOff="@drawable/settings_off"
-        app:wear_iconOn="@drawable/settings_on" />
-
 </PreferenceScreen>

--- a/wear/src/main/res/xml/watch_face_configuration_custom.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_custom.xml
@@ -50,15 +50,6 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
-        android:key="@string/key_vibrate_hourly"
-        android:summaryOn="@string/on"
-        android:summaryOff="@string/off"
-        android:title="@string/pref_vibrate_hourly"
-        app:wear_iconOff="@drawable/settings_off"
-        app:wear_iconOn="@drawable/settings_on" />
-
-    <CheckBoxPreference
-        android:defaultValue="false"
         android:key="@string/key_include_external"
         android:summaryOn="@string/on"
         android:summaryOff="@string/off"

--- a/wear/src/main/res/xml/watch_face_configuration_digitalstyle.xml
+++ b/wear/src/main/res/xml/watch_face_configuration_digitalstyle.xml
@@ -47,15 +47,6 @@
         app:wear_iconOff="@drawable/settings_off"
         app:wear_iconOn="@drawable/settings_on" />
 
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="@string/key_vibrate_hourly"
-        android:summaryOn="@string/on"
-        android:summaryOff="@string/off"
-        android:title="@string/pref_vibrate_hourly"
-        app:wear_iconOff="@drawable/settings_off"
-        app:wear_iconOn="@drawable/settings_on" />
-
     <ListPreference
         android:defaultValue="off"
         android:entries="@array/watchface_simplify_ui_name"


### PR DESCRIPTION
Watchface parameter (available with long press on current WF) is not available for WearOS 5.0 users, so I also included last selected AAPS watchface parameters into Parameter menu in Wear app

Move Vibrate on Hour parameter from Watchfaces dedicated param to global Interface param