### PR TITLE
Fix UserEntry item for long ValueWithUnit + notes

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/activities/fragments/TreatmentsUserEntryFragment.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/activities/fragments/TreatmentsUserEntryFragment.kt
@@ -135,7 +135,7 @@ class TreatmentsUserEntryFragment : DaggerFragment(), MenuProvider {
             holder.binding.time.text = dateUtil.timeStringWithSeconds(current.timestamp)
             holder.binding.action.text = userEntryPresentationHelper.actionToColoredString(current.action)
             holder.binding.notes.text = current.note
-            holder.binding.notes.visibility = (current.note != "").toVisibility()
+            holder.binding.notes.visibility = (current.note.isNotEmpty()).toVisibility()
             holder.binding.iconSource.setImageResource(userEntryPresentationHelper.iconId(current.source))
             holder.binding.values.text = userEntryPresentationHelper.listToPresentationString(current.values)
             holder.binding.values.visibility = (holder.binding.values.text != "").toVisibility()

--- a/ui/src/main/res/layout/treatments_user_entry_item.xml
+++ b/ui/src/main/res/layout/treatments_user_entry_item.xml
@@ -84,17 +84,17 @@
                 android:textStyle="bold"
                 tools:text="Values with units" />
 
-            <TextView
-                android:id="@+id/notes"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="20dp"
-                android:paddingEnd="10dp"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                tools:ignore="RtlSymmetry"
-                tools:text="Notes" />
-
         </LinearLayout>
+
+        <TextView
+            android:id="@+id/notes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="20dp"
+            android:paddingEnd="10dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            tools:ignore="RtlSymmetry"
+            tools:text="Notes" />
 
     </LinearLayout>
 


### PR DESCRIPTION
Move Notes in a third row (this also improve readability)
- issue is when you have "long strings" for `valueWithUnits` and additionaly a note (with not enough space to show the note)

<img width="900" height="876" alt="image" src="https://github.com/user-attachments/assets/7b49929b-ae28-4762-8297-ddf8d6be3bbb" />
