### PR TITLE
Adding expiry warnings to Medtrum Nano pump view

### DIFF
--- a/core/ui/src/main/res/values/attrs.xml
+++ b/core/ui/src/main/res/values/attrs.xml
@@ -102,11 +102,11 @@
     <attr name="normalColor" format="reference|color" />
     <attr name="warnColor" format="reference|color" />
     <attr name="urgentColor" format="reference|color" />
+    <attr name="infoColor" format="reference|color" />
     <!---TextColor -->
     <attr name="defaultTextColor" format="reference|color" />
     <!---Profile viewer TempBasal -->
     <attr name="tempBasalColor" format="reference|color" />
-    <attr name="infoColor" format="reference|color" />
     <!---Bolus wizard -->
     <attr name="cobAlertColor" format="reference|color" />
     <!---Fill dialog -->

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
@@ -633,4 +633,16 @@ class MedtrumPump @Inject constructor(
     private fun newRecordInfo(newRecord: Boolean): String {
         return if (newRecord) "**NEW** " else ""
     }
+
+    var hasStateColors = false
+    var defaultTextColor: Int? = null
+    var stateWarnColor: Int? = null
+    var stateUrgentColor: Int? = null
+
+    fun setStateColors(textColor: Int, warnColor: Int, urgentColor: Int) {
+        defaultTextColor = textColor
+        stateWarnColor = warnColor
+        stateUrgentColor = urgentColor
+        hasStateColors = true
+    }
 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.protection.ProtectionCheck
 import app.aaps.core.interfaces.resources.ResourceHelper
-import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.ui.dialogs.OKDialog
 import app.aaps.pump.medtrum.MedtrumPump
 import app.aaps.pump.medtrum.R
@@ -20,7 +19,6 @@ import javax.inject.Inject
 
 class MedtrumOverviewFragment : MedtrumBaseFragment<FragmentMedtrumOverviewBinding>() {
 
-    @Inject lateinit var aapsSchedulers: AapsSchedulers
     @Inject lateinit var aapsLogger: AAPSLogger
     @Inject lateinit var medtrumPump: MedtrumPump
     @Inject lateinit var protectionCheck: ProtectionCheck
@@ -77,5 +75,12 @@ class MedtrumOverviewFragment : MedtrumBaseFragment<FragmentMedtrumOverviewBindi
                 }
             }
         }
+
+        // Set pump themed state colors
+        medtrumPump.setStateColors(
+            rh.gac(view.context, app.aaps.core.ui.R.attr.defaultTextColor),
+            rh.gac(view.context, app.aaps.core.ui.R.attr.highColor),
+            rh.gac(view.context, app.aaps.core.ui.R.attr.lowColor)
+        )
     }
 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -293,7 +293,7 @@ class MedtrumOverviewViewModel @Inject constructor(
         } else {
             // Update text string and warning color color in view field
             medtrumPump.stateWarnColor?.let { _patchExpiryColor.postValue(it) }
-            _patchExpiry.postValue(rh.gs(R.string.expiry_not_enabled) + " ⚠\uFE0F")
+            _patchExpiry.postValue(rh.gs(R.string.expiry_not_enabled))
         }
     }
 

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumOverviewViewModel.kt
@@ -8,6 +8,8 @@ import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.queue.CommandQueue
 import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.keys.IntKey
+import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.pump.medtrum.MedtrumPlugin
 import app.aaps.pump.medtrum.MedtrumPump
 import app.aaps.pump.medtrum.R
@@ -31,7 +33,8 @@ class MedtrumOverviewViewModel @Inject constructor(
     private val commandQueue: CommandQueue,
     private val dateUtil: DateUtil,
     private val medtrumPlugin: MedtrumPlugin,
-    val medtrumPump: MedtrumPump
+    val medtrumPump: MedtrumPump,
+    private val preferences: Preferences
 ) : BaseViewModel<MedtrumBaseNavigator>() {
 
     private val scope = CoroutineScope(Dispatchers.Default)
@@ -80,9 +83,17 @@ class MedtrumOverviewViewModel @Inject constructor(
     val patchExpiry: LiveData<String>
         get() = _patchExpiry
 
+    private val _patchExpiryColor = SingleLiveEvent<Int>()
+    val patchExpiryColor: LiveData<Int>
+        get() = _patchExpiryColor
+
     private val _patchAge = SingleLiveEvent<String>()
     val patchAge: LiveData<String>
         get() = _patchAge
+
+    private val _patchAgeColor = SingleLiveEvent<Int>()
+    val patchAgeColor: LiveData<Int>
+        get() = _patchAgeColor
 
     private val _activeBolusStatus = SingleLiveEvent<String>()
     val activeBolusStatus: LiveData<String>
@@ -208,37 +219,82 @@ class MedtrumOverviewViewModel @Inject constructor(
         _fwVersion.postValue(medtrumPump.swVersion)
         _patchNo.postValue(medtrumPump.patchId.toString())
 
+        // Get status thresholds for AAPS Overview
+        val cageCriticalHours = preferences.get(IntKey.OverviewCageCritical).toLong()
+        val cageWarningHours = preferences.get(IntKey.OverviewCageWarning).toLong()
+
         // Pump age
+        setPumpAgeStatus(cageCriticalHours, cageWarningHours)
+        // Pump Expiration
+        setPumpExpirationStatus(cageCriticalHours, cageWarningHours)
+    }
+
+    // Set Pump Age related status fields in overview
+    private fun setPumpAgeStatus(criticalHours: Long, warningHours: Long) {
         if (medtrumPump.patchStartTime == 0L) {
             _patchAge.postValue("")
         } else {
+            // Get Age text string
             val age = System.currentTimeMillis() - medtrumPump.patchStartTime
-            val agoString = dateUtil.timeAgoFullString(age, rh)
-            val ageString = dateUtil.dateAndTimeString(medtrumPump.patchStartTime) + "\n" + agoString
+            val ageString = buildString {
+                append(dateUtil.dateAndTimeString(medtrumPump.patchStartTime))
+                appendLine()
+                append(dateUtil.timeAgoFullString(age, rh))
+            }
 
+            // Get Age field state color
+            val ageColor = when {
+                age > T.hours(criticalHours).msecs() -> medtrumPump.stateUrgentColor
+                age > T.hours(warningHours).msecs()  -> medtrumPump.stateWarnColor
+                else -> medtrumPump.defaultTextColor // fallback
+            }
+
+            // Update Age text string and color in view field
+            ageColor?.let { _patchAgeColor.postValue(it) }
             _patchAge.postValue(ageString)
         }
+    }
 
-        // Pump Expiration
+    // Set Pump expiration related status fields in overview
+    private fun setPumpExpirationStatus(criticalHours: Long, warningHours: Long) {
         if (medtrumPump.desiredPatchExpiration) {
             if (medtrumPump.patchStartTime == 0L) {
                 _patchExpiry.postValue("")
             } else {
+                // Show when patch is expiring
                 val expiry = medtrumPump.patchStartTime + T.hours(72).msecs()
-                val currentTime = System.currentTimeMillis()
-                val timeLeft = expiry - currentTime
+                val timeLeft = expiry - System.currentTimeMillis()
                 val daysLeft = T.msecs(timeLeft).days()
                 val hoursLeft = T.msecs(timeLeft).hours() % 24
 
-                val daysString = if (daysLeft > 0) "$daysLeft ${rh.gs(app.aaps.core.interfaces.R.string.days)} " else ""
-                val hoursString = "$hoursLeft ${rh.gs(app.aaps.core.interfaces.R.string.hours)}"
+                // Build Expiry text string
+                val expiryString = buildString {
+                    append(dateUtil.dateAndTimeString(expiry))
+                    appendLine()
+                    append("(")
+                    if (daysLeft > 0) {
+                        append("$daysLeft ${rh.gs(app.aaps.core.interfaces.R.string.days)} ")
+                    }
+                    append("$hoursLeft ${rh.gs(app.aaps.core.interfaces.R.string.hours)})")
+                }
 
-                val expiryString = dateUtil.dateAndTimeString(expiry) + "\n(" + daysString + hoursString + ")"
+                // Get Expiry field state color
+                val age = System.currentTimeMillis() - medtrumPump.patchStartTime
+                val expiryColor = when {
+                    age > T.hours(criticalHours).msecs() -> medtrumPump.stateUrgentColor
+                    age > T.hours(warningHours).msecs()  -> medtrumPump.stateWarnColor
+                    else -> medtrumPump.defaultTextColor
+                }
 
+                // Update text string and color in view field
+                expiryColor?.let { _patchExpiryColor.postValue(it) }
                 _patchExpiry.postValue(expiryString)
             }
         } else {
-            _patchExpiry.postValue(rh.gs(R.string.expiry_not_enabled))
+            // Update text string and warning color color in view field
+            medtrumPump.stateWarnColor?.let { _patchExpiryColor.postValue(it) }
+            _patchExpiry.postValue(rh.gs(R.string.expiry_not_enabled) + " ⚠\uFE0F")
         }
     }
+
 }

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_overview.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_overview.xml
@@ -417,6 +417,7 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.patchAge}"
+                            android:textColor="@{viewmodel.patchAgeColor}"
                             android:textSize="14sp" />
 
                     </LinearLayout>
@@ -662,6 +663,7 @@
                             android:paddingStart="5dp"
                             android:paddingEnd="5dp"
                             android:text="@{viewmodel.patchExpiry}"
+                            android:textColor="@{viewmodel.patchExpiryColor}"
                             android:textSize="14sp" />
 
                     </LinearLayout>


### PR DESCRIPTION
**Medtrum Nano pump**: Alert user on patch expiry

Context:
By factory default, the Medtrum system expires a Nano Patch after 72 hours. The AndroidAPS pump driver includes an option to disable patch expiry, allowing the patch to be used beyond 72 hours.

Options were discussed to remind the user that:
1. 	Patch expiry is disabled
2. 	The patch is (about to) expiry.

This PR implements:
1. Coloring the "patch Activation/age" field when the patch age exceeds time defined in overview->status lights
2. Coloring the "patch expires" field when the patch is about to expire.
3. Show emphasize when patch expiry is “Not enabled”.