### PR TITLE
Added date format (m/d/yy) in warning "Version X expires on"

### DIFF
--- a/plugins/constraints/src/main/res/values/strings.xml
+++ b/plugins/constraints/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="key_last_revoked_certs_check" translatable="false">last_revoked_certs_check</string>
     <string name="running_invalid_version">We have detected that you are running an invalid version. Loop disabled!</string>
     <string name="versionavailable">Version %1$s available</string>
-    <string name="version_expire">Version %1$s expire on %2$s</string>
+    <string name="version_expire">Version %1$s expire on %2$s (m/d/yy)</string>
 
     <!-- Signature verifier -->
     <string name="signature_verifier" translatable="false">Signature verifier</string>


### PR DESCRIPTION
## Description

This pull request improves the clarity of the expiration warning by adding the date format `(m/d/yy)` after the on-screen message:  
**"Version X expires on"**.

### Background

The US date format (m/d/yy) can be confusing for users in other regions. I personally encountered this doubt when interpreting an expiration date. A similar confusion was reported in the **"AAPS users"** Facebook group regarding the expiration date of version `v3.3.0-dev-g` shown as *1/11/25*. This ambiguity prompted me to submit this pull request.

You can find the discussion here:  
[Facebook Group Post](https://www.facebook.com/groups/AndroidAPSUsers/posts/4006736326214421/)

### Changes Made

- Appended `(m/d/yy)` to the expiration warning message to clarify the date format.

![472336450_596297966682925_1735305864987528930_n_after](https://github.com/user-attachments/assets/5882018b-b84c-4b6f-acb7-a99f169443f0)

### Benefits

- Improves accessibility and clarity for the global user base.  
- Reduces potential confusion caused by ambiguous date formats.