### PR TITLE
Update objective 3, first question wording.

### DIFF
--- a/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/objectives/objectives/Objective2.kt
+++ b/plugins/constraints/src/main/kotlin/app/aaps/plugins/constraints/objectives/objectives/Objective2.kt
@@ -19,7 +19,7 @@ class Objective2 @Inject constructor(
         tasks.add(
             ExamTask(this, R.string.prerequisites_label, R.string.prerequisites_what, "prerequisites")
                 .option(Option(R.string.prerequisites_nightscout, true))
-                .option(Option(R.string.prerequisites_computer, true))
+                .option(Option(R.string.prerequisites_build, true))
                 .option(Option(R.string.prerequisites_pump, true))
                 .option(Option(R.string.prerequisites_beanandroiddeveloper, false))
                 .hint(Hint(R.string.prerequisites_hint1))

--- a/plugins/constraints/src/main/res/values-bg-rBG/exam.xml
+++ b/plugins/constraints/src/main/res/values-bg-rBG/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Веднъж зададени и потвърдени, тези стойности не трябва да се променят с течение на времето.</string>
     <string name="prerequisites_label">Предпоставки</string>
     <string name="prerequisites_what">Какво е важно за настройка и използване на AAPS?</string>
-    <string name="prerequisites_computer">Компютър с инсталирано и конфигурирано Android Studio.</string>
     <string name="prerequisites_pump">Съвместима инсулинова помпа, ако планирате да използвате затворен цикъл.</string>
     <string name="prerequisites_nightscout">Nightscout, за водене на регистър на всички данни и преглед на настройките.</string>
     <string name="prerequisites_beanandroiddeveloper">Опит в програмирането или редактирането на програмен код.</string>

--- a/plugins/constraints/src/main/res/values-ca-rES/exam.xml
+++ b/plugins/constraints/src/main/res/values-ca-rES/exam.xml
@@ -47,7 +47,6 @@
     <string name="basaltest_fixed">Un cop configurats i validats, aquests valors no haurien de canviar amb el temps.</string>
     <string name="prerequisites_label">Prerequisits</string>
     <string name="prerequisites_what">Què seria essencial per configurar i utilitzar AndroidAPS?</string>
-    <string name="prerequisites_computer">Un ordinador amb Android Studio instal·lat i configurat.</string>
     <string name="prerequisites_pump">Una bomba d\'insulina compatible, si és que voleu acabar fent servir un llaç tancat.</string>
     <string name="prerequisites_nightscout">Nightscout, per tenir un registre amb totes els dades i poder revisar la configuració.</string>
     <string name="prerequisites_beanandroiddeveloper">Experiència en programació o edició de codi.</string>

--- a/plugins/constraints/src/main/res/values-cs-rCZ/exam.xml
+++ b/plugins/constraints/src/main/res/values-cs-rCZ/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/cs/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Požadavky</string>
     <string name="prerequisites_what">Co je nezbytné pro nastavení a používání AAPS?</string>
-    <string name="prerequisites_computer">Počítač s nainstalovanou a konfigurovanou aplikací Android Studio.</string>
     <string name="prerequisites_pump">Kompatibilní inzulínová pumpa, pokud plánujete spuštění uzavřené smyčky.</string>
     <string name="prerequisites_nightscout">Nightscout pro záznam všech dat a kontrolu nastavení.</string>
     <string name="prerequisites_beanandroiddeveloper">Zkušenosti s programováním nebo úpravou kódu.</string>

--- a/plugins/constraints/src/main/res/values-da-rDK/exam.xml
+++ b/plugins/constraints/src/main/res/values-da-rDK/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Når de er angivet og valideret, skal disse værdier ikke ændres over tid.</string>
     <string name="prerequisites_label">Forudsætninger</string>
     <string name="prerequisites_what">Hvad er afgørende for at opsætte og bruge AAPS?</string>
-    <string name="prerequisites_computer">En computer med Android Studio installeret og konfigureret.</string>
     <string name="prerequisites_pump">En kompatibel insulinpumpe, hvis du har planer om at køre lukket Loop.</string>
     <string name="prerequisites_nightscout">Nightscout, for at holde en log over alle data og gennemgå indstillinger.</string>
     <string name="prerequisites_beanandroiddeveloper">Erfaring med programmering eller redigering af kode.</string>

--- a/plugins/constraints/src/main/res/values-de-rDE/exam.xml
+++ b/plugins/constraints/src/main/res/values-de-rDE/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Einmal gesetzt und überprüft, sollten sich diese Werte im Laufe der Zeit nicht ändern.</string>
     <string name="prerequisites_label">Voraussetzungen</string>
     <string name="prerequisites_what">Was ist wichtig für die Einrichtung und Nutzung von AndroidAPS?</string>
-    <string name="prerequisites_computer">Ein Computer mit installiertem und konfiguriertem Android Studio.</string>
     <string name="prerequisites_pump">Eine kompatible Insulinpumpe, wenn Du einen Closed Loop planst.</string>
     <string name="prerequisites_nightscout">Nightscout, um ein Protokoll aller Daten zu erhalten und Einstellungen zu überprüfen.</string>
     <string name="prerequisites_beanandroiddeveloper">Erfahrung im Programmieren oder Bearbeiten von Codes.</string>

--- a/plugins/constraints/src/main/res/values-el-rGR/exam.xml
+++ b/plugins/constraints/src/main/res/values-el-rGR/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Μόλις ρυθμιστούν και επικυρωθούν, οι τιμές αυτές δεν θα πρέπει να μεταβάλλονται με την πάροδο του χρόνου.</string>
     <string name="prerequisites_label">Προϋποθέσεις</string>
     <string name="prerequisites_what">Τι είναι ουσιώδες για τη ρύθμιση και τη χρήση του AAPS;</string>
-    <string name="prerequisites_computer">Ένας υπολογιστής με εγκατεστημένο και ρυθμισμένο το Android Studio.</string>
     <string name="prerequisites_pump">Μια συμβατή αντλία ινσουλίνης αν σκοπεύετε να τρέξετε ένα κλειστό κύκλωμα.</string>
     <string name="prerequisites_nightscout">Nightscout, για να κρατήσετε ένα αρχείο καταγραφής όλων των δεδομένων και την αναθεώρηση των ρυθμίσεων.</string>
     <string name="prerequisites_beanandroiddeveloper">Εμπειρία στον προγραμματισμό ή την επεξεργασία κώδικα.</string>

--- a/plugins/constraints/src/main/res/values-es-rES/exam.xml
+++ b/plugins/constraints/src/main/res/values-es-rES/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/es/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Requisitos previos</string>
     <string name="prerequisites_what">¿Qué es esencial para configurar y utilizar AAPS?</string>
-    <string name="prerequisites_computer">Una computadora con Android Studio instalado y configurado.</string>
     <string name="prerequisites_pump">Una bomba de insulina compatible, si planeas usar el sistema en modo bucle cerrado.</string>
     <string name="prerequisites_nightscout">Nightscout, para tener un registro de los datos y revisar los parámetros de configuración.</string>
     <string name="prerequisites_beanandroiddeveloper">Experiencia programando o editando código.</string>

--- a/plugins/constraints/src/main/res/values-fr-rFR/exam.xml
+++ b/plugins/constraints/src/main/res/values-fr-rFR/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/fr/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Conditions préalables</string>
     <string name="prerequisites_what">Qu\'est-ce qui est essentiel pour mettre en place et utiliser AAPS ?</string>
-    <string name="prerequisites_computer">Un ordinateur avec Android Studio installé et configuré.</string>
     <string name="prerequisites_pump">Une pompe à insuline compatible si vous avez l\'intention d\'exécuter une boucle fermée.</string>
     <string name="prerequisites_nightscout">Nightscout, pour conserver un historique de toutes les données et revoir les paramètres.</string>
     <string name="prerequisites_beanandroiddeveloper">Avoir de l\'expérience en programmation ou en édition de code.</string>

--- a/plugins/constraints/src/main/res/values-it-rIT/exam.xml
+++ b/plugins/constraints/src/main/res/values-it-rIT/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Prerequisiti</string>
     <string name="prerequisites_what">Cosa è essenziale per configurare e usare AAPS?</string>
-    <string name="prerequisites_computer">Un computer con Android Studio installato e configurato.</string>
     <string name="prerequisites_pump">Un microinfusore compatibile se stai pianificando di eseguire un loop chiuso.</string>
     <string name="prerequisites_nightscout">Nightscout, per tenere un registro di tutti i dati e rivedere le impostazioni.</string>
     <string name="prerequisites_beanandroiddeveloper">Esperienza in programmazione o modifica di codice.</string>

--- a/plugins/constraints/src/main/res/values-iw-rIL/exam.xml
+++ b/plugins/constraints/src/main/res/values-iw-rIL/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">לאחר שהוגדרו ואומתו, ערכים אלה אינם צריכים להשתנות לאורך הזמן.</string>
     <string name="prerequisites_label">דרישות מקדימות</string>
     <string name="prerequisites_what">מה חיוני להגדרה ולשימוש ב-AndroidAPS?</string>
-    <string name="prerequisites_computer">מחשב עם Android Studio מותקן ומוגדר.</string>
     <string name="prerequisites_pump">משאבת אינסולין מתאימה אם אתם מתכננים להפעיל לולאה סגורה.</string>
     <string name="prerequisites_nightscout">נייטסקאוט, כדי לשמור יומן של כל הנתונים וסקירה של ההגדרות.</string>
     <string name="prerequisites_beanandroiddeveloper">ניסיון בתכנות או בעריכת קוד.</string>

--- a/plugins/constraints/src/main/res/values-ko-rKR/exam.xml
+++ b/plugins/constraints/src/main/res/values-ko-rKR/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">한 번 설정하고 확인하면, 이 값은 계속 변하면 안됨.</string>
     <string name="prerequisites_label">기본 준비사항</string>
     <string name="prerequisites_what">AAPS를 설정하고 사용하기 위해 필수적인 것은 무엇입니까?</string>
-    <string name="prerequisites_computer">Android Studio가 설치되고 환경설정된 컴퓨터</string>
     <string name="prerequisites_pump">Closed loop을 사용할 계획이라면 호환되는 인슐린 펌프</string>
     <string name="prerequisites_nightscout">모든 데이터의 log를 보관하고 설정을 검토하기 위한 Nightscout</string>
     <string name="prerequisites_beanandroiddeveloper">프로그래밍이나 코딩을 해 본 경험</string>

--- a/plugins/constraints/src/main/res/values-lt-rLT/exam.xml
+++ b/plugins/constraints/src/main/res/values-lt-rLT/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Būtinosios sąlygos</string>
     <string name="prerequisites_what">Ko reikia norint įvesti nustatymus ir pradėti naudoti AndroidAPS?</string>
-    <string name="prerequisites_computer">Kompiuterio su įdiegta ir sukonfigūruota Android Studio programa.</string>
     <string name="prerequisites_pump">Tinkamos insulino pompos, jei ketinate naudoti uždarą ciklą.</string>
     <string name="prerequisites_nightscout">Nightscout, kad galima būtų išsaugoti ir peržiūrėti visų duomenų bei nustatymų istoriją.</string>
     <string name="prerequisites_beanandroiddeveloper">Turėti programavimo ar kodo redagavimo patirties.</string>

--- a/plugins/constraints/src/main/res/values-nb-rNO/exam.xml
+++ b/plugins/constraints/src/main/res/values-nb-rNO/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Forutsetninger</string>
     <string name="prerequisites_what">Hva er nødvendig for å sette opp og bruke AAPS?</string>
-    <string name="prerequisites_computer">En computer hvor Android Studio er installert og konfigurert.</string>
     <string name="prerequisites_pump">En kompatibel insulinpumpe hvis du planlegger å kjøre lukket loop.</string>
     <string name="prerequisites_nightscout">Nightscout, for å logge alle dine data og kontrollere dine innstillinger.</string>
     <string name="prerequisites_beanandroiddeveloper">Erfaring fra programmering eller redigering av kode.</string>

--- a/plugins/constraints/src/main/res/values-nl-rNL/exam.xml
+++ b/plugins/constraints/src/main/res/values-nl-rNL/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/nl/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Vereisten</string>
     <string name="prerequisites_what">Wat is minimaal nodig om AAPS in te stellen en te gebruiken?</string>
-    <string name="prerequisites_computer">Een computer waarop Android Studio is geïnstalleerd en geconfigureerd.</string>
     <string name="prerequisites_pump">Een ondersteunde insulinepomp als je van plan bent een closed loop te gebruiken.</string>
     <string name="prerequisites_nightscout">Nightscout, om een logboek van alle gegevens bij te houden en instellingen te bekijken.</string>
     <string name="prerequisites_beanandroiddeveloper">Ervaar met programmeren of code aanpassen.</string>

--- a/plugins/constraints/src/main/res/values-pl-rPL/exam.xml
+++ b/plugins/constraints/src/main/res/values-pl-rPL/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Wymagania wstępne</string>
     <string name="prerequisites_what">Co jest niezbędne do ustawienia i używania AAPS?</string>
-    <string name="prerequisites_computer">Komputer z zainstalowanym i skonfigurowanym programem Android Studio.</string>
     <string name="prerequisites_pump">Kompatybilna pompa insulinowa, jeśli planujesz uruchomienie pętli zamkniętej.</string>
     <string name="prerequisites_nightscout">Nightscout, aby zachować dziennik wszystkich danych i przeglądać ustawienia.</string>
     <string name="prerequisites_beanandroiddeveloper">Doświadczenie w programowaniu lub edycji kodu.</string>

--- a/plugins/constraints/src/main/res/values-pt-rBR/exam.xml
+++ b/plugins/constraints/src/main/res/values-pt-rBR/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Uma vez definido e validado, estes valores não deveriam mudar ao longo do tempo.</string>
     <string name="prerequisites_label">Pré-requisitos</string>
     <string name="prerequisites_what">O que é essencial para configurar e usar o AndroidAPS?</string>
-    <string name="prerequisites_computer">Um computador com o Android Studio instalado e configurado.</string>
     <string name="prerequisites_pump">Uma bomba de insulina compatível se você pretender usar o loop fechado.</string>
     <string name="prerequisites_nightscout">Nightscout, para manter um registro de todos os dados e revisar configurações.</string>
     <string name="prerequisites_beanandroiddeveloper">Experiência na programação ou editação de código.</string>

--- a/plugins/constraints/src/main/res/values-pt-rPT/exam.xml
+++ b/plugins/constraints/src/main/res/values-pt-rPT/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Uma vez definido e validado, estes valores não devem mudar ao longo do tempo.</string>
     <string name="prerequisites_label">Pré-requisitos</string>
     <string name="prerequisites_what">O que é essencial para configurar e utilizar a AndroidAPS?</string>
-    <string name="prerequisites_computer">Um computador com Android Studio instalado e configurado.</string>
     <string name="prerequisites_pump">Uma bomba de insulina compatível se planeia correr um closed loop.</string>
     <string name="prerequisites_nightscout">Nightscout, para manter um registo de todos os dados e rever as configurações.</string>
     <string name="prerequisites_beanandroiddeveloper">Experiência na programação ou edição de código.</string>

--- a/plugins/constraints/src/main/res/values-ro-rRO/exam.xml
+++ b/plugins/constraints/src/main/res/values-ro-rRO/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">Odată setate și validate, aceste valori nu ar trebui să se modifice în timp.</string>
     <string name="prerequisites_label">Cerinţe preliminare</string>
     <string name="prerequisites_what">Ce este esențial pentru crearea și utilizarea AAPS?</string>
-    <string name="prerequisites_computer">Un computer cu Android Studio instalat și configurat.</string>
     <string name="prerequisites_pump">O pompă de insulină compatibilă dacă intenţionaţi să rulaţi o buclă închisă.</string>
     <string name="prerequisites_nightscout">Nightscout, pentru a păstra un jurnal cu toate datele și pentru evaluarea setărilor.</string>
     <string name="prerequisites_beanandroiddeveloper">Experiență în programare sau editare cod.</string>

--- a/plugins/constraints/src/main/res/values-ru-rRU/exam.xml
+++ b/plugins/constraints/src/main/res/values-ru-rRU/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/ru/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Предварительные требования</string>
     <string name="prerequisites_what">Что необходимо для настройки и использования AAPS?</string>
-    <string name="prerequisites_computer">Компьютер с установленной и настроенной Android Studio.</string>
     <string name="prerequisites_pump">Совместимая инсулиновая помпа, если вы планируете использовать замкнутый цикл.</string>
     <string name="prerequisites_nightscout">Nightscout, для записи всех данных и обзора настроек.</string>
     <string name="prerequisites_beanandroiddeveloper">Опыт программирования или редактирования кода.</string>

--- a/plugins/constraints/src/main/res/values-sk-rSK/exam.xml
+++ b/plugins/constraints/src/main/res/values-sk-rSK/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/cs/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Požiadavky</string>
     <string name="prerequisites_what">Čo je nevyhnutné pre nastavenie a používanie AAPS?</string>
-    <string name="prerequisites_computer">Počítač s nainštalovanou a nakonfigurovanou aplikáciou Android Studio.</string>
     <string name="prerequisites_pump">Kompatibilná inzulínová pumpa, pokiaľ plánujete spustenie uzavretého okruhu.</string>
     <string name="prerequisites_nightscout">Nightscout pre záznam všetkých dát a kontrolu nastavení.</string>
     <string name="prerequisites_beanandroiddeveloper">Skúsenosti s programovaním, alebo úpravou kódu.</string>

--- a/plugins/constraints/src/main/res/values-sv-rSE/exam.xml
+++ b/plugins/constraints/src/main/res/values-sv-rSE/exam.xml
@@ -54,7 +54,6 @@
     <string name="basaltest_fixed">När du väl har ställt in och validerat dessa värden bör dessa värden inte ändras över tiden.</string>
     <string name="prerequisites_label">Förutsättningar</string>
     <string name="prerequisites_what">Vad är nödvändigt för att installera och använda AAPS?</string>
-    <string name="prerequisites_computer">En dator med Android Studio installerad och konfigurerad.</string>
     <string name="prerequisites_pump">En kompatibel insulinpump om du planerar att köra closed loop.</string>
     <string name="prerequisites_nightscout">Nightscout, för att logga allt data och få en överblick över inställningar.</string>
     <string name="prerequisites_beanandroiddeveloper">Erfarenhet av programmering eller redigering av kod.</string>

--- a/plugins/constraints/src/main/res/values-tr-rTR/exam.xml
+++ b/plugins/constraints/src/main/res/values-tr-rTR/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Önkoşullar</string>
     <string name="prerequisites_what">AAPS\'yi kurmak ve kullanmak için gerekenler nelerdir?</string>
-    <string name="prerequisites_computer">Android Studio\'nun kurulu ve yapılandırılmış olduğu bir bilgisayar.</string>
     <string name="prerequisites_pump">Kapalı devre çalıştırmayı planlıyorsanız uyumlu bir insülin pompası.</string>
     <string name="prerequisites_nightscout">Tüm verilerin kaydını tutmak ve ayarları gözden geçirmek için Nightscout sitesi</string>
     <string name="prerequisites_beanandroiddeveloper">Programlama veya kod düzenleme konusunda deneyim.</string>

--- a/plugins/constraints/src/main/res/values-vi-rVN/exam.xml
+++ b/plugins/constraints/src/main/res/values-vi-rVN/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Điều kiện cần</string>
     <string name="prerequisites_what">Điều gì là cần thiết để cài đặt và sử dụng AAPS?</string>
-    <string name="prerequisites_computer">Một máy tính đã cài đặt và cấu hình Android Studio.</string>
     <string name="prerequisites_pump">Một bơm insulin tương thích nếu bạn dự định chạy vòng lặp kín (closed loop).</string>
     <string name="prerequisites_nightscout">Nightscout, để lưu nhật ký toàn bộ dữ liệu và xem lại các thiết lập.</string>
     <string name="prerequisites_beanandroiddeveloper">Kinh nghiệm về lập trình hoặc chỉnh sửa mã.</string>

--- a/plugins/constraints/src/main/res/values-zh-rCN/exam.xml
+++ b/plugins/constraints/src/main/res/values-zh-rCN/exam.xml
@@ -43,7 +43,6 @@
     <string name="basaltest_weekly">每周至少一次。</string>
     <string name="basaltest_fixed">一旦设置和验证，这些值不应随着时间而变化。</string>
     <string name="prerequisites_label">先决条件</string>
-    <string name="prerequisites_computer">一台安装和配置了Android Studio软件的计算机。</string>
     <string name="prerequisites_pump">一个兼容的胰岛素泵，如果您计划运行闭合模式。</string>
     <string name="prerequisites_nightscout">Nightscout, 以保存所有数据的日志和检查设置。</string>
     <string name="prerequisites_beanandroiddeveloper">编程或编辑代码方面的经验。</string>

--- a/plugins/constraints/src/main/res/values-zh-rTW/exam.xml
+++ b/plugins/constraints/src/main/res/values-zh-rTW/exam.xml
@@ -63,7 +63,6 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/zh-tw/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">前置條件</string>
     <string name="prerequisites_what">設置和使用AAPS的必要條件是什麼？</string>
-    <string name="prerequisites_computer">一台安裝並配置了Android Studio的電腦。</string>
     <string name="prerequisites_pump">如果計劃運行閉環，則需要一個相容的胰島素幫浦。</string>
     <string name="prerequisites_nightscout">Nightscout，用於紀錄所有資料並檢查設定。</string>
     <string name="prerequisites_beanandroiddeveloper">有編程或編輯代碼的經驗。</string>

--- a/plugins/constraints/src/main/res/values/exam.xml
+++ b/plugins/constraints/src/main/res/values/exam.xml
@@ -63,7 +63,7 @@
     <string name="basaltest_hint1">https://wiki.aaps.app/en/latest/SettingUpAaps/YourAapsProfile.html</string>
     <string name="prerequisites_label">Prerequisites</string>
     <string name="prerequisites_what">What is essential to set up and use AAPS?</string>
-    <string name="prerequisites_computer">A computer with Android Studio installed and configured.</string>
+    <string name="prerequisites_build">A way to build AAPS. Either via a browser or a computer with Android Studio installed.</string>
     <string name="prerequisites_pump">A compatible insulin pump if you are planning to run a closed loop.</string>
     <string name="prerequisites_nightscout">Nightscout, to keep a log of all data and review settings.</string>
     <string name="prerequisites_beanandroiddeveloper">Experience in programming or editing code.</string>


### PR DESCRIPTION
One of the answers to Objective 3 (index 2), question 1 felt a little out-of-date or inaccurate.

Original question:
> Prerequisites
> What is essential to set up and use AAPS?

Before:
> A computer with Android Studio installed and configured.

After:
> A way to build AAPS. Either via a browser or a computer with Android Studio installed.


This PR updates the wording. Please do let me know if something different should be done to the translations (I'm assuming deleting them will lead to new translations completed via crowdin).