### PR TITLE
Fragment lifecycle

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotuneFragment.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/autotune/AutotuneFragment.kt
@@ -324,6 +324,11 @@ class AutotuneFragment : DaggerFragment() {
         handler.removeCallbacksAndMessages(null)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     @Synchronized
     private fun updateGui() {
         _binding ?: return

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripFragment.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/xdrip/XdripFragment.kt
@@ -106,6 +106,11 @@ class XdripFragment : DaggerFragment(), MenuProvider, PluginFragment {
         handler.removeCallbacksAndMessages(null)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun updateGui() {
         if (_binding == null) return
         binding.log.text = xdripPlugin.textLog()

--- a/pump/insight/src/main/kotlin/app/aaps/pump/insight/InsightFragment.kt
+++ b/pump/insight/src/main/kotlin/app/aaps/pump/insight/InsightFragment.kt
@@ -75,6 +75,7 @@ class InsightFragment : DaggerFragment(), View.OnClickListener {
 
     @Synchronized override fun onDestroyView() {
         super.onDestroyView()
+        _binding = null
     }
 
     override fun onClick(v: View) {

--- a/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.kt
+++ b/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.kt
@@ -43,6 +43,11 @@ class RileyLinkStatusGeneralFragment : DaggerFragment() {
         binding.refresh.setOnClickListener { refreshData() }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun refreshData() {
         val targetDevice = rileyLinkServiceData.targetDevice
         binding.connectionStatus.text = rh.gs(rileyLinkServiceData.rileyLinkServiceState.resourceId)

--- a/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/dialog/RileyLinkStatusHistoryFragment.kt
+++ b/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/dialog/RileyLinkStatusHistoryFragment.kt
@@ -44,6 +44,11 @@ class RileyLinkStatusHistoryFragment : DaggerFragment() {
         refreshData()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun refreshData() {
         binding.historyList.adapter =
             RecyclerViewAdapter(rileyLinkUtil.rileyLinkHistory.filter { isValidItem(it) }.sortedWith(RLHistoryItem.Comparator()))


### PR DESCRIPTION
Fixed memory leaks by properly nulling ViewBinding references in onDestroyView():

1. AutotuneFragment - Added onDestroyView() with _binding = null
   - Prevents leak when screen rotates during Autotune calculations

2. XdripFragment - Added onDestroyView() with _binding = null
   - Prevents leak in frequently accessed xDrip+ sync status display

3. RileyLinkStatusGeneralFragment - Added onDestroyView() with _binding = null
   - Prevents leak in Riley Link device status for Medtronic pumps

4. RileyLinkStatusHistoryFragment - Added onDestroyView() with _binding = null
   - Prevents leak in Riley Link connection history

5. InsightFragment - Added _binding = null to existing onDestroyView()
   - Completes cleanup in Insight pump status display

These leaks occurred because Fragment instances survive configuration changes while their views are destroyed and recreated. Without nulling the binding reference, the old view hierarchy remains in memory causing memory leaks.