### PR TITLE
Add Juggluco support to xDrip+ source strings

### DIFF
--- a/plugins/source/src/main/res/values-bg-rBG/strings.xml
+++ b/plugins/source/src/main/res/values-bg-rBG/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">КЗ от NS</string>
     <string name="ns_client_bg_short">NS КЗ</string>
     <string name="description_source_ns_client">Изтегля стойности на КЗ от Nightscout</string>
-    <string name="source_xdrip">КЗ от xDrip+</string>
-    <string name="description_source_xdrip">Получаване на данни за КЗ от xDrip+.</string>
+    <string name="source_xdrip">КЗ от xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Получаване на данни за КЗ от xDrip+ или Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Да получава данни за КЗ от модифицираното приложение на Dexcom BYODA.</string>

--- a/plugins/source/src/main/res/values-ca-rES/strings.xml
+++ b/plugins/source/src/main/res/values-ca-rES/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Source -->
     <string name="description_source_ns_client">Descarrega dades de glucèmia des de Nightscout</string>
-    <string name="description_source_xdrip">Rebre valors de glucèmia de xDrip+.</string>
+    <string name="description_source_xdrip">Rebre valors de glucèmia de xDrip+ o Juggluco.</string>
     <string name="dexcom_app_patched">Dexcom (BYODA)</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Rebre els valors de glucosa de l\'aplicació Dexcom \'Build Your Own Device\'.</string>

--- a/plugins/source/src/main/res/values-cs-rCZ/strings.xml
+++ b/plugins/source/src/main/res/values-cs-rCZ/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Glykémie z NS</string>
     <string name="ns_client_bg_short">NSGL</string>
     <string name="description_source_ns_client">Příjem glykémií z Nightscoutu</string>
-    <string name="source_xdrip">xDrip+ glykémie</string>
-    <string name="description_source_xdrip">Příjem glykémií z xDripu+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco glykémie</string>
+    <string name="description_source_xdrip">Příjem glykémií z xDripu+ nebo Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Příjem hodnot glykémií z upravené aplikace Dexcom (BYODA).</string>

--- a/plugins/source/src/main/res/values-da-rDK/strings.xml
+++ b/plugins/source/src/main/res/values-da-rDK/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BS</string>
     <string name="ns_client_bg_short">NS BS</string>
     <string name="description_source_ns_client">Downloader BG data fra Nightscout</string>
-    <string name="source_xdrip">xDrip+ BS</string>
-    <string name="description_source_xdrip">Modtag BG-værdier fra xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BS</string>
+    <string name="description_source_xdrip">Modtag BG-værdier fra xDrip+ eller Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Modtag BS-værdier fra \'Byg din egen Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-de-rDE/strings.xml
+++ b/plugins/source/src/main/res/values-de-rDE/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Nightscout-Client BZ</string>
     <string name="ns_client_bg_short">NS BZ</string>
     <string name="description_source_ns_client">Lade Blutzuckerdaten von Nightscout</string>
-    <string name="source_xdrip">xDrip+ BZ</string>
-    <string name="description_source_xdrip">Empfange Blutzuckerwerte von xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BZ</string>
+    <string name="description_source_xdrip">Empfange Blutzuckerwerte von xDrip+ oder Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Erhalte BZ-Werte von der \'Build Your Own Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-el-rGR/strings.xml
+++ b/plugins/source/src/main/res/values-el-rGR/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Λήψη δεδομένων BG από Nightscout</string>
-    <string name="source_xdrip">xDrip+ -</string>
-    <string name="description_source_xdrip">Λάβετε τιμές BG από το xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco -</string>
+    <string name="description_source_xdrip">Λάβετε τιμές BG από το xDrip+ ή Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Λάβετε τις τιμές BG από την εφαρμογή \'Build Your Own Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-es-rES/strings.xml
+++ b/plugins/source/src/main/res/values-es-rES/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Recibir los datos de glucosa de Nightscout</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">Recibir los valores de glucosa de xDrip+</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">Recibir los valores de glucosa de xDrip+ o Juggluco</string>
     <string name="dexcom_app_patched">Dexcom (BYODA)</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Recibir los valores de glucosa de la aplicación Dexcom \'Build Your Own Device\'</string>

--- a/plugins/source/src/main/res/values-fr-rFR/strings.xml
+++ b/plugins/source/src/main/res/values-fr-rFR/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Glycémie NSClient</string>
     <string name="ns_client_bg_short">Gly NS</string>
     <string name="description_source_ns_client">Télécharge les glycémies depuis Nightscout</string>
-    <string name="source_xdrip">xDrip+ Glycémie</string>
-    <string name="description_source_xdrip">Recevoir les glycémies depuis xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco Glycémie</string>
+    <string name="description_source_xdrip">Recevoir les glycémies depuis xDrip+ ou Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Recevoir les valeurs de glycémie de l’application Dexcom patchée (BYODA).</string>

--- a/plugins/source/src/main/res/values-hr-rHR/strings.xml
+++ b/plugins/source/src/main/res/values-hr-rHR/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Source -->
     <string name="description_source_ns_client">Preuzima podatke o GUK-u s Nightscout-a</string>
-    <string name="description_source_xdrip">Preuzima podatke o GUK-a s xDrip+.</string>
+    <string name="description_source_xdrip">Preuzima podatke o GUK-a s xDrip+ ili Juggluco.</string>
     <string name="description_source_glimp">Primajte vrijednosti GUK-a od Glimpa.</string>
     <string name="description_source_mm640g">Primajte vrijednosti glukoze u krvi od 600SeriesAndroidUploader.</string>
     <string name="intelligo">Intelligo</string>

--- a/plugins/source/src/main/res/values-it-rIT/strings.xml
+++ b/plugins/source/src/main/res/values-it-rIT/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">BG NSClient</string>
     <string name="ns_client_bg_short">BG NS</string>
     <string name="description_source_ns_client">Scarica dati glicemia da Nightscout</string>
-    <string name="source_xdrip">BG xDrip+</string>
-    <string name="description_source_xdrip">Ricevi valori glicemia da xDrip+.</string>
+    <string name="source_xdrip">BG xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Ricevi valori glicemia da xDrip+ o Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Ricevi valori glicemia dall\'app Dexcom ottenuta con \'Build Your Own Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-iw-rIL/strings.xml
+++ b/plugins/source/src/main/res/values-iw-rIL/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">נתוני סוכר מ-NSClient</string>
     <string name="ns_client_bg_short">נתוני סוכר מ-NS</string>
     <string name="description_source_ns_client">הורדת ערכי סוכר בדם מ-Nightscout</string>
-    <string name="source_xdrip">נתוני סוכר מ-xDrip+</string>
-    <string name="description_source_xdrip">קבלת ערכי סוכר מ-xDrip.</string>
+    <string name="source_xdrip">נתוני סוכר מ-xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">קבלת ערכי סוכר מ-xDrip או Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">השתמש בנתוני הסוכר מאפליקציית \"בנה לעצמך דקסקום\" (BYODA).</string>

--- a/plugins/source/src/main/res/values-ko-rKR/strings.xml
+++ b/plugins/source/src/main/res/values-ko-rKR/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Nightscout에서 다운로드하여 혈당값 받기</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">xDrip+에서 혈당값 받기</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">xDrip+ 또는 Juggluco에서 혈당값 받기</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">\'자신만의 덱스콤 앱 만들기(BYODA)\'에서 BG 값을 수신합니다.</string>

--- a/plugins/source/src/main/res/values-lt-rLT/strings.xml
+++ b/plugins/source/src/main/res/values-lt-rLT/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient</string>
     <string name="ns_client_bg_short">NS Glik</string>
     <string name="description_source_ns_client">Gauti glikemijos duomenis iš Nightscout</string>
-    <string name="source_xdrip">xDrip+</string>
-    <string name="description_source_xdrip">Gauti glikemijos duomenis iš xDrip+</string>
+    <string name="source_xdrip">xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Gauti glikemijos duomenis iš xDrip+ arba Juggluco</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Gauti glikemijos duomenis iš \'Build Your Own Dexcom App\'</string>

--- a/plugins/source/src/main/res/values-nb-rNO/strings.xml
+++ b/plugins/source/src/main/res/values-nb-rNO/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BS</string>
     <string name="ns_client_bg_short">NS BS</string>
     <string name="description_source_ns_client">Last ned BS-verdier fra Nightscout</string>
-    <string name="source_xdrip">xDrip+ BS</string>
-    <string name="description_source_xdrip">Motta BS-verdier fra xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BS</string>
+    <string name="description_source_xdrip">Motta BS-verdier fra xDrip+ eller Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Motta BS-verdier fra \'Build Your Own Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-nl-rNL/strings.xml
+++ b/plugins/source/src/main/res/values-nl-rNL/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Download BG waardes van Nightscout</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">Ontvang BG waardes van xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">Ontvang BG waardes van xDrip+ of Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Ontvang BG waarden van de \'Build Your Own Dexcom App\' (BYODA).</string>

--- a/plugins/source/src/main/res/values-pl-rPL/strings.xml
+++ b/plugins/source/src/main/res/values-pl-rPL/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Pobieraj wartości BG z Nightscout</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">Pobieraj wartości BG z xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">Pobieraj wartości BG z xDrip+ lub Juggluco.</string>
     <string name="dexcom_app_patched">Dexcom Patched</string>
     <string name="dexcom_short">DEX.PATCH.</string>
     <string name="description_source_dexcom">Pobieraj glikemię ze spatchowanej aplikacji Dexcom.</string>

--- a/plugins/source/src/main/res/values-pt-rBR/strings.xml
+++ b/plugins/source/src/main/res/values-pt-rBR/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Glicemia via NSClient</string>
     <string name="ns_client_bg_short">Glicose via NS</string>
     <string name="description_source_ns_client">Downloads de dados de Glicose do Nightscout</string>
-    <string name="source_xdrip">xDrip+</string>
-    <string name="description_source_xdrip">Receber valores de glicose do xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Receber valores de glicose do xDrip+ ou Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Receber valores de glicemia do \'Build Your Own Dexcom App\'.</string>

--- a/plugins/source/src/main/res/values-pt-rPT/strings.xml
+++ b/plugins/source/src/main/res/values-pt-rPT/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Source -->
     <string name="description_source_ns_client">Descarrega dados Glicose do Nightscout</string>
-    <string name="description_source_xdrip">Receber valores Glicose do xDrip+.</string>
+    <string name="description_source_xdrip">Receber valores Glicose do xDrip+ ou Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Receber valores de glicemia do aplicativo BYODA.</string>

--- a/plugins/source/src/main/res/values-ro-rRO/strings.xml
+++ b/plugins/source/src/main/res/values-ro-rRO/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Glicemie NSClient</string>
     <string name="ns_client_bg_short">NS GL</string>
     <string name="description_source_ns_client">Descarcă datele despre glicemii din Nightscout</string>
-    <string name="source_xdrip">Glicemie xDrip+</string>
-    <string name="description_source_xdrip">Primește valorile glicemiei din xDrip+.</string>
+    <string name="source_xdrip">Glicemie xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Primește valorile glicemiei din xDrip+ sau Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Primește valori de glicemie de la aplicația Dexcom modificată.</string>

--- a/plugins/source/src/main/res/values-ru-rRU/strings.xml
+++ b/plugins/source/src/main/res/values-ru-rRU/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">ГК с клиента Nightscout</string>
     <string name="ns_client_bg_short">ГК с NS</string>
     <string name="description_source_ns_client">Получать данные гликемии с сайта Nightscout</string>
-    <string name="source_xdrip">ГК с xDrip+ </string>
-    <string name="description_source_xdrip">Получать данные гликемии от xDrip+.</string>
+    <string name="source_xdrip">ГК с xDrip+ / Juggluco</string>
+    <string name="description_source_xdrip">Получать данные гликемии от xDrip+ или Juggluco.</string>
     <string name="dexcom_app_patched">Самост собран прилож Dexcom</string>
     <string name="dexcom_short">ССП DEXCOM</string>
     <string name="description_source_dexcom">Получать данные ГК от \'Самостоятельно собранного приложения Dexcom\'.</string>

--- a/plugins/source/src/main/res/values-sk-rSK/strings.xml
+++ b/plugins/source/src/main/res/values-sk-rSK/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">Glykémia z NS</string>
     <string name="ns_client_bg_short">NS GL</string>
     <string name="description_source_ns_client">Získavať hodnoty glykémií z Nightscoutu</string>
-    <string name="source_xdrip">xDrip+ glykémia</string>
-    <string name="description_source_xdrip">Prijímať hodnoty glykémií z xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco glykémia</string>
+    <string name="description_source_xdrip">Prijímať hodnoty glykémií z xDrip+ alebo Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Prijímať hodnoty glykémií z upravenej aplikácie Dexcom (BYODA).</string>

--- a/plugins/source/src/main/res/values-sr-rCS/strings.xml
+++ b/plugins/source/src/main/res/values-sr-rCS/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Source -->
     <string name="description_source_ns_client">Preuzimajte podatke GUK sa Nightscout-a</string>
-    <string name="description_source_xdrip">Preuzimajte vrijednosti GUK od xDrip+.</string>
+    <string name="description_source_xdrip">Preuzimajte vrijednosti GUK od xDrip+ ili Juggluco.</string>
     <string name="description_source_glimp">Preuzimajte vrednosti GUK od Glimp-a.</string>
     <string name="description_source_mm640g">Preuzimajte vrednosti GUK od 600SeriesAndroidUploader-a.</string>
     <!-- Patched Ottai App -->

--- a/plugins/source/src/main/res/values-sv-rSE/strings.xml
+++ b/plugins/source/src/main/res/values-sv-rSE/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Ladda ner BG-data från Nightscout</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">Ta emot BG-data från xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">Ta emot BG-data från xDrip+ eller Juggluco.</string>
     <string name="dexcom_app_patched">Patchad Dexcom-app</string>
     <string name="dexcom_short">Dex</string>
     <string name="description_source_dexcom">Ta emot BG-värden från \"Bygg din egen Dexcom-app\".</string>

--- a/plugins/source/src/main/res/values-tr-rTR/strings.xml
+++ b/plugins/source/src/main/res/values-tr-rTR/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient KŞ</string>
     <string name="ns_client_bg_short">NS KŞ</string>
     <string name="description_source_ns_client">Nightscout\'tan KŞ verilerini yükler</string>
-    <string name="source_xdrip">xDrip+ KŞ</string>
-    <string name="description_source_xdrip">XDrip+\'ten KŞ değerlerini alır.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco KŞ</string>
+    <string name="description_source_xdrip">XDrip+ veya Juggluco\'dan KŞ değerlerini alır.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">\'Kendi Dexcom Uygulamanızı Oluşturun\' uygulamasından KŞ değerlerini alın.</string>

--- a/plugins/source/src/main/res/values-zh-rCN/strings.xml
+++ b/plugins/source/src/main/res/values-zh-rCN/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Source -->
     <string name="description_source_ns_client">从 Nightscout 下载 血糖数据</string>
-    <string name="description_source_xdrip">从 xDrip+ 接收血糖值。</string>
+    <string name="description_source_xdrip">从 xDrip+ 或 Juggluco 接收血糖值。</string>
     <string name="dexcom_app_patched">BYODA德康补丁版(构建你自己的德康应用Build Your Own Dexcom App)</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">从德康补丁版接收血糖数据(Build Your Own Dexcom App)。</string>

--- a/plugins/source/src/main/res/values-zh-rTW/strings.xml
+++ b/plugins/source/src/main/res/values-zh-rTW/strings.xml
@@ -4,8 +4,8 @@
     <string name="ns_client_bg">NSClient 血糖</string>
     <string name="ns_client_bg_short">NS 血糖</string>
     <string name="description_source_ns_client">從 Nightscout 下載血糖資料</string>
-    <string name="source_xdrip">xDrip+ 血糖</string>
-    <string name="description_source_xdrip">接收來自 xDrip+ 的血糖值。</string>
+    <string name="source_xdrip">xDrip+ / Juggluco 血糖</string>
+    <string name="description_source_xdrip">接收來自 xDrip+ 或 Juggluco 的血糖值。</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">接收來自「Build Your Own Dexcom App」的血糖值。</string>

--- a/plugins/source/src/main/res/values/strings.xml
+++ b/plugins/source/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="ns_client_bg">NSClient BG</string>
     <string name="ns_client_bg_short">NS BG</string>
     <string name="description_source_ns_client">Downloads BG data from Nightscout</string>
-    <string name="source_xdrip">xDrip+ BG</string>
-    <string name="description_source_xdrip">Receive BG values from xDrip+.</string>
+    <string name="source_xdrip">xDrip+ / Juggluco BG</string>
+    <string name="description_source_xdrip">Receive BG values from xDrip+ or Juggluco.</string>
     <string name="dexcom_app_patched">BYODA</string>
     <string name="dexcom_short">BYODA</string>
     <string name="description_source_dexcom">Receive BG values from the \'Build Your Own Dexcom App\'.</string>


### PR DESCRIPTION
Updated translations in all supported languages to reference both xDrip+ and Juggluco as sources for BG/glucose values. This clarifies that the app can now receive data from either xDrip+ or Juggluco.

*fix #4042 