### PR TITLE
Always Show Cannula Usage

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/actions/ActionsFragment.kt
@@ -286,8 +286,6 @@ class ActionsFragment : DaggerFragment() {
             val imageResource = if (isPatchPump) app.aaps.core.objects.R.drawable.ic_patch_pump_outline else R.drawable.ic_cp_age_cannula
             cannulaOrPatch.setCompoundDrawablesWithIntrinsicBounds(imageResource, 0, 0, 0)
             batteryLayout.visibility = (!isPatchPump || pump.pumpDescription.useHardwareLink).toVisibility()
-            cannulaUsageLabel.visibility = isPatchPump.not().toVisibility()
-            cannulaUsage.visibility = isPatchPump.not().toVisibility()
 
             if (!config.AAPSCLIENT) {
                 statusLightHandler.updateStatusLights(

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/ui/StatusLightHandler.kt
@@ -61,6 +61,7 @@ class StatusLightHandler @Inject constructor(
         }
 
         val insulinUnit = rh.gs(app.aaps.core.ui.R.string.insulin_unit_shortname)
+        if (cannulaUsage != null) scope.launch { handleUsage(cannulaUsage, insulinUnit) }
         if (pump.pumpDescription.isPatchPump) {
             handlePatchReservoirLevel(
                 reservoirLevel,
@@ -70,7 +71,6 @@ class StatusLightHandler @Inject constructor(
                 pump.pumpDescription.maxResorvoirReading.toDouble()
             )
         } else {
-            if (cannulaUsage != null) scope.launch { handleUsage(cannulaUsage, insulinUnit) }
             handleLevel(reservoirLevel, IntKey.OverviewResCritical, IntKey.OverviewResWarning, pump.reservoirLevel, insulinUnit)
         }
         if (!config.AAPSCLIENT) {


### PR DESCRIPTION
I think this information is usefull even with Patch Pump, so I propose to make it always visible.
On my side I manually record the overall usage in Site rotation Note, and overall usage is not always the Insulin quantity put into Reservoir of patch pump...