### PR TITLE
Improve message in constraints when BG values are doubled

### DIFF
--- a/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/bgQualityCheck/BgQualityCheckPlugin.kt
+++ b/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/bgQualityCheck/BgQualityCheckPlugin.kt
@@ -67,7 +67,7 @@ class BgQualityCheckPlugin @Inject constructor(
     // Fallback to LGS if BG values are doubled
     override fun applyMaxIOBConstraints(maxIob: Constraint<Double>): Constraint<Double> =
         if (state == BgQualityCheck.State.DOUBLED)
-            maxIob.set(0.0, "Doubled values in BGSource", this)
+            maxIob.set(0.0, "Limiting max IOB to 0 U due to doubled values in BG Source", this)
         else
             maxIob
 


### PR DESCRIPTION
To avoid confusion like in https://github.com/nightscout/AndroidAPS/issues/4111 message for this constraint could be improved