### PR TITLE
combov2: change short name from COMBOV2 to COMBO

### DIFF
--- a/pump/combov2/src/main/res/values/strings.xml
+++ b/pump/combov2/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="combov2_plugin_name">Accu-Chek Combo</string>
-    <string name="combov2_plugin_shortname" translatable="false">COMBOV2</string>
+    <string name="combov2_plugin_shortname" translatable="false">COMBO</string>
     <string name="combov2_plugin_description">Native pump integration for Accu-Chek Combo pumps</string>
     <string name="combov2_could_not_connect">Could not connect to the pump</string>
     <string name="combov2_not_paired">Not paired to a pump</string>


### PR DESCRIPTION
Very small but still reasonable change imo. There's no Ruffy driver now, so I think it'd be better to not disorient the user with the V2 name, cause there's only the V2 one in 3.3