### PR TITLE
Fix DASH alert silencing button not showing

### DIFF
--- a/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -680,7 +680,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     }
 
     private fun isAutomaticallySilenceAlertsEnabled(): Boolean {
-        return preferences.get(OmnipodBooleanPreferenceKey.AutomaticallyAcknowledgeAlerts)
+        return false // Automatic alert silencing is not supported for DASH (see also Omnipod EROS)
     }
 
     private fun displayErrorDialog(title: String, message: String, withSound: Boolean) {

--- a/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/pump/omnipod-dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -31,7 +31,6 @@ import app.aaps.core.ui.UIRunnable
 import app.aaps.core.ui.dialogs.OKDialog
 import app.aaps.pump.omnipod.common.databinding.OmnipodCommonOverviewButtonsBinding
 import app.aaps.pump.omnipod.common.databinding.OmnipodCommonOverviewPodInfoBinding
-import app.aaps.pump.omnipod.common.keys.OmnipodBooleanPreferenceKey
 import app.aaps.pump.omnipod.common.queue.command.CommandHandleTimeChange
 import app.aaps.pump.omnipod.common.queue.command.CommandResumeDelivery
 import app.aaps.pump.omnipod.common.queue.command.CommandSilenceAlerts


### PR DESCRIPTION
This PR fixes issue https://github.com/nightscout/AndroidAPS/issues/3931

Under circumstances DASH alert silencing button is not showing it can affect users that migrated from EROS to DASH where in settings "automatic alert silencing" was enabled for EROS.

DASH button is disabled due preferences setting (common for EROS and DASH) for automatic silencing Pod alerts (not supported by DASH). This fix ignores the EROS related preference setting.
