### PR TITLE
Fix issues with math notation for IOB in wizard dialog/result and calculation of COB vs IOB

### DIFF
--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
@@ -355,7 +355,7 @@ class BolusWizard @Inject constructor(
             actions.add(
                 rh.gs(app.aaps.core.ui.R.string.cobvsiob) + ": " + rh.gs(
                     app.aaps.core.ui.R.string.formatsignedinsulinunits,
-                    insulinFromBolusIOB + insulinFromBasalIOB + insulinFromCOB + insulinFromBG
+                    -insulinFromBolusIOB - insulinFromBasalIOB + insulinFromCOB + insulinFromBG
                 ).formatColor(
                     context, rh, app.aaps.core.ui.R.attr
                         .cobAlertColor
@@ -470,7 +470,7 @@ class BolusWizard @Inject constructor(
         }
         if (useCob) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_cob, cob, insulinFromCOB)
         if (useBg) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_bg, insulinFromBG)
-        if (includeBolusIOB) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_iob, insulinFromBolusIOB + insulinFromBasalIOB)
+        if (includeBolusIOB) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_iob, -insulinFromBolusIOB - insulinFromBasalIOB)
         if (useTrend) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_trend, insulinFromTrend)
         if (useSuperBolus) message += "\n" + rh.gs(app.aaps.core.ui.R.string.wizard_explain_superbolus, insulinFromSuperBolus)
         if (percentageCorrection != 100) {

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/WizardDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/WizardDialog.kt
@@ -489,7 +489,7 @@ class WizardDialog : DaggerDialogFragment() {
             binding.carbs.text = rh.gs(R.string.format_carbs_ic, carbs.toDouble(), wizard.ic)
             binding.carbsInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, wizard.insulinFromCarbs)
 
-            binding.iobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, wizard.insulinFromBolusIOB + wizard.insulinFromBasalIOB)
+            binding.iobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, -wizard.insulinFromBolusIOB - wizard.insulinFromBasalIOB)
 
             binding.correctionInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, wizard.insulinFromCorrection)
 

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/WizardInfoDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/WizardInfoDialog.kt
@@ -72,10 +72,10 @@ class WizardInfoDialog : DaggerDialogFragment() {
         binding.cobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, data.cobInsulin)
         binding.cobCheckbox.isChecked = data.wasCOBUsed
         // Bolus IOB
-        binding.bolusIobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, data.bolusIOB)
+        binding.bolusIobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, -data.bolusIOB)
         binding.bolusIobCheckbox.isChecked = data.wasBolusIOBUsed
         // Basal IOB
-        binding.basalIobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, data.basalIOB)
+        binding.basalIobInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, -data.basalIOB)
         binding.basalIobCheckbox.isChecked = data.wasBasalIOBUsed
         // Superbolus
         binding.sbInsulin.text = rh.gs(app.aaps.core.ui.R.string.format_insulin_units, data.superbolusInsulin)


### PR DESCRIPTION
My proposal to fix issue mentioned in https://github.com/nightscout/AndroidAPS/issues/3798 and some more issues I found while looking.

* Fix issues with wrong math notation for IOB in Wizard/QW dialog in phone and wear

* Fix issue with wrong math notation for IOB in Wizard/QW Calc log in treatments 

* Fix issue with wrong calculation of COB vs IOB in wizard confirmation dialog box (One could argue to remove insulinFromBG from the equation, to compare solely COB vs IOB.?)

From my testing with both positive and negative IOB, the math for the sum of calculations is equal to the bolus amount in the end.

Comparisons:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ee711ab9-57d5-45ff-b5bd-a3460b0fc365)![image](https://github.com/user-attachments/assets/7df12f5c-e7c4-41f3-ba74-f09f1d14a0c2)| ![image](https://github.com/user-attachments/assets/3745d8b8-160d-4b93-94b0-906d9a873d4a)![image](https://github.com/user-attachments/assets/367731b3-1fc6-43e9-bb0b-176e0ca4c79c)|
| Before | After (forgot 100% for comparison) |
| ![image](https://github.com/user-attachments/assets/2d6cf1ef-9bfe-44ba-8639-9577aa1b6a7c) | ![image](https://github.com/user-attachments/assets/09c9707a-3160-4257-8a08-760b7819ae46)|
| Before | After |
| ![image](https://github.com/user-attachments/assets/85bac305-bf04-4520-9bb6-4339ce88d001)![image](https://github.com/user-attachments/assets/dd13bd45-bc3d-44b8-9c88-5e61e97ac094) | ![image](https://github.com/user-attachments/assets/f6946bc2-141d-47a0-a3b3-8fef62a84d73)![image](https://github.com/user-attachments/assets/e2e0b3c9-23a7-4669-ba61-d29af4119329) | 
| Before | After |
| ![image](https://github.com/user-attachments/assets/c84f54fc-d213-4ec6-9e4c-9e6182df3120)|![image](https://github.com/user-attachments/assets/84691917-adf4-4970-880d-16076d665d4b)|