### PR TITLE
Fix "CGM Sensor Insert" spam in Careportal from G7 xDrip local broadcast

### DIFF
--- a/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
+++ b/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
@@ -123,7 +123,7 @@ class XdripSourcePlugin @Inject constructor(
                 newSensorStartTime != null &&
                 abs(newSensorStartTime - lastStoredSensorStartTime) <= 300_000) {
                 aapsLogger.debug(LTag.BGSOURCE, "Sensor start time is within 5 minutes range, skipping update.")
-                lastStoredSensorStartTime
+                null
                 } else {
                     newSensorStartTime
                 }

--- a/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
+++ b/plugins/source/src/main/kotlin/app/aaps/plugins/source/XdripSourcePlugin.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import app.aaps.core.data.model.GV
 import app.aaps.core.data.model.SourceSensor
+import app.aaps.core.data.model.TE
 import app.aaps.core.data.model.TrendArrow
 import app.aaps.core.data.plugin.PluginType
 import app.aaps.core.data.time.T
@@ -113,8 +114,21 @@ class XdripSourcePlugin @Inject constructor(
                 trendArrow = TrendArrow.fromString(bundle.getString(Intents.EXTRA_BG_SLOPE_NAME)),
                 sourceSensor = SourceSensor.fromString(bundle.getString(Intents.XDRIP_DATA_SOURCE) ?: "")
             )
-            val sensorStartTime = getSensorStartTime(bundle)
-            persistenceLayer.insertCgmSourceData(Sources.Xdrip, glucoseValues, emptyList(), sensorStartTime)
+            val newSensorStartTime = getSensorStartTime(bundle)
+            // Retrieve last stored sensorStartTime from the database
+            val lastTherapyEvent = persistenceLayer.getLastTherapyRecordUpToNow(TE.Type.SENSOR_CHANGE)
+            val lastStoredSensorStartTime = lastTherapyEvent?.timestamp
+            // Decide whether to update sensorStartTime or keep the last stored one
+            val finalSensorStartTime = if (lastStoredSensorStartTime != null &&
+                newSensorStartTime != null &&
+                abs(newSensorStartTime - lastStoredSensorStartTime) <= 300_000) {
+                aapsLogger.debug(LTag.BGSOURCE, "Sensor start time is within 5 minutes range, skipping update.")
+                lastStoredSensorStartTime
+                } else {
+                    newSensorStartTime
+                }
+            // Always update glucoseValues, but use the decided sensorStartTime
+            persistenceLayer.insertCgmSourceData(Sources.Xdrip, glucoseValues, emptyList(), finalSensorStartTime)
                 .doOnError { ret = Result.failure(workDataOf("Error" to it.toString())) }
                 .blockingGet()
                 .also { savedValues -> savedValues.all().forEach { xdripSourcePlugin.detectSource(it) } }


### PR DESCRIPTION
 My proposal to fix issue with described here: https://github.com/NightscoutFoundation/xDrip/discussions/3508 and here: https://github.com/nightscout/AndroidAPS/issues/3801
 Also fixes issue with NS reports containing alot of unnecessary sensor changes.
![image](https://github.com/user-attachments/assets/c5974874-6276-4a96-91a4-24a3c965fffd)

Sensor start time is accepted only if changed more than 5 minutes to avoid a very long list of "CGM Sensor Insert" in NS and Careportal for G7 using xDrip+. 
 
This mainly seem to affect NSClientV3. (For testers). I've updated my live rig with G7, and problem is fixed for me, but I haven't tested with changing G7 yet.