### PR TITLE
adapt switch over from "sec ago" to "min ago"

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/data/ProcessedDeviceStatusDataImpl.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/data/ProcessedDeviceStatusDataImpl.kt
@@ -108,7 +108,7 @@ class ProcessedDeviceStatusDataImpl @Inject constructor(
                 else                                                                                                                        -> ProcessedDeviceStatusData.Levels.INFO
             }
             string.append("<span style=\"color:${level.toColor()}\">")
-            if (openAPSData.clockSuggested != 0L) string.append(dateUtil.minAgo(rh, openAPSData.clockSuggested)).append(" ")
+            if (openAPSData.clockSuggested != 0L) string.append(dateUtil.minOrSecAgo(rh, openAPSData.clockSuggested)).append(" ")
             string.append("</span>") // color
             return HtmlHelper.fromHtml(string.toString())
         }

--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -226,7 +226,7 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
         if (time == null) return ""
         //val minutes = ((now() - time) / 1000 / 60).toInt()
         val seconds = (now() - time) / 1000
-        if (seconds > 99) {
+        if (seconds > 119) {
             return rh.gs(R.string.minago, (seconds / 60).toInt())
         } else {
             return rh.gs(R.string.secago, seconds.toInt())


### PR DESCRIPTION
This change is in response to a psychological issue highlighted by @olorinmaia . The discussion can be found in the orignal PR https://github.com/nightscout/AndroidAPS/pull/4092. As a compromise the switch over is moved fron 99 sec to 119 sec.

It was especially apparent in AAPSClient when I looked at it recently for the first time. Showing minOrSecAgo is now added there, too for the OAPS status.

