### PR TITLE
Wear: Add units to all activity screens

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/BolusActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/BolusActivity.kt
@@ -43,7 +43,7 @@ class BolusActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, true)
                 val initValue = SafeParse.stringToDouble(editInsulin?.editText?.text.toString(), 0.0)
                 val maxBolus = sp.getDouble(getString(R.string.key_treatments_safety_max_bolus), 3.0)
-                val title = getString(R.string.action_insulin)
+                val title = getString(R.string.action_insulin_units)
                 editInsulin = PlusMinusEditText(viewAdapter, initValue, 0.0, maxBolus, stepValues, DecimalFormat("#0.0"), false, title)
                 val view = viewAdapter.root
                 container.addView(view)

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
@@ -45,7 +45,7 @@ class CarbActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 val initValue = SafeParse.stringToDouble(editCarbs?.editText?.text.toString(), 0.0)
                 val maxCarbs = sp.getInt(getString(R.string.key_treatments_safety_max_carbs), 48).toDouble()
-                editCarbs = PlusMinusEditText(viewAdapter, initValue, -maxCarbs, maxCarbs, stepValues, DecimalFormat("0"), true, getString(R.string.action_carbs))
+                editCarbs = PlusMinusEditText(viewAdapter, initValue, -maxCarbs, maxCarbs, stepValues, DecimalFormat("0"), true, getString(R.string.action_carbs_gram))
                 container.addView(view)
                 view.requestFocus()
                 view

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ECarbActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ECarbActivity.kt
@@ -48,7 +48,7 @@ class ECarbActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 var initValue = stringToDouble(editCarbs?.editText?.text.toString(), 0.0)
                 val maxCarbs = sp.getInt(getString(R.string.key_treatments_safety_max_carbs), 48).toDouble()
-                editCarbs = PlusMinusEditText(viewAdapter, initValue, 0.0, maxCarbs, stepValues, DecimalFormat("0"), true, getString(R.string.action_carbs))
+                editCarbs = PlusMinusEditText(viewAdapter, initValue, 0.0, maxCarbs, stepValues, DecimalFormat("0"), true, getString(R.string.action_carbs_gram))
                 container.addView(view)
                 view.requestFocus()
                 view
@@ -58,7 +58,7 @@ class ECarbActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 var initValue = stringToDouble(editStartTime?.editText?.text.toString(), 0.0)
-                editStartTime = PlusMinusEditText(viewAdapter, initValue, -60.0, 300.0, 15.0, DecimalFormat("0"), false, getString(R.string.action_start_min))
+                editStartTime = PlusMinusEditText(viewAdapter, initValue, -60.0, 300.0, 15.0, DecimalFormat("0"), false, getString(R.string.action_start_minutes))
                 container.addView(view)
                 view
             }
@@ -67,7 +67,7 @@ class ECarbActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 var initValue = stringToDouble(editDuration?.editText?.text.toString(), 0.0)
-                editDuration = PlusMinusEditText(viewAdapter, initValue, 0.0, 8.0, 1.0, DecimalFormat("0"), false, getString(R.string.action_duration_h))
+                editDuration = PlusMinusEditText(viewAdapter, initValue, 0.0, 8.0, 1.0, DecimalFormat("0"), false, getString(R.string.action_duration_hours))
                 container.addView(view)
                 view
             }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/FillActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/FillActivity.kt
@@ -39,7 +39,7 @@ class FillActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 var initValue = stringToDouble(editInsulin?.editText?.text.toString(), 0.0)
-                editInsulin = PlusMinusEditText(viewAdapter, initValue, 0.0, 30.0, 0.1, DecimalFormat("#0.0"), false, getString(R.string.action_insulin))
+                editInsulin = PlusMinusEditText(viewAdapter, initValue, 0.0, 30.0, 0.1, DecimalFormat("#0.0"), false, getString(R.string.action_insulin_units))
                 container.addView(view)
                 view.requestFocus()
                 view

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ProfileSwitchActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ProfileSwitchActivity.kt
@@ -51,7 +51,7 @@ class ProfileSwitchActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 val initValue = SafeParse.stringToDouble(editTimeshift?.editText?.text.toString(), timeshift.toDouble())
-                editTimeshift = PlusMinusEditText(viewAdapter, initValue, Constants.CPP_MIN_TIMESHIFT.toDouble(), Constants.CPP_MAX_TIMESHIFT.toDouble(), 1.0, DecimalFormat("0"), true, getString(R.string.action_timeshift), true)
+                editTimeshift = PlusMinusEditText(viewAdapter, initValue, Constants.CPP_MIN_TIMESHIFT.toDouble(), Constants.CPP_MAX_TIMESHIFT.toDouble(), 1.0, DecimalFormat("0"), true, getString(R.string.action_timeshift_hours), true)
                 container.addView(view)
                 view.requestFocus()
                 view
@@ -70,7 +70,7 @@ class ProfileSwitchActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 val initValue = SafeParse.stringToDouble(editDuration?.editText?.text.toString(), duration)
-                editDuration = PlusMinusEditText(viewAdapter, initValue, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, getString(R.string.action_duration))
+                editDuration = PlusMinusEditText(viewAdapter, initValue, 0.0, Constants.MAX_PROFILE_SWITCH_DURATION, 10.0, DecimalFormat("0"), false, getString(R.string.action_duration_minutes))
                 container.addView(view)
                 view
             }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
@@ -51,7 +51,7 @@ class TempTargetActivity : ViewSelectorActivity() {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
                 val initValue = SafeParse.stringToDouble(time?.editText?.text.toString(), 60.0)
-                time = PlusMinusEditText(viewAdapter, initValue, 0.0, 24 * 60.0, 5.0, DecimalFormat("0"), false, getString(R.string.action_duration))
+                time = PlusMinusEditText(viewAdapter, initValue, 0.0, 24 * 60.0, 5.0, DecimalFormat("0"), false, getString(R.string.action_duration_minutes))
                 container.addView(view)
                 view.requestFocus()
                 view
@@ -60,7 +60,8 @@ class TempTargetActivity : ViewSelectorActivity() {
             col == 1                    -> {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
-                val title = if (isSingleTarget) getString(R.string.action_target) else getString(R.string.action_low)
+                val unit = if (isMGDL) "mg/dl" else "mmol/l"
+                val title = if (isSingleTarget) getString(R.string.action_target_unit, unit) else getString(R.string.action_low_unit, unit)
                 if (isMGDL) {
                     val initValue = SafeParse.stringToDouble(lowRange?.editText?.text.toString(), 101.0)
                     lowRange = PlusMinusEditText(viewAdapter, initValue, 72.0, 180.0, 1.0, DecimalFormat("0"), false, title)
@@ -75,12 +76,13 @@ class TempTargetActivity : ViewSelectorActivity() {
             col == 2 && !isSingleTarget -> {
                 val viewAdapter = EditPlusMinusViewAdapter.getViewAdapter(sp, applicationContext, container, false)
                 val view = viewAdapter.root
+                val unit = if (isMGDL) "mg/dl" else "mmol/l"
                 if (isMGDL) {
                     val initValue = SafeParse.stringToDouble(highRange?.editText?.text.toString(), 101.0)
-                    highRange = PlusMinusEditText(viewAdapter, initValue, 72.0, 180.0, 1.0, DecimalFormat("0"), false, getString(R.string.action_high))
+                    highRange = PlusMinusEditText(viewAdapter, initValue, 72.0, 180.0, 1.0, DecimalFormat("0"), false, getString(R.string.action_high_unit, unit))
                 } else {
                     val initValue = SafeParse.stringToDouble(highRange?.editText?.text.toString(), 5.6)
-                    highRange = PlusMinusEditText(viewAdapter, initValue, 4.0, 10.0, 0.1, DecimalFormat("#0.0"), false, getString(R.string.action_high))
+                    highRange = PlusMinusEditText(viewAdapter, initValue, 4.0, 10.0, 0.1, DecimalFormat("#0.0"), false, getString(R.string.action_high_unit, unit))
                 }
                 container.addView(view)
                 view

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
@@ -52,7 +52,7 @@ class TreatmentActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 var initValue = stringToDouble(editInsulin?.editText?.text.toString(), 0.0)
                 val maxBolus = sp.getDouble(getString(R.string.key_treatments_safety_max_bolus), 3.0)
-                editInsulin = PlusMinusEditText(viewAdapter, initValue, 0.0, maxBolus, stepValuesInsulin, DecimalFormat("#0.0"), false, getString(R.string.action_insulin))
+                editInsulin = PlusMinusEditText(viewAdapter, initValue, 0.0, maxBolus, stepValuesInsulin, DecimalFormat("#0.0"), false, getString(R.string.action_insulin_units))
                 container.addView(view)
                 view.requestFocus()
                 view
@@ -63,7 +63,7 @@ class TreatmentActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 val maxCarbs = sp.getInt(getString(R.string.key_treatments_safety_max_carbs), 48).toDouble()
                 val initValue = stringToDouble(editCarbs?.editText?.text.toString(), 0.0)
-                editCarbs = PlusMinusEditText(viewAdapter, initValue, -maxCarbs, maxCarbs, stepValuesCarbs, DecimalFormat("0"), false, getString(R.string.action_carbs))
+                editCarbs = PlusMinusEditText(viewAdapter, initValue, -maxCarbs, maxCarbs, stepValuesCarbs, DecimalFormat("0"), false, getString(R.string.action_carbs_gram))
                 container.addView(view)
                 view
             }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/WizardActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/WizardActivity.kt
@@ -47,7 +47,7 @@ class WizardActivity : ViewSelectorActivity() {
                 val view = viewAdapter.root
                 val maxCarbs = sp.getInt(getString(R.string.key_treatments_safety_max_carbs), 48).toDouble()
                 val initValue = SafeParse.stringToDouble(editCarbs?.editText?.text.toString(), 0.0)
-                editCarbs = PlusMinusEditText(viewAdapter, initValue, 0.0, maxCarbs, stepValues, DecimalFormat("0"), false, getString(R.string.action_carbs))
+                editCarbs = PlusMinusEditText(viewAdapter, initValue, 0.0, maxCarbs, stepValues, DecimalFormat("0"), false, getString(R.string.action_carbs_gram))
                 container.addView(view)
                 view.requestFocus()
                 view

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="menu_default">Default</string>
     <string name="menu_menu">Menu</string>
     <string name="quick_wizard_short">XL</string>
-    <string name="action_duration">Duration</string>
+    <string name="action_duration_minutes">Duration\n[minutes]</string>
     <string name="action_tempt_confirmation">Temp Target Requested</string>
     <string name="action_quick_wizard_confirmation">Quick Wizard Requested</string>
     <string name="action_user_action_confirmation">User Action Requested</string>
@@ -100,21 +100,24 @@
     <string name="action_fill_confirmation">Fill Requested</string>
     <string name="action_ecarb_confirmation">Carbs Requested</string>
     <string name="action_profile_switch_confirmation">Profile Switch Requested</string>
-    <string name="action_target" comment="In temp target menu, single target value">Target</string>
-    <string name="action_low" comment="In temp target menu, lower value from range">Low</string>
-    <string name="action_high" comment="In temp target menu, higher value from range">High</string>
+    <string name="action_target_unit" comment="In temp target menu, single target value">Target\n[%s]</string>
+    <string name="action_low_unit" comment="In temp target menu, lower value from range">Low\n[%s]</string>
+    <string name="action_high_unit" comment="In temp target menu, higher value from range">High\n[%s]</string>
     <string name="action_carbs">Carbs</string>
+    <string name="action_carbs_gram">Carbs [g]</string>
     <string name="action_ecarbs">eCarbs</string>
-    <string name="action_percentage">Percentage</string>
-    <string name="action_start_min">Start [min]</string>
+    <string name="action_percentage">Percentage\n[%]</string>
+    <string name="action_start_minutes">Start\n[minutes]</string>
     <string name="action_duration_h">Duration [h]</string>
+    <string name="action_duration_hours">Duration\n[hours]</string>
     <string name="action_insulin">Insulin</string>
+    <string name="action_insulin_units">Insulin [U]</string>
     <string name="action_preset_1">Preset 1</string>
     <string name="action_preset_2">Preset 2</string>
     <string name="action_preset_3">Preset 3</string>
     <string name="action_free_amount" comment="In prime/fill menu, allows one to enter any amount to be used for priming/filling">Free amount</string>
     <string name="action_confirm">CONFIRM</string>
-    <string name="action_timeshift">timeshift</string>
+    <string name="action_timeshift_hours">Timeshift\n[hours]</string>
     <string name="bolus_progress">Bolus Progress</string>
     <string name="press_to_cancel">press to cancel</string>
     <string name="cancel_bolus">CANCEL BOLUS</string>


### PR DESCRIPTION
Units are missing in almost every activity screen before confirmation screen. This will improve and unify it for all activity screens.

Tested OK with Norwegian translations with abit longer text also.

Tested OK with all different type of Activity screen layouts (input designs)

How it looks with PR:
![image](https://github.com/user-attachments/assets/d1145574-3425-4a32-a2c0-e3e907eefaf7)
