### PR TITLE
UI - Bottom buttons alignement

### DIFF
--- a/core/ui/src/main/res/values-night/styles.xml
+++ b/core/ui/src/main/res/values-night/styles.xml
@@ -341,7 +341,7 @@
     </style>
 
     <!--    Common Buttons -->
-    <dimen name="gray_material_button_margin_horizontal">5dp</dimen>
+    <dimen name="gray_material_button_margin_horizontal">2dp</dimen>
 
     <style name="GrayButton" parent="Widget.MaterialComponents.Button">
         <item name="android:backgroundTint">@color/mtrl_btn_bg_color_selector_grey</item>

--- a/core/ui/src/main/res/values/styles.xml
+++ b/core/ui/src/main/res/values/styles.xml
@@ -356,7 +356,7 @@
     </style>
 
     <!--    Common Buttons -->
-    <dimen name="gray_material_button_margin_horizontal">5dp</dimen>
+    <dimen name="gray_material_button_margin_horizontal">2dp</dimen>
 
     <style name="GrayButton" parent="Widget.MaterialComponents.Button">
         <item name="android:backgroundTint">@color/mtrl_btn_bg_color_selector_grey</item>

--- a/plugins/main/src/main/res/layout/overview_buttons_layout.xml
+++ b/plugins/main/src/main/res/layout/overview_buttons_layout.xml
@@ -31,22 +31,22 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingStart="0dp"
-        android:paddingEnd="5dp">
+        android:paddingStart="@dimen/gray_material_button_margin_horizontal"
+        android:paddingEnd="@dimen/gray_material_button_margin_horizontal">
 
         <app.aaps.core.ui.elements.SingleClickButton
             android:id="@+id/treatment_button"
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/icon_insulin_carbs"
             android:ellipsize="end"
             android:singleLine="true"
             android:text="@string/overview_treatment_label"
             android:textColor="?attr/icTreatmentColor"
-            android:visibility="gone"
+            android:visibility="visible"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton
@@ -54,7 +54,7 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_bolus"
             android:ellipsize="end"
@@ -68,7 +68,7 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_cp_bolus_carbs"
             android:ellipsize="end"
@@ -82,7 +82,7 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_calculator"
             android:ellipsize="end"
@@ -96,14 +96,15 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginStart="@dimen/gray_material_button_margin_horizontal"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_calibration"
             android:ellipsize="end"
             android:singleLine="true"
             android:text="@string/calibration"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="gone"
+            android:visibility="visible"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton
@@ -111,14 +112,15 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginStart="@dimen/gray_material_button_margin_horizontal"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_xdrip"
             android:ellipsize="end"
             android:singleLine="true"
             android:text="@string/overview_cgm"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="gone"
+            android:visibility="visible"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton
@@ -126,7 +128,8 @@
             style="@style/ButtonSmallFontStyle"
             android:layout_width="0px"
             android:layout_height="fill_parent"
-            android:layout_marginEnd="-2dp"
+            android:layout_marginStart="@dimen/gray_material_button_margin_horizontal"
+            android:layout_marginEnd="@dimen/gray_material_button_margin_horizontal"
             android:layout_weight="0.5"
             android:drawableTop="@drawable/ic_quick_wizard"
             android:hint="@string/quickwizard"

--- a/plugins/main/src/main/res/layout/overview_buttons_layout.xml
+++ b/plugins/main/src/main/res/layout/overview_buttons_layout.xml
@@ -46,7 +46,7 @@
             android:singleLine="true"
             android:text="@string/overview_treatment_label"
             android:textColor="?attr/icTreatmentColor"
-            android:visibility="visible"
+            android:visibility="gone"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton
@@ -104,7 +104,7 @@
             android:singleLine="true"
             android:text="@string/calibration"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="visible"
+            android:visibility="gone"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton
@@ -120,7 +120,7 @@
             android:singleLine="true"
             android:text="@string/overview_cgm"
             android:textColor="?attr/icCalibrationColor"
-            android:visibility="visible"
+            android:visibility="gone"
             app:iconPadding="-4dp" />
 
         <app.aaps.core.ui.elements.SingleClickButton


### PR DESCRIPTION
With current margin in button, latest buttons is truncated (see screen below)

![orign](https://github.com/user-attachments/assets/ebf76296-1d88-436b-b810-2f79ffeb8d27)

With new margin, everything will be centered (I hope), Even with some buttons hidden.
I sacrificed 1dp on each side to get the 'centering'

![Screenshot_20241213_130842](https://github.com/user-attachments/assets/2b3490d1-ffa0-4e4e-9cc0-8dc3999fa38d)
![Screenshot_20241213_130908](https://github.com/user-attachments/assets/cd8d8d6d-29ca-4d0a-88f2-4811c821fec4)
