### PR TITLE
Refactoring Medtrum patch age on pump tab (cleanup code, better l10n)

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
@@ -81,6 +81,8 @@ interface DateUtil {
     //Map:{DAYS=1, HOURS=3, MINUTES=46, SECONDS=40, MILLISECONDS=0, MICROSECONDS=0, NANOSECONDS=0}
     fun computeDiff(date1: Long, date2: Long): Map<TimeUnit, Long>
     fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String
+    fun timeAgoFullString(milliseconds: Long, rh: ResourceHelper): String
+
     fun niceTimeScalar(time: Long, rh: ResourceHelper): String
     fun qs(x: Double, numDigits: Int): String
     fun formatHHMM(timeAsSeconds: Int): String

--- a/core/interfaces/src/main/res/values/strings.xml
+++ b/core/interfaces/src/main/res/values/strings.xml
@@ -14,12 +14,18 @@
     <string name="hoursago">%1$.1fh ago</string>
     <string name="days_ago">%1$.1f days ago</string>
     <string name="days_ago_round">%1$.0f days ago</string>
-    <string name="day_hours_ago">%1$s day %2$s hours ago</string>
-    <string name="days_hours_ago">%1$s days %2$s hours ago</string>
-    <string name="hour_ago">%1$s hour ago</string>
-    <string name="hours_ago">%1$s hours ago</string>
-    <string name="minutes_ago">%1$s minutes ago</string>
-    <string name="moment_ago">a moment ago</string>
+    <plurals name="plurals_day_hour_ago">
+        <item quantity="one">%1$s day %2$s hours ago</item>
+        <item quantity="other">%1$s dayS %2$s hours ago</item>
+    </plurals>
+    <plurals name="plurals_hour_ago">
+        <item quantity="one">%1$s hour ago</item>
+        <item quantity="other">%1$s hours ago</item>
+    </plurals>
+    <plurals name="plurals_minute_ago">
+        <item quantity="one">a moment ago</item>
+        <item quantity="other">%1$s minutes ago</item>
+    </plurals>
     <string name="seconds_ago">seconds ago</string>
     <string name="in_days">in %1$.0f days</string>
     <string name="in_days_round">in %1$.0f days</string>

--- a/core/interfaces/src/main/res/values/strings.xml
+++ b/core/interfaces/src/main/res/values/strings.xml
@@ -12,9 +12,15 @@
     <string name="secago">%1$ds ago</string>
     <string name="minago_long">%1$d minutes ago</string>
     <string name="hoursago">%1$.1fh ago</string>
-    <string name="time_ago">ago</string>
     <string name="days_ago">%1$.1f days ago</string>
     <string name="days_ago_round">%1$.0f days ago</string>
+    <string name="day_hours_ago">%1$s day %2$s hours ago</string>
+    <string name="days_hours_ago">%1$s days %2$s hours ago</string>
+    <string name="hour_ago">%1$s hour ago</string>
+    <string name="hours_ago">%1$s hours ago</string>
+    <string name="minutes_ago">%1$s minutes ago</string>
+    <string name="moment_ago">a moment ago</string>
+    <string name="seconds_ago">seconds ago</string>
     <string name="in_days">in %1$.0f days</string>
     <string name="in_days_round">in %1$.0f days</string>
     <string name="shorthour">h</string>

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -23,9 +23,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.microseconds
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 class MedtrumOverviewViewModel @Inject constructor(
     private val aapsLogger: AAPSLogger,

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -23,6 +23,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class MedtrumOverviewViewModel @Inject constructor(
     private val aapsLogger: AAPSLogger,
@@ -212,16 +215,10 @@ class MedtrumOverviewViewModel @Inject constructor(
         if (medtrumPump.patchStartTime == 0L) {
             _patchAge.postValue("")
         } else {
-            val currentTime = System.currentTimeMillis()
-            val age = currentTime - medtrumPump.patchStartTime
-            val daysLeft = T.msecs(age).days()
-            val hoursLeft = T.msecs(age).hours() % 24
+            val age = System.currentTimeMillis() - medtrumPump.patchStartTime
+            val agoString = dateUtil.timeAgoFullString(age, rh)
+            val ageString = dateUtil.dateAndTimeString(medtrumPump.patchStartTime) + "\n" + agoString
 
-            val daysString = if (age > 0) "$daysLeft ${rh.gs(app.aaps.core.interfaces.R.string.days)} " else ""
-            val hoursString = "$hoursLeft ${rh.gs(app.aaps.core.interfaces.R.string.hours)}"
-            val agoString = rh.gs(app.aaps.core.interfaces.R.string.time_ago)
-
-            val ageString = dateUtil.dateAndTimeString(medtrumPump.patchStartTime) + "\n" + daysString + hoursString + " " + agoString
             _patchAge.postValue(ageString)
         }
 

--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -358,24 +358,18 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
             val daysAgo = T.msecs(milliseconds).days()
             val hoursAgo = T.msecs(milliseconds).hours() % 24
             val minutesAgo = T.msecs(milliseconds).mins() % 60
-            val agoString = if (daysAgo > 1)
-                // Show multiple days and hours ago
-                rh.gs(R.string.days_hours_ago, daysAgo.toString(), hoursAgo.toString())
-            else if (daysAgo > 0)
-                // Show single day and hours ago
-                rh.gs(R.string.day_hours_ago, daysAgo.toString(), hoursAgo.toString())
-            else if (hoursAgo > 1)
-                // Only show multiple hours ago
-                rh.gs(R.string.hours_ago, hoursAgo.toString())
+
+            val agoString = if (daysAgo > 0)
+                // Show multiple day(s) and hours ago
+                rh.gq(R.plurals.plurals_day_hour_ago, daysAgo.toInt(), daysAgo.toString(), hoursAgo.toString())
             else if (hoursAgo > 0)
-                // Only show single hour ago
-                rh.gs(R.string.hour_ago, hoursAgo.toString())
-            else if (minutesAgo > 1)
-                // Only show multiple minutes ago
-                rh.gs(R.string.minutes_ago, minutesAgo.toString())
+                // Only show single hour(s) ago
+                rh.gq(R.plurals.plurals_hour_ago, hoursAgo.toInt(), hoursAgo.toString())
             else if (minutesAgo > 0)
-                rh.gs(R.string.moment_ago)
+                // Only show minute(s) ago
+                rh.gq(R.plurals.plurals_minute_ago, minutesAgo.toInt(), minutesAgo.toString())
             else
+                // Show other
                 rh.gs(R.string.seconds_ago)
 
             return agoString

--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -352,6 +352,38 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
         return result
     }
 
+    override fun timeAgoFullString(milliseconds: Long, rh: ResourceHelper): String {
+        if (milliseconds > 0) {
+            // Show patch start time and age
+            val daysAgo = T.msecs(milliseconds).days()
+            val hoursAgo = T.msecs(milliseconds).hours() % 24
+            val minutesAgo = T.msecs(milliseconds).mins() % 60
+            val agoString = if (daysAgo > 1)
+                // Show multiple days and hours ago
+                rh.gs(R.string.days_hours_ago, daysAgo.toString(), hoursAgo.toString())
+            else if (daysAgo > 0)
+                // Show single day and hours ago
+                rh.gs(R.string.day_hours_ago, daysAgo.toString(), hoursAgo.toString())
+            else if (hoursAgo > 1)
+                // Only show multiple hours ago
+                rh.gs(R.string.hours_ago, hoursAgo.toString())
+            else if (hoursAgo > 0)
+                // Only show single hour ago
+                rh.gs(R.string.hour_ago, hoursAgo.toString())
+            else if (minutesAgo > 1)
+                // Only show multiple minutes ago
+                rh.gs(R.string.minutes_ago, minutesAgo.toString())
+            else if (minutesAgo > 0)
+                rh.gs(R.string.moment_ago)
+            else
+                rh.gs(R.string.seconds_ago)
+
+            return agoString
+        }
+        else
+            return ""
+    }
+
     override fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String {
         val diff = computeDiff(0L, milliseconds)
         var days = " " + rh.gs(R.string.days) + " "


### PR DESCRIPTION
Refactoring **Medtrum patch age** on pump tab:
- Cleaner code, move logic to _dateUtil.timeAgoFullString()_
- Change for Singular/Plural time units
- @Philoul Adapt strings for l10n
- Cleanup