### PR TITLE
Improve auto-check-HypoTT in CarbsDialog when low

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/configuration/Constants.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/configuration/Constants.kt
@@ -10,6 +10,9 @@ object Constants {
     const val defaultDIA = 5.0
     const val notificationID = 556677
 
+    // OpenAPS algorithm
+    const val ALLOW_SMB_WITH_HIGH_TT = 100
+
     // SMS COMMUNICATOR
     const val remoteBolusMinDistance = 15 * 60 * 1000L
 

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/DetermineBasalSMB.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/DetermineBasalSMB.kt
@@ -1,5 +1,6 @@
 package app.aaps.plugins.aps.openAPSSMB
 
+import app.aaps.core.data.configuration.Constants
 import app.aaps.core.interfaces.aps.APSResult
 import app.aaps.core.interfaces.aps.AutosensResult
 import app.aaps.core.interfaces.aps.CurrentTemp
@@ -67,7 +68,7 @@ class DetermineBasalSMB @Inject constructor(
         if (!microBolusAllowed) {
             consoleError.add("SMB disabled (!microBolusAllowed)")
             return false
-        } else if (!profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
+        } else if (!profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > Constants.ALLOW_SMB_WITH_HIGH_TT) {
             consoleError.add("SMB disabled due to high temptarget of $target_bg")
             return false
         }

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/CarbsDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/CarbsDialog.kt
@@ -7,6 +7,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import app.aaps.core.data.configuration.Constants
 import app.aaps.core.data.model.GlucoseUnit
 import app.aaps.core.data.model.TE
 import app.aaps.core.data.model.TT
@@ -199,9 +200,9 @@ class CarbsDialog : DialogFragmentWithDate() {
                         ((activeTT.timestamp + activeTT.duration) - now) / 60000
 
                     // Prevent auto-checking HypoTT when:
-                    // 1. Active TT target is above 100 mg/dL
+                    // 1. Active TT target is above Constants.ALLOW_SMB_WITH_HIGH_TT
                     // 2. Active TT lasts longer than the hypoTT preset
-                    if (activeTarget > 100 && remainingDurationMin > hypoTTDuration) {
+                    if (activeTarget > Constants.ALLOW_SMB_WITH_HIGH_TT && remainingDurationMin > hypoTTDuration) {
                         shouldAutoCheckHypo = false
                     }
                 }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="bolus_constraint_applied">Bolus constraint applied</string>
     <string name="carbs_constraint_applied">Carbs constraint applied</string>
-    <string name="temp_target_short">Temp target</string>
+    <string name="temp_target_short">TT</string>
     <string name="dialog_canceled">Dialog canceled</string>
     <string name="start_activity_tt">Start Activity TT</string>
     <string name="start_eating_soon_tt">Start Eating soon TT</string>


### PR DESCRIPTION
Fixes and improves upon issue described in https://github.com/nightscout/AndroidAPS/issues/4192

When low, I think Hypo TT should automatically be selected when entering carbs, unless:
There is already an active high TT > 100 mg/dl or 5,5 mmol/L with a duration longer than preset Hypo TT duration.

This will avoid Hypo TT cancelling out Activity TT or custom high TT with a longer duration than preset Hypo TT.

We experience this issue from time to time with Hypo TT cancelling out Activity TT when entering carbs when low. I think this proposal will fix issue as described in the mentioned issue and other scenarios. It's recommended to not allow SMB when a high TT is set (above 100mg/dl)

Built and tested OK.

Some screenshots when BG is low and opening Carbs Dialog:
<img width="432" height="911" alt="image" src="https://github.com/user-attachments/assets/206ea2b6-300b-4755-9326-d925d49779bc" />
<img width="432" height="911" alt="image" src="https://github.com/user-attachments/assets/6238fcef-3d29-4371-8383-e9a7cd0d2ea3" />
<img width="432" height="911" alt="image" src="https://github.com/user-attachments/assets/1bbe51f1-ecaa-4f9b-b6ad-3349aede4f63" />
<img width="432" height="911" alt="image" src="https://github.com/user-attachments/assets/e95736ce-7254-4bed-ac9f-b40d58842a93" />
