### PR TITLE
Show sec ago if less than 100sec

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
@@ -57,6 +57,7 @@ interface DateUtil {
     fun dateAndTimeString(mills: Long): String
     fun dateAndTimeAndSecondsString(mills: Long): String
     fun minAgo(rh: ResourceHelper, time: Long?): String
+    fun minOrSecAgo(rh: ResourceHelper, time: Long?): String
     fun minAgoShort(time: Long?): String
     fun minAgoLong(rh: ResourceHelper, time: Long?): String
     fun hourAgo(time: Long, rh: ResourceHelper): String

--- a/core/interfaces/src/main/res/values/strings.xml
+++ b/core/interfaces/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
 
     <!--    DateUtil-->
     <string name="minago">%1$d m ago</string>
+    <string name="secago">%1$d s ago</string>
     <string name="minago_long">%1$d minutes ago</string>
     <string name="hoursago">%1$.1f h ago</string>
     <string name="days_ago">%1$.1f days ago</string>

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -844,7 +844,7 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
             val outDate = (if (!isActualBg) rh.gs(R.string.a11y_bg_outdated) else "")
             binding.infoLayout.bg.contentDescription = rh.gs(R.string.a11y_blood_glucose) + " " + binding.infoLayout.bg.text.toString() + " " + lastBgDescription + " " + outDate
 
-            binding.infoLayout.timeAgo.text = dateUtil.minAgo(rh, lastBg?.timestamp)
+            binding.infoLayout.timeAgo.text = dateUtil.minOrSecAgo(rh, lastBg?.timestamp)
             binding.infoLayout.timeAgo.contentDescription = dateUtil.minAgoLong(rh, lastBg?.timestamp)
             binding.infoLayout.timeAgoShort.text = dateUtil.minAgoShort(lastBg?.timestamp)
 

--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -220,6 +220,17 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
         return if (abs(minutes) > 9999) "" else rh.gs(R.string.minago, minutes)
     }
 
+    override fun minOrSecAgo(rh: ResourceHelper, time: Long?): String {
+        if (time == null) return ""
+        //val minutes = ((now() - time) / 1000 / 60).toInt()
+        val seconds = (now() - time) / 1000
+        if (seconds > 99) {
+            return rh.gs(R.string.minago, (seconds / 60).toInt())
+        } else {
+            return rh.gs(R.string.secago, seconds.toInt())
+        }
+    }
+
     override fun minAgoShort(time: Long?): String {
         if (time == null) return ""
         val minutes = ((time - now()) / 1000 / 60).toInt()

--- a/ui/src/main/kotlin/app/aaps/ui/widget/Widget.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/widget/Widget.kt
@@ -183,7 +183,7 @@ class Widget : AppWidgetProvider() {
         if (!lastBgData.isActualBg()) views.setInt(R.id.bg, "setPaintFlags", Paint.STRIKE_THRU_TEXT_FLAG or Paint.ANTI_ALIAS_FLAG)
         else views.setInt(R.id.bg, "setPaintFlags", Paint.ANTI_ALIAS_FLAG)
 
-        views.setTextViewText(R.id.time_ago, dateUtil.minAgo(rh, lastBgData.lastBg()?.timestamp))
+        views.setTextViewText(R.id.time_ago, dateUtil.minOrSecAgo(rh, lastBgData.lastBg()?.timestamp))
         //views.setTextViewText(R.id.time_ago_short, "(" + dateUtil.minAgoShort(overviewData.lastBg?.timestamp) + ")")
     }
 


### PR DESCRIPTION
For Libre users with 1 minute readings the time between CGM reading and loop algo done stays at **0 m ago** more or less all day. To know whether I can "walk away" for 20 seconds it helps to see that info in seconds instead. When the gap grows beyond 99sec it reverts back to **x m ago** as usual.

![Screenshot_20250810_170924_AAPS](https://github.com/user-attachments/assets/f7ce6109-557f-4783-9137-a9e559a3ac76)  ![Screenshot_20250810_170934_AAPS](https://github.com/user-attachments/assets/932309f5-2c8a-409b-b7d5-965af7e72910)

It does not take more screen space than before. Interestingly, after a new loop run it nearly always reports **6 sec ago** no matter how weak or powerful the phone is. So the time seems dominated by synchronisation between various events and we don't have to worry too much about complexity of the algorithm itself.

![Screenshot_20250810_174935_AAPS](https://github.com/user-attachments/assets/4483ccc6-aa05-4a5a-9e39-9e8c3cb0b104)

These changes also apply to the widget.
![Screenshot_20250810_170536_One UI Home](https://github.com/user-attachments/assets/7c88cc93-bffe-401c-9790-4df87f79781f)
