### PR TITLE
Add Insulin Editor

### DIFF
--- a/app/src/main/kotlin/app/aaps/di/PluginsListModule.kt
+++ b/app/src/main/kotlin/app/aaps/di/PluginsListModule.kt
@@ -16,6 +16,7 @@ import app.aaps.plugins.constraints.safety.SafetyPlugin
 import app.aaps.plugins.constraints.signatureVerifier.SignatureVerifierPlugin
 import app.aaps.plugins.constraints.storage.StorageConstraintPlugin
 import app.aaps.plugins.constraints.versionChecker.VersionCheckerPlugin
+import app.aaps.plugins.insulin.InsulinPlugin
 import app.aaps.plugins.insulin.InsulinLyumjevPlugin
 import app.aaps.plugins.insulin.InsulinOrefFreePeakPlugin
 import app.aaps.plugins.insulin.InsulinOrefRapidActingPlugin
@@ -108,6 +109,12 @@ abstract class PluginsListModule {
     @AllConfigs
     @IntoMap
     @IntKey(30)
+    abstract fun bindInsulinPlugin(plugin: InsulinPlugin): PluginBase
+
+    @Binds
+    @AllConfigs
+    @IntoMap
+    @IntKey(35)
     abstract fun bindInsulinOrefRapidActingPlugin(plugin: InsulinOrefRapidActingPlugin): PluginBase
 
     @Binds

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/ConcentrationType.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/ConcentrationType.kt
@@ -1,0 +1,24 @@
+package app.aaps.core.interfaces.insulin
+
+import androidx.annotation.StringRes
+import app.aaps.core.data.model.ICfg
+import app.aaps.core.interfaces.R
+import app.aaps.core.interfaces.insulin.InsulinType.OREF_RAPID_ACTING
+import app.aaps.core.interfaces.resources.ResourceHelper
+
+enum class ConcentrationType(val value: Double, @StringRes val label: Int) {
+    UNKNOWN(-1.0, R.string.unknown),
+    U10(0.1, R.string.u10),
+    U40(0.4, R.string.u40),
+    U50(0.5, R.string.u50),
+    U100(1.0, R.string.u100),
+    U200(2.0, R.string.u200),
+    U300(3.0, R.string.u300),
+    U500(5.0, R.string.u500);
+
+    companion object {
+
+        fun fromDouble(type: Double) = values().firstOrNull {it.value == type} ?:UNKNOWN
+        fun fromInt(type: Int) = values().firstOrNull {it.value * 100 == type.toDouble()} ?:UNKNOWN
+    }
+}

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/Insulin.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/Insulin.kt
@@ -7,9 +7,28 @@ interface Insulin : ConfigExportImport {
 
     val id: InsulinType
     val friendlyName: String
-    val comment: String
-    val dia: Double
-    val peak: Int
 
+    /**
+     * Provide list of available Insulin
+     * with no parameter (concentration == null) or without enable_insulin_concentration, only Insulins using the current running concentration will be provided (by default 1.0)
+     * if concentration is provided with 0.à, then the overall list of available insulins is provided (external boluses provided by pens)
+     * if a specific concentration is provided, then only the list of insulin consistent with selected value will be provided (to manage changing concentration value during Insulin_Change events)
+     *
+     * @param concentration only provide the list of Insulins using a specific concentration value
+     * @return Basal insulin recalculated to U100 units used inside core of AAPS
+     */
+    fun insulinList(concentration: Double? = null): List<CharSequence> = emptyList()
+
+    val comment: String
+    @Deprecated("Use iCfg.dia instead")
+    val dia: Double
+        get() = iCfg.dia
+    @Deprecated("Use iCfg.peak instead")
+    val peak: Int
+        get() = iCfg.peak
+
+    /**
+     * Provide Current Pump Insulin
+     */
     val iCfg: ICfg
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/HardLimits.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/utils/HardLimits.kt
@@ -17,6 +17,8 @@ interface HardLimits {
         val LIMIT_TEMP_TARGET_BG = doubleArrayOf(72.0, 200.0)
         val MIN_DIA = doubleArrayOf(5.0, 5.0, 5.0, 5.0, 5.0)
         val MAX_DIA = doubleArrayOf(9.0, 9.0, 9.0, 9.0, 10.0)
+        const val MIN_PEAK = 35 // mgdl
+        const val MAX_PEAK = 120 // mgdl
         val MIN_IC = doubleArrayOf(2.0, 2.0, 2.0, 2.0, 0.3)
         val MAX_IC = doubleArrayOf(100.0, 100.0, 100.0, 100.0, 100.0)
         const val MIN_ISF = 2.0 // mgdl
@@ -39,6 +41,8 @@ interface HardLimits {
     fun maxBasal(): Double
     fun minDia(): Double
     fun maxDia(): Double
+    fun minPeak(): Int
+    fun maxPeak(): Int
     fun minIC(): Double
     fun maxIC(): Double
 

--- a/core/interfaces/src/main/res/values/strings.xml
+++ b/core/interfaces/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="forever">Forever</string>
 
     <!-- Insulin -->
+    <string name="insulin_plugin">Insulin</string>
+    <string name="insulin_shortname">INS</string>
     <string name="unknown">Unknown</string>
     <string name="rapid_acting_oref">Rapid-Acting Oref</string>
     <string name="lyumjev">Lyumjev</string>
@@ -90,5 +92,15 @@
     <string name="fast_acting_insulin_comment">Novorapid, Novolog, Humalog</string>
     <string name="ultra_fast_acting_insulin_comment">Fiasp</string>
     <string name="insulin_peak_time">Peak Time [min]</string>
+    <string name="insulin_oref_peak">IOB Curve Peak Time</string>
+
+    <!-- Concentration -->
+    <string name="u10">U10</string>
+    <string name="u40">U40</string>
+    <string name="u50">U50</string>
+    <string name="u100">U100</string>
+    <string name="u200">U200</string>
+    <string name="u300">U300</string>
+    <string name="u500">U500</string>
 
 </resources>

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/StringKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/StringKey.kt
@@ -40,6 +40,7 @@ enum class StringKey(
     MaintenanceEmail("maintenance_logs_email", "logs@aaps.app", defaultedBySM = true),
     MaintenanceIdentification("email_for_crash_report", ""),
     AutomationLocation("location", "PASSIVE", hideParentScreenIfHidden = true),
+    InsulinConfiguration("insulin_configuration","{}"),
 
     SmsAllowedNumbers("smscommunicator_allowednumbers", ""),
     SmsOtpPassword("smscommunicator_otp_password", "", dependency = BooleanKey.SmsAllowRemoteCommands, isPassword = true),

--- a/core/objects/src/main/res/drawable/ic_auto_fix.xml
+++ b/core/objects/src/main/res/drawable/ic_auto_fix.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="16dp"
+    android:width="16dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+      
+    <path android:fillColor="#888888"
+        android:pathData="M7.5,5.6L10,7 8.6,4.5 10,2 7.5,3.4 5,2l1.4,2.5L5,7zM19.5,15.4L17,14l1.4,2.5L17,19l2.5,-1.4L22,19l-1.4,-2.5L22,14zM22,2l-2.5,1.4L17,2l1.4,2.5L17,7l2.5,-1.4L22,7l-1.4,-2.5zM14.37,7.29c-0.39,-0.39 -1.02,-0.39 -1.41,0L1.29,18.96c-0.39,0.39 -0.39,1.02 0,1.41l2.34,2.34c0.39,0.39 1.02,0.39 1.41,0L16.7,11.05c0.39,-0.39 0.39,-1.02 0,-1.41l-2.33,-2.35zM13.34,12.78l-2.12,-2.12 2.44,-2.44 2.12,2.12 -2.44,2.44z"/>
+    
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -145,6 +145,8 @@
     <string name="none"><![CDATA[<none>]]></string>
     <string name="remove_label">REMOVE</string>
     <string name="activate_profile">Activate profile</string>
+    <string name="activate_insulin">Activate insulin</string>
+    <string name="confirm_concentration">Confirm concentration</string>
     <string name="reset">reset</string>
     <string name="profileswitch_ismissing">ProfileSwitch missing. Please do a profile switch or press \"Activate Profile\" in the LocalProfile.</string>
     <string name="profile">Profile</string>
@@ -171,7 +173,14 @@
     <string name="pump_disconnected">Pump disconnected</string>
     <string name="pump_suspended">Pump suspended</string>
     <string name="mode_reverted">Mode reverted</string>
+    <string name="insulin_shortname">INS</string>
+    <string name="select_insulin">Select Insulin to Edit</string>
+    <string name="select_pump_insulin">Select Pump Insulin</string>
+    <string name="select_pen_insulin">Select Insulin</string>
+    <string name="insulin_template">Template</string>
     <string name="dia">DIA</string>
+    <string name="peak">Peak</string>
+    <string name="concentration">Concentration</string>
     <string name="ic_short">IC</string>
     <string name="isf_short">ISF</string>
     <string name="canceling_tbr_failed">Canceling of temporary basal failed</string>
@@ -450,6 +459,8 @@
     <string name="temp_target_high_target">Temporary target top value</string>
     <string name="temp_target_value">Temporary target value</string>
     <string name="profile_dia">Profile DIA value</string>
+    <string name="insulin_dia">Insulin DIA value</string>
+    <string name="insulin_peak">Insulin Peak value</string>
     <string name="profile_sensitivity_value">Profile sensitivity value</string>
     <string name="profile_max_daily_basal_value">Maximal profile basal value</string>
     <string name="current_basal_value">Current basal value</string>

--- a/implementation/src/main/kotlin/app/aaps/implementation/utils/HardLimitsImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/utils/HardLimitsImpl.kt
@@ -49,6 +49,8 @@ class HardLimitsImpl @Inject constructor(
     override fun maxBasal(): Double = HardLimits.MAX_BASAL[loadAge()]
     override fun minDia(): Double = HardLimits.MIN_DIA[loadAge()]
     override fun maxDia(): Double = HardLimits.MAX_DIA[loadAge()]
+    override fun minPeak(): Int = HardLimits.MIN_PEAK
+    override fun maxPeak(): Int = HardLimits.MAX_PEAK
     override fun minIC(): Double = HardLimits.MIN_IC[loadAge()]
     override fun maxIC(): Double = HardLimits.MAX_IC[loadAge()]
 

--- a/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinNewFragment.kt
+++ b/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinNewFragment.kt
@@ -1,0 +1,258 @@
+package app.aaps.plugins.insulin
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import app.aaps.core.data.model.ICfg
+import app.aaps.core.data.ue.Action
+import app.aaps.core.data.ue.Sources
+import app.aaps.core.data.ue.ValueWithUnit
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.insulin.ConcentrationType
+import app.aaps.core.interfaces.insulin.InsulinType
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.UserEntryLogger
+import app.aaps.core.interfaces.plugin.ActivePlugin
+import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.interfaces.rx.AapsSchedulers
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.ui.UiInteraction
+import app.aaps.core.interfaces.utils.DateUtil
+import app.aaps.core.interfaces.utils.HardLimits
+import app.aaps.core.interfaces.utils.SafeParse
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.core.ui.dialogs.OKDialog
+import app.aaps.core.ui.extensions.toVisibility
+import app.aaps.plugins.insulin.databinding.InsulinNewFragmentBinding
+import dagger.android.support.DaggerFragment
+import java.text.DecimalFormat
+import javax.inject.Inject
+
+class InsulinNewFragment : DaggerFragment() {
+
+    @Inject lateinit var preferences: Preferences
+    @Inject lateinit var activePlugin: ActivePlugin
+    @Inject lateinit var hardLimits: HardLimits
+    @Inject lateinit var rh: ResourceHelper
+    @Inject lateinit var insulinPlugin: InsulinPlugin
+    @Inject lateinit var profileFunction: ProfileFunction
+    @Inject lateinit var uel: UserEntryLogger
+    @Inject lateinit var aapsLogger: AAPSLogger
+    @Inject lateinit var uiInteraction: UiInteraction
+    @Inject lateinit var dateUtil: DateUtil
+    @Inject lateinit var config: Config
+    @Inject lateinit var rxBus: RxBus
+    @Inject lateinit var aapsSchedulers: AapsSchedulers
+    @Inject lateinit var fabricPrivacy: FabricPrivacy
+
+
+    private var _binding: InsulinNewFragmentBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val binding get() = _binding!!
+
+    private val currentInsulin: ICfg get() = insulinPlugin.currentInsulin
+    private var selectedTemplate = InsulinType.OREF_RAPID_ACTING    // Default Insulin (should only be used on new install)
+    private var selectedConcentration = ConcentrationType.U100    // Default Concentration
+    private val insulinList: List<CharSequence> get() = insulinPlugin.insulinList(0.0)
+    private val minPeak: Double get() = hardLimits.minPeak().toDouble()
+    private val maxPeak: Double get() = hardLimits.maxPeak().toDouble()
+
+    private val textWatch = object : TextWatcher {
+        override fun afterTextChanged(s: Editable) {}
+        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+            currentInsulin.insulinLabel = binding.name.text.toString()
+            currentInsulin.setPeak(SafeParse.stringToInt(binding.peak.text))
+            currentInsulin.setDia(SafeParse.stringToDouble(binding.dia.text))
+            updateGui(false)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = InsulinNewFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupClickListeners()
+        if (insulinPlugin.numOfInsulins == 0) {
+            insulinPlugin.loadSettings()
+        }
+        insulinPlugin.setCurrent(insulinPlugin.iCfg)
+
+        val insulinTemplateList: List<CharSequence> = insulinPlugin.insulinTemplateLabelList()
+        setUpSpinnerAdapter(binding.insulinTemplate, insulinTemplateList)
+        binding.insulinTemplate.setText(rh.gs(InsulinType.fromPeak(currentInsulin.insulinPeakTime).label), false)
+        binding.insulinTemplateText.text = rh.gs(InsulinType.fromPeak(currentInsulin.insulinPeakTime).label)
+
+        val concentrationList: List<CharSequence> = insulinPlugin.concentrationLabelList()
+        setUpSpinnerAdapter(binding.concentrationList, concentrationList)
+        binding.concentrationList.setText(rh.gs(ConcentrationType.U100.label), false)
+    }
+
+    @Synchronized
+    override fun onResume() {
+        super.onResume()
+        updateGui()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun updateGui(withTextFields: Boolean = true) {
+        if (_binding == null) return
+        if (withTextFields) updateTextField()
+        updateFormFields()
+        updateButtonVisibility()
+        updateValidationState()
+        updateGraph()
+        setUpSpinnerAdapter(binding.insulinList, insulinList)
+    }
+
+    private fun setupClickListeners() {
+
+        binding.insulinList.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
+            if (insulinPlugin.hasUnsavedChanges) { // Switch insulin Confirmation
+                activity?.let { activity ->
+                    OKDialog.showConfirmation(
+                        activity, rh.gs(R.string.do_you_want_switch_insulin),
+                        {
+                            insulinPlugin.currentInsulinIndex = position
+                            insulinPlugin.currentInsulin = insulinPlugin.deepClone(insulinPlugin.currentInsulin())
+                            updateGui()
+                        }, null
+                    )
+                }
+            } else {
+                insulinPlugin.currentInsulinIndex = position
+                insulinPlugin.currentInsulin = insulinPlugin.deepClone(insulinPlugin.currentInsulin())
+                selectedTemplate = InsulinType.fromInt(insulinPlugin.currentInsulin.insulinTemplate)
+                updateGui()
+            }
+        }
+
+        binding.insulinTemplate.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
+            selectedTemplate = insulinPlugin.insulinTemplateList()[position]
+            insulinPlugin.currentInsulin = insulinPlugin.deepClone(selectedTemplate.getICfg(rh), true).also {
+                it.insulinLabel = insulinPlugin.createNewInsulinLabel(it, insulinPlugin.currentInsulinIndex)
+                it.concentration = selectedConcentration.value
+                it.isNew = true
+            }
+            updateGui()
+        }
+
+        binding.concentrationList.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
+            selectedConcentration = insulinPlugin.concentrationList()[position]
+            insulinPlugin.currentInsulin.concentration = selectedConcentration.value
+            updateGui()
+        }
+
+        setUpSpinnerAdapter(binding.insulinList, insulinList)
+
+        binding.insulinAdd.setOnClickListener {
+            if (insulinPlugin.hasUnsavedChanges) {
+                activity?.let { OKDialog.show(it, "", rh.gs(R.string.save_or_reset_changes_first)) }
+            } else {
+                selectedTemplate = InsulinType.OREF_RAPID_ACTING
+                insulinPlugin.addNewInsulin(insulinPlugin.deepClone(selectedTemplate.iCfg, true).also { it.isNew = true})
+                binding.concentrationList.setText(rh.gs(ConcentrationType.U100.label), false)
+                updateGui()
+            }
+        }
+        binding.insulinRemove.setOnClickListener {
+            insulinPlugin.removeCurrentInsulin(activity)
+            selectedTemplate = InsulinType.fromInt(currentInsulin.insulinTemplate)
+            updateGui()
+        }
+        binding.reset.setOnClickListener {
+            insulinPlugin.currentInsulin = insulinPlugin.deepClone(insulinPlugin.currentInsulin())
+            selectedTemplate = InsulinType.fromInt(currentInsulin.insulinTemplate)
+            updateGui()
+        }
+        binding.save.setOnClickListener {
+            if (!insulinPlugin.isValidEditState(activity)) return@setOnClickListener
+            saveCurrentInsulin()
+        }
+        binding.autoName.setOnClickListener {
+            binding.name.setText(insulinPlugin.createNewInsulinLabel(currentInsulin, insulinPlugin.currentInsulinIndex, selectedTemplate))
+            updateGui()
+        }
+    }
+
+    private fun updateTextField() {
+        binding.name.removeTextChangedListener(textWatch)
+        binding.name.setText(currentInsulin.insulinLabel)
+        binding.name.addTextChangedListener(textWatch)
+    }
+
+    private fun updateFormFields() {
+        binding.insulinList.setText(insulinPlugin.currentInsulinDisplayName, false)
+        binding.insulinTemplate.setText(insulinPlugin.getTemplateDisplayName(selectedTemplate), false)
+        binding.insulinTemplateText.text = insulinPlugin.getTemplateDisplayName(selectedTemplate)
+
+        binding.peak.setParams(currentInsulin.peak.toDouble(), minPeak, maxPeak, 1.0, DecimalFormat("0"), false, null, textWatch)
+        binding.dia.setParams(currentInsulin.dia, hardLimits.minDia(), hardLimits.maxDia(), 0.1, DecimalFormat("0.0"), false, null, textWatch)
+        binding.concentrationR.text = rh.gs(R.string.concentration_with_unit, currentInsulin.concentration * 100)
+        binding.peakR.text = rh.gs(app.aaps.core.ui.R.string.format_mins, currentInsulin.peak)
+
+        binding.peakEdit.visibility = insulinPlugin.isPeakEditable.toVisibility()
+        binding.peakRead.visibility = (!insulinPlugin.isPeakEditable).toVisibility()
+    }
+
+    private fun updateButtonVisibility() {
+        binding.save.visibility = (insulinPlugin.hasUnsavedChanges && insulinPlugin.isValidEditState(activity)).toVisibility()
+        binding.reset.visibility = (insulinPlugin.hasUnsavedChanges && !currentInsulin.isNew).toVisibility()
+        binding.insulinRemove.visibility = insulinPlugin.canRemoveCurrentInsulin.toVisibility()
+        binding.insulinTemplateMenu.visibility = (currentInsulin.isNew).toVisibility()
+        binding.insulinTemplateRead.visibility = (!currentInsulin.isNew).toVisibility()
+        binding.concentrationListMenu.visibility = (currentInsulin.isNew).toVisibility()
+        binding.concentrationRead.visibility = (!currentInsulin.isNew).toVisibility()
+        binding.peakEdit.visibility = (selectedTemplate == InsulinType.OREF_FREE_PEAK).toVisibility()
+        binding.peakRead.visibility = (selectedTemplate != InsulinType.OREF_FREE_PEAK).toVisibility()
+    }
+
+    private fun updateValidationState() {
+        val isValid = insulinPlugin.isValidEditState(activity, false)
+        val bgColor = if (isValid) app.aaps.core.ui.R.attr.okBackgroundColor else app.aaps.core.ui.R.attr.errorBackgroundColor
+        view?.setBackgroundColor(rh.gac(context, bgColor))
+        binding.insulinList.isEnabled = isValid
+    }
+
+    private fun saveCurrentInsulin() {
+        currentInsulin.isNew = false
+        uel.log(
+            action = Action.STORE_INSULIN,
+            source = Sources.Insulin,
+            value = ValueWithUnit.SimpleString(currentInsulin.insulinLabel)
+        )
+        insulinPlugin.insulins[insulinPlugin.currentInsulinIndex] = insulinPlugin.deepClone(currentInsulin).also { it.insulinTemplate = selectedTemplate.value }
+        insulinPlugin.storeSettings()
+        updateGui()
+    }
+
+    private fun updateGraph() {
+        binding.graph.show(currentInsulin)
+    }
+
+    private fun setUpSpinnerAdapter(spinner: AutoCompleteTextView, items: List<CharSequence>) {
+        context?.let { context ->
+            spinner.setAdapter(ArrayAdapter(context, app.aaps.core.ui.R.layout.spinner_centered, items))
+        }
+    }
+}

--- a/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinOrefBasePlugin.kt
+++ b/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinOrefBasePlugin.kt
@@ -34,7 +34,7 @@ abstract class InsulinOrefBasePlugin(
         .mainType(PluginType.INSULIN)
         .fragmentClass(InsulinFragment::class.java.name)
         .pluginIcon(app.aaps.core.objects.R.drawable.ic_insulin)
-        .shortName(R.string.insulin_shortname)
+        .shortName(app.aaps.core.interfaces.R.string.insulin_shortname)
         .visibleByDefault(false)
         .neverVisible(config.AAPSCLIENT),
     aapsLogger, rh

--- a/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinOrefFreePeakPlugin.kt
+++ b/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinOrefFreePeakPlugin.kt
@@ -71,7 +71,7 @@ class InsulinOrefFreePeakPlugin @Inject constructor(
         parent.addPreference(category)
         category.apply {
             key = "insulin_free_peak_settings"
-            title = rh.gs(R.string.insulin_oref_peak)
+            title = rh.gs(app.aaps.core.interfaces.R.string.insulin_oref_peak)
             initialExpandedChildrenCount = 0
             addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.InsulinOrefPeak, title = app.aaps.core.interfaces.R.string.insulin_peak_time))
         }

--- a/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinPlugin.kt
+++ b/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/InsulinPlugin.kt
@@ -1,0 +1,326 @@
+package app.aaps.plugins.insulin
+
+import androidx.fragment.app.FragmentActivity
+import app.aaps.core.data.model.ICfg
+import app.aaps.core.data.plugin.PluginType
+import app.aaps.core.data.ue.Action
+import app.aaps.core.data.ue.Sources
+import app.aaps.core.data.ue.ValueWithUnit
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.insulin.ConcentrationType
+import app.aaps.core.interfaces.insulin.Insulin
+import app.aaps.core.interfaces.insulin.InsulinType
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.UserEntryLogger
+import app.aaps.core.interfaces.notifications.Notification
+import app.aaps.core.interfaces.plugin.ActivePlugin
+import app.aaps.core.interfaces.plugin.PluginBase
+import app.aaps.core.interfaces.plugin.PluginDescription
+import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.ui.UiInteraction
+import app.aaps.core.interfaces.utils.HardLimits
+import app.aaps.core.keys.StringKey
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.core.objects.extensions.fromJson
+import app.aaps.core.objects.extensions.toJson
+import app.aaps.core.ui.toast.ToastUtils
+import org.json.JSONArray
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Created by Philoul on 29.12.2024.
+ */
+
+@Singleton
+class InsulinPlugin @Inject constructor(
+    val preferences: Preferences,
+    rh: ResourceHelper,
+    val profileFunction: ProfileFunction,
+    val rxBus: RxBus,
+    aapsLogger: AAPSLogger,
+    val config: Config,
+    val hardLimits: HardLimits,
+    val uiInteraction: UiInteraction,
+    val uel: UserEntryLogger,
+    val activePlugin: ActivePlugin
+) : PluginBase(
+    PluginDescription()
+        .mainType(PluginType.INSULIN)
+        .fragmentClass(InsulinNewFragment::class.java.name)
+        .pluginIcon(app.aaps.core.objects.R.drawable.ic_insulin)
+        .pluginName(app.aaps.core.interfaces.R.string.insulin_plugin)
+        .shortName(app.aaps.core.interfaces.R.string.insulin_shortname)
+        .setDefault(true)
+        .visibleByDefault(true)
+        .enableByDefault(true)
+        .neverVisible(config.AAPSCLIENT)
+        .description(R.string.description_insulin_plugin),
+    aapsLogger, rh
+), Insulin {
+
+    override val id = InsulinType.UNKNOWN
+    override val friendlyName get(): String = rh.gs(app.aaps.core.interfaces.R.string.insulin_plugin)
+
+    override val iCfg: ICfg
+        get() {
+            val profile = profileFunction.getProfile()
+            return profile?.iCfg ?: insulins[0]
+        }
+
+    override val comment: String
+        get() = TODO("Not yet implemented")
+
+    lateinit var currentInsulin: ICfg
+    private var lastWarned: Long = 0
+    var insulins: ArrayList<ICfg> = ArrayList()
+    var currentInsulinIndex = 0
+    val numOfInsulins get() = insulins.size
+
+    override fun onStart() {
+        super.onStart()
+        loadSettings()
+    }
+
+    override fun insulinList(concentration: Double?): List<CharSequence> {
+        return insulins.filter {
+            when {
+                concentration == null -> it.concentration == iCfg.concentration
+                concentration == 0.0  -> true
+                concentration > 0.0   -> it.concentration == concentration
+                else                  -> false
+            }
+        }.map {
+            it.insulinLabel
+        }
+    }
+
+    fun setCurrent(iCfg: ICfg): Int {
+        insulins.forEachIndexed { index, it ->
+            if (iCfg.isEqual(it)) {
+                currentInsulinIndex = index
+                currentInsulin = deepClone(currentInsulin())
+                return index
+            }
+        }
+        addNewInsulin(iCfg)
+        currentInsulin = deepClone(currentInsulin()).also { it.insulinTemplate = InsulinType.fromPeak(it.insulinPeakTime).ordinal }
+        return insulins.size - 1
+    }
+
+    fun getInsulin(insulinLabel: String): ICfg {
+        insulins.forEach {
+            if (it.insulinLabel == insulinLabel)
+                return it
+        }
+        return iCfg     // if no insulin found then return current running iCfg
+    }
+
+    fun insulinTemplateList(): List<InsulinType> = listOf(
+        InsulinType.OREF_RAPID_ACTING,
+        InsulinType.OREF_ULTRA_RAPID_ACTING,
+        InsulinType.OREF_LYUMJEV,
+        InsulinType.OREF_FREE_PEAK
+    )
+
+    fun insulinTemplateLabelList(): List<CharSequence> = insulinTemplateList().map { rh.gs(it.label) }
+
+    fun concentrationList(): List<ConcentrationType> = listOf(
+        ConcentrationType.U10,
+        ConcentrationType.U50,
+        ConcentrationType.U100,
+        ConcentrationType.U200
+    )
+
+    fun concentrationLabelList(): List<CharSequence> = concentrationList().map { rh.gs(it.label) }
+
+    fun sendShortDiaNotification(dia: Double) {
+        // Todo Check if we need this kind of function to send notification
+        if (System.currentTimeMillis() - lastWarned > 60 * 1000) {
+            lastWarned = System.currentTimeMillis()
+            uiInteraction.addNotification(Notification.SHORT_DIA, String.format(notificationPattern, dia, hardLimits.minDia()), Notification.URGENT)
+        }
+    }
+
+    private val notificationPattern: String
+        get() = rh.gs(R.string.dia_too_short)
+
+    @Synchronized
+    fun addNewInsulin(newICfg: ICfg, ue: Boolean = true): ICfg {
+        if (newICfg.insulinLabel == "" || insulinLabelAlreadyExists(newICfg.insulinLabel))
+            newICfg.insulinLabel = createNewInsulinLabel(newICfg)
+        val newInsulin = deepClone(newICfg)
+        if (newInsulin.isEqual(iCfg)) {
+            insulins.add(0, iCfg)
+            currentInsulinIndex = 0
+        } else {
+            insulins.add(newInsulin)
+            currentInsulinIndex = insulins.size - 1
+        }
+        if (ue)
+            uel.log(Action.NEW_INSULIN, Sources.Insulin, value = ValueWithUnit.SimpleString(newICfg.insulinLabel))
+        currentInsulin = deepClone(newInsulin)
+        currentInsulin.insulinTemplate = 0
+        storeSettings()
+        return newInsulin
+    }
+
+    @Synchronized
+    fun removeCurrentInsulin(activity: FragmentActivity?) {
+        // activity included to include PopUp or Toast when Remove can't be done (default insulin or insulin used within profile
+        val insulinRemoved = currentInsulin().insulinLabel
+        insulins.removeAt(currentInsulinIndex)
+        uel.log(Action.INSULIN_REMOVED, Sources.Insulin, value = ValueWithUnit.SimpleString(insulinRemoved))
+        currentInsulinIndex = 0     // Current running iCfg put in first position
+        currentInsulin = deepClone(currentInsulin())
+        storeSettings()
+    }
+
+    fun createNewInsulinLabel(iCfg: ICfg, currentIndex: Int = -1, template: InsulinType? = null): String {
+        val template = template ?: InsulinType.fromPeak(iCfg.insulinPeakTime)
+        var insulinLabel = rh.gs(template.label)
+        if (insulinLabelAlreadyExists(insulinLabel, currentIndex)) {
+            for (i in 1..10000) {
+                if (!insulinLabelAlreadyExists("${insulinLabel}_$i", currentIndex)) {
+                    insulinLabel = "${insulinLabel}_$i"
+                    break
+                }
+            }
+        }
+        return insulinLabel
+    }
+
+    private fun insulinLabelAlreadyExists(insulinLabel: String, currentIndex: Int = -1): Boolean {
+        insulins.forEachIndexed { index, insulin ->
+            if (index != currentIndex) {
+                if (insulin.insulinLabel == insulinLabel) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private fun insulinAlreadyExists(iCfg: ICfg, currentIndex: Int = -1): Boolean {
+        insulins.forEachIndexed { index, insulin ->
+            if (index != currentIndex) {
+                if (iCfg.isEqual(insulin)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    @Synchronized
+    fun loadSettings() {
+        val jsonString = preferences.get(StringKey.InsulinConfiguration)
+        try {
+            applyConfiguration(JSONObject(jsonString))
+        } catch (_: Exception) {
+            //
+        }
+    }
+
+    @Synchronized
+    fun storeSettings() {
+        preferences.put(StringKey.InsulinConfiguration, configuration().toString())
+    }
+
+    @Synchronized
+    override fun configuration(): JSONObject {
+        val json = JSONObject()
+        val jsonArray = JSONArray()
+        insulins.forEach {
+            try {
+                jsonArray.put(it.toJson())
+            } catch (_: Exception) {
+                //
+            }
+        }
+        json.put("insulins", jsonArray)
+        return json
+    }
+
+    @Synchronized
+    override fun applyConfiguration(configuration: JSONObject) {
+        insulins.clear()
+        configuration.optJSONArray("insulins")?.let {
+            if (it.length() == 0) {   // new install
+                addNewInsulin(InsulinType.OREF_RAPID_ACTING.getICfg(rh).also { it -> it.insulinTemplate = InsulinType.OREF_RAPID_ACTING.ordinal })
+            }
+            for (index in 0 until (it.length())) {
+                try {
+                    val newICfg = ICfg.fromJson(it.getJSONObject(index))
+                    if (!insulinAlreadyExists(newICfg)) // No Duplicated Insulin Allowed
+                        addNewInsulin(newICfg, newICfg.insulinLabel.isEmpty())
+                } catch (_: Exception) {
+                    //
+                }
+            }
+        } ?: apply {
+            addNewInsulin(InsulinType.OREF_RAPID_ACTING.getICfg(rh).also { it.insulinTemplate = InsulinType.OREF_RAPID_ACTING.ordinal })
+        }
+    }
+
+    @Synchronized
+    fun isValidEditState(activity: FragmentActivity?, verbose: Boolean = true): Boolean {
+        with(currentInsulin) {
+            if (dia < hardLimits.minDia() || dia > hardLimits.maxDia()) {
+                if (verbose)
+                    ToastUtils.errorToast(activity, rh.gs(app.aaps.core.ui.R.string.value_out_of_hard_limits, rh.gs(app.aaps.core.ui.R.string.insulin_dia), dia))
+                return false
+            }
+            if (peak < hardLimits.minPeak() || peak > hardLimits.maxPeak()) {
+                if (verbose)
+                    ToastUtils.errorToast(activity, rh.gs(app.aaps.core.ui.R.string.value_out_of_hard_limits, rh.gs(app.aaps.core.ui.R.string.insulin_peak), peak))
+                return false
+            }
+            if (insulinLabel.isEmpty()) {
+                if (verbose)
+                    ToastUtils.errorToast(activity, rh.gs(R.string.missing_insulin_name))
+                return false
+            }
+            // Check Inulin name is unique and insulin parameters is unique
+            if (insulinLabelAlreadyExists(this.insulinLabel, currentInsulinIndex)) {
+                if (verbose)
+                    ToastUtils.errorToast(activity, rh.gs(R.string.insulin_name_exists, insulinLabel))
+                return false
+            }
+            if (insulinAlreadyExists(this, currentInsulinIndex)) {
+                if (verbose)
+                    ToastUtils.errorToast(activity, rh.gs(R.string.insulin_duplicated, insulinLabel))
+                return false
+            }
+        }
+        return true
+    }
+
+    fun currentInsulin(): ICfg = insulins[currentInsulinIndex]
+
+    fun deepClone(iCfg: ICfg, withoutName: Boolean = false): ICfg = iCfg.deepClone().also {
+        if (withoutName)
+            it.insulinLabel = ""
+    }
+
+    val hasUnsavedChanges: Boolean
+        get() = !currentInsulin.isEqual(currentInsulin()) || currentInsulin.insulinLabel != currentInsulin().insulinLabel || currentInsulin.isNew
+
+    val canRemoveCurrentInsulin: Boolean
+        get() = numOfInsulins > 1 && !currentInsulin().isEqual(iCfg)
+
+    val currentInsulinDisplayName: String
+        get() = if (currentInsulin().isEqual(iCfg))
+            rh.gs(R.string.pump_insulin, currentInsulin().insulinLabel)
+        else
+            currentInsulin().insulinLabel
+
+    fun getTemplateDisplayName(template: InsulinType): String = rh.gs(template.label)
+
+    val isPeakEditable: Boolean
+        get() = InsulinType.fromInt(currentInsulin.insulinTemplate) == InsulinType.OREF_FREE_PEAK
+
+}

--- a/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/di/InsulinModule.kt
+++ b/plugins/insulin/src/main/kotlin/app/aaps/plugins/insulin/di/InsulinModule.kt
@@ -1,6 +1,7 @@
 package app.aaps.plugins.insulin.di
 
 import app.aaps.plugins.insulin.InsulinFragment
+import app.aaps.plugins.insulin.InsulinNewFragment
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 
@@ -9,4 +10,5 @@ import dagger.android.ContributesAndroidInjector
 abstract class InsulinModule {
 
     @ContributesAndroidInjector abstract fun contributesInsulinFragment(): InsulinFragment
+    @ContributesAndroidInjector abstract fun contributesInsulinNewFragment(): InsulinNewFragment
 }

--- a/plugins/insulin/src/main/res/layout/insulin_new_fragment.xml
+++ b/plugins/insulin/src/main/res/layout/insulin_new_fragment.xml
@@ -1,0 +1,394 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".InsulinNewFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginEnd="5dp"
+            android:hint="@string/select_insulin">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/insulin_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:orientation="horizontal"
+                android:paddingTop="5dp">
+
+                <ImageView
+                    android:id="@+id/auto_name"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_add_new_insulin"
+                    app:srcCompat="@drawable/ic_auto_fix" />
+
+                <EditText
+                    android:id="@+id/name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_weight="1"
+                    android:ems="10"
+                    android:importantForAutofill="no"
+                    android:inputType="text" />
+
+                <ImageView
+                    android:id="@+id/insulin_add"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_add_new_insulin"
+                    app:srcCompat="@drawable/ic_add" />
+
+                <ImageView
+                    android:id="@+id/insulin_remove"
+                    android:layout_width="35dp"
+                    android:layout_height="35dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="15dp"
+                    android:contentDescription="@string/a11y_delete_current_insulin"
+                    android:scaleX="1"
+                    android:scaleY="1"
+                    app:srcCompat="@drawable/ic_remove" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:visibility="gone"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                android:id="@+id/insulin_template_menu"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="5dp"
+                android:hint="@string/insulin_template">
+
+                <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                    android:id="@+id/insulin_template"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="none" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:id="@+id/insulin_template_read"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:paddingTop="10dp"
+                android:paddingBottom="10dp"
+                android:focusable="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="5dp"
+                    android:layout_weight="2"
+                    android:text="@string/insulin_template"
+                    android:textAlignment="viewEnd"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:layout_width="5dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:layout_marginEnd="2dp"
+                    android:layout_weight="0"
+                    android:gravity="center_horizontal"
+                    android:text=":"
+                    tools:ignore="HardcodedText"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                    android:id="@+id/insulin_template_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="5dp"
+                    android:layout_weight="1"
+                    android:textAlignment="viewStart"
+                    tools:text="xxxxx"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            </LinearLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                android:id="@+id/concentration_list_menu"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_marginEnd="5dp"
+                android:hint="@string/concentration">
+
+                <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                    android:id="@+id/concentration_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="none" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:shrinkColumns="0,2"
+                android:paddingTop="5dp">
+
+                <TableRow
+                    android:id="@+id/concentration_read"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/concentration"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text=":"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:id="@+id/concentration_r"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text="U100"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text=""
+                        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/peak_edit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/peak"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text=":"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <app.aaps.core.ui.elements.NumberPicker
+                        android:id="@+id/peak"
+                        android:layout_width="130dp"
+                        android:layout_height="40dp"
+                        android:layout_gravity="center"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginEnd="5dp"
+                        android:layout_marginBottom="10dp"
+                        app:customContentDescription="@string/peak" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text="@string/unit_minutes"
+                        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/peak_read"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/peak"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text=":"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:id="@+id/peak_r"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:layout_marginStart="5dp"
+                        android:text="70 min"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text=""
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                </TableRow>
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="end|center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/dia"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text=":"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <app.aaps.core.ui.elements.NumberPicker
+                        android:id="@+id/dia"
+                        android:layout_width="130dp"
+                        android:layout_height="40dp"
+                        android:layout_gravity="center"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginEnd="5dp"
+                        android:layout_marginBottom="10dp"
+                        app:customContentDescription="@string/dia" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:layout_gravity="start|center_vertical"
+                        android:layout_marginStart="5dp"
+                        android:text="@string/hours"
+                        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+                </TableRow>
+
+            </TableLayout>
+
+            <app.aaps.core.graph.ActivityGraph
+                android:id="@+id/graph"
+                android:layout_width="match_parent"
+                android:layout_height="200dip"
+                android:layout_margin="20dp" />
+
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:orientation="horizontal">
+
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/reset"
+                    style="@style/GrayButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginEnd="5dp"
+                    android:layout_weight="1"
+                    android:paddingStart="1dp"
+                    android:paddingEnd="1dp"
+                    android:text="@string/reset"
+                    android:visibility="gone"
+                    app:icon="@drawable/ic_local_reset"
+                    app:iconTint="@color/ic_local_reset" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/save"
+                    style="@style/GrayButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginEnd="5dp"
+                    android:layout_weight="1"
+                    android:paddingStart="1dp"
+                    android:paddingEnd="1dp"
+                    android:text="@string/save"
+                    android:visibility="gone"
+                    app:icon="@drawable/ic_local_save"
+                    app:iconTint="@color/ic_local_save" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/plugins/insulin/src/main/res/values/strings.xml
+++ b/plugins/insulin/src/main/res/values/strings.xml
@@ -5,9 +5,23 @@
     <string name="description_insulin_ultra_rapid">Insulin preset for Fiasp</string>
     <string name="description_insulin_lyumjev">Insulin preset for Lyumjev</string>
     <string name="description_insulin_free_peak">Allows you to define the peak of the insulin activity and should only be used by advanced users</string>
-    <string name="insulin_shortname">INS</string>
-    <string name="insulin_oref_peak">IOB Curve Peak Time</string>
+    <string name="description_insulin_plugin">Allows you to manage the different insulin you will use within AAPS</string>
     <string name="dia_too_short">DIA of %1$f too short - using %2$f instead!</string>
-
+    <string name="missing_insulin_name">Missing Insulin Name</string>
+    <string name="insulin_name_exists">Insulin Name %1$s already exists, select a new name</string>
+    <string name="insulin_duplicated">Insulin already exists Name %1$s</string>
+    <string name="do_you_want_switch_insulin">Do you want to switch insulin and discard changes made to current insulin?</string>
+    <string name="a11y_add_new_insulin">Add new insulin</string>
+    <string name="a11y_delete_current_insulin">Delete current insulin</string>
+    <string name="save_or_reset_changes_first">Save or reset current changes first</string>
+    <string name="update_profiles_title">Update Profiles</string>
+    <string name="update_profiles_message">This insulin is used within %1$d profile(s)\nDo you confirm the update of this insulin?\n\nA profile switch will be required to apply the modification within your Loop</string>
+    <string name="concentration_with_unit">U%1$.0f</string>
+    <string name="pump_insulin">%1$s (Pump)</string>
+    <string name="change_insulin_reminder">Set reminder to change Insulin on next Insulin Change</string>
+    <string name="change_concentration">Change Insulin concentration on next reservoir change</string>
+    <string name="new_concentration">New Concentration:</string>
+    <string name="save_pump_insulin_title">Save Insulin %1$s?</string>
+    <string name="save_pump_insulin_message">A Profile Switch is required to update Pump Insulin with current running profile</string>
 
 </resources>


### PR DESCRIPTION
Here it's the first step (Insulin Editor added within an additional InsulinPlugin)
- No interface to select insulin included (so just the User Interface to manage Insulins and be able to provide the available insulins with different filtering)
- Easy creation of insulins using templates (Rapid Acting, Ultra Rapid, Lyumjev or Free Peak)
- Dropdown Menu to select Concentration on Insulin Creation
- Once a new insulin has been created, some information are frozen (the same way it was within previous insulin Plugins): Peak for RapidActing, UltraRapid and Lyumjev Templates, and Concentration.

Insulin can be updated (mainly DIA, but also Peak and DIA for Freepeak template)
Current Running Insulin is always included in the top of Insulin Selector dropdown menu

User Interface is very close to Profile Editor so end user should not be lost here

Next steps:
- Confirm or adjust UI proposal concerning InsulinEditor Only
- Add User Interface to select Running Insulin with a dedicated popup (then selected insulin can be provided with "Next" button to the ProfileSwitch Popup and confirm the overall EffectiveProfile) (probably limited to U100 only in the first step)
- Remove previous InsulinPlugins
- Add Dedicated UI to Select and Confirm Concentration change (synchronized with Insulin_Change Event)
- Add Unit tests

