### PR TITLE
Wear: Add haptic and visual feedback to Wear confirmation buttons

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
@@ -88,7 +88,17 @@ class AcceptActivity : ViewSelectorActivity() {
                 // Page 1: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         if (actionKey.isNotEmpty()) startService(IntentWearToMobile(this@AcceptActivity, actionKey))
                         startForegroundService(IntentCancelNotification(this@AcceptActivity))
                         finishAffinity()

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/BolusActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/BolusActivity.kt
@@ -65,7 +65,17 @@ class BolusActivity : ViewSelectorActivity() {
                 // Page 1: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         rxBus.send(EventWearToMobile(ActionBolusPreCheck(SafeParse.stringToDouble(editInsulin?.editText?.text.toString()), 0)))
                         showToast(this@BolusActivity, R.string.action_bolus_confirmation)
                         finishAffinity()

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
@@ -62,7 +62,17 @@ class CarbActivity : ViewSelectorActivity() {
                 // Page 1: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         // With start time 0 and duration 0
                         val bolus = ActionECarbsPreCheck(SafeParse.stringToInt(editCarbs?.editText?.text.toString()), 0, 0)
                         rxBus.send(EventWearToMobile(bolus))

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ECarbActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ECarbActivity.kt
@@ -103,9 +103,17 @@ class ECarbActivity : ViewSelectorActivity() {
                 // Page 3: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
-                        // check if it can happen that the fragment is never created that hold data?
-                        // (you have to swipe past them anyways - but still)
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         val bolus = ActionECarbsPreCheck(
                             stringToInt(editCarbs?.editText?.text.toString()),
                             stringToInt(editStartTime?.editText?.text.toString()),

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/FillActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/FillActivity.kt
@@ -56,9 +56,17 @@ class FillActivity : ViewSelectorActivity() {
                 // Page 1: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
-                        // check if it can happen that the fragment is never created that hold data?
-                        // (you have to swipe past them anyways - but still)
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         rxBus.send(EventWearToMobile(ActionFillPreCheck(stringToDouble(editInsulin?.editText?.text.toString()))))
                         showToast(this@FillActivity, R.string.action_fill_confirmation)
                         finishAffinity()

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/LoopStateTimedActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/LoopStateTimedActivity.kt
@@ -90,7 +90,17 @@ class LoopStateTimedActivity : ViewSelectorActivity() {
                 // Page 1: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         rxBus.send(
                             EventWearToMobile(
                                 EventData.LoopStateSelected(

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ProfileSwitchActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/ProfileSwitchActivity.kt
@@ -106,9 +106,17 @@ class ProfileSwitchActivity : ViewSelectorActivity() {
                 // Page 3: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
-                        // check if it can happen that the fragment is never created that hold data?
-                        // (you have to swipe past them anyways - but still)
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         val ps =
                             ActionProfileSwitchPreCheck(SafeParse.stringToInt(editTimeshift?.editText?.text.toString()), SafeParse.stringToInt(editPercentage?.editText?.text.toString()), SafeParse.stringToInt(editDuration?.editText?.text.toString()))
                         rxBus.send(EventWearToMobile(ps))

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TempTargetActivity.kt
@@ -111,9 +111,17 @@ class TempTargetActivity : ViewSelectorActivity() {
                 // Page 3 (or 2 if single target): Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
-                        // check if it can happen that the fragment is never created that hold data?
-                        // (you have to swipe past them anyways - but still)
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         val action = ActionTempTargetPreCheck(
                             ActionTempTargetPreCheck.TempTargetCommand.MANUAL,
                             isMGDL,

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
@@ -89,9 +89,17 @@ class TreatmentActivity : ViewSelectorActivity() {
                 // Page 2: Confirm page
                 LayoutInflater.from(applicationContext).inflate(R.layout.action_confirm_ok, container, false).apply {
                     val confirmButton = findViewById<ImageView>(R.id.confirmbutton)
-                    confirmButton.setOnClickListener {
-                        // check if it can happen that the fragment is never created that hold data?
-                        // (you have to swipe past them anyways - but still)
+                    confirmButton.setOnClickListener { view ->
+                        // Visual feedback: scale animation
+                        view.animate()
+                            .scaleX(1.2f)
+                            .scaleY(1.2f)
+                            .setDuration(150)
+                            .start()
+
+                        // Haptic feedback
+                        view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)
+
                         val bolus = ActionBolusPreCheck(stringToDouble(editInsulin?.editText?.text.toString()), stringToInt(editCarbs?.editText?.text.toString()))
                         rxBus.send(EventWearToMobile(bolus))
                         showToast(this@TreatmentActivity, R.string.action_treatment_confirmation)


### PR DESCRIPTION
- Added scale animation and haptic feedback to confirmation buttons in Wizard, Treatment, Carb, ProfileSwitch, Bolus, TempTarget, Fill, LoopStateTimed, ECarb, and Accept activities.
- Refactored WizardActivity to extract page instantiation logic into separate private methods.