### PR TITLE
increase maximum basal rate limit for Equil pump from 1.5U/hr to 10U/hr

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdSettingSet.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdSettingSet.kt
@@ -31,7 +31,7 @@ class CmdSettingSet(
         val fastBolus = Utils.intToTwoBytes(0)
         val occlusion = Utils.intToTwoBytes(2800)
         val insulinUnit = Utils.intToTwoBytes(8)
-        val basalThreshold = Utils.intToTwoBytes(240)
+        val basalThreshold = Utils.intToTwoBytes(10 * 160)
         val bolusThreshold = Utils.intToTwoBytes(bolusThresholdStep)
         val data = Utils.concat(
             indexByte, equilCmd, useTime, autoCloseTime,


### PR DESCRIPTION
increase maximum basal rate limit for Equil pump from 1.5U/hr to 10U/hr