### PR TITLE
Moved DeltaCalculator out of Glucose Status Calculator

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPS/DeltaCalculator.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPS/DeltaCalculator.kt
@@ -1,0 +1,113 @@
+package app.aaps.plugins.aps.openAPS
+
+import app.aaps.core.data.iob.InMemoryGlucoseValue
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import dagger.Reusable
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+
+@Reusable
+class DeltaCalculator @Inject constructor(
+    private val aapsLogger: AAPSLogger
+) {
+
+    /**
+     * Holds the results from the delta calculations.
+     */
+    data class DeltaResult(
+        val delta: Double,
+        val shortAvgDelta: Double,
+        val longAvgDelta: Double
+    )
+
+    /**
+     * Calculates delta, short- and long-average delta from InMemoryGlucoseValue.
+     *
+     * @param data A list of historical glucose data, sorted from newest to oldest.
+     * @return A [DeltaResult] containing the calculated deltas.
+     */
+    fun calculateDeltas(data:  MutableList<InMemoryGlucoseValue>): DeltaResult {
+        if (data.size < 2) {
+            return DeltaResult(0.0, 0.0, 0.0)
+        }
+
+        var change: Double
+        val lastDeltas = mutableListOf<Double>()
+        val shortDeltas = mutableListOf<Double>()
+        val longDeltas = mutableListOf<Double>()
+
+        val now = data[0]
+        val nowDate = now.timestamp
+        // start at data[1] as data[0] is the value used in the now calculations
+        for (i in 1 until data.size) {
+            if (data[i].recalculated > minBgValue) {
+                val then = data[i]
+                val thenDate = then.timestamp
+                val minutesAgo = (nowDate - thenDate).milliseconds.toDouble(DurationUnit.MINUTES)
+                change = now.recalculated - then.recalculated
+                val avgDel = change / minutesAgo * 5 // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
+                // aapsLogger.debug(LTag.GLUCOSE, "$then Bucketed=$minutesAgo valueAgo=${then.value} recalcAgo=${then.recalculated} smooth=${then.smoothed} filled=${then.filledGap} avgDelta=$avgDel")
+
+                // use the average of all data points in the last 2.5m for all further "now" calculations
+                // if (0 < minutesAgo && minutesAgo < 2.5) {
+                //     // Keep and average all values within the last 2.5 minutes
+                //     nowValueList.add(then.recalculated)
+                //     now.value = average(nowValueList)
+
+                // values that are too recent are not considered (this check had been commented out before; now it's just being logged.)
+                if (minutesAgo in 0.0 .. minLastDeltaMinutes) {
+                    aapsLogger.debug(LTag.GLUCOSE, "$avgDel from $minutesAgo minutes ago is too recent to be considered.")
+                }
+
+                // last_deltas are calculated from minLastDeltaMinutes to maxLastDeltaMinutes
+                if (minutesAgo in minLastDeltaMinutes .. maxLastDeltaMinutes) { //currently min: 2.5 max 7.5
+//                    aapsLogger.debug(LTag.GLUCOSE, "$avgDel from $minutesAgo minutes ago added to lastDeltas")
+                    lastDeltas.add(avgDel)
+                }
+                // short_deltas are calculated from minShortDeltaMinutes to maxShortDeltaMinutes
+                if (minutesAgo in minShortDeltaMinutes .. maxShortDeltaMinutes) { //currently min: 2.5 max 17.5
+//                    aapsLogger.debug(LTag.GLUCOSE, "$avgDel from $minutesAgo minutes ago added to shortDeltas")
+                    shortDeltas.add(avgDel)
+                }
+                // long_deltas are calculated from minLongDeltaMinutes to maxLongDeltaMinutes
+                if (minutesAgo in minLongDeltaMinutes .. maxLongDeltaMinutes) { //currently min: 17.5 max 42.5
+//                    aapsLogger.debug(LTag.GLUCOSE, "$avgDel from $minutesAgo minutes ago added to longDeltas")
+                    longDeltas.add(avgDel)
+                } else if ( minutesAgo > maxLongDeltaMinutes){ //currently 42.5
+                    break // Do not process any more records after maxLongDeltaMinutes
+                }
+            }
+        }
+        val shortAverageDelta = average(shortDeltas)
+        val delta =
+            if (lastDeltas.isEmpty()) {
+                shortAverageDelta
+            } else {
+                average(lastDeltas)
+            }
+
+        return DeltaResult(
+            delta = delta,
+            shortAvgDelta = shortAverageDelta,
+            longAvgDelta = average(longDeltas)
+        )
+    }
+
+    companion object {
+
+        fun average(array: List<Double>): Double {
+            if (array.isEmpty()) return 0.0
+            return array.sum() / array.size
+        }
+
+        private const val minBgValue = 39.0
+        private const val minShortDeltaMinutes = 2.5
+        private const val maxShortDeltaMinutes = 17.5
+        private const val minLastDeltaMinutes = 2.5
+        private const val maxLastDeltaMinutes = 7.5
+        private const val minLongDeltaMinutes = 17.5
+        private const val maxLongDeltaMinutes = 42.5
+    }
+}

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
@@ -60,7 +60,7 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
             ).asRounded()
         }
 
-        val deltaResult = deltaCalculator.calculateDeltas(data) ?: error("DeltaCalculation is null")
+        val deltaResult = deltaCalculator.calculateDeltas(data)
 
         // calculate 2 variables for 5% range; still using 5 minute data
         val bw = 0.05
@@ -221,14 +221,6 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
     }
 
     companion object {
-
-        fun average(array: ArrayList<Double>): Double {
-            var sum = 0.0
-            if (array.isEmpty()) return 0.0
-            for (value in array) {
-                sum += value
-            }
-            return sum / array.size
-        }
+        //
     }
 }

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
@@ -6,9 +6,9 @@ import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
+import app.aaps.plugins.aps.openAPS.DeltaCalculator
 import app.aaps.plugins.aps.openAPSAutoISF.extensions.asRounded
 import app.aaps.plugins.aps.openAPSAutoISF.extensions.log
-import app.aaps.plugins.aps.openAPSSMB.GlucoseStatusCalculatorSMB
 import dagger.Reusable
 import javax.inject.Inject
 import kotlin.math.pow
@@ -21,7 +21,7 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
     private val iobCobCalculator: IobCobCalculator,
     private val dateUtil: DateUtil,
     private val decimalFormatter: DecimalFormatter,
-    private val glucoseStatusCalculatorSMB: GlucoseStatusCalculatorSMB
+    private val deltaCalculator: DeltaCalculator,
 ) {
 
     fun getGlucoseStatusData(allowOldData: Boolean): GlucoseStatusAutoIsf? {
@@ -60,7 +60,7 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
             ).asRounded()
         }
 
-        val commonCalculation = glucoseStatusCalculatorSMB.getGlucoseStatusData(allowOldData) ?: error("commonCalculation is null")
+        val deltaResult = deltaCalculator.calculateDeltas(data) ?: error("DeltaCalculation is null")
 
         // calculate 2 variables for 5% range; still using 5 minute data
         val bw = 0.05
@@ -201,12 +201,12 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
         // End parabola fit
 
         return GlucoseStatusAutoIsf(
-            glucose = commonCalculation.glucose,
-            date = commonCalculation.date,
-            noise =commonCalculation.noise, //for now set to nothing as not all CGMs report noise
-            shortAvgDelta = commonCalculation.shortAvgDelta,
-            delta = commonCalculation.delta,
-            longAvgDelta = commonCalculation.longAvgDelta,
+            glucose = now.recalculated,
+            date = nowDate,
+            noise = 0.0, //for now set to nothing as not all CGMs report noise
+            shortAvgDelta = deltaResult.shortAvgDelta,
+            delta = deltaResult.delta,
+            longAvgDelta = deltaResult.longAvgDelta,
             duraISFminutes = minutesDur.toDouble(),
             duraISFaverage = oldAvg,
             parabolaMinutes = duraP,
@@ -220,89 +220,6 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
         ).also { aapsLogger.debug(LTag.GLUCOSE, it.log(decimalFormatter)) }.asRounded()
     }
 
-    /* Real BG (previous) version
-           override fun getGlucoseStatusData(allowOldData: Boolean): GlucoseStatus? {
-            val data = iobCobCalculator.ads.getBgReadingsDataTableCopy()
-            val sizeRecords = data.size
-            if (sizeRecords == 0) {
-                aapsLogger.debug(LTag.GLUCOSE, "sizeRecords==0")
-                return null
-            }
-            if (data[0].timestamp < dateUtil.now() - 7 * 60 * 1000L && !allowOldData) {
-                aapsLogger.debug(LTag.GLUCOSE, "oldData")
-                return null
-            }
-            val now = data[0]
-            val nowDate = now.timestamp
-            var change: Double
-            if (sizeRecords == 1) {
-                aapsLogger.debug(LTag.GLUCOSE, "sizeRecords==1")
-                return GlucoseStatus(
-                    glucose = now.value,
-                    noise = 0.0,
-                    delta = 0.0,
-                    shortAvgDelta = 0.0,
-                    longAvgDelta = 0.0,
-                    date = nowDate
-                ).asRounded()
-            }
-            val nowValueList = ArrayList<Double>()
-            val lastDeltas = ArrayList<Double>()
-            val shortDeltas = ArrayList<Double>()
-            val longDeltas = ArrayList<Double>()
-
-            // Use the latest sgv value in the now calculations
-            nowValueList.add(now.value)
-            for (i in 1 until sizeRecords) {
-                if (data[i].value > 38) {
-                    val then = data[i]
-                    val thenDate = then.timestamp
-
-                    val minutesAgo = ((nowDate - thenDate) / (1000.0 * 60)).roundToLong()
-                    // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
-                    change = now.value - then.value
-                    val avgDel = change / minutesAgo * 5
-                    aapsLogger.debug(LTag.GLUCOSE, "$then minutesAgo=$minutesAgo avgDelta=$avgDel")
-
-                    // use the average of all data points in the last 2.5m for all further "now" calculations
-                    if (0 < minutesAgo && minutesAgo < 2.5) {
-                        // Keep and average all values within the last 2.5 minutes
-                        nowValueList.add(then.value)
-                        now.value = average(nowValueList)
-                        // short_deltas are calculated from everything ~5-15 minutes ago
-                    } else if (2.5 < minutesAgo && minutesAgo < 17.5) {
-                        //console.error(minutesAgo, avgDelta);
-                        shortDeltas.add(avgDel)
-                        // last_deltas are calculated from everything ~5 minutes ago
-                        if (2.5 < minutesAgo && minutesAgo < 7.5) {
-                            lastDeltas.add(avgDel)
-                        }
-                        // long_deltas are calculated from everything ~20-40 minutes ago
-                    } else if (17.5 < minutesAgo && minutesAgo < 42.5) {
-                        longDeltas.add(avgDel)
-                    } else {
-                        // Do not process any more records after >= 42.5 minutes
-                        break
-                    }
-                }
-            }
-            val shortAverageDelta = average(shortDeltas)
-            val delta = if (lastDeltas.isEmpty()) {
-                shortAverageDelta
-            } else {
-                average(lastDeltas)
-            }
-            return GlucoseStatus(
-                glucose = now.value,
-                date = nowDate,
-                noise = 0.0, //for now set to nothing as not all CGMs report noise
-                shortAvgDelta = shortAverageDelta,
-                delta = delta,
-                longAvgDelta = average(longDeltas),
-            ).also { aapsLogger.debug(LTag.GLUCOSE, it.log()) }.asRounded()
-        }
-
-    */
     companion object {
 
         fun average(array: ArrayList<Double>): Double {

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAutoISF/GlucoseStatusCalculatorAutoIsf.kt
@@ -221,6 +221,6 @@ class GlucoseStatusCalculatorAutoIsf @Inject constructor(
     }
 
     companion object {
-        //
+        //this will be useful in the next step when I replace magic numbers with vals
     }
 }

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/GlucoseStatusCalculatorSMB.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/GlucoseStatusCalculatorSMB.kt
@@ -41,7 +41,6 @@ class GlucoseStatusCalculatorSMB @Inject constructor(
         }
         val now = data[0]
         val nowDate = now.timestamp
-        var change: Double
         if (sizeRecords == 1) {
             aapsLogger.debug(LTag.GLUCOSE, "sizeRecords==1")
             return GlucoseStatusSMB(
@@ -67,14 +66,5 @@ class GlucoseStatusCalculatorSMB @Inject constructor(
     }
 
     companion object {
-
-        fun average(array: ArrayList<Double>): Double {
-            var sum = 0.0
-            if (array.isEmpty()) return 0.0
-            for (value in array) {
-                sum += value
-            }
-            return sum / array.size
-        }
     }
 }

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/GlucoseStatusCalculatorSMB.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/GlucoseStatusCalculatorSMB.kt
@@ -8,6 +8,7 @@ import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
+import app.aaps.plugins.aps.openAPS.DeltaCalculator
 import app.aaps.plugins.aps.openAPSSMB.extensions.asRounded
 import app.aaps.plugins.aps.openAPSSMB.extensions.log
 import dagger.Reusable
@@ -18,7 +19,9 @@ class GlucoseStatusCalculatorSMB @Inject constructor(
     private val aapsLogger: AAPSLogger,
     private val iobCobCalculator: IobCobCalculator,
     private val dateUtil: DateUtil,
-    private val decimalFormatter: DecimalFormatter
+    private val decimalFormatter: DecimalFormatter,
+    private val deltaCalculator: DeltaCalculator
+
 ) : GlucoseStatusProvider {
 
     override val glucoseStatusData: GlucoseStatus?
@@ -50,58 +53,16 @@ class GlucoseStatusCalculatorSMB @Inject constructor(
                 date = nowDate,
             ).asRounded()
         }
-        val lastDeltas = ArrayList<Double>()
-        val shortDeltas = ArrayList<Double>()
-        val longDeltas = ArrayList<Double>()
 
-        // Use the latest sgv value in the now calculations
-        for (i in 1 until sizeRecords) {
-            if (data[i].recalculated > 39) {
-                val then = data[i]
-                val thenDate = then.timestamp
-
-                val minutesAgo = ((nowDate - thenDate) / (1000.0 * 60))
-                // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
-                change = now.recalculated - then.recalculated
-                val avgDel = change / minutesAgo * 5
-                aapsLogger.debug(LTag.GLUCOSE, "$then minutesAgo=$minutesAgo avgDelta=$avgDel")
-
-                // use the average of all data points in the last 2.5m for all further "now" calculations
-                // if (0 < minutesAgo && minutesAgo < 2.5) {
-                //     // Keep and average all values within the last 2.5 minutes
-                //     nowValueList.add(then.recalculated)
-                //     now.value = average(nowValueList)
-                //     // short_deltas are calculated from everything ~5-15 minutes ago
-                // } else
-                if (minutesAgo in 2.5 .. 17.5) {
-                    shortDeltas.add(avgDel)
-                    // last_deltas are calculated from everything ~5 minutes ago
-                    if (minutesAgo in 2.5 .. 7.5) {
-                        lastDeltas.add(avgDel)
-                    }
-                    // long_deltas are calculated from everything ~20-40 minutes ago
-                } else if (minutesAgo in 17.5 .. 42.5) {
-                    longDeltas.add(avgDel)
-                } else {
-                    // Do not process any more records after >= 42.5 minutes
-                    break
-                }
-            }
-        }
-        val shortAverageDelta = average(shortDeltas)
-        val delta = if (lastDeltas.isEmpty()) {
-            shortAverageDelta
-        } else {
-            average(lastDeltas)
-        }
+        val deltaResult = deltaCalculator.calculateDeltas(data)
 
         return GlucoseStatusSMB(
             glucose = now.recalculated,
             date = nowDate,
             noise = 0.0, //for now set to nothing as not all CGMs report noise
-            shortAvgDelta = shortAverageDelta,
-            delta = delta,
-            longAvgDelta = average(longDeltas),
+            shortAvgDelta = deltaResult.shortAvgDelta,
+            delta = deltaResult.delta,
+            longAvgDelta = deltaResult.longAvgDelta,
         ).also { aapsLogger.debug(LTag.GLUCOSE, it.log(decimalFormatter)) }.asRounded()
     }
 


### PR DESCRIPTION
This is a continuation of https://github.com/nightscout/AndroidAPS/commit/016e4d8e2e59a9ab9020776bdc4733410d2ce410

DeltaCalculator is a class of its own - GlucoseStatusCalculators SMB and AISF were modified accordingly.
Time conversions are being done by kotlin.time
Some "magic numbers" were moved to the companion object to improve readability:
        private const val minBgValue = 39.0
        private const val minShortDeltaMinutes = 2.5
        private const val maxShortDeltaMinutes = 17.5
        private const val minLastDeltaMinutes = 2.5
        private const val maxLastDeltaMinutes = 7.5
        private const val minLongDeltaMinutes = 17.5
        private const val maxLongDeltaMinutes = 42.5
