### PR TITLE
Equil: Fixed race condition preventing commands from being sent

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilPumpPlugin.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilPumpPlugin.kt
@@ -106,7 +106,7 @@ class EquilPumpPlugin @Inject constructor(
     private val bolusProfile: BolusProfile = BolusProfile()
 
     private val disposable = CompositeDisposable()
-    private var statusChecker: Runnable
+    private lateinit var statusChecker: Runnable
 
     override fun onStart() {
         super.onStart()
@@ -179,7 +179,7 @@ class EquilPumpPlugin @Inject constructor(
     init {
         pumpDescription = PumpDescription().fillFor(pumpType)
         statusChecker = Runnable {
-            var cmd = commandQueue.performing()
+            val cmd = commandQueue.performing()
 
             if (commandQueue.size() == 0 && cmd == null) {
                 if (indexEquilReadStatus >= 5) {
@@ -194,7 +194,6 @@ class EquilPumpPlugin @Inject constructor(
                 }
 
             } else {
-                equilManager.readStatus()
                 aapsLogger.debug(
                     LTag.PUMPCOMM,
                     "Skipping Pod status check because command queue is not empty"

--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/ble/EquilBLE.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/ble/EquilBLE.kt
@@ -427,16 +427,15 @@ class EquilBLE @Inject constructor(
         baseCmd?.resolvedResult = result
     }
 
-    val equilStatus: Unit
-        get() {
-            aapsLogger.debug(LTag.PUMPCOMM, "getEquilStatus====$startTrue====$isConnected")
-            if (startTrue || isConnected) {
-                return
-            }
-            autoScan = false
-            baseCmd = null
-            startScan()
+    fun checkEquilStatus() {
+        aapsLogger.debug(LTag.PUMPCOMM, "getEquilStatus====$startTrue====$isConnected")
+        if (startTrue || isConnected) {
+            return
         }
+        autoScan = false
+        baseCmd = null
+        startScan()
+    }
 
     private fun buildScanFilters(): List<ScanFilter> {
         val scanFilterList = ArrayList<ScanFilter>()

--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/EquilManager.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/EquilManager.kt
@@ -96,7 +96,7 @@ class EquilManager @Inject constructor(
         loadPodState()
         initEquilError()
         equilBLE.init(this)
-        equilBLE.equilStatus
+        equilBLE.checkEquilStatus()
     }
 
     var listEvent: MutableList<PumpEvent> = ArrayList<PumpEvent>()
@@ -138,7 +138,7 @@ class EquilManager @Inject constructor(
     fun readStatus(): PumpEnactResult {
         val result = instantiator.providePumpEnactResult()
         try {
-            equilBLE.equilStatus
+            equilBLE.checkEquilStatus()
         } catch (ex: Exception) {
             result.success(false).enacted(false).comment(ex.message ?: "Exception")
         }
@@ -593,7 +593,7 @@ class EquilManager @Inject constructor(
         getTempBasal()?.let { equilTempBasalRecord ->
             val tempBasalStartTime = DateTime(equilTempBasalRecord.startTime)
             val tempBasalEndTime = tempBasalStartTime.plus(equilTempBasalRecord.duration.toLong())
-            return (time.isAfter(tempBasalStartTime) || time.isEqual(tempBasalStartTime)) && time.isBefore(tempBasalEndTime)
+            return (time!!.isAfter(tempBasalStartTime) || time.isEqual(tempBasalStartTime)) && time.isBefore(tempBasalEndTime)
         }
         return false
     }


### PR DESCRIPTION
This PR fixes a race condition in the Equil driver where enqueued commands were failing to execute. The status check function (running every 10 seconds) was invoking a getter that set the current command to null, even when a command was queued. This caused the driver to remain idle after establishing connection with the pump, as the ready() function invoked after connection saw that the command was null, often resulting with annoying connection errors during boluses/temp basal changes.