### PR TITLE
Step graph: Set minimum value to 0

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/graphData/GraphData.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/graphData/GraphData.kt
@@ -300,7 +300,7 @@ import kotlin.math.max
     fun addSteps(useForScale: Boolean, scale: Double) {
         val maxSteps = (overviewData.stepsCountGraphSeries as PointsWithLabelGraphSeries<DataPointWithLabelInterface>).highestValueY
         if (useForScale) {
-            minY = 30.0
+            minY = 0.0
             maxY = maxSteps
         }
         addSeries(overviewData.stepsCountGraphSeries as PointsWithLabelGraphSeries<DataPointWithLabelInterface>)


### PR DESCRIPTION
Since it is quite common for people to sit or lie down for a while but not walk, it makes sense to also display the 0-step episodes in the graph. The lower limit of 30 steps seems not intentioned, rather a takeover from heart rate graphs.