### PR TITLE
Add Basal / TBR rate complication for wear

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -233,6 +233,24 @@
         </service>
 
         <service
+            android:name=".complications.BrComplication"
+            android:exported="true"
+            android:icon="@drawable/ic_br"
+            android:label="@string/complication_br"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT" />
+            <meta-data
+                android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+                android:value="300" />
+        </service>
+
+        <service
             android:name=".complications.CobIobComplication"
             android:exported="true"
             android:icon="@drawable/ic_cob_iob"

--- a/wear/src/main/kotlin/app/aaps/wear/complications/BrComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/BrComplication.kt
@@ -1,0 +1,37 @@
+@file:Suppress("DEPRECATION")
+
+package app.aaps.wear.complications
+
+import android.app.PendingIntent
+import android.support.wearable.complications.ComplicationData
+import android.support.wearable.complications.ComplicationText
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.wear.data.RawDisplayData
+import dagger.android.AndroidInjection
+
+/*
+ * Created by olorinmaia on 2025-01-12
+ */
+class BrComplication : BaseComplicationProviderService() {
+
+    // Not derived from DaggerService, do injection here
+    override fun onCreate() {
+        AndroidInjection.inject(this)
+        super.onCreate()
+    }
+
+    override fun buildComplicationData(dataType: Int, raw: RawDisplayData, complicationPendingIntent: PendingIntent): ComplicationData? {
+        var complicationData: ComplicationData? = null
+        if (dataType == ComplicationData.TYPE_SHORT_TEXT) {
+            val builder = ComplicationData.Builder(ComplicationData.TYPE_SHORT_TEXT)
+                .setShortText(ComplicationText.plainText(displayFormat.basalRateSymbol() + raw.status[0].currentBasal))
+                .setTapAction(complicationPendingIntent)
+            complicationData = builder.build()
+        } else {
+            aapsLogger.warn(LTag.WEAR, "Unexpected complication type $dataType")
+        }
+        return complicationData
+    }
+
+    override fun getProviderCanonicalName(): String = BrComplication::class.java.canonicalName!!
+}

--- a/wear/src/main/kotlin/app/aaps/wear/di/WearServicesModule.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/di/WearServicesModule.kt
@@ -3,6 +3,7 @@ package app.aaps.wear.di
 import app.aaps.wear.comm.DataLayerListenerServiceWear
 import app.aaps.wear.complications.BaseComplicationProviderService
 import app.aaps.wear.complications.BrIobComplication
+import app.aaps.wear.complications.BrComplication
 import app.aaps.wear.complications.BrCobIobComplication
 import app.aaps.wear.complications.CobDetailedComplication
 import app.aaps.wear.complications.CobIconComplication
@@ -39,6 +40,7 @@ abstract class WearServicesModule {
     @ContributesAndroidInjector abstract fun contributesBaseComplicationProviderService(): BaseComplicationProviderService
     @ContributesAndroidInjector abstract fun contributesBrCobIobComplication(): BrCobIobComplication
     @ContributesAndroidInjector abstract fun contributesBrIobComplication(): BrIobComplication
+    @ContributesAndroidInjector abstract fun contributesBrComplication(): BrComplication
     @ContributesAndroidInjector abstract fun contributesCobDetailedComplication(): CobDetailedComplication
     @ContributesAndroidInjector abstract fun contributesCobIconComplication(): CobIconComplication
     @ContributesAndroidInjector abstract fun contributesCobIobComplication(): CobIobComplication

--- a/wear/src/main/res/drawable/ic_br.xml
+++ b/wear/src/main/res/drawable/ic_br.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="6.35"
+    android:viewportHeight="6.35">
+    <path
+        android:pathData="M1.689,0.882L1.689,3.762L0.517,3.762L0.517,4.143L2.181,4.143L2.181,1.374L2.806,1.374L2.806,2.453L3.858,2.453L3.858,4.143L5.527,4.143L5.527,3.762L4.495,3.762L4.495,2.083L3.442,2.083L3.442,0.882L1.689,0.882Z"
+        android:fillColor="@android:color/white" />
+</vector>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="complication_blood_glucose">Blood Glucose</string>
     <string name="complication_br_cob_iob">BR, CoB &amp; IoB</string>
     <string name="complication_br_iob">BR &amp; IoB</string>
+    <string name="complication_br">Basal rate</string>"
     <string name="complication_cob_iob">CoB &amp; IoB</string>
     <string name="complication_cob_icon">CoB Icon</string>
     <string name="complication_cob_detailed">CoB Detailed</string>


### PR DESCRIPTION
With latest Wear OS there is multiple watchfaces that got 5+ slots for complications. That give us the possibility to show exactly what we want in each slot. 

There is no complication right now that only show current basal / TBR rate, this will add that.

See screenshots from wear below and how this can be used:

![image](https://github.com/user-attachments/assets/795e4713-d1ed-413b-92d3-b7a4c18cb3b3)
![image](https://github.com/user-attachments/assets/1d10c35c-8007-4390-bc9b-f83a113cfde6)
