### PR TITLE
Equil Maximum basal rate limit 10 U/hr

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilConst.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilConst.kt
@@ -7,7 +7,7 @@ object EquilConst {
     const val EQUIL_BLE_NEXT_CMD: Long = 150
     const val EQUIL_SUPPORT_LEVEL = 5.3f
     const val EQUIL_BOLUS_THRESHOLD_STEP = 1600
-    const val EQUIL_BASAL_THRESHOLD_STEP = 240
+    const val EQUIL_BASAL_THRESHOLD_STEP = 10 * 160 // Maximum basal rate limit 10 U/hr
     const val EQUIL_STEP_MAX = 32000
     const val EQUIL_STEP_FILL = 160
     const val EQUIL_STEP_AIR = 120


### PR DESCRIPTION
During the pairing of the Equil pump body, the pump configuration was written via the configuration interface, which limited the maximum basal rate to 1.5 U/hr. As a result, subsequent commands attempting to set a basal rate exceeding 1.5 U/hr were rejected by the pump.