### PR TITLE
fix: Connection to RileyLink sometimes can become broken

### DIFF
--- a/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/ble/RFSpy.java
+++ b/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/ble/RFSpy.java
@@ -215,8 +215,6 @@ public class RFSpy {
             return null; // will be a null (invalid) response
         }
 
-        SystemClock.sleep(100);
-
         return reader.poll(responseTimeout_ms);
     }
 

--- a/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/ble/RFSpyReader.kt
+++ b/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/ble/RFSpyReader.kt
@@ -33,7 +33,7 @@ class RFSpyReader internal constructor(private val aapsLogger: AAPSLogger, priva
     // This timeout must be coordinated with the length of the RFSpy radio operation or Bad Things Happen.
     fun poll(timeout_ms: Int): ByteArray? {
         aapsLogger.debug(LTag.PUMPBTCOMM, "${ThreadUtil.sig()}Entering poll at t==${SystemClock.uptimeMillis()}, timeout is $timeout_ms mDataQueue size is ${mDataQueue.size}")
-        if (mDataQueue.isEmpty()) {
+        if (mDataQueue.isEmpty() || timeout_ms == 0) { //0 timeout is used for drain queue in RFSpy.writeToDataRaw before sending new command
             try {
                 // block until timeout or data available.
                 // returns null if timeout.


### PR DESCRIPTION
Make draining of mDataQueue work by fixing poll method filter condition and additionally remove extra sleep to get into polling as soon as possible to start listening before result will come.

fixes #3897  