### PR TITLE
Wear: Prevent editText clicks from propagating to ViewPager

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/utils/PlusMinusEditText.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/utils/PlusMinusEditText.kt
@@ -251,6 +251,15 @@ class PlusMinusEditText @JvmOverloads constructor(
 
         editText.showSoftInputOnFocus = false
         editText.setTextIsSelectable(false)
+
+        // Prevent editText clicks from propagating to ViewPager
+        editText.isClickable = true
+        editText.isFocusable = false
+        editText.setOnClickListener {
+            // Consume the click event without doing anything
+            // This prevents the ViewPager from receiving the touch event
+        }
+
         binding.minButton.setOnTouchListener(this)
         binding.minButton.setOnKeyListener(this)
         binding.minButton.setOnClickListener(this)


### PR DESCRIPTION
Without this fix, if you click on 75 you return to page 1. The problem is on every action and is tied to PlusMinusEditText.kt

This commit fixes this issue and improves upon the fact you can't select text and have keyboard or other pop-ups, makes the UX more responsive.

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/b05fb736-e32a-4e5d-8484-7b43602202a7" />
