### PR TITLE
Omnipod DASH - adressing race condition on connection startup AAPS 3.3.2.1 Android 16

### DIFF
--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
@@ -43,8 +43,8 @@ class BleCommCallbacks(
         super.onConnectionStateChange(gatt, status, newState)
         if (newState == BluetoothProfile.STATE_CONNECTED && status == BluetoothGatt.GATT_SUCCESS) {
             aapsLogger.debug(LTag.PUMPBTCOMM, "OnConnectionStateChange delaying gattConnected event by $SLEEP_AFTER_CONNECT_GATT ms")
-            CoroutineScope(Dispatchers.Main).launch {
-                // give GATT a chance to configure encrypt, race condition bt stack.
+            CoroutineScope(Dispatchers.IO).launch {
+                // give GATT a chance to configure encryption, race condition bt stack.
                 delay(SLEEP_AFTER_CONNECT_GATT)
                 aapsLogger.debug(LTag.PUMPBTCOMM, "OnConnectionStateChange now delivering gattConnected")
 

--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
@@ -11,6 +11,10 @@ import app.aaps.core.utils.toHex
 import app.aaps.pump.omnipod.dash.driver.comm.io.CharacteristicType.Companion.byValue
 import app.aaps.pump.omnipod.dash.driver.comm.io.IncomingPackets
 import app.aaps.pump.omnipod.dash.driver.comm.session.DisconnectHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CountDownLatch
@@ -38,7 +42,14 @@ class BleCommCallbacks(
         aapsLogger.debug(LTag.PUMPBTCOMM, "OnConnectionStateChange with status/state: $status/$newState")
         super.onConnectionStateChange(gatt, status, newState)
         if (newState == BluetoothProfile.STATE_CONNECTED && status == BluetoothGatt.GATT_SUCCESS) {
-            connected.countDown()
+            aapsLogger.debug(LTag.PUMPBTCOMM, "OnConnectionStateChange delaying gattConnected event by $SLEEP_AFTER_CONNECT_GATT ms")
+            CoroutineScope(Dispatchers.Main).launch {
+                // give GATT a chance to configure encrypt, race condition bt stack.
+                delay(SLEEP_AFTER_CONNECT_GATT)
+                aapsLogger.debug(LTag.PUMPBTCOMM, "OnConnectionStateChange now delivering gattConnected")
+
+                connected.countDown()
+            }
         }
         if (newState == BluetoothProfile.STATE_DISCONNECTED) {
             // If status == SUCCESS, it means that we initiated the disconnect.
@@ -225,5 +236,7 @@ class BleCommCallbacks(
     companion object {
 
         private const val WRITE_CONFIRM_TIMEOUT_MS = 10 // the confirmation queue should be empty anyway
+
+        const val SLEEP_AFTER_CONNECT_GATT = 1000L
     }
 }


### PR DESCRIPTION
When I switched to my new Phone, a Google Pixel 10 Pro XL, I noticed that the Omnipod DASH did no longer work reliably.

The symptom was a cycle of
  connecting -> handshaking -> connecting -> ....

Looking at system logs, I noticed:

<pre>
11-12 08:20:40.962  2824  3204 I bt_bta_gattc: system/bta/gatt/bta_gattc_act.cc:537 bta_gattc_conn: Connected to xx:xx:xx:xx:8a:d9, robust caching support is 0
11-12 08:20:40.984  2824  3393 W bt_btm_sec: system/stack/btm/btm_sec.cc:874 BTM_SetEncryption: Security Manager: BTM_SetEncryption busy, enqueue request
11-12 08:20:41.043  2824  3204 W smp_act : system/stack/smp/smp_act.cc:2086 smp_link_encrypted: SMP state machine busy so skipping encryption enable:1 device:xx:xx:xx:xx:8a:d9

11-12 08:20:41.058 24799 24933 D PUMPBTCOMM: [binder:24799_4]: [BleCommCallbacks.onConnectionStateChange():42]: OnConnectionStateChange with status/state: 0/2

11-12 08:20:41.123  2824  3393 E bt_btif_gattc: system/btif/src/btif_gatt_client.cc:270 btif_gattc_upstreams_evt: Unhandled event (17)!
</pre>

Note that
      BTA_GATTC_ENC_CMPL_CB_EVT = 17,   /* encryption complete callback event */

I.e., the encryption completed log message comes after the bluetooth callback onConnectionStateChange has been called, causing the call to discoverServices() to happen when encryption has not been completely setup.


This PR changes the behavior such to add a small delay in the OnConnectionStateChange handler waiting 1 second so that encryption can complete before discover services is called.


<img width="2932" height="277" alt="image" src="https://github.com/user-attachments/assets/9035f7e4-ed1f-4e6f-94e7-cfca704982c7" />

Now, the logs show that there is a 1 second delay before discoverServices is called.

<pre>
11-12 08:20:42.065 24799 24799 D PUMPBTCOMM: [main]: [BleCommCallbacks$onConnectionStateChange$1.invokeSuspend():49]: OnConnectionStateChange now delivering gattConnected
11-12 08:20:42.070 24799 24970 D PUMPBTCOMM: [RxCachedThreadScheduler-52]: [Connection.connectionState():174]: GATT connection state: 2

FVM now discoverServices IMMEDIATELY AFTER RECEIVING, i.e., less than 100msec later (which could be less than it takes to encrypt the link, see above)
11-12 08:20:42.071 24799 24970 D PUMPBTCOMM: [RxCachedThreadScheduler-52]: [ServiceDiscoverer.discoverServices():28]: Discovering services
</pre>


With this change, I did not have problems with my last 3 Pods.

Attached is an annotated log with this change:
[2025-11-12 previous pod - with paring - sample-event17-delay - working.txt](https://github.com/user-attachments/files/23566612/2025-11-12.previous.pod.-.with.paring.-.sample-event17-delay.-.working.txt)

Could someone with similar issues please verify

