### PR TITLE
fix: speedup rileylink communication by minimizing sleeps

### DIFF
--- a/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/RFSpy.kt
+++ b/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/RFSpy.kt
@@ -157,7 +157,7 @@ class RFSpy @Inject constructor(
     }
 
     private fun writeToDataRaw(bytes: ByteArray, responseTimeoutMs: Int): ByteArray? {
-        SystemClock.sleep(100)
+        SystemClock.sleep(1)
         // FIXME drain read queue?
         var junkInBuffer = reader.poll(0)
 
@@ -182,8 +182,6 @@ class RFSpy @Inject constructor(
             aapsLogger.error(LTag.PUMPBTCOMM, "BLE Write operation failed, code=" + writeCheck.resultCode)
             return null // will be a null (invalid) response
         }
-
-        SystemClock.sleep(100)
 
         return reader.poll(responseTimeoutMs)
     }

--- a/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/RFSpyReader.kt
+++ b/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/RFSpyReader.kt
@@ -66,9 +66,9 @@ class RFSpyReader internal constructor(private val aapsLogger: AAPSLogger, priva
                     acquireCount++
                     waitForRadioData.acquire()
                     aapsLogger.debug(LTag.PUMPBTCOMM, "${ThreadUtil.sig()}waitForRadioData acquired (count=$acquireCount) at t=${SystemClock.uptimeMillis()}")
-                    SystemClock.sleep(100)
+                    SystemClock.sleep(1)
                     var result = rileyLinkBle.readCharacteristicBlocking(serviceUUID, radioDataUUID)
-                    SystemClock.sleep(100)
+                    SystemClock.sleep(1)
                     if (result.resultCode == BLECommOperationResult.RESULT_SUCCESS) {
                         if (stopAtNull) {
                             // only data up to the first null is valid


### PR DESCRIPTION
In march 2025 during analysis of the issue #3898 I found that there are 3 extra sleeps of 100ms in the process of sending each command to RileyLink. These sleeps were there from the very beginning of the project and reason to have it was unclear. So I decided to check whether it's safe to remove them so together with @tdrkDev we created a property "Fast Mode" for RileyLink which switches these delays from 100ms to 1ms.
https://github.com/mifi100/AndroidAPS-1/commit/055a5c78e69a8f54b0bd6aeb84476a50718e08fa

So I'm using this enabled reduced sleep for half a year and for me it works very well - initial communication with RileyLink with dozens of commands and history reading became much faster with no side effects in the stability.
The version with the fix was was installed by other users and so far there were only positive feedbacks regarding this change.

So my proposal is to just do a permanent change since this property showed stable work.

Fix also removes one delay which was removed as part of fix #3898, but in future restored during code refactoring