### PR TITLE
Add autotune info to About screen

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -199,6 +199,7 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
                         message += "Flavor: ${BuildConfig.FLAVOR}${BuildConfig.BUILD_TYPE}\n"
                         message += "${rh.gs(app.aaps.plugins.configuration.R.string.configbuilder_nightscoutversion_label)} ${activePlugin.activeNsClient?.detectedNsVersion() ?: rh.gs(app.aaps.plugins.main.R.string.not_available_full)}"
                         if (config.isEngineeringMode()) message += "\n${rh.gs(app.aaps.plugins.configuration.R.string.engineering_mode_enabled)}"
+                        if (config.enableAutotune()) message += "\n${rh.gs(app.aaps.plugins.configuration.R.string.autotune_enabled)}"
                         if (config.isUnfinishedMode()) message += "\nUnfinished mode enabled"
                         if (!fabricPrivacy.fabricEnabled()) message += "\n${rh.gs(app.aaps.core.ui.R.string.fabric_upload_disabled)}"
                         message += rh.gs(app.aaps.core.ui.R.string.about_link_urls)

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotunePlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotunePlugin.kt
@@ -83,7 +83,7 @@ class AutotunePlugin @Inject constructor(
         .pluginName(app.aaps.core.ui.R.string.autotune)
         .shortName(R.string.autotune_shortname)
         .preferencesId(PluginDescription.PREFERENCE_SCREEN)
-        .showInList { config.isEngineeringMode() && config.isDev() }
+        .showInList { config.enableAutotune() }
         .description(R.string.autotune_description),
     ownPreferences = listOf(AutotuneStringKey::class.java),
     aapsLogger, rh, preferences

--- a/plugins/configuration/src/main/res/values/strings.xml
+++ b/plugins/configuration/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="delete_logs">Delete Logs</string>
     <string name="configbuilder_nightscoutversion_label">Nightscout version:</string>
     <string name="engineering_mode_enabled">Engineering mode enabled</string>
+    <string name="autotune_enabled">Autotune enabled</string>
     <string name="log_files">Log files</string>
     <string name="nav_logsettings">Log settings</string>
     <string name="miscellaneous">Miscellaneous</string>


### PR DESCRIPTION
I tried enabling autotune in the dev build and created `enable_autotune`  in `AAPS/extra` folder as a follow up to https://github.com/nightscout/AndroidAPS/commit/659d14b267a242ec18e82526c31f230ba4284cae

I noticed it was not listed in the About screen so I made this PR to add the information in the About screen. See example here:
<img width="785" height="937" alt="image" src="https://github.com/user-attachments/assets/39693e24-60ad-4edb-8480-e3358bc2d926" />

Unfortuately I don't see the Autotune plugin enabled in the build, so I think there is something more to be done.
