### PR TITLE
Fix a typo in an insulin name

### DIFF
--- a/plugins/constraints/src/main/res/values-ca-rES/exam.xml
+++ b/plugins/constraints/src/main/res/values-ca-rES/exam.xml
@@ -67,7 +67,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/insulina humana \"estàndard\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/insulina humana \"estàndard\".</string>
     <string name="sensitivity_label">Plugins de sensibilitat</string>
     <string name="wrongcarbs_label">Errors d\'entrada de carbohidrats</string>
     <string name="wrongcarbs_whattodo">Què cal fer si feu una entrada incorrecta de carbohidrats?</string>

--- a/plugins/constraints/src/main/res/values-da-rDK/exam.xml
+++ b/plugins/constraints/src/main/res/values-da-rDK/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"regulært\" humant insulin.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"regulært\" humant insulin.</string>
     <string name="sensitivity_label">Sensitivitets plugins</string>
     <string name="sensitivity_adjust">Sensitivitetsplugins giver AAPS mulighed for at justere midlertidigt eller kortvarige ændringer i insulin-følsomheden (f.eks. hormonelle ændringer eller problemer med absorption på infusionsstedet).</string>
     <string name="sensitivity_edit">Sensitivitetsplugins giver brugeren forslag til ændringer i basalrater, IC-forhold og ISF, der kan bruges til at redigere profilen.</string>

--- a/plugins/constraints/src/main/res/values-de-rDE/exam.xml
+++ b/plugins/constraints/src/main/res/values-de-rDE/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"normales\" Humaninsulin</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"normales\" Humaninsulin</string>
     <string name="sensitivity_label">Empfindlichkeits-Plugins</string>
     <string name="sensitivity_adjust">Empfindlichkeits-Plugins erlauben AndroidAPS vorübergehende oder kurzzeitige Veränderungen der Insulinempfindlichkeit (z. B. hormonelle Veränderungen oder Probleme mit der Absorption an der Infusionsstelle).</string>
     <string name="sensitivity_edit">Sensitivitäts-Plugins liefern dem Benutzer Vorschläge für Änderungen an Basalraten, I:C-Verhältnissen und ISF, die zur Bearbeitung des Profils verwendet werden können.</string>

--- a/plugins/constraints/src/main/res/values-el-rGR/exam.xml
+++ b/plugins/constraints/src/main/res/values-el-rGR/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"regular\" ανθρώπινη ινσουλίνη.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"regular\" ανθρώπινη ινσουλίνη.</string>
     <string name="sensitivity_label">Πρόσθετα Ευαισθησίας</string>
     <string name="sensitivity_adjust">Τα πρόσθετα ευαισθησίας επιτρέπουν την προσαρμογή του AAPS σε προσωρινές ή βραχύβιες αλλαγές στην ευαισθησία στην ινσουλίνη (για παράδειγμα ορμονικές αλλαγές ή ζητήματα απορρόφησης στο σημείο έγχυσης).</string>
     <string name="sensitivity_edit">Τα πρόσθετα ευαισθησίας προτείνουν στο χρήστη αλλαγές στον βασικό ρυθμό, τις αναλογίες I:C και ISF και μπορούν να χρησιμοποιηθούν στην επεξεργασία του προφίλ σας.</string>

--- a/plugins/constraints/src/main/res/values-es-rES/exam.xml
+++ b/plugins/constraints/src/main/res/values-es-rES/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"insulina humana estándar\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"insulina humana estándar\".</string>
     <string name="insulin_hint1">https://wiki.aaps.app/es/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">Plugins de sensibilidad</string>
     <string name="sensitivity_adjust">Los plugins de sensibilidad permiten a AAPS ajustarse para cambios temporales o de corta duración en la sensibilidad a la insulina (por ejemplo, cambios hormonales o problemas con la absorción en el sitio de infusión).</string>

--- a/plugins/constraints/src/main/res/values-fr-rFR/exam.xml
+++ b/plugins/constraints/src/main/res/values-fr-rFR/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/Insuline humaine \"Normale\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/Insuline humaine \"Normale\".</string>
     <string name="insulin_hint1">https://wiki.aaps.app/fr/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">Plugins de Sensibilité</string>
     <string name="sensitivity_adjust">Les plugins de sensibilité permettent à AAPS de s\'adapter aux changements temporaires ou de courte durée de la sensibilité à l\'insuline (par ex. changements hormonaux ou problèmes d\'absorption sur le site d\'infusion).</string>

--- a/plugins/constraints/src/main/res/values-it-rIT/exam.xml
+++ b/plugins/constraints/src/main/res/values-it-rIT/exam.xml
@@ -84,7 +84,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/insulina umana \"regolare\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/insulina umana \"regolare\".</string>
     <string name="sensitivity_label">Plugin sensibilità</string>
     <string name="sensitivity_adjust">I plugin di sensibilità consentono ad AAPS di adattarsi a cambiamenti temporanei o di breve durata nella sensibilità all\'insulina (ad esempio cambiamenti ormonali o problemi di assorbimento legati al sito di infusione).</string>
     <string name="sensitivity_edit">I plugin di sensibilità forniscono all\'utente suggerimenti su cambi a velocità basali, rapporti I:C e ISF che possono essere utilizzati per modificare il profilo.</string>

--- a/plugins/constraints/src/main/res/values-iw-rIL/exam.xml
+++ b/plugins/constraints/src/main/res/values-iw-rIL/exam.xml
@@ -84,7 +84,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/ אינסולין אנושי \"רגיל\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/ אינסולין אנושי \"רגיל\".</string>
     <string name="sensitivity_label">תוספי רגישות</string>
     <string name="sensitivity_adjust">תוספי רגישות מאפשרים ל-AndroidAPS לפצות על שינויים זמניים או קצרים ברגישות לאינסולין (לדוגמה משינויים הורמונליים או בעיות עם קליטה באתר העירוי).</string>
     <string name="sensitivity_edit">תוספי רגישות מספקים למשתמש הצעות לשינויים למינוני הבזאלי, יחסי התיקון והפחמימות, שאיתם ניתן לערוך את הפרופיל.</string>

--- a/plugins/constraints/src/main/res/values-ko-rKR/exam.xml
+++ b/plugins/constraints/src/main/res/values-ko-rKR/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">피아스프(Fiasp®)</string>
     <string name="insulin_novorapid">노보래피드(NovoRapid®)/노보로그(Novolog®)</string>
     <string name="insulin_humalog">휴마로그(Humalog®)</string>
-    <string name="insulin_actrapid">액트라피드(Actrapid®)/휴말린 R(Humalin R®)/\"보통의\" 인간 인슐린.</string>
+    <string name="insulin_actrapid">액트라피드(Actrapid®)/휴말린 R(Humulin R®)/\"보통의\" 인간 인슐린.</string>
     <string name="sensitivity_label">민감도 플러그인</string>
     <string name="sensitivity_adjust">민감도 플러그인은 AAPS가 일시적 또는 단기적으로 인슐린 민감도를 조절할 수 있도록 합니다 (예를 들어, 호르몬 변화 또는 주입 부위의 흡수 문제).</string>
     <string name="sensitivity_edit">민감도 플러그인은 프로파일을 수정할 때 사용할 수 있도록 basal양, I:C ratio, 그리고 ISF의 제안된 변경 사항을 사용자에게 제공합니다.</string>

--- a/plugins/constraints/src/main/res/values-nb-rNO/exam.xml
+++ b/plugins/constraints/src/main/res/values-nb-rNO/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"regulært\" humant insulin.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"regulært\" humant insulin.</string>
     <string name="insulin_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">Sensitivitets plugin</string>
     <string name="sensitivity_adjust">Sensitivitets plugin gjør det mulig for AAPS å gjøre midlertidige eller kortvarige justeringer av insulin sensitivitet (f. eks. hormonelle forandringer eller problemer med absorpsjon ved innstikkstedet).</string>

--- a/plugins/constraints/src/main/res/values-nl-rNL/exam.xml
+++ b/plugins/constraints/src/main/res/values-nl-rNL/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"regular\" menselijke insuline.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"regular\" menselijke insuline.</string>
     <string name="insulin_hint1">https://wiki.aaps.app/nl/latest/Configuration/Config-Builder.html#insuline</string>
     <string name="sensitivity_label">Gevoeligheidsplugins</string>
     <string name="sensitivity_adjust">Gevoeligheidsplugins stellen AndroidAPS in staat om aan te passen aan tijdelijke of kortstondige veranderingen in insulinegevoeligheid (bijvoorbeeld hormonale veranderingen of problemen met insuline-opname bij de infuusplaats).</string>

--- a/plugins/constraints/src/main/res/values-pt-rBR/exam.xml
+++ b/plugins/constraints/src/main/res/values-pt-rBR/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/insulina humana regular.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/insulina humana regular.</string>
     <string name="sensitivity_label">Tópico: Plugins de Sensibilidade</string>
     <string name="sensitivity_adjust">Plugins de sensibilidade permitem ao AAPS ajustar de forma temporária ou por uma curta duração alterações na sensibilidade à insulina (por exemplo, mudanças hormonais ou problemas com absorção de insulina no local onde ela é aplicada).</string>
     <string name="sensitivity_edit">Os plugins de sensibilidade fornecem ao usuário sugestões de alterações nas taxas basais, relações I:C e ISF, que podem ser usadas para editar o perfil.</string>

--- a/plugins/constraints/src/main/res/values-pt-rPT/exam.xml
+++ b/plugins/constraints/src/main/res/values-pt-rPT/exam.xml
@@ -80,7 +80,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog ®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/\"regular\" insulina humana.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/\"regular\" insulina humana.</string>
     <string name="sensitivity_label">Plugins de Sensibilidade</string>
     <string name="sensitivity_adjust">Plugins de sensibilidade permitem que a AAPS ajuste mudanças temporárias ou de curta duração na sensibilidade à insulina (por exemplo, alterações hormonais ou problemas de absorção no local de colocação do cateter).</string>
     <string name="sensitivity_edit">Plugins de sensibilidade fornecem ao utilizador alterações sugeridas nas taxas de basal, taxas de I:HC e FSI que podem ser usados para editar perfil.</string>

--- a/plugins/constraints/src/main/res/values-ro-rRO/exam.xml
+++ b/plugins/constraints/src/main/res/values-ro-rRO/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/insulină umană \"regular\".</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/insulină umană \"regular\".</string>
     <string name="sensitivity_label">Plugin-uri de sensibilitate</string>
     <string name="sensitivity_adjust">Plugin-urile de sensibilitate permit AAPS să se ajusteze pentru modificări temporare sau de scurtă durată ale sensibilității la insulină (de exemplu, modificări hormonale sau probleme cu absorbția la locul perfuziei).</string>
     <string name="sensitivity_edit">Plugin-urile de sensibilitate oferă utilizatorului sugestii pentru modificarea ratelor bazale, raportului I:C și ISF, sugestii care pot fi utilizate pentru a edita profilul.</string>

--- a/plugins/constraints/src/main/res/values-ru-rRU/exam.xml
+++ b/plugins/constraints/src/main/res/values-ru-rRU/exam.xml
@@ -99,7 +99,7 @@ Context | Edit Context</string>
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">Novoapid ® /Novolog ®</string>
     <string name="insulin_humalog">Хумалог®</string>
-    <string name="insulin_actrapid">Actrapid ® /Humalin R ®/\"обычный\" человеческий инсулин.</string>
+    <string name="insulin_actrapid">Actrapid ® /Humulin R ®/\"обычный\" человеческий инсулин.</string>
     <string name="insulin_hint1">https://wiki.aaps.app/ru/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">Модули чувствительности</string>
     <string name="sensitivity_adjust">Модули чувствительности позволяют AAPS подстраиваться под временные или кратковременные изменения в чувствительности к инсулину (например, гормональные изменения или проблемы с поглощением в месте установки катетера).</string>

--- a/plugins/constraints/src/main/res/values-sv-rSE/exam.xml
+++ b/plugins/constraints/src/main/res/values-sv-rSE/exam.xml
@@ -81,7 +81,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog ®</string>
-    <string name="insulin_actrapid">Actrapid ®/Humalin R ®/\"reguljärt\" human-insulin.</string>
+    <string name="insulin_actrapid">Actrapid ®/Humulin R ®/\"reguljärt\" human-insulin.</string>
     <string name="sensitivity_label">Insticksprogram för känslighet</string>
     <string name="sensitivity_adjust">Insticksprogram för känslighet gör det möjligt för AAPS att justera för tillfälliga eller kortvariga förändringar i insulinkänsligheten (t. ex. hormonella förändringar eller problem med absorption vid infusionsstället).</string>
     <string name="sensitivity_edit">Insticksprogram för känslighet ger användaren föreslagna ändringar av basaldoser, KH-kvoter och ISF som kan användas för att redigera profilen.</string>

--- a/plugins/constraints/src/main/res/values-zh-rTW/exam.xml
+++ b/plugins/constraints/src/main/res/values-zh-rTW/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/「常規型」人胰島素。</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/「常規型」人胰島素。</string>
     <string name="insulin_hint1">https://wiki.aaps.app/zh-tw/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">敏感性外掛</string>
     <string name="sensitivity_adjust">敏感性外掛允許AAPS調整因臨時或短期的胰島素敏感性變化（例如荷爾蒙變化或注射部位的吸收問題）。</string>

--- a/plugins/constraints/src/main/res/values/exam.xml
+++ b/plugins/constraints/src/main/res/values/exam.xml
@@ -97,7 +97,7 @@
     <string name="insulin_fiasp">Fiasp®</string>
     <string name="insulin_novorapid">NovoRapid®/Novolog®</string>
     <string name="insulin_humalog">Humalog®</string>
-    <string name="insulin_actrapid">Actrapid®/Humalin R®/"regular" human insulin.</string>
+    <string name="insulin_actrapid">Actrapid®/Humulin R®/"regular" human insulin.</string>
     <string name="insulin_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/ConfigBuilder.html#insulin</string>
     <string name="sensitivity_label">Sensitivity Plugins</string>
     <string name="sensitivity_adjust">Sensitivity plugins allow AAPS to adjust for temporary or short-lived changes in insulin sensitivity (for example hormonal changes or issues with absorption at the infusion site).</string>


### PR DESCRIPTION
It is Humulin, not Humalin: https://www.drugs.com/humulin-r.html