### PR TITLE
Use Two Decimals for Insulin Remaining

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
@@ -111,7 +111,7 @@ class StatusLightHandler @Inject constructor(
     private fun handleLevel(view: TextView?, criticalSetting: IntKey, warnSetting: IntKey, level: Double, units: String) {
         val resUrgent = preferences.get(criticalSetting)
         val resWarn = preferences.get(warnSetting)
-        if (level > 0) view?.text = " " + decimalFormatter.to0Decimal(level, units)
+        if (level > 0) view?.text = " " + decimalFormatter.to2Decimal(level, units)
         else view?.text = ""
         warnColors.setColorInverse(view, level, resWarn, resUrgent)
     }


### PR DESCRIPTION
This allows the Overview ("Home") screen to show two decimal points if the insulin remaining is <50U. This is useful for issuing boluses that use up all of the remaining reservoir without having to check the reservoir amount in the pump's settings.

Use Case for Explanation:
1. I use Omnipod Dash with AAPS. Often, towards the end of the pump, I will want to issue a bolus that empties the reservoir (at least as empty as the Dash will allow it, since it doesn't actually report 100% of the insulin in it) before changing to a new pump.
2. The current overview/"Home" tab rounds the reservoir value to the nearest whole number. The Dash reports to two decimals (hudredths of a unit). If you go by the overview screen, you can issue a bolus that results in an error (Not enough insulin in reservoir) or that doesn't empty the pump (up to 0.45U remaining). You don't know which without checking the unrounded number.
3. Current workflow to do this is to go to the "Dash" menu and check the "Reservoir" value, then return to the "Home" menu to tap "Insulin" and deliver that value. This is time consuming, especially if you're about to switch out the pump and go through that process anyway.

This PR thus changes the home screen to show, e.g. "1.95U" remaining at the end of a pump, so that without changing tabs one can issue a bolus of 1.95U. Note that the current home screen would show "2U" but issuing that bolus would result in an error. 

Using this on a Pixel 8. I havent' run into any UI glitches or issues with space.