### PR TITLE
Add receiver intents for the patched Ottai app corresponding to the C…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,8 +95,10 @@
                 <action android:name="com.fanqies.tomatofn.BgEstimate" />
                 <!-- Receiver from GlucoRx Aidex -->
                 <action android:name="com.microtechmd.cgms.aidex.action.BgEstimate" />
-                <!-- Receiver from patched Ottai app -->
+                <!-- Receiver from patched Ottai app (International) -->
                 <action android:name="info.nightscout.androidaps.action.OTTAI_APP" />
+                <!-- Receiver from patched Ottai app (China) -->
+                <action android:name="cn.diyaps.sharing.OT_APP" />
                 <!-- Receiver from patched Syai Tag app -->
                 <action android:name="info.nightscout.androidaps.action.SYAI_TAG_APP" />
             </intent-filter>

--- a/app/src/main/kotlin/app/aaps/receivers/DataReceiver.kt
+++ b/app/src/main/kotlin/app/aaps/receivers/DataReceiver.kt
@@ -71,7 +71,7 @@ open class DataReceiver : DaggerBroadcastReceiver() {
                         it.copyString("data", bundle)
                     }.build()).build()
 
-            Intents.OTTAI_APP                       ->
+            Intents.OTTAI_APP, Intents.OTTAI_APP_CN ->
                 OneTimeWorkRequest.Builder(OttaiPlugin.OttaiWorker::class.java)
                     .setInputData(Data.Builder().also {
                         it.copyString("collection", bundle)

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/receivers/Intents.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/receivers/Intents.kt
@@ -44,8 +44,10 @@ interface Intents {
 
         // Broadcast status
         const val AAPS_BROADCAST = "info.nightscout.androidaps.status"
-        // Patched Ottai App -> AAPS
+        // Patched Ottai App -> AAPS (International)
         const val OTTAI_APP = "info.nightscout.androidaps.action.OTTAI_APP"
+        // Patched Ottai App -> AAPS (China)
+        const val OTTAI_APP_CN = "cn.diyaps.sharing.OT_APP"
         // Patched Syai Tag App -> AAPS
         const val SYAI_TAG_APP = "info.nightscout.androidaps.action.SYAI_TAG_APP"
     }


### PR DESCRIPTION
#3513 
In addition to the configuration mentioned by KORuL, when using the Chinese version, it is still necessary to add the intent name.
Adding this intent name allows the app to receive the newly added Chinese version of Ottai and ensures compatibility with OttaiPlugin.

Chinese version of Ottai:
https://ottai.com.cn/70ICjxAI4i

[Receive Log for Ottai (Chinese Version)](https://github.com/user-attachments/files/22853285/ottai_cn.log)
Please review.
