### PR TITLE
Date util refactor

### DIFF
--- a/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
+++ b/app/src/main/kotlin/app/aaps/activities/HistoryBrowseActivity.kt
@@ -113,7 +113,7 @@ class HistoryBrowseActivity : TranslatedDaggerAppCompatActivity() {
 
         binding.date.setOnClickListener {
             MaterialDatePicker.Builder.datePicker()
-                .setSelection(dateUtil.timeStampToUtcDateMillis(historyBrowserData.overviewData.fromTime))
+                .setSelection(dateUtil.getTimestampWithCurrentTimeOfDay(historyBrowserData.overviewData.fromTime))
                 .setTheme(app.aaps.core.ui.R.style.DatePicker)
                 .build()
                 .apply {

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/DateUtil.kt
@@ -1,94 +1,491 @@
 package app.aaps.core.interfaces.utils
 
 import app.aaps.core.interfaces.resources.ResourceHelper
-import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 /**
- * The Class DateUtil. A simple wrapper around SimpleDateFormat to ease the handling of iso date string &lt;-&gt; date obj
- * with TZ
+ * The Class DateUtil. A modern utility class for handling dates, times, and durations using the `java.time` API.
+ * It provides methods for parsing, formatting, and manipulating timestamps with proper timezone and locale handling.
  */
 interface DateUtil {
 
     /**
-     * Takes in an ISO date string of the following format:
-     * yyyy-mm-ddThh:mm:ss.ms+HoMo
-     *
-     * @param isoDateString the iso date string
-     * @return the date
+     * Parses a standard ISO-8601 date string into a Unix timestamp in milliseconds.
+     * @param isoDateString The string to parse (e.g., "2023-10-27T10:30:00Z").
+     * @return The number of milliseconds since the Unix epoch.
+     * Unlike the old Joda-Time, this will throw an exception if the provided
+     * string is not in the correct format.
      */
     fun fromISODateString(isoDateString: String): Long
 
     /**
-     * Render date
-     *
-     * @param date   the date obj
-     * @return the iso-formatted date string
+     * Converts a Unix timestamp in milliseconds into a standard ISO-8601 formatted string in UTC.
+     * @param date The timestamp in milliseconds.
+     * @return An ISO-formatted date string (e.g., "2023-10-27T10:30:00Z").
      */
     fun toISOString(date: Long): String
+
+    /**
+     * Converts a timestamp to an ISO-like string, forced into UTC and with a specific "Z" suffix format.
+     * @param timestamp The timestamp in milliseconds.
+     * @return A UTC formatted string like "2023-10-27T10:30:00.1230000Z".
+     */
     fun toISOAsUTC(timestamp: Long): String
+
+    /**
+     * Converts a timestamp to an ISO-like string representing the local date and time in the app's `systemZone`, without any timezone information.
+     * @param timestamp The timestamp in milliseconds.
+     * @return A local formatted string like "2023-10-27T06:30:00".
+     */
     fun toISONoZone(timestamp: Long): String
+
+    /**
+     * Converts a number of minutes from the beginning of today into a full Unix timestamp for that time.
+     * @param seconds The number of seconds past midnight.
+     * @return The full timestamp in milliseconds for that time on the current day.
+     */
+    fun minutesOfTheDayToMilliseconds(seconds: Int): Long
+
+    /**
+     * Converts a number of seconds from the beginning of today into a full Unix timestamp for that time.
+     * @param seconds The number of seconds past midnight.
+     * @return The full timestamp in milliseconds for that time on the current day.
+     */
     fun secondsOfTheDayToMilliseconds(seconds: Int): Long
+
+    /**
+     * Parses a time string (e.g., "14:30", "2:30 PM") into the total number of seconds from the start of the day.
+     * @param hhColonMm The time string to parse.
+     * @return The total number of seconds from midnight.
+     */
     fun toSeconds(hhColonMm: String): Int
+
+    /**
+     * Formats a timestamp into a localized date string (e.g., "10/27/2023").
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted date string.
+     */
     fun dateString(mills: Long): String
+
+    /**
+     * Formats a timestamp into a user-friendly, relative date string (e.g., "Today", "Yesterday", "Tomorrow").
+     * Falls back to a standard date format for dates further in the past or future.
+     * @param mills The timestamp in milliseconds.
+     * @param rh A resource helper to get localized strings like "Today".
+     * @return The relative date string.
+     */
     fun dateStringRelative(mills: Long, rh: ResourceHelper): String
+
+    /**
+     * Formats a timestamp into a short date string (e.g., "10/27" or "27/10") based on the user's 12/24 hour preference.
+     * @param mills The timestamp in milliseconds.
+     * @return A short date string.
+     */
     fun dateStringShort(mills: Long): String
+
+    /**
+     * Gets the current time formatted as a string (e.g., "10:30 AM"), respecting the device's 12/24 hour setting.
+     * @return The formatted time string.
+     */
     fun timeString(): String
+
+    /**
+     * Formats a timestamp as a string (e.g., "10:30 AM"), respecting the device's 12/24 hour setting.
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted time string.
+     */
     fun timeString(mills: Long): String
+
+    /**
+     * Gets the seconds part of the current time as a two-digit string (e.g., "05").
+     * @return The formatted seconds string.
+     */
     fun secondString(): String
+
+    /**
+     * Extracts the seconds part of a timestamp as a two-digit string (e.g., "05").
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted seconds string.
+     */
     fun secondString(mills: Long): String
+
+    /**
+     * Gets the minutes part of the current time as a two-digit string (e.g., "30").
+     * @return The formatted minutes string.
+     */
     fun minuteString(): String
+
+    /**
+     * Extracts the minutes part of a timestamp as a two-digit string (e.g., "30").
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted minutes string.
+     */
     fun minuteString(mills: Long): String
+
+    /**
+     * Gets the hour part of the current time as a string, respecting the 12/24 hour format.
+     * @return The formatted hour string.
+     */
     fun hourString(): String
+
+    /**
+     * Extracts the hour part of a timestamp as a string, respecting the 12/24 hour format.
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted hour string.
+     */
     fun hourString(mills: Long): String
+
+    /**
+     * Gets the localized AM/PM designator for the current time.
+     * @return The AM/PM string (e.g., "AM", "PM").
+     */
     fun amPm(): String
+
+    /**
+     * Gets the localized AM/PM designator for a given timestamp.
+     * @param mills The timestamp in milliseconds.
+     * @return The AM/PM string.
+     */
     fun amPm(mills: Long): String
+
+    /**
+     * Gets the day name for the current date, formatted according to the given pattern.
+     * @param format A pattern like "EEE" (short name) or "EEEE" (full name).
+     * @return The formatted day name.
+     */
     fun dayNameString(format: String = "E"): String
+
+    /**
+     * Gets the day name for a given timestamp, formatted according to the given pattern.
+     * @param mills The timestamp in milliseconds.
+     * @param format A pattern like "EEE" (short name) or "EEEE" (full name).
+     * @return The formatted day name.
+     */
     fun dayNameString(mills: Long, format: String = "E"): String
+
+    /**
+     * Gets the day of the month for the current date as a two-digit string (e.g., "27").
+     * @return The formatted day string.
+     */
     fun dayString(): String = dayString(now())
+
+    /**
+     * Extracts the day of the month from a timestamp as a two-digit string (e.g., "27").
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted day string.
+     */
     fun dayString(mills: Long): String
+
+    /**
+     * Gets the month for the current date, formatted according to the given pattern.
+     * @param format A pattern like "M" (number), "MMM" (short name), or "MMMM" (full name).
+     * @return The formatted month string.
+     */
     fun monthString(format: String = "MMM"): String
+
+    /**
+     * Extracts the month from a timestamp, formatted according to the given pattern.
+     * @param mills The timestamp in milliseconds.
+     * @param format A pattern like "M" (number), "MMM" (short name), or "MMMM" (full name).
+     * @return The formatted month string.
+     */
     fun monthString(mills: Long, format: String = "MMM"): String
+
+    /**
+     * Gets the week of the year for the current date as a string.
+     * @return The formatted week string.
+     */
     fun weekString(): String
+
+    /**
+     * Extracts the week of the year from a timestamp as a string.
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted week string.
+     */
     fun weekString(mills: Long): String
+
+    /**
+     * Formats a timestamp into a time string that includes seconds (e.g., "10:30:05 AM").
+     * Respects the device's 12/24 hour setting.
+     * @param mills The timestamp in milliseconds.
+     * @return The formatted time string with seconds.
+     */
     fun timeStringWithSeconds(mills: Long): String
+
+    /**
+     * Creates a string representing a date and time range.
+     * @param start The start timestamp in milliseconds.
+     * @param end The end timestamp in milliseconds.
+     * @return A formatted string like "10/27/2023 10:00 AM - 11:00 AM".
+     */
     fun dateAndTimeRangeString(start: Long, end: Long): String
+
+    /**
+     * Creates a string representing a time range.
+     * @param start The start timestamp in milliseconds.
+     * @param end The end timestamp in milliseconds.
+     * @return A formatted string like "10:00 AM - 11:00 AM".
+     */
     fun timeRangeString(start: Long, end: Long): String
+
+    /**
+     * Combines the localized date and time strings for a given timestamp.
+     * @param mills The timestamp in milliseconds. Returns empty string if 0.
+     * @return A formatted string like "10/27/2023 10:30 AM".
+     */
     fun dateAndTimeString(mills: Long): String
+
+    /**
+     * Combines the localized date and time strings for a given timestamp, returning null if the timestamp is null or 0.
+     * @param mills The nullable timestamp in milliseconds.
+     * @return A formatted string like "10/27/2023 10:30 AM", or null.
+     */
     fun dateAndTimeStringNullable(mills: Long?): String?
+
+    /**
+     * Combines the localized date and time (with seconds) strings for a given timestamp.
+     * @param mills The timestamp in milliseconds. Returns empty string if 0.
+     * @return A formatted string like "10/27/2023 10:30:05 AM".
+     */
     fun dateAndTimeAndSecondsString(mills: Long): String
+
+    /**
+     * Returns a string describing how many minutes ago a timestamp was (e.g., "5 min ago").
+     * @param rh Resource helper for localized strings.
+     * @param time The timestamp in milliseconds. Can be null.
+     * @return The relative time string.
+     */
     fun minAgo(rh: ResourceHelper, time: Long?): String
+
+    /**
+     * Returns a string describing how many minutes or seconds ago a timestamp was.
+     * Uses seconds if under 2 minutes, otherwise minutes.
+     * @param rh Resource helper for localized strings.
+     * @param time The timestamp in milliseconds. Can be null.
+     * @return The relative time string (e.g., "30 sec ago" or "3 min ago").
+     */
     fun minOrSecAgo(rh: ResourceHelper, time: Long?): String
+
+    /**
+     * Returns a short string showing the difference in minutes between now and a given time, with a sign.
+     * E.g., "(+5)" for 5 minutes in the future, "(-10)" for 10 minutes in the past.
+     * @param time The timestamp in milliseconds. Can be null.
+     * @return The short formatted difference string.
+     */
     fun minAgoShort(time: Long?): String
+
+    /**
+     * Returns a verbose string describing how many minutes ago a timestamp was.
+     * @param rh Resource helper for localized strings.
+     * @param time The timestamp in milliseconds. Can be null.
+     * @return The verbose relative time string.
+     */
     fun minAgoLong(rh: ResourceHelper, time: Long?): String
+
+    /**
+     * Returns a string describing how many hours ago a timestamp was.
+     * @param time The timestamp in milliseconds.
+     * @param rh Resource helper for localized strings.
+     * @return The relative hours string.
+     */
     fun hourAgo(time: Long, rh: ResourceHelper): String
+
+    /**
+     * Returns a string describing how many days ago (or in how many days) a timestamp is.
+     * @param time The timestamp in milliseconds.
+     * @param rh Resource helper for localized strings.
+     * @param round If true, rounds to the nearest whole day. Otherwise uses fractional days.
+     * @return The relative days string.
+     */
     fun dayAgo(time: Long, rh: ResourceHelper, round: Boolean = false): String
+
+    /**
+     * Calculates the timestamp for the beginning of the day (midnight) for a given timestamp.
+     * @param mills The timestamp in milliseconds.
+     * @return The timestamp in milliseconds for midnight at the start of that day.
+     */
     fun beginOfDay(mills: Long): Long
+
+    /**
+     * Converts seconds from the start of the day to a formatted time string, with caching for performance.
+     * @param seconds The number of seconds past midnight.
+     * @return A formatted time string (e.g., "10:30 AM").
+     */
     fun timeStringFromSeconds(seconds: Int): String
+
+    /**
+     * Formats a duration in milliseconds into a human-readable string with hours and minutes.
+     * @param timeInMillis The duration in milliseconds.
+     * @param rh Resource helper for localized units (e.g., "h").
+     * @return A formatted duration string like "(1h 30m)".
+     */
     fun timeFrameString(timeInMillis: Long, rh: ResourceHelper): String
+
+    /**
+     * Calculates the elapsed time since a given timestamp and formats it as a duration.
+     * @param timestamp The past timestamp in milliseconds.
+     * @param rh Resource helper.
+     * @return A formatted duration string of the elapsed time.
+     */
     fun sinceString(timestamp: Long, rh: ResourceHelper): String
+
+    /**
+     * Calculates the time remaining until a future timestamp and formats it as a duration.
+     * @param timestamp The future timestamp in milliseconds.
+     * @param rh Resource helper.
+     * @return A formatted duration string of the remaining time.
+     */
     fun untilString(timestamp: Long, rh: ResourceHelper): String
+
+    /**
+     * Gets the current system time in milliseconds.
+     * @return The current timestamp.
+     */
     fun now(): Long
+
+    /**
+     * Gets the current system time in milliseconds, with the millisecond part set to zero.
+     * @return The current timestamp, truncated to the second.
+     */
     fun nowWithoutMilliseconds(): Long
+
+    /**
+     * Checks if a given timestamp is older than a specified number of minutes from now.
+     * @param date The timestamp to check, in milliseconds.
+     * @param minutes The number of minutes to check against.
+     * @return True if the date is older, false otherwise.
+     */
     fun isOlderThan(date: Long, minutes: Long): Boolean
+
+    /**
+     * Gets the standard (non-DST) timezone offset for the app's `systemZone` in milliseconds.
+     * @return The standard offset in milliseconds.
+     */
     fun getTimeZoneOffsetMs(): Long
+
+    /**
+     * Gets the DST-aware timezone offset for the app's `systemZone` in milliseconds.
+     * @return The standard offset in milliseconds.
+     */
+    fun getTimeZoneOffsetMsWithDST(): Long
+
+    /**
+     * Gets the timezone offset in minutes for a specific moment in time.
+     * This correctly handles Daylight Saving Time (DST), returning the actual offset for that instant.
+     * @param timestamp The timestamp in milliseconds to check.
+     * @return The total offset from UTC in minutes (e.g., -240 for EDT, -300 for EST).
+     */
     fun getTimeZoneOffsetMinutes(timestamp: Long): Int
+
+    /**
+     * Checks if two timestamps occur on the same calendar day in the app's `systemZone`.
+     * This is DST-safe and correctly handles timestamps that might be on different UTC dates but the same local date.
+     * @param timestamp1 The first timestamp in milliseconds.
+     * @param timestamp2 The second timestamp in milliseconds.
+     * @return True if they are on the same local calendar day, false otherwise.
+     */
     fun isSameDay(timestamp1: Long, timestamp2: Long): Boolean
+
+    /**
+     * Checks if the current time in the app's `systemZone` is past noon (12:00 PM).
+     * @return True if the hour is 12 or greater, false otherwise.
+     */
     fun isAfterNoon(): Boolean
 
+    /**
+     * A specialized check to see if two timestamps are on the same day, with an additional
+     * condition that the current time (`now`) does not fall between them.
+     * @param timestamp1 The first timestamp in milliseconds.
+     * @param timestamp2 The second timestamp in milliseconds.
+     * @return False if `now` is between the two timestamps, otherwise the result of `isSameDay()`.
+     */
     fun isSameDayGroup(timestamp1: Long, timestamp2: Long): Boolean
 
+    /**
+     * Computes the difference between two timestamps and breaks it down into whole days, hours, and minutes.
+     * @param date1 The start timestamp in milliseconds.
+     * @param date2 The end timestamp in milliseconds.
+     * @return A map containing the total number of full days, leftover hours, and leftover minutes.
+     */
     //Map:{DAYS=1, HOURS=3, MINUTES=46, SECONDS=40, MILLISECONDS=0, MICROSECONDS=0, NANOSECONDS=0}
     fun computeDiff(date1: Long, date2: Long): Map<TimeUnit, Long>
+
+    /**
+     * Converts a duration in milliseconds into a human-readable "age" string (e.g., "5 days 3 hours").
+     * @param milliseconds The duration to format.
+     * @param useShortText If true, uses abbreviated units (e.g., "d", "h"). If false, uses full names (e.g., "days", "hours").
+     * @param rh Resource helper to get localized unit strings.
+     * @return The formatted age string.
+     */
     fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String
     fun timeAgoFullString(milliseconds: Long, rh: ResourceHelper): String
 
+
+    /**
+     * Converts a duration in milliseconds into a simplified, human-readable string with the largest appropriate unit.
+     * (e.g., 120000ms becomes "2 minutes"). It handles pluralization for different languages.
+     * @param time The duration in milliseconds.
+     * @param rh Resource helper to get localized unit strings (e.g., "second", "seconds").
+     * @return The formatted string with a single unit (e.g., "5 days").
+     */
     fun niceTimeScalar(time: Long, rh: ResourceHelper): String
+    /**
+     * A thread-safe, locale-agnostic utility to format a double into a string with a specific number of decimal digits.
+     * It is optimized to use a cached formatter on the UI thread.
+     * @param x The double value to format.
+     * @param numDigits The number of decimal digits. If -1, it attempts to auto-detect.
+     * @return The formatted string.
+     */
     fun qs(x: Double, numDigits: Int): String
+
+    /**
+     * Formats a total number of seconds into a zero-padded HH:mm string.
+     * @param timeAsSeconds The total duration in seconds.
+     * @return A formatted string like "08:05".
+     */
     fun formatHHMM(timeAsSeconds: Int): String
 
-    fun timeZoneByOffset(offsetInMilliseconds: Long): TimeZone
+    /**
+     * Attempts to find a representative IANA timezone name (e.g., "America/New_York")
+     * that matches a given offset in milliseconds at the present time.
+     * @param offsetInMilliseconds The timezone offset from UTC.
+     * @return A matching timezone ID string, or "UTC" if no match is found.
+     */
+    fun timeZoneByOffset(offsetInMilliseconds: Long): String
+
+    /**
+     * Calculates the timestamp for midnight UTC at the beginning of the day for a given timestamp.
+     * This effectively strips the time-of-day information, keeping the UTC date.
+     * @param timestamp The timestamp in milliseconds.
+     * @return A timestamp in milliseconds, representing the start of the UTC day (00:00:00Z).
+     */
     fun timeStampToUtcDateMillis(timestamp: Long): Long
+
+    /**
+     * Only used in HistoryBrowser instead of timeStampToUtcDateMillis. [LEGACY SUPPORT FUNCTION]
+     * Creates a new timestamp by combining the DATE from the input
+     * with the TIME OF DAY from the current system time, interpreted in the local timezone.
+     * @param timestamp The timestamp providing the date.
+     * @return A new timestamp mixing the input date with the current time of day.
+     */
+    fun getTimestampWithCurrentTimeOfDay(timestamp: Long): Long
+
+    /**
+     * Merges a UTC date with a local time from another timestamp.
+     * It takes the date part from `dateUtcMillis` and the time-of-day part from `timestamp`.
+     * @param timestamp The timestamp providing the time-of-day (in the app's `systemZone`).
+     * @param dateUtcMillis The timestamp providing the date (in UTC).
+     * @return A new timestamp combining the UTC date and the local time.
+     */
     fun mergeUtcDateToTimestamp(timestamp: Long, dateUtcMillis: Long): Long
+
+    /**
+     * Creates a new timestamp by replacing the hour and minute of an existing timestamp.
+     * @param timestamp The base timestamp to modify.
+     * @param hour The new hour to set (0-23).
+     * @param minute The new minute to set (0-59).
+     * @param randomSecond If true, sets the second to a pseudo-random, incrementing value.
+     * @return The new, updated timestamp in milliseconds.
+     */
     fun mergeHourMinuteToTimestamp(timestamp: Long, hour: Int, minute: Int, randomSecond: Boolean = false): Long
 }

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/profile/ProfileSealed.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/profile/ProfileSealed.kt
@@ -330,7 +330,7 @@ sealed class ProfileSealed(
         val o = JSONObject()
         o.put("units", units.asText)
         o.put("dia", dia)
-        o.put("timezone", dateUtil.timeZoneByOffset(utcOffset).id ?: "UTC")
+        o.put("timezone", dateUtil.timeZoneByOffset(utcOffset))
         // SENS
         val sens = JSONArray()
         var elapsedHours = 0L

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/QuickWizardEntry.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/QuickWizardEntry.kt
@@ -181,9 +181,9 @@ class QuickWizardEntry @Inject constructor(
 
     fun carbs(): Int = safeGetInt(storage, "carbs")
 
-    fun validFromDate(): Long = dateUtil.secondsOfTheDayToMilliseconds(validFrom())
+    fun validFromDate(): Long = dateUtil.minutesOfTheDayToMilliseconds(validFrom())
 
-    fun validToDate(): Long = dateUtil.secondsOfTheDayToMilliseconds(validTo())
+    fun validToDate(): Long = dateUtil.minutesOfTheDayToMilliseconds(validTo())
 
     fun validFrom(): Int = safeGetInt(storage, "validFrom")
 

--- a/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
+++ b/shared/impl/src/main/kotlin/app/aaps/shared/impl/utils/DateUtilImpl.kt
@@ -2,101 +2,95 @@ package app.aaps.shared.impl.utils
 
 import android.content.Context
 import androidx.collection.LongSparseArray
-import app.aaps.core.data.time.T
 import app.aaps.core.interfaces.R
 import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.SafeParse
-import app.aaps.core.utils.pump.ThreadUtil
-import org.apache.commons.lang3.time.DateUtils.isSameDay
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.format.ISODateTimeFormat
 import java.security.SecureRandom
-import java.text.DateFormat
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
-import java.text.SimpleDateFormat
+import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
-import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
-import java.util.Calendar
-import java.util.Date
-import java.util.EnumSet
-import java.util.GregorianCalendar
+import java.time.temporal.ChronoField
+import java.time.temporal.ChronoUnit
 import java.util.Locale
-import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
-import java.util.stream.Collectors
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import android.text.format.DateFormat as AndroidDateFormat
 
-/**
- * The Class DateUtil. A simple wrapper around SimpleDateFormat to ease the handling of iso date string &lt;-&gt; date obj
- * with TZ
- */
 @Singleton
-class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil {
+class DateUtilImpl @Inject constructor(
+    private val context: Context,
+    private val clock: Clock = Clock.systemDefaultZone()
+) : DateUtil {
 
-    /**
-     * The date format in iso.
-     */
-    @Suppress("PrivatePropertyName", "SpellCheckingInspection")
-    private val FORMAT_DATE_ISO_OUT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    /** The timezone is captured each time systemZone is accessed.*/
+    private val systemZone: ZoneId get() = ZoneId.systemDefault()
+    /** The locale used for formatting strings (e.g., date formats, AM/PM) is captured each time displayLocale is accessed.*/
+    private val displayLocale: Locale get() = Locale.getDefault()
 
-    /**
-     * Takes in an ISO date string of the following format:
-     * yyyy-mm-ddThh:mm:ss.ms+HoMo
-     *
-     * @param isoDateString the iso date string
-     * @return the date
-     */
     override fun fromISODateString(isoDateString: String): Long {
-        val parser = ISODateTimeFormat.dateTimeParser()
-        val dateTime = DateTime.parse(isoDateString, parser)
-        return dateTime.toDate().time
+        // This custom formatter handles multiple common ISO-like formats.
+        val formatter = DateTimeFormatterBuilder()
+            // 1. Append the standard date and time part
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            // 2. Optionally append fractional seconds (milliseconds)
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+            .optionalEnd()
+            // 3. Append an offset pattern that can handle "+HHMM" (no colon)
+            //    The second argument "Z" tells it to use 'Z' for a zero offset.
+            .appendOffset("+HHMM", "Z")
+            .toFormatter()
+        return ZonedDateTime.parse(isoDateString, formatter).toInstant().toEpochMilli()
     }
 
-    /**
-     * Render date
-     *
-     * @param date   the date obj
-     * @return the iso-formatted date string
-     */
     override fun toISOString(date: Long): String {
-        val f: DateFormat = SimpleDateFormat(FORMAT_DATE_ISO_OUT, Locale.getDefault())
-        f.timeZone = TimeZone.getTimeZone("UTC")
-        return f.format(date)
+        /** Formatter for converting an Instant to a standard ISO-8601 UTC string (e.g., "2023-10-27T10:30:00Z"). */
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("UTC"))
+        return formatter.format(Instant.ofEpochMilli(date))
     }
 
-    @Suppress("SpellCheckingInspection")
     override fun toISOAsUTC(timestamp: Long): String {
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'0000Z'", Locale.US)
-        format.timeZone = TimeZone.getTimeZone("UTC")
-        return format.format(timestamp)
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'0000Z'", Locale.US)
+        return formatter.withZone(ZoneId.of("UTC")).format(Instant.ofEpochMilli(timestamp))
     }
 
-    @Suppress("SpellCheckingInspection")
     override fun toISONoZone(timestamp: Long): String {
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
-        format.timeZone = TimeZone.getDefault()
-        return format.format(timestamp)
+        val instant = Instant.ofEpochMilli(timestamp)
+        val zonedDateTime = instant.atZone(systemZone)
+        return ISO_LOCAL_FORMATTER.format(zonedDateTime)
+    }
+
+    override fun minutesOfTheDayToMilliseconds(seconds: Int): Long {
+        //TODO: This function replicates the old "secondsOfTheDayToMilliseconds",
+        // which ignored the seconds component of the input.
+        val startOfToday = LocalDate.now(clock).atStartOfDay(systemZone)
+        val totalMinutes = seconds / 60
+        val targetTime = startOfToday.plusMinutes(totalMinutes.toLong())
+        return targetTime.toInstant().toEpochMilli()
     }
 
     override fun secondsOfTheDayToMilliseconds(seconds: Int): Long {
-        val calendar: Calendar = GregorianCalendar()
-        calendar[Calendar.MONTH] = 0 // Set january to be sure we miss DST changing
-        calendar[Calendar.HOUR_OF_DAY] = seconds / 60 / 60
-        calendar[Calendar.MINUTE] = seconds / 60 % 60
-        calendar[Calendar.SECOND] = 0
-        return calendar.timeInMillis
+        val startOfToday = LocalDate.now(clock).atStartOfDay(systemZone)
+        val targetTime = startOfToday.plusSeconds(seconds.toLong())
+        return targetTime.toInstant().toEpochMilli()
     }
 
     override fun toSeconds(hhColonMm: String): Int {
@@ -104,108 +98,98 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
         val m = p.matcher(hhColonMm)
         var retVal = 0
         if (m.find()) {
-            retVal = SafeParse.stringToInt(m.group(1)) * 60 * 60 + SafeParse.stringToInt(m.group(2)) * 60
-            if ((m.group(3) == " a.m." || m.group(3) == " AM" || m.group(3) == "AM") && m.group(1) == "12") retVal -= 12 * 60 * 60
-            if ((m.group(3) == " p.m." || m.group(3) == " PM" || m.group(3) == "PM") && m.group(1) != "12") retVal += 12 * 60 * 60
+            var hour = SafeParse.stringToInt(m.group(1))
+            val minute = SafeParse.stringToInt(m.group(2))
+            val amPm = m.group(3)?.trim()?.uppercase(Locale.US) ?: ""
+            if (amPm.endsWith("AM") && hour == 12) hour = 0 // Midnight case
+            if (amPm.endsWith("PM") && hour != 12) hour += 12 // Afternoon case
+            retVal = (hour * 3600) + (minute * 60)
         }
         return retVal
     }
 
-    override fun dateString(mills: Long): String {
-        val zonedTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), ZoneId.systemDefault())
-        val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
-        return zonedTime.format(dateFormatter)
-    }
+    override fun dateString(mills: Long): String =
+        Instant.ofEpochMilli(mills).atZone(systemZone).format(getLocalizedDateFormatter())
 
-    override fun dateStringRelative(mills: Long, rh: ResourceHelper): String {
-        val df = DateFormat.getDateInstance(DateFormat.SHORT)
-        val day = df.format(mills)
-        val beginOfToday = beginOfDay(now())
-        return if (mills < now()) // Past
+    override fun dateStringRelative(mills: Long, rh: ResourceHelper): String {        // Get the current time and the start of today as simple millisecond timestamps.
+        val nowMillis = now()
+        val startOfTodayMillis = beginOfDay(nowMillis)
+        return if (mills < nowMillis) { // Past
             when {
-                mills > beginOfToday -> rh.gs(R.string.today)
-                mills > beginOfToday - T.days(1).msecs() -> rh.gs(R.string.yesterday)
-                mills > beginOfToday - T.days(7).msecs() -> dayAgo(mills, rh, true)
-                else -> day
+                mills > startOfTodayMillis                                  -> rh.gs(R.string.today)
+                mills > startOfTodayMillis - 1.days.inWholeMilliseconds -> rh.gs(R.string.yesterday)
+                mills > startOfTodayMillis - 7.days.inWholeMilliseconds -> dayAgo(mills, rh, true)
+                else                                                        -> dateString(mills)
             }
-        else // Future
+        } else { // Future
             when {
-                mills < beginOfToday + T.days(1).msecs() -> rh.gs(R.string.later_today)
-                mills < beginOfToday + T.days(2).msecs() -> rh.gs(R.string.tomorrow)
-                mills < beginOfToday + T.days(7).msecs() -> dayAgo(mills, rh, true)
-                else                                     -> day
+                mills < startOfTodayMillis + 1.days.inWholeMilliseconds -> rh.gs(R.string.later_today)
+                mills < startOfTodayMillis + 2.days.inWholeMilliseconds -> rh.gs(R.string.tomorrow)
+                mills < startOfTodayMillis + 7.days.inWholeMilliseconds -> dayAgo(mills, rh, true)
+                else                                                        -> dateString(mills)
             }
+        }
     }
 
     override fun dateStringShort(mills: Long): String {
-        var format = "MM/dd"
-        if (android.text.format.DateFormat.is24HourFormat(context)) {
-            format = "dd/MM"
-        }
-        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        val pattern = if (AndroidDateFormat.is24HourFormat(context)) "dd/MM" else "MM/dd"
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        return Instant.ofEpochMilli(mills).atZone(systemZone).format(formatter)
     }
 
     override fun timeString(): String = timeString(now())
     override fun timeString(mills: Long): String {
-        var format = "hh:mm a"
-        if (android.text.format.DateFormat.is24HourFormat(context)) {
-            format = "HH:mm"
-        }
-        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        val pattern = if (AndroidDateFormat.is24HourFormat(context)) "HH:mm" else "hh:mm a"
+        val formatter = DateTimeFormatter.ofPattern(pattern, displayLocale)
+        return Instant.ofEpochMilli(mills).atZone(systemZone).format(formatter)
     }
 
     override fun secondString(): String = secondString(now())
     override fun secondString(mills: Long): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern("ss"))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern("ss"))
 
     override fun minuteString(): String = minuteString(now())
     override fun minuteString(mills: Long): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern("mm"))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern("mm"))
 
     override fun hourString(): String = hourString(now())
     override fun hourString(mills: Long): String {
-        var format = "hh"
-        if (android.text.format.DateFormat.is24HourFormat(context)) {
-            format = "HH"
-        }
-        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        val pattern = if (AndroidDateFormat.is24HourFormat(context)) "HH" else "hh"
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(formatter)
     }
 
     override fun amPm(): String = amPm(now())
     override fun amPm(mills: Long): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern("a"))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern("a", displayLocale))
 
     override fun dayNameString(format: String): String = dayNameString(now(), format)
     override fun dayNameString(mills: Long, format: String): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern(format, displayLocale))
 
     override fun dayString(): String = dayString(now())
     override fun dayString(mills: Long): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern("dd"))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern("dd"))
 
     override fun monthString(format: String): String = monthString(now(), format)
     override fun monthString(mills: Long, format: String): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern(format, displayLocale))
 
     override fun weekString(): String = weekString(now())
     override fun weekString(mills: Long): String =
-        DateTime(mills).toString(DateTimeFormat.forPattern("ww"))
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), systemZone).format(DateTimeFormatter.ofPattern("ww"))
 
     override fun timeStringWithSeconds(mills: Long): String {
-        var format = "hh:mm:ss a"
-        if (android.text.format.DateFormat.is24HourFormat(context)) {
-            format = "HH:mm:ss"
-        }
-        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+        val pattern = if (AndroidDateFormat.is24HourFormat(context)) "HH:mm:ss" else "hh:mm:ss a"
+        val formatter = DateTimeFormatter.ofPattern(pattern, displayLocale)
+        return Instant.ofEpochMilli(mills).atZone(systemZone).format(formatter)
     }
 
-    override fun dateAndTimeRangeString(start: Long, end: Long): String {
-        return dateAndTimeString(start) + " - " + timeString(end)
-    }
+    override fun dateAndTimeRangeString(start: Long, end: Long): String =
+        dateAndTimeString(start) + " - " + timeString(end)
 
-    override fun timeRangeString(start: Long, end: Long): String {
-        return timeString(start) + " - " + timeString(end)
-    }
+    override fun timeRangeString(start: Long, end: Long): String =
+        timeString(start) + " - " + timeString(end)
 
     override fun dateAndTimeString(mills: Long): String =
         if (mills == 0L) "" else dateString(mills) + " " + timeString(mills)
@@ -213,71 +197,73 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
     override fun dateAndTimeStringNullable(mills: Long?): String? =
         if (mills == null || mills == 0L) null else dateString(mills) + " " + timeString(mills)
 
-    override fun dateAndTimeAndSecondsString(mills: Long): String {
-        return if (mills == 0L) "" else dateString(mills) + " " + timeStringWithSeconds(mills)
-    }
+    override fun dateAndTimeAndSecondsString(mills: Long): String =
+        if (mills == 0L) "" else dateString(mills) + " " + timeStringWithSeconds(mills)
 
     override fun minAgo(rh: ResourceHelper, time: Long?): String {
         if (time == null) return ""
-        val minutes = ((now() - time) / 1000 / 60).toInt()
+        val duration = (now() - time).milliseconds
+        val minutes = duration.inWholeMinutes.toInt()
         return if (abs(minutes) > 9999) "" else rh.gs(R.string.minago, minutes)
     }
 
     override fun minOrSecAgo(rh: ResourceHelper, time: Long?): String {
         if (time == null) return ""
-        //val minutes = ((now() - time) / 1000 / 60).toInt()
-        val seconds = (now() - time) / 1000
-        if (seconds > 119) {
-            return rh.gs(R.string.minago, (seconds / 60).toInt())
-        } else {
-            return rh.gs(R.string.secago, seconds.toInt())
+        val duration = (now() - time).milliseconds
+        return when {
+            duration.inWholeMinutes >= 2 -> { // If the duration is 2 minutes or more, show minutes
+                rh.gs(R.string.minago, duration.inWholeMinutes.toInt())
+            }
+            else                         -> { // Otherwise, show seconds
+                rh.gs(R.string.secago, duration.inWholeSeconds.toInt())
+            }
         }
     }
 
     override fun minAgoShort(time: Long?): String {
         if (time == null) return ""
-        val minutes = ((time - now()) / 1000 / 60).toInt()
+        val duration = (time - now()).milliseconds
+        val minutes = duration.inWholeMinutes.toInt()
         return if (abs(minutes) > 9999) ""
         else "(" + (if (minutes > 0) "+" else "") + minutes + ")"
     }
 
     override fun minAgoLong(rh: ResourceHelper, time: Long?): String {
         if (time == null) return ""
-        val minutes = ((now() - time) / 1000 / 60).toInt()
+        val duration = (now() - time).milliseconds
+        val minutes = duration.inWholeMinutes.toInt()
         return if (abs(minutes) > 9999) "" else rh.gs(R.string.minago_long, minutes)
     }
 
     override fun hourAgo(time: Long, rh: ResourceHelper): String {
-        val hours = (now() - time) / 1000.0 / 60 / 60
+        val duration = (now() - time).milliseconds
+        val hours = duration.inWholeHours
         return rh.gs(R.string.hoursago, hours)
     }
 
     override fun dayAgo(time: Long, rh: ResourceHelper, round: Boolean): String {
-        var days = (now() - time) / 1000.0 / 60 / 60 / 24
+        val duration = (now() - time).milliseconds
         if (round) {
-            return if (now() > time) {
-                days = ceil(days)
-                rh.gs(R.string.days_ago_round, days)
+            val daysAsDouble = duration.toDouble(DurationUnit.DAYS)
+            return if (duration.isPositive()) {
+                val roundedDays = ceil(daysAsDouble)
+                rh.gs(R.string.days_ago_round, roundedDays)
             } else {
-                days = floor(days)
-                rh.gs(R.string.in_days_round, days)
+                val roundedDays = floor(daysAsDouble)
+                rh.gs(R.string.in_days_round, roundedDays)
             }
         }
-        return if (now() > time)
-            rh.gs(R.string.days_ago, days)
-        else
-            rh.gs(R.string.in_days, days)
+        return if (duration.isPositive()) {
+            rh.gs(R.string.days_ago, duration.inWholeDays)
+        } else {
+            rh.gs(R.string.in_days, abs(duration.inWholeDays))
+        }
     }
 
-    override fun beginOfDay(mills: Long): Long {
-        val givenDate = Calendar.getInstance()
-        givenDate.timeInMillis = mills
-        givenDate[Calendar.HOUR_OF_DAY] = 0
-        givenDate[Calendar.MINUTE] = 0
-        givenDate[Calendar.SECOND] = 0
-        givenDate[Calendar.MILLISECOND] = 0
-        return givenDate.timeInMillis
-    }
+    override fun beginOfDay(mills: Long): Long =
+        Instant.ofEpochMilli(mills).atZone(systemZone)
+            .truncatedTo(ChronoUnit.DAYS)
+            .toInstant().toEpochMilli()
 
     override fun timeStringFromSeconds(seconds: Int): String {
         val cached = timeStrings[seconds.toLong()]
@@ -288,145 +274,143 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
     }
 
     override fun timeFrameString(timeInMillis: Long, rh: ResourceHelper): String {
-        var remainingTimeMinutes = timeInMillis / (1000 * 60)
-        val remainingTimeHours = remainingTimeMinutes / 60
-        remainingTimeMinutes %= 60
-        return "(" + (if (remainingTimeHours > 0) remainingTimeHours.toString() + rh.gs(R.string.shorthour) + " " else "") + remainingTimeMinutes + "')"
+        val duration = timeInMillis.milliseconds
+        val totalHours = duration.inWholeHours
+        val remainingMinutes = (duration - totalHours.hours).inWholeMinutes
+        val hoursPart = if (totalHours > 0) "$totalHours${rh.gs(R.string.shorthour)} " else ""
+        return "($hoursPart$remainingMinutes')"
     }
 
-    override fun sinceString(timestamp: Long, rh: ResourceHelper): String {
-        return timeFrameString(System.currentTimeMillis() - timestamp, rh)
-    }
+    override fun sinceString(timestamp: Long, rh: ResourceHelper): String =
+        timeFrameString(now() - timestamp, rh)
 
     override fun untilString(timestamp: Long, rh: ResourceHelper): String {
-        return timeFrameString(timestamp - System.currentTimeMillis(), rh)
+        val durationMillis = timestamp - now()
+        return timeFrameString(durationMillis, rh)
     }
 
-    override fun now(): Long {
-        return System.currentTimeMillis()
-    }
+    override fun now(): Long = clock.millis()
 
-    override fun nowWithoutMilliseconds(): Long {
-        var n = System.currentTimeMillis()
-        n -= n % 1000
-        return n
-    }
+    override fun nowWithoutMilliseconds(): Long =
+        clock.instant().truncatedTo(ChronoUnit.SECONDS).toEpochMilli()
 
-    override fun isOlderThan(date: Long, minutes: Long): Boolean {
-        val diff = now() - date
-        return diff > T.mins(minutes).msecs()
-    }
+    override fun isOlderThan(date: Long, minutes: Long): Boolean =
+        Instant.ofEpochMilli(date).isBefore(clock.instant().minus(minutes, ChronoUnit.MINUTES))
 
     override fun getTimeZoneOffsetMs(): Long {
-        return GregorianCalendar().timeZone.rawOffset.toLong()
+        val standardOffset = systemZone.rules.getStandardOffset(clock.instant())
+        return standardOffset.totalSeconds.seconds.inWholeMilliseconds
+    }
+// TODO: getTimeZoneOffsetMs was __AND IS__ not DST aware. Check if intended.
+//  If not intended, use the following:
+    override fun getTimeZoneOffsetMsWithDST(): Long {
+        val dSTAwareOffset = systemZone.rules.getOffset(clock.instant())
+        return dSTAwareOffset.totalSeconds.seconds.inWholeMilliseconds
     }
 
     override fun getTimeZoneOffsetMinutes(timestamp: Long): Int {
-        return TimeZone.getDefault().getOffset(timestamp) / 60000
+        val actualOffset = systemZone.rules.getOffset(Instant.ofEpochMilli(timestamp))
+        return actualOffset.totalSeconds / 60
     }
 
-    override fun isSameDay(timestamp1: Long, timestamp2: Long) = isSameDay(Date(timestamp1), Date(timestamp2))
+    override fun isSameDay(timestamp1: Long, timestamp2: Long): Boolean {
+        val instant1 = Instant.ofEpochMilli(timestamp1)
+        val instant2 = Instant.ofEpochMilli(timestamp2)
+        val date1 = instant1.atZone(systemZone).toLocalDate()
+        val date2 = instant2.atZone(systemZone).toLocalDate()
+        return date1.isEqual(date2)
+    }
 
     override fun isAfterNoon(): Boolean =
-        Instant.now().atZone(ZoneId.systemDefault()).hour >= 12
+        ZonedDateTime.now(clock).hour >= 12
 
     override fun isSameDayGroup(timestamp1: Long, timestamp2: Long): Boolean {
         val now = now()
-        if (now in (timestamp1 + 1) until timestamp2 || now in (timestamp2 + 1) until timestamp1)
-            return false
-        return isSameDay(Date(timestamp1), Date(timestamp2))
+        if (now in (timestamp1 + 1) until timestamp2 || now in (timestamp2 + 1) until timestamp1) return false
+        return isSameDay(timestamp1, timestamp2)
     }
 
     //Map:{DAYS=1, HOURS=3, MINUTES=46, SECONDS=40, MILLISECONDS=0, MICROSECONDS=0, NANOSECONDS=0}
     override fun computeDiff(date1: Long, date2: Long): Map<TimeUnit, Long> {
-        val units: MutableList<TimeUnit> = ArrayList(EnumSet.allOf(TimeUnit::class.java))
-        units.reverse()
-        val result: MutableMap<TimeUnit, Long> = LinkedHashMap()
-        var millisecondsRest = date2 - date1
-        for (unit in units) {
-            val diff = unit.convert(millisecondsRest, TimeUnit.MILLISECONDS)
-            val diffInMillisecondsForUnit = unit.toMillis(diff)
-            millisecondsRest -= diffInMillisecondsForUnit
-            result[unit] = diff
+        val duration = (date2 - date1).milliseconds
+        return duration.toComponents { days, hours, minutes, seconds, nanoseconds ->
+            mapOf(
+                TimeUnit.DAYS to days,
+                TimeUnit.HOURS to hours.toLong(),
+                TimeUnit.MINUTES to minutes.toLong(),
+                TimeUnit.SECONDS to seconds.toLong(),
+                // Convert remaining nanoseconds into millis, micros, and nanos for the map.
+                TimeUnit.MILLISECONDS to nanoseconds.toLong() / 1_000_000,
+                TimeUnit.MICROSECONDS to (nanoseconds.toLong() / 1_000) % 1000,
+                TimeUnit.NANOSECONDS to nanoseconds.toLong() % 1000
+            )
         }
-        return result
     }
 
     override fun timeAgoFullString(milliseconds: Long, rh: ResourceHelper): String {
-        if (milliseconds > 0) {
-            // Show patch start time and age
-            val daysAgo = T.msecs(milliseconds).days()
-            val hoursAgo = T.msecs(milliseconds).hours() % 24
-            val minutesAgo = T.msecs(milliseconds).mins() % 60
+        return when {
+            milliseconds <= 0 -> ""
+            else -> {
+                val duration = milliseconds.milliseconds
+                val days = duration.inWholeDays
+                val hours = (duration - days.days).inWholeHours
+                val minutes = (duration - days.days - hours.hours).inWholeMinutes
 
-            val agoString = if (daysAgo > 0)
-                // Show multiple day(s) and hours ago
-                rh.gq(R.plurals.plurals_day_hour_ago, daysAgo.toInt(), daysAgo.toString(), hoursAgo.toString())
-            else if (hoursAgo > 0)
-                // Only show single hour(s) ago
-                rh.gq(R.plurals.plurals_hour_ago, hoursAgo.toInt(), hoursAgo.toString())
-            else if (minutesAgo > 0)
-                // Only show minute(s) ago
-                rh.gq(R.plurals.plurals_minute_ago, minutesAgo.toInt(), minutesAgo.toString())
-            else
-                // Show other
-                rh.gs(R.string.seconds_ago)
-
-            return agoString
-        }
-        else
-            return ""
-    }
-
-    override fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String {
-        val diff = computeDiff(0L, milliseconds)
-        var days = " " + rh.gs(R.string.days) + " "
-        var hours = " " + rh.gs(R.string.hours) + " "
-        var minutes = " " + rh.gs(R.string.unit_minutes) + " "
-        if (useShortText) {
-            days = " " + rh.gs(R.string.shortday) + " "
-            hours = " " + rh.gs(R.string.shorthour) + " "
-            minutes = " " + rh.gs(R.string.shortminute) + " "
-        }
-        if (T.msecs(milliseconds).days() > 1000) return rh.gs(R.string.forever)
-        var result = ""
-        if (diff.getOrDefault(TimeUnit.DAYS, -1) > 0) result += diff[TimeUnit.DAYS].toString() + days
-        if (diff.getOrDefault(TimeUnit.HOURS, -1) > 0) result += diff[TimeUnit.HOURS].toString() + hours
-        if (diff[TimeUnit.DAYS] == 0L) result += diff[TimeUnit.MINUTES].toString() + minutes
-        return result
-    }
-
-    override fun niceTimeScalar(time: Long, rh: ResourceHelper): String {
-        var t = time
-        var unit = rh.gs(R.string.unit_second)
-        t /= 1000
-        if (t != 1L) unit = rh.gs(R.string.unit_seconds)
-        if (t > 59) {
-            unit = rh.gs(R.string.unit_minute)
-            t /= 60
-            if (t != 1L) unit = rh.gs(R.string.unit_minutes)
-            if (t > 59) {
-                unit = rh.gs(R.string.unit_hour)
-                t /= 60
-                if (t != 1L) unit = rh.gs(R.string.unit_hours)
-                if (t > 24) {
-                    unit = rh.gs(R.string.unit_day)
-                    t /= 24
-                    if (t != 1L) unit = rh.gs(R.string.unit_days)
-                    if (t > 28) {
-                        unit = rh.gs(R.string.unit_week)
-                        t /= 7
-                        @Suppress("KotlinConstantConditions")
-                        if (t != 1L) unit = rh.gs(R.string.unit_weeks)
-                    }
+                when {
+                    days > 0        -> rh.gq(R.plurals.plurals_day_hour_ago, days.toInt(), days.toString(), hours.toString())
+                    hours > 0       -> rh.gq(R.plurals.plurals_hour_ago, hours.toInt(), hours.toString())
+                    minutes > 0     -> rh.gq(R.plurals.plurals_minute_ago, minutes.toInt(), minutes.toString())
+                    else            -> rh.gs(R.string.seconds_ago)
                 }
             }
         }
-        //if (t != 1) unit = unit + "s"; //implemented plurality in every step, because in other languages plurality of time is not every time adding the same character
-        return qs(t.toDouble(), 0) + " " + unit
+    }
+
+    override fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String {
+        val duration = milliseconds.milliseconds
+        if (duration.inWholeDays > 1000) return rh.gs(R.string.forever)
+        val daysUnit = if (useShortText) rh.gs(R.string.shortday) else rh.gs(R.string.days)
+        val hoursUnit = if (useShortText) rh.gs(R.string.shorthour) else rh.gs(R.string.hours)
+        val minutesUnit = if (useShortText) rh.gs(R.string.shortminute) else rh.gs(R.string.unit_minutes)
+        val days = duration.inWholeDays
+        val hours = (duration - days.days).inWholeHours
+        val minutes = (duration - days.days - hours.hours).inWholeMinutes
+        return when {
+            days > 0  -> "$days $daysUnit $hours $hoursUnit "
+            hours > 0 -> "$hours $hoursUnit $minutes $minutesUnit "
+            else      -> "${duration.inWholeMinutes} $minutesUnit"
+        }
+    }
+
+    override fun niceTimeScalar(time: Long, rh: ResourceHelper): String {
+        val duration = time.milliseconds
+        val (value, unitId) = when {
+            duration.inWholeDays > 6 -> {
+                val weeks = duration.inWholeDays / 7
+                weeks to if (weeks == 1L) R.string.unit_week else R.string.unit_weeks
+            }
+            duration.inWholeHours > 23 -> {
+                val days = duration.inWholeDays
+                days to if (days == 1L) R.string.unit_day else R.string.unit_days
+            }
+            duration.inWholeMinutes > 59 -> {
+                val hours = duration.inWholeHours
+                hours to if (hours == 1L) R.string.unit_hour else R.string.unit_hours
+            }
+            duration.inWholeSeconds > 59 -> {
+                val minutes = duration.inWholeMinutes
+                minutes to if (minutes == 1L) R.string.unit_minute else R.string.unit_minutes
+            }
+            else -> {
+                val seconds = duration.inWholeSeconds
+                seconds to if (seconds == 1L) R.string.unit_second else R.string.unit_seconds
+            }
+        }
+        return "${qs(value.toDouble(), 0)} ${rh.gs(unitId)}"
     }
 
     override fun qs(x: Double, numDigits: Int): String {
+        val formatter = decimalFormatter.get()
         var digits = numDigits
         if (digits == -1) {
             digits = 0
@@ -438,83 +422,83 @@ class DateUtilImpl @Inject constructor(private val context: Context) : DateUtil 
                 }
             }
         }
-        if (dfs == null) {
-            val localDfs = DecimalFormatSymbols()
-            localDfs.decimalSeparator = '.'
-            dfs = localDfs // avoid race condition
-        }
-        val thisDf: DecimalFormat?
-        // use singleton if on ui thread otherwise allocate new as DecimalFormat is not thread safe
-        if (ThreadUtil.threadId() == 1L) {
-            if (df == null) {
-                val localDf = DecimalFormat("#", dfs)
-                localDf.minimumIntegerDigits = 1
-                df = localDf // avoid race condition
-            }
-            thisDf = df
-        } else {
-            thisDf = DecimalFormat("#", dfs)
-        }
-        thisDf?.maximumFractionDigits = digits
-        return thisDf?.format(x) ?: ""
+        // Use maximumFractionDigits to replicate the original behavior
+        // of not showing trailing zeros (e.g., 12.0 -> "12").
+        formatter!!.maximumFractionDigits = digits
+        // We must also set the minimum to 0 to allow for truncation.
+        formatter.minimumFractionDigits = 0
+        return formatter.format(x)
     }
 
     override fun formatHHMM(timeAsSeconds: Int): String {
-        val hour = timeAsSeconds / 60 / 60
-        val minutes = (timeAsSeconds - hour * 60 * 60) / 60
-        val df = DecimalFormat("00")
-        return df.format(hour.toLong()) + ":" + df.format(minutes.toLong())
+        val duration = timeAsSeconds.seconds
+        val hours = duration.inWholeHours
+        val minutes = (duration - hours.hours).inWholeMinutes
+        return "%02d:%02d".format(hours, minutes)
     }
 
-    override fun timeZoneByOffset(offsetInMilliseconds: Long): TimeZone =
-        TimeZone.getTimeZone(
-            if (offsetInMilliseconds == 0L) ZoneId.of("UTC")
-            else ZoneId.getAvailableZoneIds()
-                .stream()
-                .map(ZoneId::of)
-                .filter { z -> z.rules.getOffset(Instant.now()).totalSeconds == ZoneOffset.ofHours((offsetInMilliseconds / 1000 / 3600).toInt()).totalSeconds }
-                .collect(Collectors.toList())
-                .firstOrNull() ?: ZoneId.of("UTC")
-        )
+    override fun timeZoneByOffset(offsetInMilliseconds: Long): String {
+        if (offsetInMilliseconds == 0L) return "UTC"
+        val offsetInSeconds = offsetInMilliseconds.milliseconds.inWholeSeconds.toInt()
+        val now = clock.instant()
+        return ZoneId.getAvailableZoneIds()
+            .firstOrNull { zoneIdString ->
+                val zoneId = ZoneId.of(zoneIdString)
+                // Compare the zone's current offset in seconds to the requested offset.
+                zoneId.rules.getOffset(now).totalSeconds == offsetInSeconds
+            }
+            ?: "UTC" // Default to "UTC" if no match is found.
+    }
 
-    override fun timeStampToUtcDateMillis(timestamp: Long): Long {
-        val current = Calendar.getInstance().apply { timeInMillis = timestamp }
-        return Calendar.getInstance().apply {
-            set(Calendar.YEAR, current[Calendar.YEAR])
-            set(Calendar.MONTH, current[Calendar.MONTH])
-            set(Calendar.DAY_OF_MONTH, current[Calendar.DAY_OF_MONTH])
-        }.timeInMillis
+    override fun timeStampToUtcDateMillis(timestamp: Long): Long =
+        Instant.ofEpochMilli(timestamp).truncatedTo(ChronoUnit.DAYS).toEpochMilli()
+
+    //TODO: timeStampToUtcDateMillis has a different output than the old function.
+    // Since that seems to be desired behaviour in the history browser,
+    // the functionality was refactored in getTimestampWithCurrentTimeOfDay()
+    override fun getTimestampWithCurrentTimeOfDay(timestamp: Long): Long {
+        val inputDate = Instant.ofEpochMilli(timestamp).atZone(systemZone).toLocalDate()
+        val timeOfNow = ZonedDateTime.now(clock).toLocalTime()
+        return inputDate.atTime(timeOfNow).atZone(systemZone).toInstant().toEpochMilli()
     }
 
     override fun mergeUtcDateToTimestamp(timestamp: Long, dateUtcMillis: Long): Long {
-        // - TimeZone.getDefault().rawOffset is only workaround for MaterialDatePicket bug
-        // Remove after lib fix
-        // https://github.com/material-components/material-components-android/issues/4373
-        val selected = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply { timeInMillis = dateUtcMillis }
-        return Calendar.getInstance().apply {
-            timeInMillis = timestamp
-            set(Calendar.YEAR, selected[Calendar.YEAR])
-            set(Calendar.MONTH, selected[Calendar.MONTH])
-            set(Calendar.DAY_OF_MONTH, selected[Calendar.DAY_OF_MONTH])
-        }.timeInMillis
+        val localTime = Instant.ofEpochMilli(timestamp).atZone(systemZone).toLocalTime()
+        val utcDate = Instant.ofEpochMilli(dateUtcMillis).atZone(ZoneId.of("UTC")).toLocalDate()
+        val finalDateTime = utcDate.atTime(localTime).atZone(systemZone)
+        return finalDateTime.toInstant().toEpochMilli()
     }
 
     override fun mergeHourMinuteToTimestamp(timestamp: Long, hour: Int, minute: Int, randomSecond: Boolean): Long {
-        return Calendar.getInstance().apply {
-            timeInMillis = timestamp
-            set(Calendar.HOUR_OF_DAY, hour)
-            set(Calendar.MINUTE, minute)
-            if (randomSecond) set(Calendar.SECOND, seconds++)
-        }.timeInMillis
+        val originalDateTime = Instant.ofEpochMilli(timestamp).atZone(systemZone)
+        var updatedDateTime = originalDateTime.withHour(hour).withMinute(minute)
+        if (randomSecond) updatedDateTime = updatedDateTime.withSecond(seconds++)
+        return updatedDateTime.toInstant().toEpochMilli()
     }
+
+    /**
+     * Creates a date formatter based on the user's current device locale (e.g., MM/dd/yyyy for US, dd/MM/yyyy for UK).
+     * @return A `DateTimeFormatter` configured for a short, localized date.
+     */
+    private fun getLocalizedDateFormatter(): DateTimeFormatter =
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(displayLocale)
 
     companion object {
 
+        /** Formatter for creating a local ISO-like string without a timezone (e.g., "2023-10-27T10:30:00"). */
+        private val ISO_LOCAL_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
         private val timeStrings = LongSparseArray<String>()
         private var seconds: Int = (SecureRandom().nextDouble() * 59.0).toInt()
 
-        // singletons to avoid repeated allocation
-        private var dfs: DecimalFormatSymbols? = null
-        private var df: DecimalFormat? = null
+        val decimalFormatter = object : ThreadLocal<DecimalFormat>() {
+            override fun initialValue(): DecimalFormat {
+                // Each thread gets its own DecimalFormat instance, configured once.
+                return DecimalFormat().apply {
+                    decimalFormatSymbols = DecimalFormatSymbols().apply {
+                        decimalSeparator = '.'
+                    }
+                }
+            }
+        }
     }
 }

--- a/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilImplTest.kt
+++ b/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilImplTest.kt
@@ -1,0 +1,1438 @@
+package app.aaps.shared.impl.utils
+
+import android.content.Context
+import android.content.res.AssetFileDescriptor
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import android.text.format.DateFormat
+import android.util.DisplayMetrics
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import org.joda.time.DateTimeZone
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit tests for [DateUtilImpl].
+ *
+ * This class validates that the refactored `DateUtilImpl` is both correct and
+ * produces output identical to the legacy `DateUtilOldImpl`.
+ * It uses a fixed timezone and locale to ensure tests are repeatable.
+ */
+@ExtendWith(MockitoExtension::class)
+class DateUtilImplTest {
+
+    @Mock
+    private lateinit var mockContext: Context
+    private lateinit var dateUtilImpl: DateUtilImpl
+    private lateinit var dateUtilImplDeter: DateUtilImpl
+    private lateinit var dateUtilOldImpl: DateUtilOldImpl
+    private lateinit var fixedClock: Clock
+
+    private val fixedInstant = Instant.parse("2023-10-27T16:00:00Z")
+    private val fixedZone = ZoneId.of("America/New_York")
+
+    @BeforeEach
+    fun setUp() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"))
+        DateTimeZone.setDefault(DateTimeZone.forID("America/New_York"))
+        Locale.setDefault(Locale.US)
+        fixedClock = Clock.fixed(fixedInstant, fixedZone)
+        dateUtilImpl = DateUtilImpl(mockContext)
+        dateUtilImplDeter = DateUtilImpl(mockContext, fixedClock)
+        dateUtilOldImpl = DateUtilOldImpl(mockContext)
+    }
+
+    //region ISO and Timestamp Conversion
+    @Test
+    fun `fromISODateString works for full UTC timestamp and matches old behavior`() {
+        val isoString = "2023-10-26T09:07:03.344Z"
+        val expectedMillis = 1698311223344L
+        val newResult = dateUtilImpl.fromISODateString(isoString)
+        val oldResult = dateUtilOldImpl.fromISODateString(isoString)
+
+        assertThat(newResult).isEqualTo(expectedMillis)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `toISOString works and matches old behavior`() {
+        val millis = 1698311223344L
+        val expectedString = "2023-10-26T09:07:03.344Z"
+        val newResult = dateUtilImpl.toISOString(millis)
+        val oldResult = dateUtilOldImpl.toISOString(millis)
+
+        assertThat(newResult).isEqualTo(expectedString)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `toISOAsUTC works and matches old behavior`() {
+        val millis = 1698311223344L
+        val expectedString = "2023-10-26T09:07:03.3440000Z"
+        val newResult = dateUtilImpl.toISOAsUTC(millis)
+        val oldResult = dateUtilOldImpl.toISOAsUTC(millis)
+
+        assertThat(newResult).isEqualTo(expectedString)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `toISONoZone works and matches old behavior`() {
+        val millis = 1698311223344L // 09:07:03.344 UTC
+        val expectedString = "2023-10-26T05:07:03" // 05:07:03 in New York (EDT)
+        val newResult = dateUtilImpl.toISONoZone(millis)
+        val oldResult = dateUtilOldImpl.toISONoZone(millis)
+
+        assertThat(newResult).isEqualTo(expectedString)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `timeStampToUtcDateMillis works correctly now`() {
+        val timestamp = 1698311223344L // 2023-10-26 09:07:03.344Z
+       val expectedMillis = 1698278400000L // 2023-10-26 00:00:00.000Z
+        val newResult = dateUtilImpl.timeStampToUtcDateMillis(timestamp)
+        val oldResult = dateUtilOldImpl.timeStampToUtcDateMillis(timestamp)
+
+        assertThat(newResult).isEqualTo(expectedMillis)
+        // Assert the NEW implementation is NOT the same as the OLD one.
+//TODO: the original timeStampToUtcDateMillis couldn't parse milliseconds.
+        assertThat(newResult).isNotEqualTo(oldResult)
+    }
+    @Test
+    fun `minutesOfTheDayToMilliseconds correctly truncates to the minute`() {
+        // ARRANGE
+        // Use the deterministic util to get a predictable start of the day based on our fixedClock.
+        val startOfToday = dateUtilImplDeter.beginOfDay(dateUtilImplDeter.now())
+
+        // Input representing 1 hour, 1 minute, and 45 seconds. This should be truncated to 61 minutes.
+        val inputSeconds = (1 * 3600) + (1 * 60) + 45
+        val expectedMillis = startOfToday + (61 * 60 * 1000L) // Exactly 61 minutes past the start of the day
+
+        // ACT
+        val newResult = dateUtilImplDeter.minutesOfTheDayToMilliseconds(inputSeconds)
+        val oldResult = dateUtilOldImpl.secondsOfTheDayToMilliseconds(inputSeconds) // The old function with this logic
+
+        // ASSERT
+        // 1. Assert that the new implementation produces the EXACT expected millisecond value.
+        assertThat(newResult).isEqualTo(expectedMillis)
+
+        // 2. Assert that the new implementation's formatted time matches the old implementation's intended behavior.
+        val newTime = dateUtilImpl.timeString(newResult)
+        val oldTime = dateUtilOldImpl.timeString(oldResult)
+        assertThat(newTime).isEqualTo("01:01 AM") // Based on our fixed clock's timezone
+        assertThat(newTime).isEqualTo(oldTime)
+    }
+    @Test
+    fun `secondsOfTheDayToMilliseconds works correctly now (without truncating seconds)`() {
+        // ARRANGE: Input representing 1 hour, 1 minute, and 45 seconds.
+        val inputSeconds = (1 * 3600) + (1 * 60) + 45
+        val now = dateUtilImpl.now()
+        val startOfToday = dateUtilImpl.beginOfDay(now)
+        val expectedMillis = startOfToday + (inputSeconds * 1000L)
+
+        // ACT
+        val newResult = dateUtilImpl.secondsOfTheDayToMilliseconds(inputSeconds)
+        val oldResult = dateUtilOldImpl.secondsOfTheDayToMilliseconds(inputSeconds)
+
+        // ASSERT
+        // 1. Assert the NEW implementation is as expected.
+        assertThat(newResult).isEqualTo(expectedMillis)
+        // 2. Assert the NEW implementation is different from the old one which ignored seconds.
+//TODO: the original secondsOfTheDayToMilliseconds couldn't parse seconds.
+        assertThat(newResult).isNotEqualTo(oldResult)
+    }
+    //endregion
+
+    //region Date and Time Formatting
+    @Test
+    fun `dateString works and matches old behavior`() {
+        val millis = 1698393600000L
+        val expected = "10/27/23"
+        val newResult = dateUtilImpl.dateString(millis)
+        val oldResult = dateUtilOldImpl.dateString(millis)
+
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `timeString works for 12-hour format and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val millis = 1698436800000L // 20:00 UTC -> 16:00 EDT (4 PM)
+            val expected = "04:00 PM"
+            val newResult = dateUtilImpl.timeString(millis)
+            val oldResult = dateUtilOldImpl.timeString(millis)
+
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(newResult).isEqualTo(oldResult)
+        }
+    }
+    @Test
+    fun `timeString works for 24-hour format and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(true)
+            val millis = 1698458400000L // 10:00 PM EDT, which is 22:00
+            val expected = "22:00"
+            val newResult = dateUtilImpl.timeString(millis)
+            val oldResult = dateUtilOldImpl.timeString(millis)
+
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(newResult).isEqualTo(oldResult)
+        }
+    }
+    @Test
+    fun `timeStringWithSeconds works and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            // Test 12-hour format
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val millis = 1698436812345L // 16:00:12 EDT
+            val expected12Hour = "04:00:12 PM"
+            assertThat(dateUtilImpl.timeStringWithSeconds(millis)).isEqualTo(expected12Hour)
+            assertThat(dateUtilOldImpl.timeStringWithSeconds(millis)).isEqualTo(expected12Hour)
+
+            // Test 24-hour format
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(true)
+            val expected24Hour = "16:00:12"
+            assertThat(dateUtilImpl.timeStringWithSeconds(millis)).isEqualTo(expected24Hour)
+            assertThat(dateUtilOldImpl.timeStringWithSeconds(millis)).isEqualTo(expected24Hour)
+        }
+    }
+    @Test
+    fun `dateStringShort works and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            // Test for 12-hour format first (MM/dd in US)
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val millis = 1698393600000L // Oct 27, 2023
+            val expected12Hour = "10/27"
+            val newResult12 = dateUtilImpl.dateStringShort(millis)
+            val oldResult12 = dateUtilOldImpl.dateStringShort(millis)
+            assertThat(newResult12).isEqualTo(expected12Hour)
+            assertThat(newResult12).isEqualTo(oldResult12)
+
+            // Test for 24-hour format (dd/MM in US)
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(true)
+            val expected24Hour = "27/10"
+            val newResult24 = dateUtilImpl.dateStringShort(millis)
+            val oldResult24 = dateUtilOldImpl.dateStringShort(millis)
+            assertThat(newResult24).isEqualTo(expected24Hour)
+            assertThat(newResult24).isEqualTo(oldResult24)
+        }
+    }
+    @Test
+    fun `dateAndTimeString works and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            // ARRANGE
+            val millis = 1698436800000L // Oct 27, 2023 at 4:00 PM
+            // Expected output combines dateString() + " " + timeString()
+            // "10/27/23" + " " + "04:00 PM"
+            val expected = "10/27/23 04:00 PM"
+
+            // ACT
+            val newResult = dateUtilImpl.dateAndTimeString(millis)
+            val oldResult = dateUtilOldImpl.dateAndTimeString(millis)
+
+            // ASSERT
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(oldResult).isEqualTo(expected)
+        }
+    }
+    @Test
+    fun `dateAndTimeAndSecondsString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // Oct 27, 2023 16:00:12 EDT
+
+        // Expected output combines dateString() + " " + timeStringWithSeconds()
+        // Based on previous tests, this should be "10/27/23" + " " + "04:00:12 PM"
+        val expected = "10/27/23 04:00:12 PM"
+
+        // ACT
+        val newResult = dateUtilImpl.dateAndTimeAndSecondsString(millis)
+        val oldResult = dateUtilOldImpl.dateAndTimeAndSecondsString(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        // The old implementation also padded the hour, so they should match.
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `dateAndTimeRangeString works and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            // ARRANGE
+            // Start: Oct 27, 2023 4:00 PM, End: Oct 27, 2023 6:00 PM
+            val startTime = 1698436800000L
+            val endTime = 1698444000000L
+
+            // Expected output: dateAndTimeString(start) + " - " + timeString(end)
+            val expected = "10/27/23 04:00 PM - 06:00 PM"
+
+            // ACT
+            val newResult = dateUtilImpl.dateAndTimeRangeString(startTime, endTime)
+            val oldResult = dateUtilOldImpl.dateAndTimeRangeString(startTime, endTime)
+
+            // ASSERT
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(oldResult).isEqualTo(expected)
+        }
+    }
+    @Test
+    fun `dateAndTimeStringNullable works and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+
+            // --- Test Case 1: Valid timestamp ---
+            val millis = 1698436800000L // Oct 27, 2023 4:00 PM
+            val expected = "10/27/23 04:00 PM"
+            assertThat(dateUtilImpl.dateAndTimeStringNullable(millis)).isEqualTo(expected)
+            assertThat(dateUtilOldImpl.dateAndTimeStringNullable(millis)).isEqualTo(expected)
+
+            // --- Test Case 2: Null timestamp ---
+            assertThat(dateUtilImpl.dateAndTimeStringNullable(null)).isNull()
+            assertThat(dateUtilOldImpl.dateAndTimeStringNullable(null)).isNull()
+
+            // --- Test Case 3: Zero timestamp ---
+            assertThat(dateUtilImpl.dateAndTimeStringNullable(0L)).isNull()
+            assertThat(dateUtilOldImpl.dateAndTimeStringNullable(0L)).isNull()
+        }
+    }
+    @Test
+    fun `timeRangeString works and matches old behavior`() {
+        val startTime = 1698436800000L // 16:00 EDT -> "04:00 PM"
+        val endTime = 1698444000000L   // 18:00 EDT -> "06:00 PM"
+        val expected = "04:00 PM - 06:00 PM"
+
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val newResult = dateUtilImpl.timeRangeString(startTime, endTime)
+            val oldResult = dateUtilOldImpl.timeRangeString(startTime, endTime)
+
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(newResult).isEqualTo(oldResult)
+        }
+    }
+    @Test
+    fun `formatHHMM works and matches old behavior`() {
+        // ARRANGE
+        val timeAsSeconds = (14 * 3600) + (5 * 60) // 14:05
+        val expected = "14:05"
+
+        // ACT
+        val newResult = dateUtilImpl.formatHHMM(timeAsSeconds)
+        val oldResult = dateUtilOldImpl.formatHHMM(timeAsSeconds)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    //endregion
+
+    //region Relative Time Formatting
+    @Test
+    fun `dateStringRelative identifies today and yesterday and matches old behavior`() {
+        val rh = FakeResourceHelper()
+        // This test is kept as a simple regression check. It's not fully deterministic.
+        val oneHourAgo = System.currentTimeMillis() - (60 * 60 * 1000)
+        val twentyFiveHoursAgo = System.currentTimeMillis() - (25 * 60 * 60 * 1000)
+
+        val newTodayResult = dateUtilImpl.dateStringRelative(oneHourAgo, rh)
+        val oldTodayResult = dateUtilOldImpl.dateStringRelative(oneHourAgo, rh)
+        assertThat(newTodayResult).isEqualTo("Today")
+        assertThat(newTodayResult).isEqualTo(oldTodayResult)
+
+        val newYesterdayResult = dateUtilImpl.dateStringRelative(twentyFiveHoursAgo, rh)
+        val oldYesterdayResult = dateUtilOldImpl.dateStringRelative(twentyFiveHoursAgo, rh)
+        assertThat(newYesterdayResult).isEqualTo("Yesterday")
+        assertThat(newYesterdayResult).isEqualTo(oldYesterdayResult)
+    }
+    @Test
+    fun `dateStringRelative is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        // Use a fixed start of day in the test's timezone to be absolutely clear.
+        val startOfDay = ZonedDateTime.of(2023, 10, 27, 0, 0, 0, 0, fixedZone).toInstant()
+
+        // --- Test for "Today" ---
+        // A timestamp for a few hours into that day.
+        val todayTimestamp = startOfDay.plus(10, java.time.temporal.ChronoUnit.HOURS).toEpochMilli()
+        // The clock is now fixed to a time later on the same day.
+        val clockForTodayTest = Clock.fixed(startOfDay.plus(12, java.time.temporal.ChronoUnit.HOURS), fixedZone)
+        val utilForToday = DateUtilImpl(mockContext, clockForTodayTest)
+        assertThat(utilForToday.dateStringRelative(todayTimestamp, rh)).isEqualTo("Today")
+
+        // --- Test for "Yesterday" ---
+        // A timestamp from the previous day.
+        val yesterdayTimestamp = startOfDay.minus(2, java.time.temporal.ChronoUnit.HOURS).toEpochMilli()
+        assertThat(utilForToday.dateStringRelative(yesterdayTimestamp, rh)).isEqualTo("Yesterday")
+
+        // --- Test for "Later today" ---
+        val laterTodayTimestamp = startOfDay.plus(14, java.time.temporal.ChronoUnit.HOURS).toEpochMilli()
+        assertThat(utilForToday.dateStringRelative(laterTodayTimestamp, rh)).isEqualTo("Later today")
+
+        // --- Test for "Tomorrow" ---
+        val tomorrowTimestamp = startOfDay.plus(26, java.time.temporal.ChronoUnit.HOURS).toEpochMilli()
+        assertThat(utilForToday.dateStringRelative(tomorrowTimestamp, rh)).isEqualTo("Tomorrow")
+    }
+    @Test
+    fun `minAgo formats minutes ago and matches old behavior`() {
+        val rh = FakeResourceHelper()
+        // Test assumes that dateUtil.now() inside minAgo is close enough to System.currentTimeMillis()
+        val fiveMinutesInMillis = 5 * 60 * 1000L
+        val timestamp = System.currentTimeMillis() - fiveMinutesInMillis
+
+        val newResult = dateUtilImpl.minAgo(rh, timestamp)
+        val oldResult = dateUtilOldImpl.minAgo(rh, timestamp)
+
+        assertThat(newResult).startsWith("5 min ago") // Using startsWith to avoid issues with test execution time
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `minAgo is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val fiveMinutesAgo = fixedInstant.minus(5, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val expected = "5 min ago"
+
+        // ACT
+        val newResult = dateUtilImplDeter.minAgo(rh, fiveMinutesAgo)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `minOrSecAgo formats seconds and minutes correctly and matches old behavior`() {
+        val rh = FakeResourceHelper()
+        // Test for seconds
+        val thirtySecondsAgo = System.currentTimeMillis() - 30_000L
+        val newSecResult = dateUtilImpl.minOrSecAgo(rh, thirtySecondsAgo)
+        val oldSecResult = dateUtilOldImpl.minOrSecAgo(rh, thirtySecondsAgo)
+        assertThat(newSecResult).contains("30 sec ago")
+        assertThat(newSecResult).isEqualTo(oldSecResult)
+
+        // Test for minutes (e.g., 3 minutes ago)
+        val threeMinutesAgo = System.currentTimeMillis() - 180_000L
+        val newMinResult = dateUtilImpl.minOrSecAgo(rh, threeMinutesAgo)
+        val oldMinResult = dateUtilOldImpl.minOrSecAgo(rh, threeMinutesAgo)
+        assertThat(newMinResult).contains("3 min ago")
+        assertThat(newMinResult).isEqualTo(oldMinResult)
+    }
+    @Test
+    fun `minOrSecAgo is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+
+        // --- Test seconds case ---
+        val fortyFiveSecondsAgo = fixedInstant.minus(45, java.time.temporal.ChronoUnit.SECONDS).toEpochMilli()
+        val expectedSeconds = "45 sec ago"
+        assertThat(dateUtilImplDeter.minOrSecAgo(rh, fortyFiveSecondsAgo)).isEqualTo(expectedSeconds)
+
+        // --- Test minutes case ---
+        val threeMinutesAgo = fixedInstant.minus(3, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val expectedMinutes = "3 min ago"
+        assertThat(dateUtilImplDeter.minOrSecAgo(rh, threeMinutesAgo)).isEqualTo(expectedMinutes)
+    }
+    @Test
+    fun `minAgoShort works and matches old behavior`() {
+        // ARRANGE
+        val now = System.currentTimeMillis()
+        val fiveMinAgo = now - (5 * 60 * 1000L)
+        val expected = "(-5)"
+
+        // ACT
+        val newResult = dateUtilImpl.minAgoShort(fiveMinAgo)
+        val oldResult = dateUtilOldImpl.minAgoShort(fiveMinAgo)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `minAgoShort is deterministic with fixed clock`() {
+        // ARRANGE
+        val fiveMinutesAgo = fixedInstant.minus(5, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val fiveMinutesHence = fixedInstant.plus(5, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+
+        // ACT & ASSERT for past
+        assertThat(dateUtilImplDeter.minAgoShort(fiveMinutesAgo)).isEqualTo("(-5)")
+
+        // ACT & ASSERT for future
+        assertThat(dateUtilImplDeter.minAgoShort(fiveMinutesHence)).isEqualTo("(+5)")
+    }
+    @Test
+    fun `minAgoLong works and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val now = System.currentTimeMillis()
+        val sevenMinutesAgo = now - (7 * 60 * 1000L)
+        val expected = "7 minutes ago"
+
+        // ACT
+        val newResult = dateUtilImpl.minAgoLong(rh, sevenMinutesAgo)
+        val oldResult = dateUtilOldImpl.minAgoLong(rh, sevenMinutesAgo)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `minAgoLong is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val sevenMinutesAgo = fixedInstant.minus(7, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val expected = "7 minutes ago"
+
+        // ACT
+        val newResult = dateUtilImplDeter.minAgoLong(rh, sevenMinutesAgo)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `hourAgo works and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val now = System.currentTimeMillis()
+        val twoHoursAgo = now - (2 * 60 * 60 * 1000L)
+        val expected = "2 hours ago"
+
+        // ACT
+        val newResult = dateUtilImpl.hourAgo(twoHoursAgo, rh)
+        val oldResult = dateUtilOldImpl.hourAgo(twoHoursAgo, rh)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `hourAgo is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val twoHoursAgo = fixedInstant.minus(2, java.time.temporal.ChronoUnit.HOURS).toEpochMilli()
+        val expected = "2 hours ago"
+
+        // ACT
+        val newResult = dateUtilImplDeter.hourAgo(twoHoursAgo, rh)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `dayAgo works and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val now = System.currentTimeMillis()
+        val threeDaysAgo = now - (3 * 24 * 60 * 60 * 1000L)
+        val expected = "3 days ago"
+
+        // ACT
+        val newResult = dateUtilImpl.dayAgo(threeDaysAgo, rh)
+        val oldResult = dateUtilOldImpl.dayAgo(threeDaysAgo, rh)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `dayAgo is deterministic with fixed clock`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val threeDaysAgo = fixedInstant.minus(3, java.time.temporal.ChronoUnit.DAYS).toEpochMilli()
+        val expected = "3 days ago"
+
+        // ACT
+        // We test the non-rounding case here for simplicity
+        val newResult = dateUtilImplDeter.dayAgo(threeDaysAgo, rh, round = false)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `sinceString produces correct timeFrameString and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val pastTimestamp = 1698426000000L // 13:00:00 EDT
+        val nowForSince = 1698435000000L  // 15:30:00 EDT (2h 30m later)
+        val expectedSinceString = "(2h 30')"
+
+        // ACT
+        // Test the function it wraps: timeFrameString. This is a more direct unit test.
+        val sinceDuration = nowForSince - pastTimestamp
+        val newResult = dateUtilImpl.timeFrameString(sinceDuration, rh)
+        val oldResult = dateUtilOldImpl.timeFrameString(sinceDuration, rh)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expectedSinceString)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `sinceString is deterministic with fixed clock`() {
+        val rh = FakeResourceHelper()
+        val pastTimestamp = fixedInstant.minus(2, java.time.temporal.ChronoUnit.HOURS).minus(30, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val expected = "(2h 30')"
+        val newResult = dateUtilImplDeter.sinceString(pastTimestamp, rh)
+
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `untilString produces correct timeFrameString and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+        val nowForUntil = 1698436800000L // 16:00:00 EDT
+        val futureTimestamp = 1698441300000L // 17:15:00 EDT (1h 15m later)
+        val expectedUntilString = "(1h 15')"
+
+        // ACT
+        // Test the function it wraps: timeFrameString directly
+        val untilDuration = futureTimestamp - nowForUntil
+        val newResult = dateUtilImpl.timeFrameString(untilDuration, rh)
+        val oldResult = dateUtilOldImpl.timeFrameString(untilDuration, rh)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expectedUntilString)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `untilString is deterministic with fixed clock`() {
+        val rh = FakeResourceHelper()
+        // Our fixed clock is at 16:00 UTC. Let's test a timestamp for 1h 15m *after* that.
+        val futureTimestamp = fixedInstant.plus(1, java.time.temporal.ChronoUnit.HOURS).plus(15, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        val expected = "(1h 15')"
+        val newResult = dateUtilImplDeter.untilString(futureTimestamp, rh)
+        assertThat(newResult).isEqualTo(expected)
+    }
+    @Test
+    fun `age works for duration over a day and matches old behavior`() {
+        val millis = 95400 * 1000L // 1 day, 2 hours, 30 minutes
+        val rh = FakeResourceHelper()
+        val expected = "1 d 2 h "
+        val newResult = dateUtilImpl.age(millis, true, rh)
+        val oldResult = dateUtilOldImpl.age(millis, true, rh)
+
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+//TODO: age: Check if trailing whitespaces are needed
+        // expected                           : 1 d 2 h
+        // but was missing trailing whitespace: ␣
+    }
+    @Test
+    fun `age works for duration less than a day and matches old behavior`() {
+        val millis = 12600 * 1000L // 3 hours, 30 minutes
+        val rh = FakeResourceHelper()
+        val expected = "3 h 30 m "
+        val newResult = dateUtilImpl.age(millis, true, rh)
+        val oldResult = dateUtilOldImpl.age(millis, true, rh)
+
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `niceTimeScalar works works correctly now`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+
+        // ACT & ASSERT for seconds
+        val newSec = dateUtilImpl.niceTimeScalar(15 * 1000L, rh) // 15 seconds
+        val oldSec = dateUtilOldImpl.niceTimeScalar(15 * 1000L, rh)
+        assertThat(newSec).isEqualTo("15 seconds")
+        assertThat(newSec).isEqualTo(oldSec)
+
+        // ACT & ASSERT for minutes
+        val newMin = dateUtilImpl.niceTimeScalar(5 * 60 * 1000L, rh) // 5 minutes
+        val oldMin = dateUtilOldImpl.niceTimeScalar(5 * 60 * 1000L, rh)
+        assertThat(newMin).isEqualTo("5 minutes")
+        assertThat(newMin).isEqualTo(oldMin)
+
+        // ACT & ASSERT for hours
+        val newHour = dateUtilImpl.niceTimeScalar(2 * 3600 * 1000L, rh) // 2 hours
+        val oldHour = dateUtilOldImpl.niceTimeScalar(2 * 3600 * 1000L, rh)
+        assertThat(newHour).isEqualTo("2 hours")
+        assertThat(newHour).isEqualTo(oldHour)
+
+        // ACT & ASSERT for days
+        val newDay = dateUtilImpl.niceTimeScalar(4 * 86400 * 1000L, rh) // 4 days
+        val oldDay = dateUtilOldImpl.niceTimeScalar(4 * 86400 * 1000L, rh)
+        assertThat(newDay).isEqualTo("4 days")
+        assertThat(newDay).isEqualTo(oldDay)
+
+        // ACT & ASSERT for weeks
+        val newWeek = dateUtilImpl.niceTimeScalar(3 * 7 * 86400 * 1000L, rh) // 3 weeks
+        val oldWeek = dateUtilOldImpl.niceTimeScalar(3 * 7 * 86400 * 1000L, rh)
+        // 1. Assert the NEW implementation is as expected.
+        assertThat(newWeek).isEqualTo("3 weeks")
+        // 2. Assert the OLD implementation is different.
+//TODO: the old niceTimeScalar couldn't parse weeks.
+        assertThat(newWeek).isNotEqualTo(oldWeek)
+    }
+    //endregion
+
+    //region Date and Time Part Formatting
+    @Test
+    fun `secondString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // ...16:00:12.345
+        val expected = "12"
+
+        // ACT
+        val newResult = dateUtilImpl.secondString(millis)
+        val oldResult = dateUtilOldImpl.secondString(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `minuteString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // ...16:00:12.345
+        val expected = "00"
+
+        // ACT
+        val newResult = dateUtilImpl.minuteString(millis)
+        val oldResult = dateUtilOldImpl.minuteString(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `hourString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // ...16:00:12.345 (4 PM)
+
+        // ACT & ASSERT for 12-hour format
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val expected12Hour = "04"
+            assertThat(dateUtilImpl.hourString(millis)).isEqualTo(expected12Hour)
+            assertThat(dateUtilOldImpl.hourString(millis)).isEqualTo(expected12Hour)
+        }
+
+        // ACT & ASSERT for 24-hour format
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(true)
+            val expected24Hour = "16"
+            assertThat(dateUtilImpl.hourString(millis)).isEqualTo(expected24Hour)
+            assertThat(dateUtilOldImpl.hourString(millis)).isEqualTo(expected24Hour)
+        }
+    }
+    @Test
+    fun `amPm works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // ...16:00:12.345 (PM)
+        val expected = "PM"
+
+        // ACT
+        val newResult = dateUtilImpl.amPm(millis)
+        val oldResult = dateUtilOldImpl.amPm(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `dayNameString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // A Friday
+
+        // ACT & ASSERT for short name
+        val newShort = dateUtilImpl.dayNameString(millis, "EEE")
+        val oldShort = dateUtilOldImpl.dayNameString(millis, "EEE")
+        assertThat(newShort).isEqualTo("Fri")
+        assertThat(oldShort).isEqualTo("Fri")
+
+        // ACT & ASSERT for full name
+        val newFull = dateUtilImpl.dayNameString(millis, "EEEE")
+        val oldFull = dateUtilOldImpl.dayNameString(millis, "EEEE")
+        assertThat(newFull).isEqualTo("Friday")
+        assertThat(oldFull).isEqualTo("Friday")
+    }
+    @Test
+    fun `dayString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // The 27th of the month
+        val expected = "27"
+
+        // ACT
+        val newResult = dateUtilImpl.dayString(millis)
+        val oldResult = dateUtilOldImpl.dayString(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    @Test
+    fun `monthString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // October
+
+        // ACT & ASSERT for short name
+        val newShort = dateUtilImpl.monthString(millis, "MMM")
+        val oldShort = dateUtilOldImpl.monthString(millis, "MMM")
+        assertThat(newShort).isEqualTo("Oct")
+        assertThat(oldShort).isEqualTo("Oct")
+
+        // ACT & ASSERT for full name
+        val newFull = dateUtilImpl.monthString(millis, "MMMM")
+        val oldFull = dateUtilOldImpl.monthString(millis, "MMMM")
+        assertThat(newFull).isEqualTo("October")
+        assertThat(oldFull).isEqualTo("October")
+    }
+    @Test
+    fun `weekString works and matches old behavior`() {
+        // ARRANGE
+        val millis = 1698436812345L // Week 43 of the year
+        val expected = "43"
+
+        // ACT
+        val newResult = dateUtilImpl.weekString(millis)
+        val oldResult = dateUtilOldImpl.weekString(millis)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(oldResult).isEqualTo(expected)
+    }
+    //endregion
+
+    //region Time Calculation and Logic
+    @Test
+    fun `toSeconds works and matches old behavior`() {
+        val timeString = "2:30 PM"
+        val expectedSeconds = (14 * 3600) + (30 * 60)
+        val newResult = dateUtilImpl.toSeconds(timeString)
+        val oldResult = dateUtilOldImpl.toSeconds(timeString)
+
+        assertThat(newResult).isEqualTo(expectedSeconds)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `beginOfDay works and matches old behavior`() {
+        val millis = 1698455400000L // 2023-10-27 10:30 PM EDT
+        val expectedMillis = 1698379200000L // 2023-10-27 00:00:00 EDT
+        val newResult = dateUtilImpl.beginOfDay(millis)
+        val oldResult = dateUtilOldImpl.beginOfDay(millis)
+
+        assertThat(newResult).isEqualTo(expectedMillis)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `nowWithoutMilliseconds is deterministic with fixed clock`() {
+        // ARRANGE
+        // Our fixed clock is set to a time with milliseconds.
+        val expected = fixedInstant.truncatedTo(java.time.temporal.ChronoUnit.SECONDS).toEpochMilli()
+
+        // ACT
+        val newResult
+            = dateUtilImplDeter.nowWithoutMilliseconds()
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult %1000).isEqualTo(0L)
+    }
+
+    @Test
+    fun `isOlderThan is deterministic with fixed clock`() {
+        val tenMinutes = 10L
+        // --- Test for a timestamp that IS older ---
+        val fifteenMinutesAgo = fixedInstant.minus(15, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        Truth.assertThat(dateUtilImplDeter.isOlderThan(fifteenMinutesAgo, tenMinutes)).isTrue()
+        // --- Test for a timestamp that is NOT older ---
+        val fiveMinutesAgo = fixedInstant.minus(5, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        Truth.assertThat(dateUtilImplDeter.isOlderThan(fiveMinutesAgo, tenMinutes)).isFalse()
+        // --- Test for a timestamp that is exactly the same age ---
+        val tenMinutesAgo = fixedInstant.minus(10, java.time.temporal.ChronoUnit.MINUTES).toEpochMilli()
+        Truth.assertThat(dateUtilImplDeter.isOlderThan(tenMinutesAgo, tenMinutes)).isFalse()
+    }
+        @Test
+    fun `nowWithoutMilliseconds works and matches old behavior`() {
+        // We can't test the exact value, but we can test the property: it should be divisible by 1000
+        val newResult = dateUtilImpl.nowWithoutMilliseconds()
+        val oldResult = dateUtilOldImpl.nowWithoutMilliseconds()
+
+        assertThat(newResult % 1000).isEqualTo(0L)
+        assertThat(oldResult % 1000).isEqualTo(0L)
+    }
+    @Test
+    fun `isOlderThan works and matches old behavior`() {
+        val now = dateUtilImpl.now() // Use a fixed "now" for the test
+
+        // Test a timestamp that IS older
+        val timestampFrom15MinAgo = now - (15 * 60 * 1000L)
+        assertThat(dateUtilImpl.isOlderThan(timestampFrom15MinAgo, 10)).isTrue()
+        assertThat(dateUtilOldImpl.isOlderThan(timestampFrom15MinAgo, 10)).isTrue()
+
+        // Test a timestamp that is NOT older
+        val timestampFrom5MinAgo = now - (5 * 60 * 1000L)
+        assertThat(dateUtilImpl.isOlderThan(timestampFrom5MinAgo, 10)).isFalse()
+        assertThat(dateUtilOldImpl.isOlderThan(timestampFrom5MinAgo, 10)).isFalse()
+    }
+    @Test
+    fun `isAfterNoon works and matches old behavior`() {
+        val newResult = dateUtilImpl.isAfterNoon()
+        val oldResult = dateUtilOldImpl.isAfterNoon()
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `isAfterNoon is deterministic with fixed clock`() {
+        // ARRANGE: An instant that is in the afternoon (16:00 UTC)
+        val afternoonInstant = Instant.parse("2023-10-27T16:00:00Z")
+        val afternoonClock = Clock.fixed(afternoonInstant, fixedZone)
+        val afternoonDateUtil = DateUtilImpl(mockContext, afternoonClock)
+
+        // ASSERT that 4 PM is after noon
+        assertThat(afternoonDateUtil.isAfterNoon()).isTrue()
+
+        // ARRANGE: An instant that is in the morning (10:00 UTC)
+        val morningInstant = Instant.parse("2023-10-27T10:00:00Z")
+        val morningClock = Clock.fixed(morningInstant, fixedZone)
+        val morningDateUtil = DateUtilImpl(mockContext, morningClock)
+
+        // ASSERT that 10 AM is not after noon
+        assertThat(morningDateUtil.isAfterNoon()).isFalse()
+        // ARRANGE: A clock fixed to 2 PM in the test's default zone
+        val afternoonInstantb = Instant.parse("2023-10-27T18:00:00Z") // 18:00 UTC is 14:00 (2 PM) EDT
+        val afternoonClockb = Clock.fixed(afternoonInstantb, fixedZone)
+        val afternoonDateUtilb = DateUtilImpl(mockContext, afternoonClockb)
+
+        // ASSERT that 2 PM is after noon
+        Truth.assertThat(afternoonDateUtilb.isAfterNoon()).isTrue()
+
+        // ARRANGE: A clock fixed to 10 AM in the test's default zone
+        val morningInstantb = Instant.parse("2023-10-27T14:00:00Z") // 14:00 UTC is 10:00 AM EDT
+        val morningClockb = Clock.fixed(morningInstantb, fixedZone)
+        val morningDateUtilb = DateUtilImpl(mockContext, morningClockb)
+
+        // ASSERT that 10 AM is not after noon
+        assertThat(morningDateUtilb.isAfterNoon()).isFalse()
+    }
+    @Test
+    fun `isSameDayGroup works and matches old behavior`() {
+        // ARRANGE
+        val now = dateUtilImpl.now() // Use a fixed "now" for the test
+        val oneHour = 3600 * 1000L
+
+        // --- Case 1: TRUE ---
+        // Both timestamps on the same day, and "now" is NOT between them.
+        val ts1_case1 = now - (2 * oneHour) // 2 hours ago
+        val ts2_case1 = now - (1 * oneHour) // 1 hour ago
+        assertThat(dateUtilImpl.isSameDayGroup(ts1_case1, ts2_case1)).isTrue()
+        assertThat(dateUtilOldImpl.isSameDayGroup(ts1_case1, ts2_case1)).isTrue()
+
+        // --- Case 2: FALSE (due to "now" check) ---
+        // Both timestamps on the same day, but "now" IS between them.
+        val ts1_case2 = now - oneHour // 1 hour ago
+        val ts2_case2 = now + oneHour // 1 hour in the future
+        assertThat(dateUtilImpl.isSameDayGroup(ts1_case2, ts2_case2)).isFalse()
+        assertThat(dateUtilOldImpl.isSameDayGroup(ts1_case2, ts2_case2)).isFalse()
+
+        // --- Case 3: FALSE (due to date check) ---
+        // Timestamps on different days.
+        val ts1_case3 = now - (36 * oneHour) // Yesterday
+        val ts2_case3 = now - (12 * oneHour) // Today
+        assertThat(dateUtilImpl.isSameDayGroup(ts1_case3, ts2_case3)).isFalse()
+        assertThat(dateUtilOldImpl.isSameDayGroup(ts1_case3, ts2_case3)).isFalse()
+    }
+
+    @Test
+    fun `computeDiff works and matches old behavior`() {
+        // ARRANGE
+        val date1 = 1698311223344L // Some start time
+        val date2 = date1 + (1 * 86400000L) + (3 * 3600000L) + (46 * 60000L) + (40 * 1000L) // 1d, 3h, 46m, 40s later
+
+        // ACT
+        val newResult = dateUtilImpl.computeDiff(date1, date2)
+        val oldResult = dateUtilOldImpl.computeDiff(date1, date2)
+
+        // ASSERT
+        assertThat(newResult[TimeUnit.DAYS]).isEqualTo(1L)
+        assertThat(newResult[TimeUnit.HOURS]).isEqualTo(3L)
+        assertThat(newResult[TimeUnit.MINUTES]).isEqualTo(46L)
+        assertThat(newResult[TimeUnit.SECONDS]).isEqualTo(40L)
+
+        // Check that the new, clearer implementation matches the old, complex one
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+
+    @Test
+    fun `timeStringFromSeconds produces a minute-precision string and matches old behavior`() {
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(true)
+            val inputSeconds = (14 * 3600) + (5 * 60) + 30
+            val expected = "14:05"
+            val newResult = dateUtilImpl.timeStringFromSeconds(inputSeconds)
+            val oldResult = dateUtilOldImpl.timeStringFromSeconds(inputSeconds)
+
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(oldResult).isEqualTo(newResult)
+        }
+    }
+    @Test
+    fun`timeFrameString formats durations correctly and matches old behavior`() {
+        // ARRANGE
+        val rh = FakeResourceHelper()
+
+        // --- Case 1: Hours and Minutes ---
+        // 2 hours and 30 minutes
+        val duration1 = (2 *3600 * 1000L) + (30 * 60 * 1000L)
+        val expected1 = "(2h 30')"
+        assertThat(dateUtilImpl.timeFrameString(duration1, rh)).isEqualTo(expected1)
+        assertThat(dateUtilOldImpl.timeFrameString(duration1, rh)).isEqualTo(expected1)
+
+        // --- Case 2: Only Minutes ---
+        // 45 minutes
+        val duration2 = 45 * 60 * 1000L
+        val expected2 = "(45')"
+        assertThat(dateUtilImpl.timeFrameString(duration2, rh)).isEqualTo(expected2)
+        assertThat(dateUtilOldImpl.timeFrameString(duration2, rh)).isEqualTo(expected2)
+
+        // --- Case 3: Zero ---
+        val duration3 = 0L
+        val expected3 = "(0')"
+        assertThat(dateUtilImpl.timeFrameString(duration3, rh)).isEqualTo(expected3)
+        assertThat(dateUtilOldImpl.timeFrameString(duration3, rh)).isEqualTo(expected3)
+    }
+    //endregion
+
+    //region Timezone Logic
+                         @Test
+    fun `getTimeZoneOffsetMs works and matches old non-DST-aware behavior`() {
+        // ARRANGE
+        // For America/New_York, the standard offset is always UTC-5 (EST).
+        // Both the old and new functions are NOT DST-aware.
+        val expectedStandardOffsetMillis = -5 * 60 * 60 * 1000L
+        val newResult = dateUtilImpl.getTimeZoneOffsetMs()
+        val oldResult = dateUtilOldImpl.getTimeZoneOffsetMs()
+
+        // Assert that both functions return the correct standard offset, ignoring DST.
+        assertThat(newResult).isEqualTo(expectedStandardOffsetMillis)
+        assertThat(oldResult).isEqualTo(expectedStandardOffsetMillis)
+    }
+    @Test
+    fun `getTimeZoneOffsetMs variants behave as expected`() {
+        // ARRANGE
+        // A time in the winter (Standard Time, EST, UTC-5)
+        val winterInstant = Instant.parse("2023-01-15T12:00:00Z")
+        val winterClock = Clock.fixed(winterInstant, fixedZone)
+        val winterDateUtil = DateUtilImpl(mockContext, winterClock)
+        val expectedStandardOffset = -5 * 3600 * 1000L // -18,000,000
+
+        // A time in the summer (Daylight Time, EDT, UTC-4)
+        val summerInstant = Instant.parse("2023-07-15T12:00:00Z")
+        val summerClock = Clock.fixed(summerInstant, fixedZone)
+        val summerDateUtil = DateUtilImpl(mockContext, summerClock)
+        val expectedDaylightOffset = -4 * 3600 * 1000L // -14,400,000
+
+        // --- ACT & ASSERT for Winter (Standard Time) ---
+        val newResultWinter = winterDateUtil.getTimeZoneOffsetMs()
+        val newResultWinterDst = winterDateUtil.getTimeZoneOffsetMsWithDST()
+        val oldResultWinter = dateUtilOldImpl.getTimeZoneOffsetMs()
+
+        // In winter, all three should agree and be the standard offset.
+        assertThat(newResultWinter).isEqualTo(expectedStandardOffset)
+        assertThat(newResultWinterDst).isEqualTo(expectedStandardOffset)
+        assertThat(oldResultWinter).isEqualTo(expectedStandardOffset)
+
+        // --- ACT & ASSERT for Summer (Daylight Time) ---
+        val newResultSummer = summerDateUtil.getTimeZoneOffsetMs()
+        val newResultSummerDst = summerDateUtil.getTimeZoneOffsetMsWithDST()
+        val oldResultSummer = dateUtilOldImpl.getTimeZoneOffsetMs()
+
+        // In summer, the two non-DST-aware functions should still report the STANDARD offset.
+        assertThat(newResultSummer).isEqualTo(expectedStandardOffset)
+        assertThat(oldResultSummer).isEqualTo(expectedStandardOffset)
+
+        // But the new DST-aware function should report the correct DAYLIGHT offset.
+        assertThat(newResultSummerDst).isEqualTo(expectedDaylightOffset)
+
+        // This also proves the DST-aware function is different from the others in summer.
+        assertThat(newResultSummerDst).isNotEqualTo(newResultSummer)
+    }
+    @Test
+    fun `getTimeZoneOffsetMinutes reports correct offset for standard and daylight time and matches old behavior`() {
+        // A time in the winter (Standard Time, EST, UTC-5)
+        val winterTimestamp = Instant.parse("2023-01-15T12:00:00Z").toEpochMilli()
+        val expectedWinterMinutes = -5 * 60
+        // A time in the summer (Daylight Time, EDT, UTC-4)
+        val summerTimestamp = Instant.parse("2023-07-15T12:00:00Z").toEpochMilli()
+        val expectedSummerMinutes = -4 * 60
+        val newWinterResult = dateUtilImpl.getTimeZoneOffsetMinutes(winterTimestamp)
+        val newSummerResult = dateUtilImpl.getTimeZoneOffsetMinutes(summerTimestamp)
+        val oldWinterResult = dateUtilOldImpl.getTimeZoneOffsetMinutes(winterTimestamp)
+        val oldSummerResult = dateUtilOldImpl.getTimeZoneOffsetMinutes(summerTimestamp)
+
+        assertThat(newWinterResult).isEqualTo(expectedWinterMinutes)
+        assertThat(newSummerResult).isEqualTo(expectedSummerMinutes)
+        assertThat(newWinterResult).isEqualTo(oldWinterResult)
+        assertThat(newSummerResult).isEqualTo(oldSummerResult)
+    }
+    @Test
+    fun `timeZoneByOffset finds a timezone with the correct offset including non-hourly offsets`() {
+        // ARRANGE: A list of offsets to test (in milliseconds)
+        val offsetsToTest = listOf(
+            -18000000L, // UTC-5 (EST)
+            -14400000L, // UTC-4 (EDT)
+            3600000L    // UTC+1 (CET)
+        )
+        val indiaOffset = 19800000L // UTC+5:30 (India Standard Time)
+
+        // Test the standard, hourly offsets first
+        for (offset in offsetsToTest) {
+            val newZoneIdString = dateUtilImpl.timeZoneByOffset(offset)
+            val oldZoneIdString = dateUtilOldImpl.timeZoneByOffset(offset).id
+            val newZoneId = ZoneId.of(newZoneIdString)
+            val oldZoneId = ZoneId.of(oldZoneIdString)
+            val newOffsetSeconds = newZoneId.rules.getOffset(Instant.now()).totalSeconds
+            val oldOffsetSeconds = oldZoneId.rules.getOffset(Instant.now()).totalSeconds
+            val expectedOffsetSeconds = (offset / 1000).toInt()
+
+            // Assert both new and old are correct for hourly offsets
+            assertThat(newOffsetSeconds).isEqualTo(expectedOffsetSeconds)
+            assertThat(oldOffsetSeconds).isEqualTo(expectedOffsetSeconds)
+        }
+
+        // Test the non-hourly offset separately to document the bug fix
+        val expectedIndiaOffsetSeconds = (indiaOffset / 1000).toInt() // 19800
+        val newIndiaZoneIdString = dateUtilImpl.timeZoneByOffset(indiaOffset)
+        val oldIndiaZoneIdString = dateUtilOldImpl.timeZoneByOffset(indiaOffset).id
+        val newIndiaOffsetSeconds = ZoneId.of(newIndiaZoneIdString).rules.getOffset(Instant.now()).totalSeconds
+        val oldIndiaOffsetSeconds = ZoneId.of(oldIndiaZoneIdString).rules.getOffset(Instant.now()).totalSeconds
+
+        // 1. Assert the NEW implementation is as expected.
+        assertThat(newIndiaOffsetSeconds).isEqualTo(expectedIndiaOffsetSeconds)
+        // 2. Assert the OLD implementation is different.
+// TODO the old timeZoneByOffset didn't work for non-hourly offset:
+        assertThat(oldIndiaOffsetSeconds).isNotEqualTo(expectedIndiaOffsetSeconds)
+
+        // Also test the zero case specifically
+        assertThat(dateUtilImpl.timeZoneByOffset(0L)).isEqualTo("UTC")
+        assertThat(dateUtilOldImpl.timeZoneByOffset(0L).id).isEqualTo("UTC")
+    }
+    @Test
+    fun `getTimestampWithCurrentTimeOfDay combines date and time correctly (new implementation)`() {
+        // This test is tricky because it depends on `now()`.
+        // We can't test the exact output, but we can test that the date part is correct.
+        val oldDateTimestamp = 1668556800000L // A date in the past: Nov 16, 2022
+        val resultTimestamp = dateUtilImpl.getTimestampWithCurrentTimeOfDay(oldDateTimestamp)
+
+        // Get the date part of the result and the original
+        val resultDateString = dateUtilImpl.dateString(resultTimestamp)
+        val originalDateString = dateUtilImpl.dateString(oldDateTimestamp)
+
+        assertThat(resultDateString).isEqualTo(originalDateString)
+    }
+    @Test
+    fun `mergeUtcDateToTimestamp works and matches old behavior`() {
+        // The original timestamp, which contains the TIME we want to keep (16:00 EDT)
+        val timeToKeep = 1698436800000L
+        // The new date from the picker, which is a UTC midnight timestamp (e.g., Oct 20)
+        val newDate = 1697760000000L
+
+        // Expected result: Oct 20 at 16:00 EDT
+        val expectedResult = 1697832000000L
+
+        val newResult = dateUtilImpl.mergeUtcDateToTimestamp(timeToKeep, newDate)
+        val oldResult = dateUtilOldImpl.mergeUtcDateToTimestamp(timeToKeep, newDate)
+
+        assertThat(newResult).isEqualTo(expectedResult)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `mergeHourMinuteToTimestamp works and matches old behavior`() {
+        // ARRANGE: A base timestamp and the hour/minute we want to set
+        val baseTimestamp = 1698379200000L // Oct 27, 2023 00:00:00 EDT
+        val hour = 14 // 2:00 PM
+        val minute = 30
+
+        // Expected result: Oct 27, 2023 at 14:30:00 EDT
+        val expectedResult = 1698431400000L
+
+        // ACT
+        val newResult = dateUtilImpl.mergeHourMinuteToTimestamp(baseTimestamp, hour, minute)
+        val oldResult = dateUtilOldImpl.mergeHourMinuteToTimestamp(baseTimestamp, hour, minute)
+
+        // ASSERT
+        assertThat(newResult).isEqualTo(expectedResult)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    //endregion
+
+    //region DST Transition Scenarios
+                         @Test
+    fun `beginOfDay works correctly on DST spring forward day and matches old behavior`() {
+        // In New York, 2023, DST starts on March 12.
+        val millisOnSpringForwardDay = 1678604700000L // 2023-03-12 03:05:00 EDT
+        val expectedStartOfDay = 1678597200000L // 2023-03-12 00:00:00 EST
+
+        val newResult = dateUtilImpl.beginOfDay(millisOnSpringForwardDay)
+        val oldResult = dateUtilOldImpl.beginOfDay(millisOnSpringForwardDay)
+
+        assertThat(newResult).isEqualTo(expectedStartOfDay)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `isSameDay works correctly across the DST fall back transition and matches old behavior`() {
+        // In New York, 2023, DST ends on Nov 5.
+        val timeBeforeFallback = 1699162200000L // Represents 1:30 AM EDT
+        val timeAfterFallback = 1699165800000L  // Represents 1:30 AM EST (an hour later)
+
+        val newResult = dateUtilImpl.isSameDay(timeBeforeFallback, timeAfterFallback)
+        val oldResult = dateUtilOldImpl.isSameDay(timeBeforeFallback, timeAfterFallback)
+
+        assertThat(newResult).isTrue()
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `timeString correctly formats time during non-existent DST spring forward gap and matches old behavior`() {
+        // On March 12, 2023, in New York, 2:30 AM does not exist.
+        // A timestamp that would fall into this gap is automatically moved forward.
+        // 06:30:00 UTC corresponds to the non-existent 02:30:00 EST.
+        // java.time will represent this as 03:30:00 EDT.
+        val nonExistentTimeMillis = 1678602600000L
+        val expected = "01:30 AM" // since 02:30:00 EST does not exist, it reverts to 01:30 AM
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            val newResult = dateUtilImpl.timeString(nonExistentTimeMillis)
+            val oldResult = dateUtilOldImpl.timeString(nonExistentTimeMillis)
+
+            assertThat(newResult).isEqualTo(expected)
+            assertThat(newResult).isEqualTo(oldResult)
+        }
+    }
+    @Test
+    fun `timeString correctly formats ambiguous time during DST fall back and matches old behavior`() {
+        // On Nov 5, 2023, in New York, 1:30 AM happens twice.
+        val timeBeforeFallback = 1699162200000L // This is 1:30 AM EDT
+        val timeAfterFallback = 1699165800000L  // This is 1:30 AM EST (one hour later)
+        val expected = "01:30 AM"
+        mockStatic(DateFormat::class.java).use { mockedStatic ->
+            mockedStatic.`when`<Boolean> { DateFormat.is24HourFormat(mockContext) }.thenReturn(false)
+            // Both should appear as "1:30 AM" to the user, even though they are an hour apart.
+            val resultBefore = dateUtilImpl.timeString(timeBeforeFallback)
+            val resultAfter = dateUtilImpl.timeString(timeAfterFallback)
+            val oldResultBefore = dateUtilOldImpl.timeString(timeBeforeFallback)
+            val oldResultAfter = dateUtilOldImpl.timeString(timeAfterFallback)
+
+            assertThat(resultBefore).isEqualTo(expected)
+            assertThat(resultAfter).isEqualTo(expected)
+            assertThat(oldResultBefore).isEqualTo(resultBefore)
+            assertThat(oldResultAfter).isEqualTo(resultAfter)
+        }
+    }
+    @Test
+    fun `age calculation is correct across DST spring forward and matches old behavior`() {
+        // A duration that starts just before the DST gap and ends just after.
+        // In New York on March 12, 2023, time jumps from 1:59:59 EST to 3:00:00 EDT.
+        // The duration between 1:00 AM EST and 3:00 AM EDT is only ONE hour, not two.
+        val startTime = 1678599600000L // 2023-03-12 01:00:00 EST
+        val endTime = 1678606800000L   // 2023-03-12 03:00:00 EDT
+        val durationMillis = endTime - startTime
+        val rh = FakeResourceHelper()
+        val expected = "2 h 0 m "
+// TODO: age calculation should be evaluated - only one hour passes but the clock jumps two.
+        val newResult = dateUtilImpl.age(durationMillis, true, rh)
+        val oldResult = dateUtilOldImpl.age(durationMillis, true, rh)
+
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `age calculation is correct across DST fall back and matches old behavior`() {
+        // In New York on Nov 5, 2023, the clock goes from 1:59 EDT to 1:00 EST.
+        // The real-world elapsed time between 1:00 EDT and 2:00 EST is 2 hours,
+        // but the raw millisecond duration is 3 hours.
+// TODO: check what The age() function's output should actually be.
+        val startTime = 1699160400000L // 2023-11-05 01:00:00 EDT
+        val endTime = 1699171200000L   // 2023-11-05 02:00:00 EST
+        val durationMillis = endTime - startTime // This value is 10,800,000
+        val rh = FakeResourceHelper()
+        val expected = "3 h 0 m "
+        val newResult = dateUtilImpl.age(durationMillis, true, rh)
+        val oldResult = dateUtilOldImpl.age(durationMillis, true, rh)
+
+        assertThat(newResult).isEqualTo(expected)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `isSameDay is false for times just under 24 hours apart across DST and matches old behavior`() {
+        // Spring forward day (March 12) is only 23 hours long.
+        val startOfDay = 1678597200000L // Mar 12, 00:00:00 EST
+        val endOfDay = startOfDay + (23 * 60 * 60 * 1000) - 1 // 22:59:59 from start
+        val isSame = dateUtilImpl.isSameDay(startOfDay, endOfDay)
+        val isDifferent = dateUtilImpl.isSameDay(startOfDay, endOfDay + 1) // Now on the next day
+        val isSameOld = dateUtilOldImpl.isSameDay(startOfDay, endOfDay)
+        val isDifferentOld = dateUtilOldImpl.isSameDay(startOfDay, endOfDay + 1) // Now on the next day
+
+        assertThat(isSame).isTrue()
+        assertThat(isDifferent).isFalse()
+        assertThat(isSame).isEqualTo(isSameOld)
+        assertThat(isDifferent).isEqualTo(isDifferentOld)
+    }
+    @Test
+    fun `beginOfDay works correctly on DST fall back day and matches old behavior`() {
+        // On Nov 5, the day is 25 hours long, but beginOfDay should still find the start.
+        val timeDuringFallback = 1699203600000L // 2023-11-05 12:00:00 EST
+        val expectedStartOfDay = 1699156800000L // 2023-11-05 00:00:00 EDT
+        val newResult = dateUtilImpl.beginOfDay(timeDuringFallback)
+        val oldResult = dateUtilOldImpl.beginOfDay(timeDuringFallback)
+
+        assertThat(newResult).isEqualTo(expectedStartOfDay)
+        assertThat(newResult).isEqualTo(oldResult)
+    }
+    @Test
+    fun `getTimeZoneOffsetMinutes works for European DST and matches old behavior`() {
+        // This test MUST change the global default timezone because the functions
+        // are hard-coded to use ZoneId.systemDefault() and DateTimeZone.getDefault().
+
+        // 1. Save the original global defaults
+        val originalZone = TimeZone.getDefault()
+        val originalJodaZone = DateTimeZone.getDefault()
+
+        try {
+            // 2. Set the global defaults to a European timezone for this test
+            // The redundant qualifiers have been removed as requested.
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"))
+            DateTimeZone.setDefault(DateTimeZone.forID("Europe/Berlin"))
+
+            // 3. Re-instantiate the classes to make them pick up the new default zone
+            val localDateUtil = DateUtilImpl(mockContext)
+            val localDateUtilOld = DateUtilOldImpl(mockContext)
+
+            // ARRANGE: Timestamps in winter (CET, UTC+1) and summer (CEST, UTC+2)
+            val winterTimestamp = Instant.parse("2023-01-15T12:00:00Z").toEpochMilli()
+            val expectedWinterMinutes = 60
+            val summerTimestamp = Instant.parse("2023-07-15T12:00:00Z").toEpochMilli()
+            val expectedSummerMinutes = 120
+
+            // ACT
+            val newWinterResult = localDateUtil.getTimeZoneOffsetMinutes(winterTimestamp)
+            val newSummerResult = localDateUtil.getTimeZoneOffsetMinutes(summerTimestamp)
+            val oldWinterResult = localDateUtilOld.getTimeZoneOffsetMinutes(winterTimestamp)
+            val oldSummerResult = localDateUtilOld.getTimeZoneOffsetMinutes(summerTimestamp)
+
+            // ASSERT
+            assertThat(newWinterResult).isEqualTo(expectedWinterMinutes)
+            assertThat(newSummerResult).isEqualTo(expectedSummerMinutes)
+            assertThat(newWinterResult).isEqualTo(oldWinterResult)
+            assertThat(newSummerResult).isEqualTo(oldSummerResult)
+
+        } finally {
+            // 4. CRITICAL: Always reset the global defaults to not affect other tests.
+            TimeZone.setDefault(originalZone)
+            DateTimeZone.setDefault(originalJodaZone)
+        }
+    }
+    //endregion
+
+
+    //region Formatting Utilities
+    @Test
+    fun `qs formats numbers correctly and matches old behavior`() {
+        // --- Case 1: Explicit number of digits ---
+        val number = 12.345
+        assertThat(dateUtilImpl.qs(number, 0)).isEqualTo("12")
+        assertThat(dateUtilImpl.qs(number, 1)).isEqualTo("12.3")
+        assertThat(dateUtilImpl.qs(number, 2)).isEqualTo("12.35") // Note: DecimalFormat rounds!
+
+        // Compare new and old implementations
+        assertThat(dateUtilImpl.qs(number, 0)).isEqualTo(dateUtilOldImpl.qs(number, 0))
+        assertThat(dateUtilImpl.qs(number, 1)).isEqualTo(dateUtilOldImpl.qs(number, 1))
+        assertThat(dateUtilImpl.qs(number, 2)).isEqualTo(dateUtilOldImpl.qs(number, 2))
+
+        // --- Case 2: Automatic digit detection (numDigits = -1) ---
+        // This logic is complex, so we test its known outputs.
+
+        // The original implementation returns "12" for 12.0, not "12.0".
+        // This is because it sets maximumFractionDigits, which does not show trailing zeros.
+        // We assert this behavior is maintained.
+        assertThat(dateUtilImpl.qs(12.0, -1)).isEqualTo("12")
+//        assertThat(dateUtilImpl.qs(12.3, -1)).isEqualTo("12.3")
+//        assertThat(dateUtilImpl.qs(12.34, -1)).isEqualTo("12.34")
+
+        // Compare new and old implementations for the automatic case
+        assertThat(dateUtilImpl.qs(12.0, -1)).isEqualTo(dateUtilOldImpl.qs(12.0, -1))
+        assertThat(dateUtilImpl.qs(12.3, -1)).isEqualTo(dateUtilOldImpl.qs(12.3, -1))
+        assertThat(dateUtilImpl.qs(12.34, -1)).isEqualTo(dateUtilOldImpl.qs(12.34, -1))
+    }
+//endregion
+
+     /**
+     * A fake implementation of ResourceHelper for unit testing.
+     * This class implements the full ResourceHelper interface, providing predictable values.
+     */
+    class FakeResourceHelper : app.aaps.core.interfaces.resources.ResourceHelper {
+
+        // --- Methods genuinely used by DateUtil tests ---
+        override fun gs(id: Int): String = getStringForId(id)
+        override fun gs(id: Int, vararg args: Any?): String {
+            return when (id) {
+                app.aaps.core.interfaces.R.string.minago -> "${args.firstOrNull() ?: ""} min ago"
+                app.aaps.core.interfaces.R.string.minago_long -> "${args.firstOrNull() ?: ""} minutes ago"
+                app.aaps.core.interfaces.R.string.secago -> "${args.firstOrNull() ?: ""} sec ago"
+                app.aaps.core.interfaces.R.string.hoursago -> {
+                    val hours = when (val arg = args.firstOrNull()) {
+                        is Double -> arg.toLong()
+                        is Long -> arg
+                        else -> 0L
+                    }
+                    "${hours} hours ago"
+                }
+                app.aaps.core.interfaces.R.string.days_ago_round,
+                app.aaps.core.interfaces.R.string.days_ago -> {
+                    val days = when (val arg = args.firstOrNull()) {
+                        is Double -> arg.toLong()
+                        is Long -> arg
+                        else -> 0L
+                    }
+                    "${days} days ago"
+                }
+                // Add more formatted strings here as needed by other tests
+                else -> getStringForId(id)
+            }
+        }
+
+        private fun getStringForId(id: Int): String {
+            return when (id) {
+                app.aaps.core.interfaces.R.string.shortday -> "d"
+                app.aaps.core.interfaces.R.string.shorthour -> "h"
+                app.aaps.core.interfaces.R.string.shortminute -> "m"
+                app.aaps.core.interfaces.R.string.unit_seconds -> "seconds"
+                app.aaps.core.interfaces.R.string.unit_minutes -> "minutes"
+                app.aaps.core.interfaces.R.string.unit_hours -> "hours"
+                app.aaps.core.interfaces.R.string.unit_days -> "days"
+                app.aaps.core.interfaces.R.string.unit_weeks -> "weeks"
+                app.aaps.core.interfaces.R.string.hours -> "hours"
+                app.aaps.core.interfaces.R.string.today -> "Today"
+                app.aaps.core.interfaces.R.string.yesterday -> "Yesterday"
+                app.aaps.core.interfaces.R.string.tomorrow -> "Tomorrow"
+                app.aaps.core.interfaces.R.string.later_today -> "Later today"
+                else -> "unhandled" // Default for unhandled resources
+            }
+        }
+
+        // --- Dummy implementations for the rest of the interface ---
+        override fun gq(id: Int, quantity: Int, vararg args: Any?): String = ""
+        override fun gsNotLocalised(id: Int, vararg args: Any?): String = ""
+        override fun gc(id: Int): Int = 0
+        override fun gd(id: Int): Drawable? = null
+        override fun gb(id: Int): Boolean = false
+        override fun gcs(id: Int): String = ""
+        override fun gsa(id: Int): Array<String> = emptyArray()
+        override fun openRawResourceFd(id: Int): AssetFileDescriptor? = null
+        override fun decodeResource(id: Int): Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        override fun getDisplayMetrics(): DisplayMetrics = DisplayMetrics()
+        override fun dpToPx(dp: Int): Int = dp
+        override fun dpToPx(dp: Float): Int = dp.toInt()
+        override fun shortTextMode(): Boolean = true
+        override fun gac(attributeId: Int): Int = 0
+        override fun gac(context: Context?, attributeId: Int): Int = 0
+        override fun getThemedCtx(context: Context): Context = context
+    }
+}

--- a/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilOld.kt
+++ b/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilOld.kt
@@ -1,0 +1,92 @@
+package app.aaps.shared.impl.utils
+
+import app.aaps.core.interfaces.resources.ResourceHelper
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+
+/**
+ * The Class DateUtil. A simple wrapper around SimpleDateFormat to ease the handling of iso date string &lt;-&gt; date obj
+ * with TZ
+ */
+interface DateUtilOld {
+
+    /**
+     * Takes in an ISO date string of the following format:
+     * yyyy-mm-ddThh:mm:ss.ms+HoMo
+     *
+     * @param isoDateString the iso date string
+     * @return the date
+     */
+    fun fromISODateString(isoDateString: String): Long
+
+    /**
+     * Render date
+     *
+     * @param date   the date obj
+     * @return the iso-formatted date string
+     */
+    fun toISOString(date: Long): String
+    fun toISOAsUTC(timestamp: Long): String
+    fun toISONoZone(timestamp: Long): String
+    fun secondsOfTheDayToMilliseconds(seconds: Int): Long
+    fun toSeconds(hhColonMm: String): Int
+    fun dateString(mills: Long): String
+    fun dateStringRelative(mills: Long, rh: ResourceHelper): String
+    fun dateStringShort(mills: Long): String
+    fun timeString(): String
+    fun timeString(mills: Long): String
+    fun secondString(): String
+    fun secondString(mills: Long): String
+    fun minuteString(): String
+    fun minuteString(mills: Long): String
+    fun hourString(): String
+    fun hourString(mills: Long): String
+    fun amPm(): String
+    fun amPm(mills: Long): String
+    fun dayNameString(format: String = "E"): String //fun dayNameString(format: String): String //original broke the contract
+    fun dayNameString(mills: Long, format: String = "E"): String //fun dayNameString(mills: Long, format: String): String //original broke the contract
+    fun dayString(): String = dayString(now())
+    fun dayString(mills: Long): String
+    fun monthString(format: String = "MMM"): String //fun monthString(format: String): String //original broke the contract
+    fun monthString(mills: Long, format: String = "MMM"): String //fun monthString(mills: Long, format: String): String //original broke the contract
+    fun weekString(): String
+    fun weekString(mills: Long): String
+    fun timeStringWithSeconds(mills: Long): String
+    fun dateAndTimeRangeString(start: Long, end: Long): String
+    fun timeRangeString(start: Long, end: Long): String
+    fun dateAndTimeString(mills: Long): String
+    fun dateAndTimeStringNullable(mills: Long?): String?
+    fun dateAndTimeAndSecondsString(mills: Long): String
+    fun minAgo(rh: ResourceHelper, time: Long?): String
+    fun minOrSecAgo(rh: ResourceHelper, time: Long?): String
+    fun minAgoShort(time: Long?): String
+    fun minAgoLong(rh: ResourceHelper, time: Long?): String
+    fun hourAgo(time: Long, rh: ResourceHelper): String
+    fun dayAgo(time: Long, rh: ResourceHelper, round: Boolean = false): String //fun dayAgo(time: Long, rh: ResourceHelper, round: Boolean): String //original broke the contract
+    fun beginOfDay(mills: Long): Long
+    fun timeStringFromSeconds(seconds: Int): String
+    fun timeFrameString(timeInMillis: Long, rh: ResourceHelper): String
+    fun sinceString(timestamp: Long, rh: ResourceHelper): String
+    fun untilString(timestamp: Long, rh: ResourceHelper): String
+    fun now(): Long
+    fun nowWithoutMilliseconds(): Long
+    fun isOlderThan(date: Long, minutes: Long): Boolean
+    fun getTimeZoneOffsetMs(): Long
+    fun getTimeZoneOffsetMinutes(timestamp: Long): Int
+    fun isSameDay(timestamp1: Long, timestamp2: Long): Boolean
+    fun isAfterNoon(): Boolean
+
+    fun isSameDayGroup(timestamp1: Long, timestamp2: Long): Boolean
+
+    //Map:{DAYS=1, HOURS=3, MINUTES=46, SECONDS=40, MILLISECONDS=0, MICROSECONDS=0, NANOSECONDS=0}
+    fun computeDiff(date1: Long, date2: Long): Map<TimeUnit, Long>
+    fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String
+    fun niceTimeScalar(time: Long, rh: ResourceHelper): String
+    fun qs(x: Double, numDigits: Int): String
+    fun formatHHMM(timeAsSeconds: Int): String
+
+    fun timeZoneByOffset(offsetInMilliseconds: Long): TimeZone
+    fun timeStampToUtcDateMillis(timestamp: Long): Long
+    fun mergeUtcDateToTimestamp(timestamp: Long, dateUtcMillis: Long): Long
+    fun mergeHourMinuteToTimestamp(timestamp: Long, hour: Int, minute: Int, randomSecond: Boolean = false): Long //fun mergeHourMinuteToTimestamp(timestamp: Long, hour: Int, minute: Int, randomSecond: Boolean): Long //original broke the contract
+}

--- a/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilOldImpl.kt
+++ b/shared/impl/src/test/kotlin/app/aaps/shared/impl/utils/DateUtilOldImpl.kt
@@ -1,0 +1,493 @@
+package app.aaps.shared.impl.utils
+
+import android.content.Context
+import androidx.collection.LongSparseArray
+import app.aaps.core.data.time.T
+import app.aaps.core.interfaces.R
+import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.interfaces.utils.SafeParse
+import app.aaps.core.utils.pump.ThreadUtil
+import org.apache.commons.lang3.time.DateUtils.isSameDay
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.ISODateTimeFormat
+import java.security.SecureRandom
+import java.text.DateFormat
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Calendar
+import java.util.Date
+import java.util.EnumSet
+import java.util.GregorianCalendar
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
+import java.util.stream.Collectors
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * The Class DateUtil. A simple wrapper around SimpleDateFormat to ease the handling of iso date string &lt;-&gt; date obj
+ * with TZ
+ */
+@Singleton
+class DateUtilOldImpl @Inject constructor(private val context: Context) : DateUtilOld {
+
+    /**
+     * The date format in iso.
+     */
+    @Suppress("PrivatePropertyName", "SpellCheckingInspection")
+    private val FORMAT_DATE_ISO_OUT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+
+    /**
+     * Takes in an ISO date string of the following format:
+     * yyyy-mm-ddThh:mm:ss.ms+HoMo
+     *
+     * @param isoDateString the iso date string
+     * @return the date
+     */
+    override fun fromISODateString(isoDateString: String): Long {
+        val parser = ISODateTimeFormat.dateTimeParser()
+        val dateTime = DateTime.parse(isoDateString, parser)
+        return dateTime.toDate().time
+    }
+
+    /**
+     * Render date
+     *
+     * @param date   the date obj
+     * @return the iso-formatted date string
+     */
+    override fun toISOString(date: Long): String {
+        val f: DateFormat = SimpleDateFormat(FORMAT_DATE_ISO_OUT, Locale.getDefault())
+        f.timeZone = TimeZone.getTimeZone("UTC")
+        return f.format(date)
+    }
+
+    @Suppress("SpellCheckingInspection")
+    override fun toISOAsUTC(timestamp: Long): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'0000Z'", Locale.US)
+        format.timeZone = TimeZone.getTimeZone("UTC")
+        return format.format(timestamp)
+    }
+
+    @Suppress("SpellCheckingInspection")
+    override fun toISONoZone(timestamp: Long): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+        format.timeZone = TimeZone.getDefault()
+        return format.format(timestamp)
+    }
+
+    override fun secondsOfTheDayToMilliseconds(seconds: Int): Long {
+        val calendar: Calendar = GregorianCalendar()
+        calendar[Calendar.MONTH] = 0 // Set january to be sure we miss DST changing
+        calendar[Calendar.HOUR_OF_DAY] = seconds / 60 / 60
+        calendar[Calendar.MINUTE] = seconds / 60 % 60
+        calendar[Calendar.SECOND] = 0
+        return calendar.timeInMillis
+    }
+
+    override fun toSeconds(hhColonMm: String): Int {
+        val p = Pattern.compile("(\\d+):(\\d+)( a.m.| p.m.| AM| PM|AM|PM|)")
+        val m = p.matcher(hhColonMm)
+        var retVal = 0
+        if (m.find()) {
+            retVal = SafeParse.stringToInt(m.group(1)) * 60 * 60 + SafeParse.stringToInt(m.group(2)) * 60
+            if ((m.group(3) == " a.m." || m.group(3) == " AM" || m.group(3) == "AM") && m.group(1) == "12") retVal -= 12 * 60 * 60
+            if ((m.group(3) == " p.m." || m.group(3) == " PM" || m.group(3) == "PM") && m.group(1) != "12") retVal += 12 * 60 * 60
+        }
+        return retVal
+    }
+
+    override fun dateString(mills: Long): String {
+        val zonedTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(mills), ZoneId.systemDefault())
+        val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+        return zonedTime.format(dateFormatter)
+    }
+
+    override fun dateStringRelative(mills: Long, rh: ResourceHelper): String {
+        val df = DateFormat.getDateInstance(DateFormat.SHORT)
+        val day = df.format(mills)
+        val beginOfToday = beginOfDay(now())
+        return if (mills < now()) // Past
+            when {
+                mills > beginOfToday -> rh.gs(R.string.today)
+                mills > beginOfToday - T.days(1).msecs() -> rh.gs(R.string.yesterday)
+                mills > beginOfToday - T.days(7).msecs() -> dayAgo(mills, rh, true)
+                else -> day
+            }
+        else // Future
+            when {
+                mills < beginOfToday + T.days(1).msecs() -> rh.gs(R.string.later_today)
+                mills < beginOfToday + T.days(2).msecs() -> rh.gs(R.string.tomorrow)
+                mills < beginOfToday + T.days(7).msecs() -> dayAgo(mills, rh, true)
+                else                                     -> day
+            }
+    }
+
+    override fun dateStringShort(mills: Long): String {
+        var format = "MM/dd"
+        if (android.text.format.DateFormat.is24HourFormat(context)) {
+            format = "dd/MM"
+        }
+        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+    }
+
+    override fun timeString(): String = timeString(now())
+    override fun timeString(mills: Long): String {
+        var format = "hh:mm a"
+        if (android.text.format.DateFormat.is24HourFormat(context)) {
+            format = "HH:mm"
+        }
+        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+    }
+
+    override fun secondString(): String = secondString(now())
+    override fun secondString(mills: Long): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern("ss"))
+
+    override fun minuteString(): String = minuteString(now())
+    override fun minuteString(mills: Long): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern("mm"))
+
+    override fun hourString(): String = hourString(now())
+    override fun hourString(mills: Long): String {
+        var format = "hh"
+        if (android.text.format.DateFormat.is24HourFormat(context)) {
+            format = "HH"
+        }
+        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+    }
+
+    override fun amPm(): String = amPm(now())
+    override fun amPm(mills: Long): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern("a"))
+
+    override fun dayNameString(format: String): String = dayNameString(now(), format)
+    override fun dayNameString(mills: Long, format: String): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern(format))
+
+    override fun dayString(): String = dayString(now())
+    override fun dayString(mills: Long): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern("dd"))
+
+    override fun monthString(format: String): String = monthString(now(), format)
+    override fun monthString(mills: Long, format: String): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern(format))
+
+    override fun weekString(): String = weekString(now())
+    override fun weekString(mills: Long): String =
+        DateTime(mills).toString(DateTimeFormat.forPattern("ww"))
+
+    override fun timeStringWithSeconds(mills: Long): String {
+        var format = "hh:mm:ss a"
+        if (android.text.format.DateFormat.is24HourFormat(context)) {
+            format = "HH:mm:ss"
+        }
+        return DateTime(mills).toString(DateTimeFormat.forPattern(format))
+    }
+
+    override fun dateAndTimeRangeString(start: Long, end: Long): String {
+        return dateAndTimeString(start) + " - " + timeString(end)
+    }
+
+    override fun timeRangeString(start: Long, end: Long): String {
+        return timeString(start) + " - " + timeString(end)
+    }
+
+    override fun dateAndTimeString(mills: Long): String =
+        if (mills == 0L) "" else dateString(mills) + " " + timeString(mills)
+
+    override fun dateAndTimeStringNullable(mills: Long?): String? =
+        if (mills == null || mills == 0L) null else dateString(mills) + " " + timeString(mills)
+
+    override fun dateAndTimeAndSecondsString(mills: Long): String {
+        return if (mills == 0L) "" else dateString(mills) + " " + timeStringWithSeconds(mills)
+    }
+
+    override fun minAgo(rh: ResourceHelper, time: Long?): String {
+        if (time == null) return ""
+        val minutes = ((now() - time) / 1000 / 60).toInt()
+        return if (abs(minutes) > 9999) "" else rh.gs(R.string.minago, minutes)
+    }
+
+    override fun minOrSecAgo(rh: ResourceHelper, time: Long?): String {
+        if (time == null) return ""
+        //val minutes = ((now() - time) / 1000 / 60).toInt()
+        val seconds = (now() - time) / 1000
+        if (seconds > 119) {
+            return rh.gs(R.string.minago, (seconds / 60).toInt())
+        } else {
+            return rh.gs(R.string.secago, seconds.toInt())
+        }
+    }
+
+    override fun minAgoShort(time: Long?): String {
+        if (time == null) return ""
+        val minutes = ((time - now()) / 1000 / 60).toInt()
+        return if (abs(minutes) > 9999) ""
+        else "(" + (if (minutes > 0) "+" else "") + minutes + ")"
+    }
+
+    override fun minAgoLong(rh: ResourceHelper, time: Long?): String {
+        if (time == null) return ""
+        val minutes = ((now() - time) / 1000 / 60).toInt()
+        return if (abs(minutes) > 9999) "" else rh.gs(R.string.minago_long, minutes)
+    }
+
+    override fun hourAgo(time: Long, rh: ResourceHelper): String {
+        val hours = (now() - time) / 1000.0 / 60 / 60
+        return rh.gs(R.string.hoursago, hours)
+    }
+
+    override fun dayAgo(time: Long, rh: ResourceHelper, round: Boolean): String {
+        var days = (now() - time) / 1000.0 / 60 / 60 / 24
+        if (round) {
+            return if (now() > time) {
+                days = ceil(days)
+                rh.gs(R.string.days_ago_round, days)
+            } else {
+                days = floor(days)
+                rh.gs(R.string.in_days_round, days)
+            }
+        }
+        return if (now() > time)
+            rh.gs(R.string.days_ago, days)
+        else
+            rh.gs(R.string.in_days, days)
+    }
+
+    override fun beginOfDay(mills: Long): Long {
+        val givenDate = Calendar.getInstance()
+        givenDate.timeInMillis = mills
+        givenDate[Calendar.HOUR_OF_DAY] = 0
+        givenDate[Calendar.MINUTE] = 0
+        givenDate[Calendar.SECOND] = 0
+        givenDate[Calendar.MILLISECOND] = 0
+        return givenDate.timeInMillis
+    }
+
+    override fun timeStringFromSeconds(seconds: Int): String {
+        val cached = timeStrings[seconds.toLong()]
+        if (cached != null) return cached
+        val t = timeString(secondsOfTheDayToMilliseconds(seconds))
+        timeStrings.put(seconds.toLong(), t)
+        return t
+    }
+
+    override fun timeFrameString(timeInMillis: Long, rh: ResourceHelper): String {
+        var remainingTimeMinutes = timeInMillis / (1000 * 60)
+        val remainingTimeHours = remainingTimeMinutes / 60
+        remainingTimeMinutes %= 60
+        return "(" + (if (remainingTimeHours > 0) remainingTimeHours.toString() + rh.gs(R.string.shorthour) + " " else "") + remainingTimeMinutes + "')"
+    }
+
+    override fun sinceString(timestamp: Long, rh: ResourceHelper): String {
+        return timeFrameString(System.currentTimeMillis() - timestamp, rh)
+    }
+
+    override fun untilString(timestamp: Long, rh: ResourceHelper): String {
+        return timeFrameString(timestamp - System.currentTimeMillis(), rh)
+    }
+
+    override fun now(): Long {
+        return System.currentTimeMillis()
+    }
+
+    override fun nowWithoutMilliseconds(): Long {
+        var n = System.currentTimeMillis()
+        n -= n % 1000
+        return n
+    }
+
+    override fun isOlderThan(date: Long, minutes: Long): Boolean {
+        val diff = now() - date
+        return diff > T.mins(minutes).msecs()
+    }
+
+    override fun getTimeZoneOffsetMs(): Long {
+        return GregorianCalendar().timeZone.rawOffset.toLong()
+    }
+
+    override fun getTimeZoneOffsetMinutes(timestamp: Long): Int {
+        return TimeZone.getDefault().getOffset(timestamp) / 60000
+    }
+
+    override fun isSameDay(timestamp1: Long, timestamp2: Long) = isSameDay(Date(timestamp1), Date(timestamp2))
+
+    override fun isAfterNoon(): Boolean =
+        Instant.now().atZone(ZoneId.systemDefault()).hour >= 12
+
+    override fun isSameDayGroup(timestamp1: Long, timestamp2: Long): Boolean {
+        val now = now()
+        if (now in (timestamp1 + 1) until timestamp2 || now in (timestamp2 + 1) until timestamp1)
+            return false
+        return isSameDay(Date(timestamp1), Date(timestamp2))
+    }
+
+    //Map:{DAYS=1, HOURS=3, MINUTES=46, SECONDS=40, MILLISECONDS=0, MICROSECONDS=0, NANOSECONDS=0}
+    override fun computeDiff(date1: Long, date2: Long): Map<TimeUnit, Long> {
+        val units: MutableList<TimeUnit> = ArrayList(EnumSet.allOf(TimeUnit::class.java))
+        units.reverse()
+        val result: MutableMap<TimeUnit, Long> = LinkedHashMap()
+        var millisecondsRest = date2 - date1
+        for (unit in units) {
+            val diff = unit.convert(millisecondsRest, TimeUnit.MILLISECONDS)
+            val diffInMillisecondsForUnit = unit.toMillis(diff)
+            millisecondsRest -= diffInMillisecondsForUnit
+            result[unit] = diff
+        }
+        return result
+    }
+
+    override fun age(milliseconds: Long, useShortText: Boolean, rh: ResourceHelper): String {
+        val diff = computeDiff(0L, milliseconds)
+        var days = " " + rh.gs(R.string.days) + " "
+        var hours = " " + rh.gs(R.string.hours) + " "
+        var minutes = " " + rh.gs(R.string.unit_minutes) + " "
+        if (useShortText) {
+            days = " " + rh.gs(R.string.shortday) + " "
+            hours = " " + rh.gs(R.string.shorthour) + " "
+            minutes = " " + rh.gs(R.string.shortminute) + " "
+        }
+        if (T.msecs(milliseconds).days() > 1000) return rh.gs(R.string.forever)
+        var result = ""
+        if (diff.getOrDefault(TimeUnit.DAYS, -1) > 0) result += diff[TimeUnit.DAYS].toString() + days
+        if (diff.getOrDefault(TimeUnit.HOURS, -1) > 0) result += diff[TimeUnit.HOURS].toString() + hours
+        if (diff[TimeUnit.DAYS] == 0L) result += diff[TimeUnit.MINUTES].toString() + minutes
+        return result
+    }
+
+    override fun niceTimeScalar(time: Long, rh: ResourceHelper): String {
+        var t = time
+        var unit = rh.gs(R.string.unit_second)
+        t /= 1000
+        if (t != 1L) unit = rh.gs(R.string.unit_seconds)
+        if (t > 59) {
+            unit = rh.gs(R.string.unit_minute)
+            t /= 60
+            if (t != 1L) unit = rh.gs(R.string.unit_minutes)
+            if (t > 59) {
+                unit = rh.gs(R.string.unit_hour)
+                t /= 60
+                if (t != 1L) unit = rh.gs(R.string.unit_hours)
+                if (t > 24) {
+                    unit = rh.gs(R.string.unit_day)
+                    t /= 24
+                    if (t != 1L) unit = rh.gs(R.string.unit_days)
+                    if (t > 28) {
+                        unit = rh.gs(R.string.unit_week)
+                        t /= 7
+                        @Suppress("KotlinConstantConditions")
+                        if (t != 1L) unit = rh.gs(R.string.unit_weeks)
+                    }
+                }
+            }
+        }
+        //if (t != 1) unit = unit + "s"; //implemented plurality in every step, because in other languages plurality of time is not every time adding the same character
+        return qs(t.toDouble(), 0) + " " + unit
+    }
+
+    override fun qs(x: Double, numDigits: Int): String {
+        var digits = numDigits
+        if (digits == -1) {
+            digits = 0
+            if ((x.toInt() % x == 0.0)) {
+                digits++
+                if ((x.toInt() * 10 / 10).toDouble() != x) {
+                    digits++
+                    if ((x.toInt() * 100 / 100).toDouble() != x) digits++
+                }
+            }
+        }
+        if (dfs == null) {
+            val localDfs = DecimalFormatSymbols()
+            localDfs.decimalSeparator = '.'
+            dfs = localDfs // avoid race condition
+        }
+        val thisDf: DecimalFormat?
+        // use singleton if on ui thread otherwise allocate new as DecimalFormat is not thread safe
+        if (ThreadUtil.threadId() == 1L) {
+            if (df == null) {
+                val localDf = DecimalFormat("#", dfs)
+                localDf.minimumIntegerDigits = 1
+                df = localDf // avoid race condition
+            }
+            thisDf = df
+        } else {
+            thisDf = DecimalFormat("#", dfs)
+        }
+        thisDf?.maximumFractionDigits = digits
+        return thisDf?.format(x) ?: ""
+    }
+
+    override fun formatHHMM(timeAsSeconds: Int): String {
+        val hour = timeAsSeconds / 60 / 60
+        val minutes = (timeAsSeconds - hour * 60 * 60) / 60
+        val df = DecimalFormat("00")
+        return df.format(hour.toLong()) + ":" + df.format(minutes.toLong())
+    }
+
+    override fun timeZoneByOffset(offsetInMilliseconds: Long): TimeZone =
+        TimeZone.getTimeZone(
+            if (offsetInMilliseconds == 0L) ZoneId.of("UTC")
+            else ZoneId.getAvailableZoneIds()
+                .stream()
+                .map(ZoneId::of)
+                .filter { z -> z.rules.getOffset(Instant.now()).totalSeconds == ZoneOffset.ofHours((offsetInMilliseconds / 1000 / 3600).toInt()).totalSeconds }
+                .collect(Collectors.toList())
+                .firstOrNull() ?: ZoneId.of("UTC")
+        )
+
+    override fun timeStampToUtcDateMillis(timestamp: Long): Long {
+        val current = Calendar.getInstance().apply { timeInMillis = timestamp }
+        return Calendar.getInstance().apply {
+            set(Calendar.YEAR, current[Calendar.YEAR])
+            set(Calendar.MONTH, current[Calendar.MONTH])
+            set(Calendar.DAY_OF_MONTH, current[Calendar.DAY_OF_MONTH])
+        }.timeInMillis
+    }
+
+    override fun mergeUtcDateToTimestamp(timestamp: Long, dateUtcMillis: Long): Long {
+        // - TimeZone.getDefault().rawOffset is only workaround for MaterialDatePicket bug
+        // Remove after lib fix
+        // https://github.com/material-components/material-components-android/issues/4373
+        val selected = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply { timeInMillis = dateUtcMillis }
+        return Calendar.getInstance().apply {
+            timeInMillis = timestamp
+            set(Calendar.YEAR, selected[Calendar.YEAR])
+            set(Calendar.MONTH, selected[Calendar.MONTH])
+            set(Calendar.DAY_OF_MONTH, selected[Calendar.DAY_OF_MONTH])
+        }.timeInMillis
+    }
+
+    override fun mergeHourMinuteToTimestamp(timestamp: Long, hour: Int, minute: Int, randomSecond: Boolean): Long {
+        return Calendar.getInstance().apply {
+            timeInMillis = timestamp
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            if (randomSecond) set(Calendar.SECOND, seconds++)
+        }.timeInMillis
+    }
+
+    companion object {
+
+        private val timeStrings = LongSparseArray<String>()
+        private var seconds: Int = (SecureRandom().nextDouble() * 59.0).toInt()
+
+        // singletons to avoid repeated allocation
+        private var dfs: DecimalFormatSymbols? = null
+        private var df: DecimalFormat? = null
+    }
+}

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/EditQuickWizardDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/EditQuickWizardDialog.kt
@@ -146,13 +146,13 @@ class EditQuickWizardDialog : DaggerDialogFragment(), View.OnClickListener {
                 .build()
             timePicker.addOnPositiveButtonClickListener {
                 fromSeconds = (T.hours(timePicker.hour.toLong()).secs() + T.mins(timePicker.minute.toLong()).secs()).toInt()
-                binding.from.text = dateUtil.timeString(dateUtil.secondsOfTheDayToMilliseconds(fromSeconds))
+                binding.from.text = dateUtil.timeString(dateUtil.minutesOfTheDayToMilliseconds(fromSeconds))
             }
             timePicker.show(parentFragmentManager, "event_time_time_picker")
         }
 
         fromSeconds = entry.validFrom()
-        binding.from.text = dateUtil.timeString(dateUtil.secondsOfTheDayToMilliseconds(fromSeconds))
+        binding.from.text = dateUtil.timeString(dateUtil.minutesOfTheDayToMilliseconds(fromSeconds))
 
         binding.to.setOnClickListener {
             val clockFormat = if (DateFormat.is24HourFormat(context)) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H
@@ -163,7 +163,7 @@ class EditQuickWizardDialog : DaggerDialogFragment(), View.OnClickListener {
                 .build()
             timePicker.addOnPositiveButtonClickListener {
                 toSeconds = (T.hours(timePicker.hour.toLong()).secs() + T.mins(timePicker.minute.toLong()).secs()).toInt()
-                binding.to.text = dateUtil.timeString(dateUtil.secondsOfTheDayToMilliseconds(toSeconds))
+                binding.to.text = dateUtil.timeString(dateUtil.minutesOfTheDayToMilliseconds(toSeconds))
             }
             timePicker.show(parentFragmentManager, "event_time_time_picker")
         }
@@ -233,7 +233,7 @@ class EditQuickWizardDialog : DaggerDialogFragment(), View.OnClickListener {
         binding.correctionInput.value = entry.percentage().toDouble()
 
         toSeconds = entry.validTo()
-        binding.to.text = dateUtil.timeString(dateUtil.secondsOfTheDayToMilliseconds(toSeconds))
+        binding.to.text = dateUtil.timeString(dateUtil.minutesOfTheDayToMilliseconds(toSeconds))
 
         binding.buttonEdit.setText(entry.buttonText())
         when (entry.device()) {


### PR DESCRIPTION
This replaces  [the old PRs](https://github.com/nightscout/AndroidAPS/pull/4309/).
Added tests, corrections and improvements

The new tests are in app/aaps/shared/impl/utils/DateUtilImplTest.kt

The old test (app/aaps/core/objects/utils/DateUtilImplTest.kt) for secondsOfTheDayToMilliseconds still fails because the original function actually set the seconds to 0 before outputting ms.
I created a new (more appropriately named) function minutesOfTheDayToMilliseconds which does what the old one did.
