### PR TITLE
Only use ntp1.aliyun.com as the NTP server for zh-CN

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/locale/LocaleDependentSettingImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/locale/LocaleDependentSettingImpl.kt
@@ -10,8 +10,9 @@ class LocaleDependentSettingImpl @Inject constructor() : LocaleDependentSetting 
 
     private val language get() = Resources.getSystem().configuration.locales[0]
     override val ntpServer: String
-        get() =
-            if (language.language.startsWith("zh")) "ntp1.aliyun.com"
-            else "time.google.com"
-
+        get() {
+            val lang = language.language
+            val country = language.country
+            return if (lang == "zh" && country.equals("CN", ignoreCase = true)) "ntp1.aliyun.com" else "time.google.com"
+        }
 }


### PR DESCRIPTION

<img width="1080" height="2400" alt="圖片" src="https://github.com/user-attachments/assets/3c7e70a1-7000-4a66-a8d5-be2dd257613c" />

Because there are multiple language variants labeled as zh, determining only by the language without checking the region may cause issues for non-CN regions.
Therefore, limit CN regions to connect to aliyun only.

please review