### PR TITLE
feat(equil): add multi-version pump support

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilConst.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/EquilConst.kt
@@ -6,6 +6,9 @@ object EquilConst {
     const val EQUIL_BLE_WRITE_TIME_OUT: Long = 20
     const val EQUIL_BLE_NEXT_CMD: Long = 150
     const val EQUIL_SUPPORT_LEVEL = 5.3f
+    const val EQUIL_SUPPORT_LEVEL_PUMP_V1_0 = 5.3f  // 1.0 PUMP
+    const val EQUIL_SUPPORT_LEVEL_PUMP_V1_5 = 1.3f  // 1.5 PUMP
+    const val EQUIL_SUPPORT_LEVEL_PUMP_V1_5R = 2.3f  // 1.5R PUMP
     const val EQUIL_BOLUS_THRESHOLD_STEP = 1600
     const val EQUIL_BASAL_THRESHOLD_STEP = 240
     const val EQUIL_STEP_MAX = 32000

--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
@@ -174,7 +174,22 @@ class CmdDevicesOldGet(
         }
     }
 
-    fun isSupport(): Boolean = firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL
+    fun isSupport(serialNumber: String): Boolean {
+        val firstChar = serialNumber.firstOrNull()?.uppercaseChar()
+        return when {
+            // 1.0 pump
+            firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL_PUMP_V1_0 -> true
+
+            // 1.5 pump
+            firstChar != null && firstChar in '6'..'9' ->
+                firmwareVersion <= EquilConst.EQUIL_SUPPORT_LEVEL_PUMP_V1_5
+            
+            // 1.5R pump
+            firstChar == 'A' -> firmwareVersion < EquilConst.EQUIL_SUPPORT_LEVEL_PUMP_V1_5R
+
+            else -> false
+        }
+    }
 
     override fun getEventType(): EquilHistoryRecord.EventType? = null
 }


### PR DESCRIPTION
Previously only supported Equil 1.0 pump. This commit extends compatibility to include all three hardware versions:

- Equil 1.0 (support level: 5.3)
- Equil 1.5 (support level: 1.3)
- Equil 1.5R (support level: 2.3)

Each version has different protocol characteristics that are now handled accordingly.