### PR TITLE
Hide Medtrum setting key_pump_warning_expiry_hour instead of not clickable when not relevant

### DIFF
--- a/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPlugin.kt
+++ b/pump/medtrum/src/main/java/info/nightscout/pump/medtrum/MedtrumPlugin.kt
@@ -275,7 +275,7 @@ import kotlin.math.abs
         val pumpWarningNotificationPref = preferenceFragment.findPreference<SwitchPreference>(rh.gs(R.string.key_pump_warning_notification))
         val pumpWarningExpiryHourPref = preferenceFragment.findPreference<ValidatingEditTextPreference>(rh.gs(R.string.key_pump_warning_expiry_hour))
 
-        pumpWarningExpiryHourPref?.isEnabled = patchExpirationPref?.isChecked == true && pumpWarningNotificationPref?.isChecked == true
+        pumpWarningExpiryHourPref?.isVisible = patchExpirationPref?.isChecked == true && pumpWarningNotificationPref?.isChecked == true
     }
 
     override fun isInitialized(): Boolean {


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/3600

https://github.com/user-attachments/assets/7b2fd4b0-c98d-45af-83fd-9bc26d8ddf3a

