### PR TITLE
Fix unreliability of the application PIN/password

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -349,8 +349,8 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
         if (!isProtectionCheckActive) {
             isProtectionCheckActive = true
             protectionCheck.queryProtection(this, ProtectionCheck.Protection.APPLICATION, UIRunnable { isProtectionCheckActive = false },
-                                            UIRunnable { OKDialog.show(this, "", rh.gs(R.string.authorizationfailed)) { isProtectionCheckActive = false; finish() } },
-                                            UIRunnable { OKDialog.show(this, "", rh.gs(R.string.authorizationfailed)) { isProtectionCheckActive = false; finish() } }
+                                            UIRunnable { OKDialog.show(this, "", rh.gs(R.string.authorizationfailed), true) { isProtectionCheckActive = false; finish() } },
+                                            UIRunnable { OKDialog.show(this, "", rh.gs(R.string.authorizationfailed), true) { isProtectionCheckActive = false; finish() } }
             )
         }
     }

--- a/app/src/main/kotlin/app/aaps/implementations/UiInteractionImpl.kt
+++ b/app/src/main/kotlin/app/aaps/implementations/UiInteractionImpl.kt
@@ -222,7 +222,7 @@ class UiInteractionImpl @Inject constructor(
                 NotificationWithAction(injector, id, text, level, validityCheck)
                     .also { n ->
                         n.action(actionButtonId) {
-                            n.contextForAction?.let { OKDialog.show(it, title, message, null) }
+                            n.contextForAction?.let { OKDialog.show(it, title, message) }
                         }
                     })
         )

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/dialogs/OKDialog.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/dialogs/OKDialog.kt
@@ -18,7 +18,7 @@ object OKDialog {
     }
 
     @SuppressLint("InflateParams")
-    fun show(context: Context, title: String, message: String, runnable: Runnable? = null) {
+    fun show(context: Context, title: String, message: String, runOnDismiss: Boolean = false, runnable: Runnable? = null) {
         var okClicked = false
         var notEmptyTitle = title
         if (notEmptyTitle.isEmpty()) notEmptyTitle = context.getString(R.string.message)
@@ -35,12 +35,17 @@ object OKDialog {
                     runOnUiThread(runnable)
                 }
             }
+            .setOnDismissListener {
+                if (runOnDismiss) {
+                    runOnUiThread(runnable)
+                }
+            }
             .show()
             .setCanceledOnTouchOutside(false)
     }
 
     @SuppressLint("InflateParams")
-    fun show(context: Context, title: String, message: Spanned, runnable: Runnable? = null) {
+    fun show(context: Context, title: String, message: Spanned, runOnDismiss: Boolean = false, runnable: Runnable? = null) {
         var okClicked = false
         var notEmptyTitle = title
         if (notEmptyTitle.isEmpty()) notEmptyTitle = context.getString(R.string.message)
@@ -57,12 +62,17 @@ object OKDialog {
                     runOnUiThread(runnable)
                 }
             }
+            .setOnDismissListener {
+                if (runOnDismiss) {
+                    runOnUiThread(runnable)
+                }
+            }
             .show()
             .setCanceledOnTouchOutside(false)
     }
 
     @SuppressLint("InflateParams")
-    fun show(activity: FragmentActivity, title: String, message: Spanned, runnable: Runnable? = null) {
+    fun show(activity: FragmentActivity, title: String, message: Spanned, runOnDismiss: Boolean = false, runnable: Runnable? = null) {
         var okClicked = false
         var notEmptyTitle = title
         if (notEmptyTitle.isEmpty()) notEmptyTitle = activity.getString(R.string.message)
@@ -77,6 +87,11 @@ object OKDialog {
                     dialog.dismiss()
                     SystemClock.sleep(100)
                     runnable?.let { activity.runOnUiThread(it) }
+                }
+            }
+            .setOnDismissListener {
+                if (runOnDismiss) {
+                    runOnUiThread(runnable)
                 }
             }
             .show()

--- a/implementation/src/main/kotlin/app/aaps/implementation/protection/BiometricCheck.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/protection/BiometricCheck.kt
@@ -86,6 +86,7 @@ object BiometricCheck {
             .setTitle(activity.getString(title))
             .setDescription(activity.getString(R.string.biometric_title))
             .setNegativeButtonText(activity.getString(R.string.cancel)) // not possible with setDeviceCredentialAllowed
+            .setConfirmationRequired(false)
 //            .setDeviceCredentialAllowed(true) // setDeviceCredentialAllowed creates new activity when PIN is requested, activity.fragmentManager crash afterwards
             .build()
 

--- a/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/MedtronicFragment.kt
+++ b/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/MedtronicFragment.kt
@@ -253,7 +253,7 @@ class MedtronicFragment : DaggerFragment() {
         context?.let {
             OKDialog.show(
                 it, rh.gs(R.string.medtronic_warning),
-                rh.gs(R.string.medtronic_error_operation_not_possible_no_configuration), null
+                rh.gs(R.string.medtronic_error_operation_not_possible_no_configuration)
             )
         }
     }

--- a/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -691,7 +691,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     private fun displayOkDialog(title: String, message: String) {
         context?.let {
             UIRunnable {
-                OKDialog.show(it, title, message, null)
+                OKDialog.show(it, title, message)
             }.run()
         }
     }

--- a/pump/omnipod-eros/src/main/java/app/aaps/pump/omnipod/eros/ui/ErosPodManagementActivity.kt
+++ b/pump/omnipod-eros/src/main/java/app/aaps/pump/omnipod/eros/ui/ErosPodManagementActivity.kt
@@ -255,7 +255,7 @@ class ErosPodManagementActivity : TranslatedDaggerAppCompatActivity() {
             app.aaps.core.ui.UIRunnable {
                 OKDialog.show(
                     it, rh.gs(app.aaps.pump.omnipod.common.R.string.omnipod_common_warning),
-                    rh.gs(R.string.omnipod_eros_error_operation_not_possible_no_configuration), null
+                    rh.gs(R.string.omnipod_eros_error_operation_not_possible_no_configuration)
                 )
             }.run()
         }

--- a/pump/omnipod-eros/src/main/java/app/aaps/pump/omnipod/eros/ui/OmnipodErosOverviewFragment.kt
+++ b/pump/omnipod-eros/src/main/java/app/aaps/pump/omnipod/eros/ui/OmnipodErosOverviewFragment.kt
@@ -602,7 +602,7 @@ class OmnipodErosOverviewFragment : DaggerFragment() {
             app.aaps.core.ui.UIRunnable {
                 OKDialog.show(
                     it, rh.gs(app.aaps.pump.omnipod.common.R.string.omnipod_common_warning),
-                    rh.gs(R.string.omnipod_eros_error_operation_not_possible_no_configuration), null
+                    rh.gs(R.string.omnipod_eros_error_operation_not_possible_no_configuration)
                 )
             }.run()
         }
@@ -615,7 +615,7 @@ class OmnipodErosOverviewFragment : DaggerFragment() {
     private fun displayOkDialog(title: String, message: String) {
         context?.let {
             app.aaps.core.ui.UIRunnable {
-                OKDialog.show(it, title, message, null)
+                OKDialog.show(it, title, message)
             }.run()
         }
     }


### PR DESCRIPTION
An intruder may bypass the application password by first tapping "CANCEL" while the password dialog is shown, then using system's back button, dismissing the error dialog. AAPS is fully working after that.

The second commit fixes an unnecessary tap between face unlock and entering AAPS on devices with Class 3 face biometrics (test device - Pixel 8).