### PR TITLE
3330 dev b/dev mini graphs

### DIFF
--- a/core/graphview/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
+++ b/core/graphview/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
@@ -382,7 +382,7 @@ public class GridLabelRenderer {
         int p = mGraphView.getGraphContentTop(); // start
         int pixelStep = height / (numVerticalLabels - 1);
         for (int i = 0; i < numVerticalLabels; i++) {
-            mStepsVerticalSecondScale.put(p, v);
+            mStepsVerticalSecondScale.put((int) (p+(1-i)*0.5*pixelStep), v);
             p += pixelStep;
             v -= exactSteps;
         }
@@ -479,7 +479,7 @@ public class GridLabelRenderer {
         for (int i = 0; i < numVerticalLabels; i++) {
             mStepsVertical.put(p, v);
             p += pixelStep;
-            v -= exactSteps;
+            v -= exactSteps;    // active
         }
 
         return true;
@@ -863,7 +863,7 @@ public class GridLabelRenderer {
                 }
             }
             if (mStyles.gridStyle.drawVertical()) {
-                canvas.drawLine(e.getKey(), mGraphView.getGraphContentTop(), e.getKey(), mGraphView.getGraphContentTop() + mGraphView.getGraphContentHeight(), mPaintLine);
+                canvas.drawLine(e.getKey(), mGraphView.getGraphContentTop(), e.getKey(), mGraphView.getGraphContentTop() + mGraphView.getGraphContentHeight(), mPaintLine); // active
             }
 
             // draw label
@@ -883,7 +883,7 @@ public class GridLabelRenderer {
                 for (int li = 0; li < lines.length; li++) {
                     // for the last line y = height
                     float y = (canvas.getHeight() - mStyles.padding - getHorizontalAxisTitleHeight()) - (lines.length - li - 1) * getTextSize() * 1.1f + mStyles.labelsSpace;
-                    canvas.drawText(lines[li], e.getKey(), y, mPaintLabel);
+                    canvas.drawText(lines[li], e.getKey(), y, mPaintLabel); // active
                 }
             }
             i++;
@@ -938,6 +938,7 @@ public class GridLabelRenderer {
         float startLeft = mGraphView.getGraphContentLeft();
         mPaintLabel.setColor(getVerticalLabelsColor());
         mPaintLabel.setTextAlign(getVerticalLabelsAlign());
+        int lIndex = -1;
         for (Map.Entry<Integer, Double> e : mStepsVertical.entrySet()) {
             // draw line
             if (mStyles.highlightZeroLines) {
@@ -948,7 +949,7 @@ public class GridLabelRenderer {
                 }
             }
             if (mStyles.gridStyle.drawHorizontal()) {
-                canvas.drawLine(startLeft, e.getKey(), startLeft + mGraphView.getGraphContentWidth(), e.getKey(), mPaintLine);
+                canvas.drawLine(startLeft, e.getKey(), startLeft + mGraphView.getGraphContentWidth(), e.getKey(), mPaintLine);  // active
             }
 
             // draw label
@@ -963,7 +964,12 @@ public class GridLabelRenderer {
                 }
                 labelsOffset += mStyles.padding + getVerticalAxisTitleWidth();
 
-                float y = e.getKey();
+                float labelMinMaxOffset = 0f;
+                if (mNumVerticalLabels==3) {
+                    lIndex ++;
+                    labelMinMaxOffset = (1-lIndex) * labelsWidth * 0.4f;
+                }
+                float y = e.getKey() + labelMinMaxOffset;
 
                 String label = mLabelFormatter.formatLabel(e.getValue(), false);
                 if (label == null) {
@@ -974,7 +980,7 @@ public class GridLabelRenderer {
                 for (int li = 0; li < lines.length; li++) {
                     // for the last line y = height
                     float y2 = y - (lines.length - li - 1) * getTextSize() * 1.1f;
-                    canvas.drawText(lines[li], labelsOffset, y2, mPaintLabel);
+                    canvas.drawText(lines[li], labelsOffset, y2, mPaintLabel);  // active
                 }
             }
         }

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -767,7 +767,8 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
 
                 val graph = GraphView(context)
                 graph.layoutParams =
-                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, rh.dpToPx(skinProvider.activeSkin().secondaryGraphHeight)).also { it.setMargins(0, rh.dpToPx(15), 0, rh.dpToPx(10)) }
+                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, rh.dpToPx(skinProvider.activeSkin().secondaryGraphHeight)).also { it.setMargins(0, rh.dpToPx(0), 0, rh.dpToPx(0)) }
+                    //LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, rh.dpToPx(skinProvider.activeSkin().secondaryGraphHeight)).also { it.setMargins(0, rh.dpToPx(15), 0, rh.dpToPx(10)) }
                 graph.gridLabelRenderer?.gridColor = rh.gac(context, app.aaps.core.ui.R.attr.graphGrid)
                 graph.gridLabelRenderer?.reloadStyles()
                 graph.gridLabelRenderer?.isHorizontalLabelsVisible = false
@@ -777,7 +778,8 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
                 relativeLayout.addView(graph)
 
                 val label = TextView(context)
-                val layoutParams = RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).also { it.setMargins(rh.dpToPx(30), rh.dpToPx(25), 0, 0) }
+                val layoutParams = RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).also { it.setMargins(rh.dpToPx(35), rh.dpToPx(10), 0, 0) }
+                //val layoutParams = RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).also { it.setMargins(rh.dpToPx(30), rh.dpToPx(25), 0, 0) }
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP)
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
                 label.layoutParams = layoutParams


### PR DESCRIPTION
This is about the layout of the subgraphs.

Change 1: depending on the default font size of the phone the bottom label of all the subgraphs is partly obscured. So I moved the vertical labels somewhat inwards.

Change 2: after moving the labels in change 1 the margin between the subgraphs can be reduced. Now the screen can show more of the subgraph(s).

<img width="671" height="719" alt="grafik" src="https://github.com/user-attachments/assets/2604e1ca-722e-45b7-b6b8-6278e347e1fc" />

