### PR TITLE
Increase Max value for AAPS 5Min absorption limit in preferences. As …

### DIFF
--- a/core/keys/src/main/kotlin/app/aaps/core/keys/DoubleKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/DoubleKey.kt
@@ -33,7 +33,7 @@ enum class DoubleKey(
     ApsMaxCurrentBasalMultiplier("openapsama_current_basal_safety_multiplier", 4.0, 1.0, 10.0, defaultedBySM = true),
     ApsAmaBolusSnoozeDivisor("bolussnooze_dia_divisor", 2.0, 1.0, 10.0, defaultedBySM = true),
     ApsAmaMin5MinCarbsImpact("openapsama_min_5m_carbimpact", 3.0, 1.0, 12.0, defaultedBySM = true),
-    ApsSmbMin5MinCarbsImpact("openaps_smb_min_5m_carbimpact", 8.0, 1.0, 12.0, defaultedBySM = true),
+    ApsSmbMin5MinCarbsImpact("openaps_smb_min_5m_carbimpact", 8.0, 1.0, 24.0, defaultedBySM = true),
     AbsorptionCutOff("absorption_cutoff", 6.0, 4.0, 10.0),
     AbsorptionMaxTime("absorption_maxtime", 6.0, 4.0, 10.0),
     AutosensMin("autosens_min", 0.7, 0.1, 1.0, defaultedBySM = true, hideParentScreenIfHidden = true),


### PR DESCRIPTION
As discussed on [Issue#3976](https://github.com/nightscout/AndroidAPS/issues/3976)