### PR TITLE
Claude/LeakCanary

### DIFF
--- a/app/src/debug/kotlin/app/aaps/utils/LeakCanaryConfig.kt
+++ b/app/src/debug/kotlin/app/aaps/utils/LeakCanaryConfig.kt
@@ -1,8 +1,25 @@
 package app.aaps.utils
 
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
 import leakcanary.LeakCanary
 
-fun configureLeakCanary(isEnabled: Boolean = false) {
-    LeakCanary.config = LeakCanary.config.copy(dumpHeap = isEnabled)
+/**
+ * Configures LeakCanary with optional Firebase Crashlytics reporting.
+ *
+ * @param isEnabled Whether to enable heap dumping and the launcher icon
+ * @param fabricPrivacy FabricPrivacy instance for uploading memory leaks to Firebase Crashlytics.
+ *                      When provided, memory leaks will be uploaded via FabricPrivacy.logException.
+ */
+fun configureLeakCanary(isEnabled: Boolean = false, fabricPrivacy: FabricPrivacy? = null) {
+    val eventListeners = if (fabricPrivacy != null) {
+        LeakCanary.config.eventListeners + LeakUploadService(fabricPrivacy)
+    } else {
+        LeakCanary.config.eventListeners
+    }
+
+    LeakCanary.config = LeakCanary.config.copy(
+        dumpHeap = isEnabled,
+        eventListeners = eventListeners
+    )
     LeakCanary.showLeakDisplayActivityLauncherIcon(isEnabled)
 }

--- a/app/src/debug/kotlin/app/aaps/utils/LeakUploadService.kt
+++ b/app/src/debug/kotlin/app/aaps/utils/LeakUploadService.kt
@@ -1,0 +1,83 @@
+package app.aaps.utils
+
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import leakcanary.EventListener
+import leakcanary.EventListener.Event.HeapAnalysisDone
+import shark.HeapAnalysisSuccess
+import shark.Leak
+import shark.LeakTrace
+
+/**
+ * LeakCanary EventListener that uploads memory leaks to Firebase Crashlytics.
+ *
+ * This service intercepts heap analysis results and converts leak traces to Throwable objects
+ * that can be recorded by Firebase Crashlytics. Each leak trace line is converted to a
+ * StackTraceElement to avoid truncation in Firebase.
+ *
+ * Based on: https://blog.ah.technology/upload-leakcanary-memory-leaks-to-firebase-f79c31615d76
+ */
+class LeakUploadService(
+    private val fabricPrivacy: FabricPrivacy
+) : EventListener {
+
+    override fun onEvent(event: EventListener.Event) {
+        if (event is HeapAnalysisDone<*>) {
+            val heapAnalysis = event.heapAnalysis
+            if (heapAnalysis is HeapAnalysisSuccess) {
+                val allLeaks = heapAnalysis.allLeaks.toList()
+
+                allLeaks.forEach { leak ->
+                    leak.leakTraces.forEach { leakTrace ->
+                        val throwable = leak.toThrowable(leakTrace)
+                        fabricPrivacy.logException(throwable)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Extension function to convert a Leak to a Throwable for Firebase Crashlytics.
+ *
+ * The leak trace is converted to StackTraceElements to preserve the full trace
+ * without truncation in Firebase.
+ */
+private fun Leak.toThrowable(leakTrace: LeakTrace): Throwable {
+    val exception = MemoryLeakException(shortDescription)
+    val stackTraceElements = mutableListOf<StackTraceElement>()
+
+    // Add header element using declaringClass for the title in Firebase
+    stackTraceElements.add(
+        StackTraceElement(
+            shortDescription,  // declaringClass - shown as title in Firebase
+            "",                // methodName
+            null,              // fileName
+            0                  // lineNumber - 0 means it won't be shown
+        )
+    )
+
+    // Convert each line of the leak trace to a StackTraceElement
+    // Using methodName property as it provides the cleanest output in Firebase
+    leakTrace.toString().lines().forEach { line ->
+        if (line.isNotBlank()) {
+            stackTraceElements.add(
+                StackTraceElement(
+                    "",       // declaringClass
+                    line,     // methodName - the actual leak trace line
+                    null,     // fileName
+                    0         // lineNumber
+                )
+            )
+        }
+    }
+
+    exception.stackTrace = stackTraceElements.toTypedArray()
+    return exception
+}
+
+/**
+ * Custom exception class for memory leaks.
+ * This allows Firebase to properly group and display memory leak reports.
+ */
+class MemoryLeakException(message: String) : Exception(message)

--- a/app/src/main/kotlin/app/aaps/MainApp.kt
+++ b/app/src/main/kotlin/app/aaps/MainApp.kt
@@ -33,6 +33,7 @@ import app.aaps.core.interfaces.ui.compose.ComposeUi
 import app.aaps.core.interfaces.ui.compose.ComposeUiProvider
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.SafeParse
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
 import app.aaps.core.interfaces.versionChecker.VersionCheckerUtils
 import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.IntKey
@@ -107,6 +108,7 @@ class MainApp : DaggerApplication(), ComposeUiProvider {
     @Inject lateinit var rh: Provider<ResourceHelper>
     @Inject lateinit var loop: Loop
     @Inject lateinit var profileFunction: ProfileFunction
+    @Inject lateinit var fabricPrivacy: FabricPrivacy
     lateinit var appComponent: AppComponent
 
     private var handler = Handler(HandlerThread(this::class.simpleName + "Handler").also { it.start() }.looper)
@@ -119,7 +121,12 @@ class MainApp : DaggerApplication(), ComposeUiProvider {
         // Here should be everything injected
         aapsLogger.debug("onCreate")
         ProcessLifecycleOwner.get().lifecycle.addObserver(processLifecycleListener.get())
-        if (config.disableLeakCanary()) configureLeakCanary(false)
+        // Configure LeakCanary with Firebase reporting
+        // Memory leaks will be uploaded to Firebase Crashlytics via FabricPrivacy.logException
+        configureLeakCanary(
+            isEnabled = !config.disableLeakCanary(),
+            fabricPrivacy = fabricPrivacy
+        )
 
         // Do necessary migrations
         doMigrations()

--- a/app/src/release/kotlin/app/aaps/utils/LeakCanaryConfig.kt
+++ b/app/src/release/kotlin/app/aaps/utils/LeakCanaryConfig.kt
@@ -1,8 +1,12 @@
 package app.aaps.utils
 
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+
 /**
  * This method is added just to ensure we can build the application in release mode.
+ * LeakCanary is not included in release builds.
  */
-fun configureLeakCanary(isEnabled: Boolean = false) {
-    // do nothing
+@Suppress("UNUSED_PARAMETER")
+fun configureLeakCanary(isEnabled: Boolean = false, fabricPrivacy: FabricPrivacy? = null) {
+    // do nothing - LeakCanary is not available in release builds
 }


### PR DESCRIPTION
Implement automatic upload of memory leaks detected by LeakCanary to Firebase Crashlytics for better visibility and monitoring in debug builds.

Changes:
- Add LeakCanary 2.14 dependency for debug builds
- Create LeakUploadService EventListener that intercepts heap analysis
- Convert leak traces to StackTraceElements to avoid truncation in Firebase
- Configure LeakCanary in MainApp with FabricPrivacy consent check
- Add debug/release variants of LeakCanaryConfig for proper build support

Memory leaks are uploaded as non-fatal exceptions to Firebase Crashlytics only when the user has enabled Fabric/Firebase analytics.

Based on: https://blog.ah.technology/upload-leakcanary-memory-leaks-to-firebase-f79c31615d76