### PR TITLE
Allow the reception of heart rate data

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
@@ -404,6 +404,7 @@ class GarminPlugin @Inject constructor(
     /** Returns glucose values in Nightscout/Xdrip format. */
     @VisibleForTesting
     fun onSgv(uri: URI): CharSequence {
+        receiveHeartRate(uri)
         val count = getQueryParameter(uri, "count", 24L)
             .toInt().coerceAtMost(1000).coerceAtLeast(1)
         val briefMode = getQueryParameter(uri, "brief_mode", false)


### PR DESCRIPTION
Allow the reception of heart rate data also for Garmin apps that follow the xDrip+/Nightscout standard when querying.