### PR TITLE
Change logging behavior and logfile location

### DIFF
--- a/app/src/main/assets/logback.xml
+++ b/app/src/main/assets/logback.xml
@@ -1,19 +1,13 @@
 <configuration>
     <!-- Create a file appender for a log in the application's data directory -->
-    <property name="EXT_FILES_DIR" scope="context" value="${EXT_DIR:-/sdcard}" />
+    <property name="EXT_FILES_DIR" scope="context" value="/storage/emulated/0/Documents/aapsLogs" />
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${EXT_FILES_DIR}/AndroidAPS.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- daily rollover. Make sure the path matches the one in the file element or else
-             the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${EXT_FILES_DIR}/AndroidAPS._%d{yyyy-MM-dd}_%d{HH-mm-ss, aux}_.%i.zip
-            </fileNamePattern>
+            <!-- hourly rollover. Log files will be placed in Documents/aapsLogs. -->
+            <fileNamePattern>${EXT_FILES_DIR}/AndroidAPS._%d{yyyy-MM-dd_HH}.zip</fileNamePattern>
 
-            <timeBasedFileNamingAndTriggeringPolicy
-                class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>5MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 30 days' worth of history -->
+            <!-- keep 5 days (hourly archives) worth of history -->
             <maxHistory>120</maxHistory>
         </rollingPolicy>
         <encoder>

--- a/app/src/main/kotlin/app/aaps/receivers/KeepAliveWorker.kt
+++ b/app/src/main/kotlin/app/aaps/receivers/KeepAliveWorker.kt
@@ -131,7 +131,7 @@ class KeepAliveWorker(
         localAlertUtils.checkStaleBGAlert()
         checkPump()
         checkAPS()
-        maintenancePlugin.deleteLogs(30)
+        maintenancePlugin.deleteLogs(240)
         workerDbStatus()
         databaseCleanup()
 

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/FileListProvider.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/maintenance/FileListProvider.kt
@@ -7,6 +7,7 @@ import java.io.File
 interface FileListProvider {
 
     val resultPath: File
+    val aapsLogsPath: File
     fun ensurePreferenceDirExists(): DocumentFile?
     fun ensureExportDirExists(): DocumentFile?
     fun ensureTempDirExists(): DocumentFile?
@@ -18,6 +19,7 @@ interface FileListProvider {
 
     fun ensureResultDirExists(): File
     fun newResultFile(): File
+    fun ensureAapsLogsDirExists(): File
     fun listPreferenceFiles(): MutableList<PrefsFile>
     fun listCustomWatchfaceFiles(): MutableList<CwfFile>
     fun checkMetadata(metadata: Map<PrefsMetadataKey, PrefMetadata>): Map<PrefsMetadataKey, PrefMetadata>

--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/FileListProviderImpl.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/FileListProviderImpl.kt
@@ -50,6 +50,7 @@ class FileListProviderImpl @Inject constructor(
 
     private val documentsPath get() = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), "AAPS")
     override val resultPath get() = File(documentsPath, File.separator + "results")
+    override val aapsLogsPath get() = File(documentsPath, File.separator + "aapsLogs")
 
     val preferencesPath = "preferences"
     val exportsPath = "exports"
@@ -167,6 +168,13 @@ class FileListProviderImpl @Inject constructor(
     override fun ensureResultDirExists(): File {
         if (!resultPath.exists()) {
             resultPath.mkdirs()
+        }
+        return resultPath
+    }
+
+    override fun ensureAapsLogsDirExists(): File {
+        if (!aapsLogsPath.exists()) {
+            aapsLogsPath.mkdirs()
         }
         return resultPath
     }

--- a/wear/src/main/assets/logback.xml
+++ b/wear/src/main/assets/logback.xml
@@ -1,21 +1,14 @@
 <configuration>
     <!-- Create a file appender for a log in the application's data directory -->
-    <property name="EXT_FILES_DIR" scope="context"
-        value="${EXT_DIR:-/sdcard}/AAPS/logs/${PACKAGE_NAME}" />
+    <property name="EXT_FILES_DIR" scope="context" value="/storage/emulated/0/Documents/aapsLogs" />
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${EXT_FILES_DIR}/AndroidAPS.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- daily rollover. Make sure the path matches the one in the file element or else
-             the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${EXT_FILES_DIR}/AndroidAPS._%d{yyyy-MM-dd}_%d{HH-mm-ss, aux}_.%i.zip
-            </fileNamePattern>
+            <!-- hourly rollover. Log files will be placed in Documents/aapsLogs. -->
+            <fileNamePattern>${EXT_FILES_DIR}/AAPSWear._%d{yyyy-MM-dd_HH}.zip</fileNamePattern>
 
-            <timeBasedFileNamingAndTriggeringPolicy
-                class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>5MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 7 days' worth of history -->
-            <maxHistory>7</maxHistory>
+            <!-- keep 5 days (hourly archives) worth of history -->
+            <maxHistory>120</maxHistory>
         </rollingPolicy>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %.-1level/%logger: %msg%n</pattern>


### PR DESCRIPTION
I'll give it another try.

- logfiles will be placed in Documents/aapsLogs so they are easily accessible.
- there will be 24 logs per day.
- logs will be kept for 5 days (120 logs).

I've been running versions of this setup since August 2024 and it works for me. 
If you sync your Documents folder in some cloud, you may want to exclude aapsLogs.