### PR TITLE
fix typo for HbA1c in Statistics page

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/stats/DexcomTirImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/stats/DexcomTirImpl.kt
@@ -81,7 +81,7 @@ class DexcomTirImpl : DexcomTIR {
                     (10 * (mean() + 46.7) / 28.7).roundToInt() / 10.0 + "%" +
                     " (" +
                     (((mean() + 46.7) / 28.7 - 2.15) * 10.929).roundToInt() +
-                    " mmol/L)"
+                    " mmol/mol)"
             setTypeface(typeface, Typeface.NORMAL)
             gravity = Gravity.CENTER_HORIZONTAL
         }


### PR DESCRIPTION
For https://github.com/nightscout/AndroidAPS/issues/3691

![image](https://github.com/user-attachments/assets/2a47c544-4123-47e4-89d0-3e5f9606eb55)
