### PR TITLE
Claude/leaks

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/loop/LoopFragment.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/loop/LoopFragment.kt
@@ -117,6 +117,11 @@ class LoopFragment : DaggerFragment(), MenuProvider {
         preferences.put(BooleanNonKey.ObjectivesLoopUsed, true)
     }
 
+    override fun onPause() {
+        super.onPause()
+        disposable.clear()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         handler.removeCallbacksAndMessages(null)
@@ -125,6 +130,7 @@ class LoopFragment : DaggerFragment(), MenuProvider {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        _binding?.swipeRefresh?.setOnRefreshListener(null)
         _binding = null
     }
 


### PR DESCRIPTION
- Add onPause() to dispose RxBus subscriptions created in onResume()
- Remove swipeRefresh listener in onDestroyView() before nulling binding

Subscriptions were never disposed, causing fragment to be retained via lambdas that capture 'this'.