### PR TITLE
aaps-ci: adjust assemblefullRelease order for app and wear

### DIFF
--- a/.github/workflows/aaps-ci.yml
+++ b/.github/workflows/aaps-ci.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Build APKs
         run: |
-              ./gradlew assemble${{ env.BUILD_VARIANT }} \
+              ./gradlew :app:assemble${{ env.BUILD_VARIANT }} :wear:assemble${{ env.BUILD_VARIANT }} \
               -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
               -Dkotlin.daemon.jvm.options="-Xmx2g" \
               -Dkotlin.compiler.execution.strategy="in-process" \

--- a/.github/workflows/cherry-pick-ci.yml
+++ b/.github/workflows/cherry-pick-ci.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Build APKs
         run: |
-          ./gradlew assemble${{ env.BUILD_VARIANT }} \
+          ./gradlew :app:assemble${{ env.BUILD_VARIANT }} :wear:assemble${{ env.BUILD_VARIANT }} \
             -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
             -Dkotlin.daemon.jvm.options="-Xmx2g" \
             -Dkotlin.compiler.execution.strategy="in-process" \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Build APKs
         run: |
-          ./gradlew assemble${{ env.BUILD_VARIANT }} \
+          ./gradlew :app:assemble${{ env.BUILD_VARIANT }} :wear:assemble${{ env.BUILD_VARIANT }} \
             -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
             -Dkotlin.daemon.jvm.options="-Xmx2g" \
             -Dkotlin.compiler.execution.strategy="in-process" \


### PR DESCRIPTION
AAPS-CI previously invoked `assemblefullRelease` on both app and wear
modules together, which sometimes caused build order issues.
This change enforces building app first, then wear, to ensure stability.

Related to #4134 

### Test Cases

**Branch**
- dev
- master

**Variant**
- fullRelease
- fullDebug
- aapsclientRelease
- aapsclientDebug
- aapsclient2Release
- aapsclient2Debug
- pumpcontrolRelease
- pumpcontrolDebug