### PR TITLE
Start timer alarm after successful bolus.

### DIFF
--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
@@ -542,14 +542,13 @@ class BolusWizard @Inject constructor(
                             override fun run() {
                                 if (!result.success) {
                                     uiInteraction.runAlarm(result.comment, rh.gs(app.aaps.core.ui.R.string.treatmentdeliveryerror), app.aaps.core.ui.R.raw.boluserror)
+                                } else if (useAlarm && carbs > 0 && carbTime > 0) {
+                                    automation.scheduleTimeToEatReminder(T.mins(carbTime.toLong()).secs().toInt())
                                 }
                             }
                         })
                     }
                     bolusCalculatorResult?.let { persistenceLayer.insertOrUpdateBolusCalculatorResult(it).blockingGet() }
-                }
-                if (useAlarm && carbs > 0 && carbTime > 0) {
-                    automation.scheduleTimeToEatReminder(T.mins(carbTime.toLong()).secs().toInt())
                 }
             }
             if (quickWizardEntry != null) {


### PR DESCRIPTION
- no need to cancel alarm after bolus error
- my pump (AC Combo) sometimes connect immediately, sometimes it can take up to 3 minutes, if that happens time to meal is to short. I am not sure how many pumps have similar issue