### PR TITLE
Remove bold text type from commit version in overview

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewPlugin.kt
@@ -212,7 +212,6 @@ class OverviewPlugin @Inject constructor(
             view.text = "${config.VERSION_NAME} (${config.HEAD.substring(0, 4)})"
             if (config.COMMITTED) {
                 view.setTextColor(rh.gac(context, app.aaps.core.ui.R.attr.omniGrayColor))
-                view.setTypeface(null, Typeface.BOLD)
                 view.alpha = 1.0f
             } else if (sp.getLong(rh.gs(app.aaps.core.utils.R.string.key_app_expiration) + "_" + config.VERSION_NAME, 0) != 0L) {
                 view.setTextColor(rh.gac(context, app.aaps.core.ui.R.attr.metadataTextWarningColor))


### PR DESCRIPTION
I personally think it looks better if `view.setTypeface(null, Typeface.BOLD)` is removed. I don't think the version number in overview should be bold, because it is not information that the user really needs to pay attention to. Having it bold makes it more visible than necessary.

@MilosKozak If you prefer Bold text like it is now in dev you can close this PR .

**Bold:**

![Image](https://github.com/user-attachments/assets/a45154bf-c044-4896-8f57-cefc8071df4d)

**Not bold:**

![Image](https://github.com/user-attachments/assets/01b63c40-088e-4dbf-8f4a-ae769ba4d06b)