### PR TITLE
Fix OverviewFragment memory leak with GraphView series

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewFragment.kt
@@ -389,6 +389,15 @@ class OverviewFragment : DaggerFragment(), View.OnClickListener, OnLongClickList
     @Synchronized
     override fun onDestroyView() {
         super.onDestroyView()
+        // Remove listeners and detach series to prevent memory leaks
+        _binding?.graphsLayout?.bgGraph?.let { graph ->
+            graph.setOnLongClickListener(null)
+            graph.removeAllSeries()
+        }
+        for (graph in secondaryGraphs) {
+            graph.setOnLongClickListener(null)
+            graph.removeAllSeries()
+        }
         _binding = null
         carbAnimation?.stop()
         carbAnimation = null

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/graphData/GraphData.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/graphData/GraphData.kt
@@ -265,8 +265,8 @@ class GraphData @Inject constructor(
     private fun addSeries(s: Series<*>) = series.add(s)
 
     fun performUpdate() {
-        // clear old data
-        graph.series.clear()
+        // clear old data - use removeAllSeries() to properly detach GraphView from series
+        graph.removeAllSeries()
 
         // add pre calculated series
         for (s in series) {


### PR DESCRIPTION
The leak occurred because:
1. OverviewDataImpl (singleton) holds LineGraphSeries objects
2. When series.addSeries() is called, GraphView is stored in BaseSeries.mGraphViews
3. graph.series.clear() bypassed proper cleanup - didn't call onGraphViewDetached()
4. Old GraphView references accumulated, keeping destroyed Activities alive

Fixes:
- OverviewFragment.onDestroyView(): Remove long click listeners and call removeAllSeries() on bgGraph and secondary graphs before nulling binding
- GraphData.performUpdate(): Use graph.removeAllSeries() instead of graph.series.clear() to properly detach GraphView from series

This breaks the leak chain:
NSClientV3Service → nsDeviceStatusHandler → OverviewDataImpl → absoluteBasalGraphSeries → mGraphViews → GraphView → destroyed MainActivity