### PR TITLE
Improved UTC to calendar conversion

### DIFF
--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -447,7 +447,7 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
         // - TimeZone.getDefault().rawOffset is only workaround for MaterialDatePicket bug
         // Remove after lib fix
         // https://github.com/material-components/material-components-android/issues/4373
-        val selected = Calendar.getInstance().apply { timeInMillis = dateUtcMillis - TimeZone.getDefault().rawOffset }
+        val selected = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply { timeInMillis = dateUtcMillis }
         return Calendar.getInstance().apply {
             timeInMillis = timestamp
             set(Calendar.YEAR, selected[Calendar.YEAR])


### PR DESCRIPTION
#3264:
https://github.com/material-components/material-components-android/issues/4373 was regarded as not a bug.

The current version is fine. However, the new version supports Daylight Saving Time, so it will be more useful than the current version in the future update. I can't edit the comment. @MilosKozak, please edit it.