### PR TITLE
Fix VAR_SENS Visibility for AutoISF

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewMenusImpl.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewMenusImpl.kt
@@ -84,7 +84,7 @@ class OverviewMenusImpl @Inject constructor(
             }
         }
         CharTypeData.DEVSLOPE.visibility = { config.isDev() }
-        CharTypeData.VAR_SENS.visibility = { preferences.get(BooleanKey.ApsUseDynamicSensitivity) }
+        CharTypeData.VAR_SENS.visibility = { preferences.get(BooleanKey.ApsUseDynamicSensitivity) || (preferences.get(BooleanKey.ApsUseAutoIsfWeights) && config.isDev()) }
     }
 
     companion object {


### PR DESCRIPTION
If Variable ISF is enabled within AutoISF plugin (and `config.isDev()` due to current limitations for AutoISF plugin), then show Var_Sens item in Graph Sub-Menu