### PR TITLE
feat: Expand insulin pump compatibility by serial number prefix

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
@@ -123,7 +123,7 @@ class CmdDevicesOldGet(
         firmwareVersion = fv.toFloat()
         aapsLogger.debug(
             LTag.PUMPCOMM, "CmdDevicesOldGet====" +
-                Utils.bytesToHex(data) + "========" + firmwareVersion + "===" + (firmwareVersion < EquilConst.EQUIL_SUPPORT_LEVEL)
+                    Utils.bytesToHex(data) + "========" + firmwareVersion + "===" + (firmwareVersion < EquilConst.EQUIL_SUPPORT_LEVEL)
         )
         reqModel.ciphertext = Utils.bytesToHex(getNextData())
         synchronized(this) {
@@ -165,8 +165,8 @@ class CmdDevicesOldGet(
         firmwareVersion = fv.toFloat()
         aapsLogger.debug(
             LTag.PUMPCOMM, ("CmdDevicesOldGet====" +
-                Utils.bytesToHex(data) + "=====" + value + "===" + firmwareVersion + "===="
-                + (firmwareVersion < EquilConst.EQUIL_SUPPORT_LEVEL))
+                    Utils.bytesToHex(data) + "=====" + value + "===" + firmwareVersion + "===="
+                    + (firmwareVersion < EquilConst.EQUIL_SUPPORT_LEVEL))
         )
         synchronized(this) {
             cmdSuccess = true
@@ -174,7 +174,15 @@ class CmdDevicesOldGet(
         }
     }
 
-    fun isSupport(): Boolean = firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL
+
+    fun isSupport(serialNumber: String): Boolean {
+        val firstChar = serialNumber.firstOrNull()?.uppercaseChar()
+        val needsVersionCheck = setOf('0', '1', '3', 'A', 'D')
+        return when (firstChar) {
+            in needsVersionCheck -> firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL
+            else -> true
+        }
+    }
 
     override fun getEventType(): EquilHistoryRecord.EventType? = null
 }


### PR DESCRIPTION
Add serial number-based support check for insulin pumps. Only pumps with serial numbers starting with '0', '1', '3', 'A', or 'D' require firmware version validation. All other pump models are now supported by default.