### PR TITLE
Wear: Improve loop status display run/enact logic

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
@@ -243,12 +243,17 @@ class LoopStatusActivity : AppCompatActivity() {
                 val enactTimeString = dateUtil.timeString(lastEnact)
                 val enactAgeMs = System.currentTimeMillis() - lastEnact
 
-                // Compare only HH:mm part of times
-                if (runTimeString == enactTimeString) {
-                    // Show combined row
+                val timeWindowMs = 30_000L // 30 seconds
+
+                // Check if enacted is within 30 seconds of suggested (before or after)
+                val timeDiff = kotlin.math.abs(lastRun - lastEnact)
+                val timesAreClose = timeDiff <= timeWindowMs
+
+                if (timesAreClose) {
+                    // Show combined row - use the enacted time since it's the actual action
                     lastRunEnactCombinedRow.visibility = View.VISIBLE
-                    lastRunEnactCombinedValue.text = runTimeString
-                    lastRunEnactCombinedValue.setTextColor(runColor)
+                    lastRunEnactCombinedValue.text = enactTimeString
+                    lastRunEnactCombinedValue.setTextColor(ContextCompat.getColor(this, getAgeColorRes(enactAgeMs)))
 
                     // Hide separate rows
                     lastRunRow.visibility = View.GONE


### PR DESCRIPTION
Split out from https://github.com/nightscout/AndroidAPS/pull/4448

Problem
SMB enacted times not properly tracked in Loop Status on wear
Enacted times used for AAPSClient can be a few seconds before Suggested times

Solution
Track max(TBR, SMB) enacted time
Add time buffer and check if enacted is within 30 seconds of suggested (before or after)