### PR TITLE
Changed wait condition, in waitForFinishedThread

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
@@ -239,7 +239,7 @@ class CommandQueueImplementation @Inject constructor(
     }
 
     fun waitForFinishedThread() {
-        while (workIsRunning() && waitingForDisconnect) {
+        while (workIsRunning() || waitingForDisconnect) {
             aapsLogger.debug(LTag.PUMPQUEUE, "Waiting for previous work finish")
             SystemClock.sleep(500)
         }


### PR DESCRIPTION
Changed wait condition, in waitForFinishedThread. 
Change waiting while workIsRunning AND waitingForDisconnect to waiting while workIsRunning OR waitingForDisconnect.

Hopefully this will fix freezing of the app 
See this issue: https://github.com/nightscout/AndroidAPS/issues/3984


