### PR TITLE
Unbond Pod after deactivation

### DIFF
--- a/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -458,7 +458,7 @@ class OmnipodDashManagerImpl @Inject constructor(
             )
             val userExpiryReminderEnabled = userConfiguredExpirationReminderHours != null && userConfiguredExpirationReminderHours > 0
             val userExpiryReminderDelay = podLifeLeft.minus(
-                Duration.ofHours(userConfiguredExpirationReminderHours ?: MAX_POD_LIFETIME.toHours() + 1)
+                Duration.ofHours(userConfiguredExpirationReminderHours ?: (MAX_POD_LIFETIME.toHours() + 1))
             )
             if (userExpiryReminderDelay.isNegative) {
                 logger.warn(
@@ -688,7 +688,7 @@ class OmnipodDashManagerImpl @Inject constructor(
                     .setNonce(NONCE)
                     .build(),
                 DefaultStatusResponse::class
-            )
+            ).doOnComplete { bleManager.removeBond() }
         }
 
     override fun deactivatePod(): Observable<PodEvent> {

--- a/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/wizard/deactivation/viewmodel/action/DashDeactivatePodViewModel.kt
+++ b/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/wizard/deactivation/viewmodel/action/DashDeactivatePodViewModel.kt
@@ -13,14 +13,12 @@ import app.aaps.core.interfaces.rx.events.EventDismissNotification
 import app.aaps.pump.omnipod.common.R
 import app.aaps.pump.omnipod.common.queue.command.CommandDeactivatePod
 import app.aaps.pump.omnipod.common.ui.wizard.deactivation.viewmodel.action.DeactivatePodViewModel
-import app.aaps.pump.omnipod.dash.driver.comm.OmnipodDashBleManager
 import app.aaps.pump.omnipod.dash.driver.pod.state.OmnipodDashPodStateManager
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class DashDeactivatePodViewModel @Inject constructor(
     private val podStateManager: OmnipodDashPodStateManager,
-    private val bleManager: OmnipodDashBleManager,
     private val commandQueue: CommandQueue,
     private val rxBus: RxBus,
     instantiator: Instantiator,
@@ -40,7 +38,6 @@ class DashDeactivatePodViewModel @Inject constructor(
     }
 
     override fun discardPod() {
-        bleManager.removeBond()
         podStateManager.reset()
         rxBus.send(EventDismissNotification(Notification.OMNIPOD_POD_FAULT))
     }


### PR DESCRIPTION
Omnipod Dash unbonding

The current call in "DashDeactivatePodViewModel.kt" in function "discardPod" does not work. 
One rather needs to implement the call of "removeBond()" in "OmnipodDashManagerImpl.kt" and add 

".doOnComplete { bleManager.removeBond() }"

to Pod event "observeSendDeactivateCommand"