### PR TITLE
Wear fix logback: excessive storage use

### DIFF
--- a/wear/src/main/assets/logback.xml
+++ b/wear/src/main/assets/logback.xml
@@ -14,8 +14,8 @@
                 class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>5MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 30 days' worth of history -->
-            <maxHistory>120</maxHistory>
+            <!-- keep 7 days' worth of history -->
+            <maxHistory>7</maxHistory>
         </rollingPolicy>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %.-1level/%logger: %msg%n</pattern>


### PR DESCRIPTION
Remove logfiles older than 7 days to prevent excessive storage use on watch by AAPS