### PR TITLE
Improve OpenAPS reason display logic for AAPSClient

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/data/ProcessedDeviceStatusDataImpl.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclient/data/ProcessedDeviceStatusDataImpl.kt
@@ -75,21 +75,57 @@ class ProcessedDeviceStatusDataImpl @Inject constructor(
         get() {
             val string = StringBuilder()
             val enacted = openAPSData.enacted
-            val suggested = openAPSData.suggested
-            if (enacted != null && openAPSData.clockEnacted != openAPSData.clockSuggested) string
-                .append("<b>")
-                .append("Enacted: </br>")
-                .append(dateUtil.minAgo(rh, openAPSData.clockEnacted))
-                .append("</b> ")
-                .append(enacted.reason)
-                .append("<br>")
-            if (suggested != null) string
-                .append("<b>")
-                .append("Suggested: </br>")
-                .append(dateUtil.minAgo(rh, openAPSData.clockSuggested))
-                .append("</b> ")
-                .append(suggested.reason)
-                .append("<br>")
+            val suggested = openAPSData.suggested ?: return HtmlHelper.fromHtml("")  // Early return if no suggested data (though this should always exist)
+
+            // Check if enacted is recent
+            val enactedIsRecent = enacted != null &&
+                openAPSData.clockEnacted >= (openAPSData.clockSuggested)
+
+            // Check if reasons are the same (when both exist and enacted is recent)
+            val reasonsMatch = enactedIsRecent &&
+                enacted.reason.trim() == suggested.reason.trim()
+
+            when {
+                // Case 1: Enacted is recent and reasons match → show as single "Loop" entry
+                reasonsMatch -> {
+                    string
+                        .append("<b>")
+                        .append("Loop: </br>")
+                        .append(dateUtil.minAgo(rh, openAPSData.clockEnacted))
+                        .append("</b> ")
+                        .append(enacted.reason)
+                        .append("<br>")
+                }
+
+                // Case 2: Enacted is recent but reasons differ → show both
+                enactedIsRecent -> {
+                    string
+                        .append("<b>")
+                        .append("Enacted: </br>")
+                        .append(dateUtil.minAgo(rh, openAPSData.clockEnacted))
+                        .append("</b> ")
+                        .append(enacted.reason)
+                        .append("<br>")
+                        .append("<b>")
+                        .append("Suggested: </br>")
+                        .append(dateUtil.minAgo(rh, openAPSData.clockSuggested))
+                        .append("</b> ")
+                        .append(suggested.reason)
+                        .append("<br>")
+                }
+
+                // Case 3: No enacted or enacted is old → show only suggested
+                else -> {
+                    string
+                        .append("<b>")
+                        .append("Loop: </br>")
+                        .append(dateUtil.minAgo(rh, openAPSData.clockSuggested))
+                        .append("</b> ")
+                        .append(suggested.reason)
+                        .append("<br>")
+                }
+            }
+
             return HtmlHelper.fromHtml(string.toString())
         }
 


### PR DESCRIPTION
Split out from: https://github.com/nightscout/AndroidAPS/pull/4448

**Problem**
Duplicate "Enacted" and "Suggested" messages shown when they're the same
Stale enacted data in AAPSClient OpenAPS pill.

**Solution**
Show "Loop" label when enacted/suggested match
Hide stale enacted data

**Testing**
✅ TBR only
✅ SMB only
✅ TBR + SMB
✅ No changes loop
✅ Stale enacted data

**Result:** Cleaner, more accurate loop status display.

Some pictures to illustrate. See also: https://github.com/nightscout/AndroidAPS/issues/3706

**BEFORE**
| Duplicated data | Stale enacted data | Stale misleading enacted data |
|--------|--------|--------|
| <img width="609" height="911" alt="image" src="https://github.com/user-attachments/assets/effe017d-69cb-4390-8214-59c8d80f4da6" /> | <img width="627" height="911" alt="image" src="https://github.com/user-attachments/assets/cee4d2f1-43e9-45ab-a2b7-5df0d1427f08" /> | <img width="1168" height="1018" alt="image" src="https://github.com/user-attachments/assets/83b0bf30-028e-483f-a3af-72a6b3d5428b" /> | 

**AFTER PR**
| Loop result | AAPSClient OpenAPS pill |
|--------|--------|
| <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/ef2c9494-757f-485f-9faa-5e4cb78d1fd7" /> | <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/f7cf2565-7dcc-4d46-a97c-08bec8c237ac" /> |
| <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/62fc5bab-9cae-4dbe-8609-ae8b0b04070c" /> | <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/3ed48b95-45a4-4c14-bfa0-58536a150020" /> |
| <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/8e2b54c3-801b-4d56-a800-9a3d5edac867" /> | <img width="278" height="587" alt="image" src="https://github.com/user-attachments/assets/0db02ffb-af8d-4601-86ba-6c4602ddeb3e" /> | 