### PR TITLE
Fix: Update SourceSensor enum to match Libre2 naming in xDrip

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
@@ -28,7 +28,7 @@ enum class SourceSensor(val text: String) {
     LIBRE_1_BUBBLE("Bubble"),
     LIBRE_1_ATOM("Bubble"),
     LIBRE_1_GLIMP("Glimp"),
-    LIBRE_2_NATIVE("Libre2"),
+    LIBRE_2_NATIVE("Libre2 Native"),
     LIBRE_3("Libre3"),
     POCTECH_NATIVE("Poctech"),
     GLUNOVO_NATIVE("Glunovo"),


### PR DESCRIPTION
I had hoped that SMB would always be enabled for the Libre2 starting from version 3.3.0. However, during testing of this version, it didn’t work. Upon examining the code, I noticed that the enum text SourceSensor didn’t match the name used in xDrip.
To enable SMBs for the "Libre2," the SourceSensor has been updated to "Libre2 Native." See also: [BgReading.java line 1221](https://github.com/NightscoutFoundation/xDrip/blob/master/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java#L1221) and [BgReading.java line 1245](https://github.com/NightscoutFoundation/xDrip/blob/master/app/src/main/java/com/eveningoutpost/dexdrip/models/BgReading.java#L1245)
