### PR TITLE
Add CI KeyStore Export

### DIFF
--- a/.github/workflows/keystore-export.yml
+++ b/.github/workflows/keystore-export.yml
@@ -1,0 +1,267 @@
+name: CI Keystore Export
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: KeyStore Export
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode Secrets Keystore Set and Oauth2 ZIP_PASSWORD to Env
+        run: |
+          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+            echo "🔐 Decoding KEYSTORE_SET..."
+            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+
+            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
+            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
+            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
+            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
+
+            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
+            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
+            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
+            echo "KEYSTORE_SET=${{ secrets.KEYSTORE_SET }}" >> $GITHUB_ENV
+
+            echo "::add-mask::$KEYSTORE_BASE64"
+            echo "::add-mask::$KEYSTORE_PASSWORD"
+            echo "::add-mask::$KEY_ALIAS"
+            echo "::add-mask::$KEY_PASSWORD"
+
+            echo "✅ Keystore parameters extracted from KEYSTORE_SET"
+          else
+            echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
+            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
+            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
+            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+          fi
+          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
+          echo "ZIP_PASSWORD=${{ secrets.ZIP_PASSWORD }}" >> $GITHUB_ENV
+
+      - name: Check Secrets
+        run: |
+          echo "🔍 Checking required secrets..."
+          MISSING=0
+
+          check_secret() {
+            if [ -z "$1" ]; then
+              echo "❌ Missing secret: $2"
+              MISSING=1
+            fi
+          }
+
+          # Check secrets
+          check_secret "$GDRIVE_OAUTH2" "GDRIVE_OAUTH2"
+          check_secret "$ZIP_PASSWORD" "ZIP_PASSWORD"
+          
+          check_secret "$KEYSTORE_BASE64" "KEYSTORE_BASE64"
+          check_secret "$KEYSTORE_PASSWORD" "KEYSTORE_PASSWORD"
+          check_secret "$KEY_ALIAS" "KEY_ALIAS"
+          check_secret "$KEY_PASSWORD" "KEY_PASSWORD"
+
+          if [ "$MISSING" -eq 1 ]; then
+            echo "🛑 Missing required secrets. Stopping build."
+            exit 1
+          fi
+
+          echo "✅ All required secrets are present."
+
+      - name: Decode keystore file
+        run: |
+          mkdir -p "$RUNNER_TEMP/keystore"
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/keystore/keystore.jks"
+
+      - name: Validating keystore, alias and password
+        run: |
+          set -x
+          echo "🔐 Validating keystore, alias and password"
+
+          # Create a dummy JAR file (quick method using zip)
+          echo "test" > dummy.txt
+          zip -q dummy.jar dummy.txt
+          rm dummy.txt
+          
+          # Attempt to validate using jarsigner
+          JARSIGNER_LOG=$(mktemp)
+          if ! jarsigner \
+              -keystore "$RUNNER_TEMP/keystore/keystore.jks" \
+              -storepass "$KEYSTORE_PASSWORD" \
+              -keypass "$KEY_PASSWORD" \
+              dummy.jar "$KEY_ALIAS" > "$JARSIGNER_LOG" 2>&1; then
+            echo "❌ Either KEYSTORE_BASE64, KEYSTORE_PASSWORD, KEY_PASSWORD, or KEY_ALIAS is incorrect"
+            echo "🔍 jarsigner error output:"
+            cat "$JARSIGNER_LOG"
+            rm -f "$JARSIGNER_LOG" dummy.jar
+            exit 1
+          fi
+          rm -f "$JARSIGNER_LOG" dummy.jar
+          echo "✅ Keystore, alias, and key password are valid."
+
+          rm -f "$KEYTOOL_LOG"
+          echo "✅ Keystore and credentials validated."
+
+      - name: Decode GDrive OAuth2 secrets
+        run: |
+          echo "🔐 Decoding GDRIVE_OAUTH2..."
+          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
+          
+          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
+          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
+          
+          echo "::add-mask::$GDRIVE_CLIENT_ID"
+          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
+          
+          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
+          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
+          
+          echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
+
+      - name: Retrieving Google Drive access token
+        run: |
+          echo "🔐 Getting Google OAuth2 access token..."
+          TOKEN_RESPONSE=$(curl -s -X POST https://oauth2.googleapis.com/token \
+            -d client_id="$GDRIVE_CLIENT_ID" \
+            -d refresh_token="$GDRIVE_REFRESH_TOKEN" \
+            -d grant_type=refresh_token)
+          ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r .access_token)
+          echo "::add-mask::$ACCESS_TOKEN"
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "❌ Failed to get access token."
+            echo "$TOKEN_RESPONSE"
+            exit 1
+          fi
+          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
+          echo "✅ Access token obtained."
+
+      - name: Encrypt the keystore using zip.
+        run: |
+          echo "🔐 Creating encrypted zip file from keystore..."
+          cd "$RUNNER_TEMP/keystore"
+          
+          # Create keyStoreInfo.txt with keystore passwords and alias
+          echo "Creating keyStoreInfo.txt with keystore information..."
+          cat > keyStoreInfo.txt << EOF
+            KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD
+            KEY_PASSWORD=$KEY_PASSWORD
+            ALIAS=$KEY_ALIAS
+          EOF
+          
+          # Create keystore_set.txt with KEYSTORE_SET content (only if KEYSTORE_SET has value)
+          ZIP_FILES="keystore.jks keyStoreInfo.txt"
+          if [ -n "$KEYSTORE_SET" ]; then
+            echo "Creating keystore_set.txt with KEYSTORE_SET content..."
+            echo "$KEYSTORE_SET" > keystore_set.txt
+            ZIP_FILES="$ZIP_FILES keystore_set.txt"
+            echo "📋 KEYSTORE_SET found, will include keystore_set.txt"
+          else
+            echo "📋 KEYSTORE_SET not found, skipping keystore_set.txt"
+          fi
+          
+          # Create encrypted zip with available files
+          echo "📦 Adding files to encrypted zip: $ZIP_FILES"
+          echo "🔐 Using password protection for zip file..."
+
+          # Use ZIP_PASSWORD secret directly with command substitution to avoid env var exposure
+          set +x  # Disable command echoing to prevent password leakage
+          ZIP_ERROR_LOG=$(mktemp)
+          if ! zip -P "$ZIP_PASSWORD" keystore.zip $ZIP_FILES > /dev/null 2>"$ZIP_ERROR_LOG"; then
+            set -x  # Re-enable command echoing for error output
+            echo "❌ Failed to create encrypted zip file"
+            echo "🔍 zip command error output:"
+            cat "$ZIP_ERROR_LOG"
+            rm -f "$ZIP_ERROR_LOG"
+            exit 1
+          fi
+          rm -f "$ZIP_ERROR_LOG"
+          set -x  # Re-enable command echoing
+          
+          echo "✅ Keystore and info files encrypted successfully as keystore.zip"
+          echo "📋 Files included: $ZIP_FILES"
+
+      - name: Upload APKs to Google Drive
+        run: |
+          set -e
+          echo "🔐 Start uploading APKs to Google Drive..."
+
+          echo "📁 Checking or creating AAPS folder"
+          AAPS_FOLDER_ID=$(curl -s -X GET \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            "https://www.googleapis.com/drive/v3/files?q=name='AAPS'+and+mimeType='application/vnd.google-apps.folder'+and+trashed=false" \
+            | jq -r '.files[0].id')
+
+          if [ "$AAPS_FOLDER_ID" == "null" ] || [ -z "$AAPS_FOLDER_ID" ]; then
+            AAPS_FOLDER_ID=$(curl -s -X POST \
+              -H "Authorization: Bearer $ACCESS_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{"name": "AAPS", "mimeType": "application/vnd.google-apps.folder"}' \
+              "https://www.googleapis.com/drive/v3/files" | jq -r '.id')
+            echo "📂 Created AAPS folder: $AAPS_FOLDER_ID"
+          else
+            echo "📂 Found AAPS folder: $AAPS_FOLDER_ID"
+          fi
+
+          echo "📁 Checking or creating KeyStore folder"
+          KEYSTORE_FOLDER_ID=$(curl -s -X GET \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            "https://www.googleapis.com/drive/v3/files?q=name='KeyStore'+and+mimeType='application/vnd.google-apps.folder'+and+'$AAPS_FOLDER_ID'+in+parents+and+trashed=false" \
+            | jq -r '.files[0].id')
+
+          if [ "$KEYSTORE_FOLDER_ID" == "null" ] || [ -z "$KEYSTORE_FOLDER_ID" ]; then
+            KEYSTORE_FOLDER_ID=$(curl -s -X POST \
+              -H "Authorization: Bearer $ACCESS_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\": \"KeyStore\", \"mimeType\": \"application/vnd.google-apps.folder\", \"parents\": [\"$AAPS_FOLDER_ID\"]}" \
+              "https://www.googleapis.com/drive/v3/files" | jq -r '.id')
+            echo "📂 Created KeyStore folder"
+          else
+            echo "📂 Found KeyStore folder"
+          fi
+
+          upload_to_gdrive() {
+            FILE=$1
+            NAME=$2
+            if [ ! -f "$FILE" ]; then
+              echo "❌ File not found: $FILE"
+              exit 26
+            fi
+
+            echo "📄 Checking if file $NAME already exists in Google Drive..."
+            QUERY="name='${NAME}' and '${KEYSTORE_FOLDER_ID}' in parents and trashed=false"
+            ENCODED_QUERY=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$QUERY'''))")
+            FILE_ID=$(curl -s \
+              -H "Authorization: Bearer $ACCESS_TOKEN" \
+              "https://www.googleapis.com/drive/v3/files?q=${ENCODED_QUERY}&fields=files(id)" \
+              | jq -r '.files[0].id')
+
+            if [[ -n "$FILE_ID" && "$FILE_ID" != "null" ]]; then
+              echo "🗑️ Deleting existing file with ID: $FILE_ID"
+              curl -s -X DELETE \
+                -H "Authorization: Bearer $ACCESS_TOKEN" \
+                "https://www.googleapis.com/drive/v3/files/${FILE_ID}"
+            fi
+
+            echo "⬆️ Uploading $FILE as $NAME to Google Drive..."
+            RESPONSE=$(curl -s -w "%{http_code}" -o /tmp/gdrive_response.json \
+              -X POST \
+              -H "Authorization: Bearer $ACCESS_TOKEN" \
+              -F "metadata={\"name\":\"$NAME\", \"parents\":[\"$KEYSTORE_FOLDER_ID\"]};type=application/json;charset=UTF-8" \
+              -F "file=@$FILE;type=application/zip" \
+              "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart")
+
+            HTTP_CODE="${RESPONSE: -3}"
+            if [[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "201" ]]; then
+              echo "❌ Upload failed with HTTP status: $HTTP_CODE"
+              cat /tmp/gdrive_response.json
+              exit 1
+            fi
+
+            echo "✅ Uploaded: $NAME"
+          }
+
+          # Upload the encrypted keystore zip file
+          upload_to_gdrive "$RUNNER_TEMP/keystore/keystore.zip" "keystore-$(date +%Y%m%d-%H%M%S).zip"
+
+          echo "🎉 Encrypted keystore successfully uploaded to Google Drive!"


### PR DESCRIPTION
When users want to switch to Android Studio, they can export the previously configured KeyStore in an encrypted format.

Step Instructions: [CI KeyStore Export](https://aaps-ci-preview.readthedocs.io/en/latest/SettingUpAaps/BrowserBuild.html#ci-keystore-export)

Please review.