### PR TITLE
Wear: Fix TileConfiguration crash and improve preferences UI

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -658,11 +658,15 @@
 
         <activity
             android:name=".interaction.TileConfigurationActivity"
+            android:theme="@style/TileConfigTheme"
             android:exported="true">
             <intent-filter>
                 <action android:name="tile_configuration_activity" />
+                <category android:name="com.google.android.clockwork.tiles.category.PROVIDER_CONFIG" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="tile_configuration_tempt" />
-
                 <category android:name="com.google.android.clockwork.tiles.category.PROVIDER_CONFIG" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/wear/src/main/res/drawable/tile_config_background.xml
+++ b/wear/src/main/res/drawable/tile_config_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FF424242" />
+    <corners android:radius="8dp" />
+</shape>

--- a/wear/src/main/res/layout/tile_preference_item.xml
+++ b/wear/src/main/res/layout/tile_preference_item.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="56dp"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingTop="12dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="12dp"
+    android:background="?android:attr/selectableItemBackground">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:ellipsize="marquee"
+        android:fadingEdge="horizontal"
+        android:singleLine="true" />
+
+    <TextView
+        android:id="@android:id/summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textSize="14sp"
+        android:textColor="#CCCCCC"
+        android:maxLines="4"
+        android:ellipsize="end" />
+
+</LinearLayout>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -24,4 +24,17 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
+    <!-- Theme for Tile Configuration Activity -->
+    <style name="TileConfigTheme" parent="Theme.AppCompat">
+        <item name="android:windowBackground">@drawable/tile_config_background</item>
+        <item name="android:textColorPrimary">#FFFFFF</item>
+        <item name="android:textColorSecondary">#CCCCCC</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+    </style>
+
+    <!-- Custom preference style for better visibility -->
+    <style name="TilePreferenceStyle" parent="@style/Preference.Material">
+        <item name="android:layout">@layout/tile_preference_item</item>
+    </style>
 </resources>

--- a/wear/src/main/res/xml/tile_configuration_activity.xml
+++ b/wear/src/main/res/xml/tile_configuration_activity.xml
@@ -6,27 +6,31 @@
         android:entries="@array/tile_action_names"
         android:entryValues="@array/tile_action_values"
         android:key="tile_action_1"
-        android:title="@string/tile_action_1" />
+        android:title="@string/tile_action_1"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="treatment"
         android:entries="@array/tile_action_names"
         android:entryValues="@array/tile_action_values"
         android:key="tile_action_2"
-        android:title="@string/tile_action_2" />
+        android:title="@string/tile_action_2"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="carbs"
         android:entries="@array/tile_action_names"
         android:entryValues="@array/tile_action_values"
         android:key="tile_action_3"
-        android:title="@string/tile_action_3" />
+        android:title="@string/tile_action_3"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="temp_target"
         android:entries="@array/tile_action_names"
         android:entryValues="@array/tile_action_values"
         android:key="tile_action_4"
-        android:title="@string/tile_action_4" />
+        android:title="@string/tile_action_4"
+        android:summary="%s" />
 
 </PreferenceScreen>

--- a/wear/src/main/res/xml/tile_configuration_tempt.xml
+++ b/wear/src/main/res/xml/tile_configuration_tempt.xml
@@ -6,27 +6,31 @@
         android:entries="@array/tile_tempt_names"
         android:entryValues="@array/tile_tempt_values"
         android:key="tile_tempt_1"
-        android:title="@string/tile_tempt_1" />
+        android:title="@string/tile_tempt_1"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="eating_soon"
         android:entries="@array/tile_tempt_names"
         android:entryValues="@array/tile_tempt_values"
         android:key="tile_tempt_2"
-        android:title="@string/tile_tempt_2" />
+        android:title="@string/tile_tempt_2"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="hypo"
         android:entries="@array/tile_tempt_names"
         android:entryValues="@array/tile_tempt_values"
         android:key="tile_tempt_3"
-        android:title="@string/tile_tempt_3" />
+        android:title="@string/tile_tempt_3"
+        android:summary="%s" />
 
     <ListPreference
         android:defaultValue="manual"
         android:entries="@array/tile_tempt_names"
         android:entryValues="@array/tile_tempt_values"
         android:key="tile_tempt_4"
-        android:title="@string/tile_tempt_4" />
+        android:title="@string/tile_tempt_4"
+        android:summary="%s" />
 
 </PreferenceScreen>


### PR DESCRIPTION
Also see #4413 as it continues on this PR. Especially when it comes to padding to see all options at top/bottom clearly.

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/68e48618-cf72-499f-a0a3-2713a0c87466" />

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/ba7ce418-870a-4f13-928a-64fa5288506c" />
