### PR TITLE
Small fix to time range in the history browser

### DIFF
--- a/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
@@ -264,7 +264,10 @@ class HistoryBrowseActivity : TranslatedDaggerAppCompatActivity() {
 
     private fun adjustTimeRange(start: Long) {
         historyBrowserData.overviewData.fromTime = start
-        historyBrowserData.overviewData.toTime = historyBrowserData.overviewData.fromTime + T.hours(rangeToDisplay.toLong()).msecs()
+        historyBrowserData.overviewData.toTime =
+            historyBrowserData.overviewData.fromTime +
+            T.hours(rangeToDisplay.toLong()).msecs() +
+            100000 // little bit more to avoid wrong rounding - GraphView specific
         historyBrowserData.overviewData.endTime = historyBrowserData.overviewData.toTime
     }
 


### PR DESCRIPTION
As was discussed in a Discord [thread](https://discord.com/channels/629952586895851530/629954570394533889/1412413761972732015) - this aligns the time range extraction to the way it's done in [PreparePredictionsWorker](https://github.com/nightscout/AndroidAPS/blob/master/workflow/src/main/kotlin/app/aaps/workflow/PreparePredictionsWorker.kt#L66).