### PR TITLE
Mark SMBs as 'automated' when uploading to Tidepool

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/elements/BolusElement.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/elements/BolusElement.kt
@@ -15,5 +15,8 @@ class BolusElement(bolus: BS, dateUtil: DateUtil) : BaseElement(bolus.timestamp,
         type = "bolus"
         normal = bolus.amount
         expectedNormal = bolus.amount
+        if (bolus.type == BS.Type.SMB) {
+            subType = "automated"
+        }
     }
 }

--- a/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunkTest.kt
+++ b/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunkTest.kt
@@ -1,0 +1,64 @@
+package app.aaps.plugins.sync.tidepool.comm
+
+import app.aaps.core.data.model.BS
+import app.aaps.core.interfaces.db.PersistenceLayer
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.plugin.ActivePlugin
+import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.profile.ProfileUtil
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.sharedPreferences.SP
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.plugins.sync.tidepool.elements.BolusElement
+import app.aaps.plugins.sync.tidepool.utils.GsonInstance
+import com.google.common.truth.Truth.assertThat
+import com.google.gson.reflect.TypeToken
+import io.reactivex.rxjava3.core.Single
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+
+@ExtendWith(MockitoExtension::class)
+class UploadChunkTest {
+
+    @Mock lateinit var sp: SP
+    @Mock lateinit var rxBus: RxBus
+    @Mock lateinit var aapsLogger: AAPSLogger
+    @Mock lateinit var profileFunction: ProfileFunction
+    @Mock lateinit var profileUtil: ProfileUtil
+    @Mock lateinit var activePlugin: ActivePlugin
+    @Mock lateinit var persistenceLayer: PersistenceLayer
+    @Mock lateinit var dateUtil: DateUtil
+
+    @InjectMocks lateinit var sut: UploadChunk
+
+    @Test
+    fun `SMBs should be marked as 'automated' when uploading to Tidepool`() {
+        // setup mocked test data
+        val boluses = listOf(
+            BS(timestamp = 100, amount = 7.5, type = BS.Type.NORMAL),
+            BS(timestamp = 200, amount = 0.5, type = BS.Type.SMB)
+        )
+        `when`(persistenceLayer.getBolusesFromTimeToTime(any(), any(), any())).thenReturn(boluses)
+        `when`(persistenceLayer.getTherapyEventDataFromToTime(any(), any())).thenReturn(Single.just(listOf()))
+
+        // when
+        val resultJson = sut.get(1, 500)
+
+        // then
+        val resultBolusElements = convertResultJsonToBolusElements(resultJson)
+        assertThat(resultBolusElements[0].subType).isEqualTo("normal")
+        assertThat(resultBolusElements[0].normal).isEqualTo(7.5)
+        assertThat(resultBolusElements[1].subType).isEqualTo("automated")
+        assertThat(resultBolusElements[1].normal).isEqualTo(0.5)
+    }
+
+    private fun convertResultJsonToBolusElements(json: String): List<BolusElement> {
+        val itemType = object : TypeToken<List<BolusElement>>() {}.type
+        return GsonInstance.defaultGsonInstance().fromJson(json, itemType)
+    }
+}


### PR DESCRIPTION
### Motivation
Currently, the Tidepool plugin uploads all boluses with `"subType": "normal"`. This leads to confusion when viewing the data on https://app.tidepool.org/ or when generating the Tidepool PDF report, since it cannot be distinguished if the bolus was administered manually, or automatically by the loop.

This PR proposes to upload boluses with `Type.SMB` as `"subType": "automated"` (see Tidepool documentation [here](https://tidepool.stoplight.io/docs/tidepool-api/5d4b8be93bf4f-automated-bolus-automated)).

### Testing the fix
The PDF report now shows manual boluses as a black bar, and SMBs as grey bars:
![Screenshot from 2025-03-16 17-30-16](https://github.com/user-attachments/assets/508651f2-515a-4880-8e60-d1e6cd6bc950)

When viewing directly on https://app.tidepool.org/, the SMBs have a different color and contain the label `Automated` when hovering over it:
![Screenshot from 2025-03-16 17-20-53](https://github.com/user-attachments/assets/6b7c9237-0c7b-4d84-bcda-ec95b3c3ac49)
![Screenshot from 2025-03-16 17-20-50](https://github.com/user-attachments/assets/ac83878c-e654-4f9d-84d8-6eec13172a50)
