### PR TITLE
fix: Adjust layout to prevent aps_mode_text cutoff

### DIFF
--- a/plugins/main/src/main/res/layout/overview_info_layout.xml
+++ b/plugins/main/src/main/res/layout/overview_info_layout.xml
@@ -215,8 +215,8 @@
 
         <TextView
             android:id="@+id/aps_mode_text"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:paddingTop="3dp"
             android:paddingBottom="3dp"


### PR DESCRIPTION
With v3.4.0.0, the aps_mode_text is cut off.. on the pixel 9 only hours are visible, the minutes are cut off, since the text is adjusted to the aps_mode icon width.

This PR will adjust the text to match the content width. Rather have a bad layout but readable text than unreadable/missing text and a pretty layout.

Before: 
<img width="215" height="149" alt="grafik" src="https://github.com/user-attachments/assets/42cb929a-4158-4281-a944-e53e7e3254e8" />

After:
<img width="236" height="174" alt="grafik" src="https://github.com/user-attachments/assets/62507456-888c-4de2-b9a2-b7e98e085969" />

fixes #4478 
