### PR TITLE
Restore Garmin key preference setting

### DIFF
--- a/core/keys/src/main/kotlin/app/aaps/core/keys/StringKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/StringKey.kt
@@ -51,4 +51,5 @@ enum class StringKey(
     TidepoolUsername("tidepool_username", ""),
     TidepoolPassword("tidepool_password", "", isPassword = true),
     TidepoolTestLogin(key = "tidepool_test_login", ""),
+    GarminRequestKey(key = "garmin_aaps_key", defaultValue = ""),
 }

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
@@ -75,7 +75,8 @@ class GarminPlugin @Inject constructor(
 
     /** HTTP Server for local HTTP server communication (device app requests values) .*/
     private var server: HttpServer? = null
-    private var garminMessengerField: GarminMessenger? = null
+    @VisibleForTesting
+    var garminMessengerField: GarminMessenger? = null
     val garminMessenger: GarminMessenger
         get() {
             return synchronized(this) {

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/garmin/GarminPlugin.kt
@@ -20,7 +20,10 @@ import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.IntKey
 import app.aaps.core.keys.Preferences
+import app.aaps.core.keys.StringKey
+import app.aaps.core.validators.DefaultEditTextValidator
 import app.aaps.core.validators.preferences.AdaptiveIntPreference
+import app.aaps.core.validators.preferences.AdaptiveStringPreference
 import app.aaps.core.validators.preferences.AdaptiveSwitchPreference
 import app.aaps.plugins.sync.R
 import com.google.gson.JsonArray
@@ -96,13 +99,13 @@ class GarminPlugin @Inject constructor(
     var newValue: Condition = valueLock.newCondition()
     private var lastGlucoseValueTimestamp: Long? = null
     private val glucoseUnitStr get() = if (loopHub.glucoseUnit == GlucoseUnit.MGDL) "mgdl" else "mmoll"
-    private val garminAapsKey get() = sp.getString("garmin_aaps_key", "")
+    private val garminAapsKey get() = preferences.get(StringKey.GarminRequestKey) ?: ""
 
     private fun onPreferenceChange(event: EventPreferenceChange) {
         when (event.changedKey) {
             "communication_debug_mode"                                           -> setupGarminMessenger()
             BooleanKey.GarminLocalHttpServer.key, IntKey.GarminLocalHttpPort.key -> setupHttpServer()
-            "garmin_aaps_key"                                                    -> sendPhoneAppMessage()
+            StringKey.GarminRequestKey.key                                       -> sendPhoneAppMessage()
         }
     }
 
@@ -465,6 +468,12 @@ class GarminPlugin @Inject constructor(
             initialExpandedChildrenCount = 0
             addPreference(AdaptiveSwitchPreference(ctx = context, booleanKey = BooleanKey.GarminLocalHttpServer, title = R.string.garmin_local_http_server))
             addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.GarminLocalHttpPort, title = R.string.garmin_local_http_server_port))
+            addPreference(AdaptiveStringPreference(
+                ctx = context,
+                stringKey = StringKey.GarminRequestKey,
+                title = R.string.garmin_request_key,
+                summary = R.string.garmin_request_key_summary,
+                validatorParams = DefaultEditTextValidator.Parameters(emptyAllowed = true)))
         }
     }
 }

--- a/plugins/sync/src/main/res/values/strings.xml
+++ b/plugins/sync/src/main/res/values/strings.xml
@@ -243,5 +243,7 @@
     <string name="wear_action_loop_state_now_invalid">Invalid</string>
     <string name="wear_action_loop_state_now_pump_disconnected">Pump disconnected</string>
     <string name="wear_action_loop_state_now_pump_reconnected">Pump reconnected</string>
+    <string name="garmin_request_key">Request Key</string>
+    <string name="garmin_request_key_summary">Optional key to secure HTTP communication between Garmin device and AAPS.</string>
 
 </resources>

--- a/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminPluginTest.kt
+++ b/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminPluginTest.kt
@@ -254,7 +254,7 @@ class GarminPluginTest : TestBaseWithProfile() {
 
     @Test
     fun requestHandler_KeyRequired() {
-        gp.garminMessenger = mock(GarminMessenger::class.java)
+        gp.garminMessengerField = mock(GarminMessenger::class.java)
 
         `when`(preferences.get(StringKey.GarminRequestKey)).thenReturn("foo")
         val uri = createUri(emptyMap())
@@ -286,7 +286,7 @@ class GarminPluginTest : TestBaseWithProfile() {
 
     @Test
     fun onConnectDevice() {
-        gp.garminMessenger = mock(GarminMessenger::class.java)
+        gp.garminMessengerField = mock(GarminMessenger::class.java)
         `when`(preferences.get(StringKey.GarminRequestKey)).thenReturn("foo")
         val device = GarminDevice(mock(), 1, "Edge")
         gp.onConnectDevice(device)

--- a/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminPluginTest.kt
+++ b/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/garmin/GarminPluginTest.kt
@@ -8,7 +8,9 @@ import app.aaps.core.data.model.TrendArrow
 import app.aaps.core.interfaces.rx.events.EventNewBG
 import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.IntKey
+import app.aaps.core.keys.StringKey
 import app.aaps.core.validators.preferences.AdaptiveIntPreference
+import app.aaps.core.validators.preferences.AdaptiveStringPreference
 import app.aaps.core.validators.preferences.AdaptiveSwitchPreference
 import app.aaps.shared.tests.TestBaseWithProfile
 import com.google.common.truth.Truth
@@ -66,6 +68,10 @@ class GarminPluginTest : TestBaseWithProfile() {
                 it.preferences = preferences
                 it.sharedPrefs = sharedPrefs
                 it.config = config
+            }
+            if (it is AdaptiveStringPreference) {
+                it.preferences = preferences
+                it.sharedPrefs = sharedPrefs
             }
         }
     }
@@ -236,7 +242,7 @@ class GarminPluginTest : TestBaseWithProfile() {
 
     @Test
     fun requestHandler_KeyRequiredAndProvided() {
-        `when`(sp.getString("garmin_aaps_key", "")).thenReturn("foo")
+        `when`(preferences.get(StringKey.GarminRequestKey)).thenReturn("foo")
         val uri = createUri(mapOf("key" to "foo"))
         val handler = gp.requestHandler { u: URI -> assertEquals(uri, u); "OK" }
         assertEquals(
@@ -250,7 +256,7 @@ class GarminPluginTest : TestBaseWithProfile() {
     fun requestHandler_KeyRequired() {
         gp.garminMessenger = mock(GarminMessenger::class.java)
 
-        `when`(sp.getString("garmin_aaps_key", "")).thenReturn("foo")
+        `when`(preferences.get(StringKey.GarminRequestKey)).thenReturn("foo")
         val uri = createUri(emptyMap())
         val handler = gp.requestHandler { u: URI -> assertEquals(uri, u); "OK" }
         assertEquals(
@@ -281,7 +287,7 @@ class GarminPluginTest : TestBaseWithProfile() {
     @Test
     fun onConnectDevice() {
         gp.garminMessenger = mock(GarminMessenger::class.java)
-        `when`(sp.getString("garmin_aaps_key", "")).thenReturn("foo")
+        `when`(preferences.get(StringKey.GarminRequestKey)).thenReturn("foo")
         val device = GarminDevice(mock(), 1, "Edge")
         gp.onConnectDevice(device)
 


### PR DESCRIPTION
This setting was lost and that caused some confusion. It allows setting up more secure communication with the watch, so adding it back.