### PR TITLE
Omnipod Dash Drift resolution

### DIFF
--- a/app/src/main/kotlin/app/aaps/implementations/ConfigImpl.kt
+++ b/app/src/main/kotlin/app/aaps/implementations/ConfigImpl.kt
@@ -44,6 +44,7 @@ class ConfigImpl @Inject constructor(
     private var ignoreNightscoutV3Errors: Boolean? = null
     private var doNotSendSmsOnProfileChange: Boolean? = null
     private var enableAutotune: Boolean? = null
+    private var enableOmnipodDriftCompensation: Boolean? = null
     private var disableLeakCanary: Boolean? = null
 
     override fun isEngineeringModeOrRelease(): Boolean = if (!APS) true else isEngineeringMode() || !isDev()
@@ -54,5 +55,6 @@ class ConfigImpl @Inject constructor(
     override fun ignoreNightscoutV3Errors(): Boolean = ignoreNightscoutV3Errors ?: (fileListProvider.get().ensureExtraDirExists()?.findFile("ignore_nightscout_v3_errors") != null).also { ignoreNightscoutV3Errors = it }
     override fun doNotSendSmsOnProfileChange(): Boolean = doNotSendSmsOnProfileChange ?: (fileListProvider.get().ensureExtraDirExists()?.findFile("do_not_send_sms_on_profile_change") != null).also { doNotSendSmsOnProfileChange = it }
     override fun enableAutotune(): Boolean = enableAutotune ?: (fileListProvider.get().ensureExtraDirExists()?.findFile("enable_autotune") != null).also { enableAutotune = it }
+    override fun enableOmnipodDriftCompensation(): Boolean = enableOmnipodDriftCompensation ?: (fileListProvider.get().ensureExtraDirExists()?.findFile("omnipod_drift_compensation") != null).also { enableOmnipodDriftCompensation = it }
     override fun disableLeakCanary(): Boolean = disableLeakCanary ?: (fileListProvider.get().ensureExtraDirExists()?.findFile("disable_leakcanary") != null).also { disableLeakCanary = it }
 }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/configuration/Config.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/configuration/Config.kt
@@ -34,6 +34,7 @@ interface Config {
     fun ignoreNightscoutV3Errors(): Boolean
     fun doNotSendSmsOnProfileChange(): Boolean
     fun enableAutotune(): Boolean
+    fun enableOmnipodDriftCompensation(): Boolean
 
     /**
      * Disable LeakCanary (memory leaks detection). By default it's enabled in DEBUG builds.

--- a/pump/omnipod/common/build.gradle.kts
+++ b/pump/omnipod/common/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     api(libs.androidx.navigation.fragment)
     api(libs.com.google.android.material)
 
+    testImplementation(project(":shared:tests"))
+
     ksp(libs.com.google.dagger.compiler)
     ksp(libs.com.google.dagger.android.processor)
 }

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManager.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManager.kt
@@ -138,6 +138,10 @@ interface OmnipodDashPodStateManager {
 
     fun updateLowReservoirAlertSettings(lowReservoirAlertEnabled: Boolean, lowReservoirAlertUnits: Int): Completable
 
+    var lastBasalCorrectionTime: Long?
+    var basalCorrectionInProgress: Boolean
+    fun needsBasalCorrection(): Boolean
+
     data class ActiveCommand(
         val sequence: Short,
         val createdRealtime: Long,

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -2,6 +2,7 @@ package app.aaps.pump.omnipod.common.bledriver.pod.state
 
 import android.os.SystemClock
 import app.aaps.core.data.model.BS
+import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.rx.bus.RxBus
@@ -43,7 +44,8 @@ import javax.inject.Singleton
 class OmnipodDashPodStateManagerImpl @Inject constructor(
     private val logger: AAPSLogger,
     private val rxBus: RxBus,
-    private val preferences: Preferences
+    private val preferences: Preferences,
+    private val config: Config
 ) : OmnipodDashPodStateManager {
 
     private var podState: PodState
@@ -322,6 +324,8 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     }
 
     override fun needsBasalCorrection(): Boolean {
+        if (!config.enableOmnipodDriftCompensation()) return false  // Semaphore file check
+
         val correctionThreshold = -PodConstants.POD_PULSE_BOLUS_UNITS / 2  // -0.025U
         
         if (!isActivationCompleted) return false  // Don't correct during activation/priming
@@ -735,6 +739,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     }
 
     override fun onStart() {
+        logger.info(LTag.PUMP, "Omnipod Dash drift compensation: ${if (config.enableOmnipodDriftCompensation()) "enabled" else "disabled"}")
         when (getCommandConfirmationFromState()) {
             CommandConfirmationSuccess, CommandConfirmationDenied -> {
                 val now = SystemClock.elapsedRealtime()

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -48,7 +48,8 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     private val config: Config
 ) : OmnipodDashPodStateManager {
 
-    private var podState: PodState
+    /** Internal (rather than private) to allow unit testing within this module. */
+    internal var podState: PodState
 
     init {
         podState = load()
@@ -261,9 +262,24 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         // Compute drift (actual - expected: positive = over-delivery, negative = under-delivery)
         get() = basalDelivered - (podState.basalExpected ?: basalDelivered)
 
-    private fun integrateExpectedDelivery(startTime: Long, endTime: Long): Double? {
+    /**
+     * Integrates expected basal delivery (in units) over [startTime, endTime].
+     * Internal (rather than private) to allow unit testing within this module.
+     */
+    internal fun integrateExpectedDelivery(
+        startTime: Long,
+        endTime: Long,
+        timeZoneOffset: Int?,
+        tempBasal: OmnipodDashPodStateManager.TempBasal?,
+        basalProgram: BasalProgram?
+    ): Double? {
         logger.debug(LTag.PUMP, "integrateExpectedDelivery: period ${(endTime - startTime) / 1000.0}s")
-        
+
+        if (timeZoneOffset == null) {
+            logger.error(LTag.PUMP, "integrateExpectedDelivery: pod timezone unknown, skipping")
+            return null
+        }
+
         // Validate time period
         if (startTime > endTime) {
             logger.error(LTag.PUMP, "Invalid time period: startTime=$startTime > endTime=$endTime")
@@ -284,7 +300,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         // Add basal program segment boundaries
         basalProgram?.segments?.forEach { segment ->
             // Calculate day boundaries in pod's local timezone, not UTC
-            val timeZoneOffset = podState.timeZoneOffset ?: 0
+
             val dayStartLocal = ((startTime + timeZoneOffset) / 86400_000L) * 86400_000L - timeZoneOffset
             var segmentStart = dayStartLocal + segment.startSlotIndex.toLong() * 30 * 60_000L
             
@@ -299,6 +315,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
                 segmentStart += 86400_000L
             }
         }
+
+        // Offset to convert UTC epoch to pod-local time for rateAt (which uses device timezone internally)
+        val deviceOffsetMs = TimeZone.getDefault().getOffset(startTime)
+        val podTimeAdjustmentMs = timeZoneOffset - deviceOffsetMs
         
         // Integrate over each segment
         return boundaries.sorted().windowed(2).mapIndexed { index, (boundaryStart, boundaryEnd) ->
@@ -309,7 +329,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             val rate = tempBasal?.let { tb ->
                 val tempBasalEnd = tb.startTime + tb.durationInMinutes * 60_000L
                 tb.rate.takeIf { segmentMid in tb.startTime until tempBasalEnd }
-            } ?: basalProgram?.rateAt(segmentMid) ?: return null  // Abort if rate unknown
+            } ?: basalProgram?.rateAt(segmentMid + podTimeAdjustmentMs) ?: return null  // Abort if rate unknown
             
             val delivery = rate * segmentHours
             
@@ -339,7 +359,9 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         // Compute drift once for efficiency
         val drift = basalDrift
 
-        // Reset if drift exceeds boundaries (over-delivery or severe under-delivery)
+        // Reset if drift exceeds boundaries (over-delivery or severe under-delivery).
+        // Thresholds are intentionally tight: a reset is preferred over risking over-correction.
+        // Even so, reaching this point is genuinely exceptional and has not been observed in practice; widen if needed.
         if (drift >= PodConstants.POD_PULSE_BOLUS_UNITS * 2 || drift <= -PodConstants.POD_PULSE_BOLUS_UNITS * 2) {
             logger.warn(
                 LTag.PUMP,
@@ -703,7 +725,8 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         store()
     }
 
-    private fun calculateBolusPulseIncrease(
+    /** Internal (rather than private) to allow unit testing within this module. */
+    internal fun calculateBolusPulseIncrease(
         previousTotalPulses: Short,
         newTotalPulses: Short,
         previousBolusPulsesRemaining: Short?,
@@ -768,7 +791,8 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         }
     }
 
-    private fun updatePodState(
+    /** Internal (rather than private) to allow unit testing within this module. */
+    internal fun updatePodState(
         deliveryStatus: DeliveryStatus,
         podStatus: PodStatus,
         totalPulsesDelivered: Short,
@@ -790,9 +814,13 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
 
         // Update basal expected delivery
         podState.basalExpected = podState.basalExpected?.let {
-            integrateExpectedDelivery(podState.lastUpdatedSystem, now)?.let { delta ->
-                it + delta
-            }
+            integrateExpectedDelivery(
+                startTime = podState.lastUpdatedSystem,
+                endTime = now,
+                timeZoneOffset = podState.timeZoneOffset,
+                tempBasal = tempBasal,
+                basalProgram = basalProgram
+            )?.let { delta -> it + delta }
         } ?: basalDelivered.takeIf { isActivationCompleted }
         
         // Update bolus pulses delivered (exclude basal corrections)

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -244,7 +244,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         get() = podState.bolusPulsesDelivered
 
     private val basalPulsesDelivered: Short?
-        // Compute basal pulses delivered by subtracting bolus pulses from total pulses delivered
+        // Compute basal pulses (including corrections) by subtracting user bolus pulses from total
         get() = pulsesDelivered?.let { total ->
             bolusPulsesDelivered?.let { bolus ->
                 (total - bolus).toShort()
@@ -320,6 +320,63 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             logger.debug(LTag.PUMP, "  total integrated delivery: ${"%.4f".format(total)}U")
         }
     }
+
+    override fun needsBasalCorrection(): Boolean {
+        val correctionThreshold = -PodConstants.POD_PULSE_BOLUS_UNITS / 2  // -0.025U
+        
+        if (!isActivationCompleted) return false  // Don't correct during activation/priming
+        if (isSuspended || isPodKaput) return false
+
+        // Check cooldown: 2 minutes minimum between corrections (prevents rapid corrections while allowing timely response)
+        podState.lastBasalCorrectionTime?.let {
+            if (System.currentTimeMillis() - it < 2 * 60 * 1000L) return false
+        }
+
+        // Compute drift once for efficiency
+        val drift = basalDrift
+
+        // Reset if drift exceeds boundaries (over-delivery or severe under-delivery)
+        if (drift >= PodConstants.POD_PULSE_BOLUS_UNITS * 2 || drift <= -PodConstants.POD_PULSE_BOLUS_UNITS * 2) {
+            logger.warn(
+                LTag.PUMP,
+                "Resetting basal drift: drift=${"%.3f".format(drift)}U, " +
+                    "expected=${"%.3f".format(podState.basalExpected ?: 0.0)}U -> actual=${"%.3f".format(basalDelivered)}U"
+            )
+            podState.basalExpected = basalDelivered
+            store()
+            return false
+        }
+
+        // No correction if drift too small
+        if (drift > correctionThreshold) {
+            return false
+        }
+
+        // Safety check: don't correct when TBR = 0 (algorithm explicitly requested zero insulin)
+        // Except zero temp due to bolus delivery, allow corrections in that case
+        if (tempBasal?.rate == 0.0) {
+            val timeSinceLastBolus = podState.lastBolus?.startTime?.let { System.currentTimeMillis() - it }
+            if (timeSinceLastBolus == null || timeSinceLastBolus >= 5 * 60 * 1000L) {
+                return false
+            }
+        }
+
+        // Correction triggers when: -0.10U < drift <= -0.025U and no zero-TBR (unless recent bolus)
+        return true
+    }
+
+    override var lastBasalCorrectionTime: Long?
+        get() = podState.lastBasalCorrectionTime
+        set(value) {
+            podState.lastBasalCorrectionTime = value
+            store()
+        }
+
+    override var basalCorrectionInProgress: Boolean
+        get() = podState.basalCorrectionInProgress
+        set(value) {
+            podState.basalCorrectionInProgress = value
+        }
 
     override val lastStatusResponseReceived: Long
         get() = podState.lastStatusResponseReceived
@@ -733,10 +790,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             }
         } ?: basalDelivered.takeIf { isActivationCompleted }
         
-        // Update bolus pulses delivered
+        // Update bolus pulses delivered (exclude basal corrections)
         podState.bolusPulsesDelivered = podState.bolusPulsesDelivered?.let {
             podState.pulsesDelivered
-                ?.takeIf { podState.lastBolus?.deliveryComplete == false }
+                ?.takeIf { podState.lastBolus?.deliveryComplete == false && !podState.basalCorrectionInProgress }
                 ?.let { previousTotalPulses ->
                     (it + calculateBolusPulseIncrease(
                         previousTotalPulses,
@@ -967,6 +1024,9 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var lastBolus: OmnipodDashPodStateManager.LastBolus? = null,
 
         var bolusPulsesDelivered: Short? = null,  // Cumulative count of bolus pulses for basal tracking
-        var basalExpected: Double? = null  // Initialized to actual on first drift calculation
+        var basalExpected: Double? = null,  // Initialized to actual on first drift calculation
+        
+        var lastBasalCorrectionTime: Long? = null,  // Timestamp of last basal correction attempt (for cooldown)
+        @Transient var basalCorrectionInProgress: Boolean = false  // Transient flag: true while basal correction is delivering
     ) : Serializable
 }

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -239,6 +239,88 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             store()
         }
 
+    private val bolusPulsesDelivered: Short?
+        // Track pulses delivered via bolus for basal delivery detection
+        get() = podState.bolusPulsesDelivered
+
+    private val basalPulsesDelivered: Short?
+        // Compute basal pulses delivered by subtracting bolus pulses from total pulses delivered
+        get() = pulsesDelivered?.let { total ->
+            bolusPulsesDelivered?.let { bolus ->
+                (total - bolus).toShort()
+            }
+        }
+
+    private val basalDelivered: Double
+        // Compute basal delivered in insulin units
+        get() = (basalPulsesDelivered ?: 0) * PodConstants.POD_PULSE_BOLUS_UNITS
+
+    private val basalDrift: Double
+        // Compute drift (actual - expected: positive = over-delivery, negative = under-delivery)
+        get() = basalDelivered - (podState.basalExpected ?: basalDelivered)
+
+    private fun integrateExpectedDelivery(startTime: Long, endTime: Long): Double? {
+        logger.debug(LTag.PUMP, "integrateExpectedDelivery: period ${(endTime - startTime) / 1000.0}s")
+        
+        // Validate time period
+        if (startTime > endTime) {
+            logger.error(LTag.PUMP, "Invalid time period: startTime=$startTime > endTime=$endTime")
+            return null
+        }
+        
+        // Build set of time boundaries where rate changes
+        val boundaries = mutableSetOf(startTime, endTime)
+        
+        // Add temp basal start/end if within period
+        tempBasal?.let { tb ->
+            val tempStart = tb.startTime
+            val tempEnd = tb.startTime + tb.durationInMinutes * 60_000L
+            if (tempStart in startTime until endTime) boundaries.add(tempStart)
+            if (tempEnd in startTime until endTime) boundaries.add(tempEnd)
+        }
+        
+        // Add basal program segment boundaries
+        basalProgram?.segments?.forEach { segment ->
+            // Calculate day boundaries in pod's local timezone, not UTC
+            val timeZoneOffset = podState.timeZoneOffset ?: 0
+            val dayStartLocal = ((startTime + timeZoneOffset) / 86400_000L) * 86400_000L - timeZoneOffset
+            var segmentStart = dayStartLocal + segment.startSlotIndex.toLong() * 30 * 60_000L
+            
+            // If segment already passed today, start checking tomorrow
+            if (segmentStart <= startTime) {
+                segmentStart += 86400_000L
+            }
+            
+            // Add all occurrences of this segment boundary until endTime
+            while (segmentStart < endTime) {
+                boundaries.add(segmentStart)
+                segmentStart += 86400_000L
+            }
+        }
+        
+        // Integrate over each segment
+        return boundaries.sorted().windowed(2).mapIndexed { index, (boundaryStart, boundaryEnd) ->
+            val segmentHours = (boundaryEnd - boundaryStart) / 3600_000.0
+            val segmentMid = (boundaryStart + boundaryEnd) / 2
+            
+            // Get rate: temp basal if active at midpoint, otherwise scheduled basal program
+            val rate = tempBasal?.let { tb ->
+                val tempBasalEnd = tb.startTime + tb.durationInMinutes * 60_000L
+                tb.rate.takeIf { segmentMid in tb.startTime until tempBasalEnd }
+            } ?: basalProgram?.rateAt(segmentMid) ?: return null  // Abort if rate unknown
+            
+            val delivery = rate * segmentHours
+            
+            logger.debug(
+                LTag.PUMP,
+                "  segment ${index + 1}/${boundaries.size - 1}: ${segmentHours * 3600}s @ ${rate}U/h = ${"%.4f".format(delivery)}U"
+            )
+            delivery
+        }.sum().also { total ->
+            logger.debug(LTag.PUMP, "  total integrated delivery: ${"%.4f".format(total)}U")
+        }
+    }
+
     override val lastStatusResponseReceived: Long
         get() = podState.lastStatusResponseReceived
 
@@ -560,6 +642,41 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         store()
     }
 
+    private fun calculateBolusPulseIncrease(
+        previousTotalPulses: Short,
+        newTotalPulses: Short,
+        previousBolusPulsesRemaining: Short?,
+        newBolusPulsesRemaining: Short
+    ): Short {
+        var increase = newTotalPulses - previousTotalPulses
+        
+        // Cap increase if we know the expected bolus pulse decrease
+        if (previousBolusPulsesRemaining != null) {
+            val expectedIncrease = previousBolusPulsesRemaining - newBolusPulsesRemaining
+            when {
+                increase > expectedIncrease -> {
+                    logger.debug(
+                        LTag.PUMP,
+                        "Bolus pulse tracking: Total pulse increase ($increase) exceeds bolus decrease " +
+                        "($expectedIncrease), indicating ${increase - expectedIncrease} basal pulses " +
+                        "delivered concurrently. Capping bolus attribution to $expectedIncrease."
+                    )
+                    increase = expectedIncrease
+                }
+                increase != expectedIncrease -> {
+                    logger.debug(
+                        LTag.PUMP,
+                        "Bolus pulse tracking anomaly: Expected $expectedIncrease bolus pulses based on " +
+                        "remaining count, but total pulses increased by $increase. " +
+                        "Difference: ${increase - expectedIncrease} pulses."
+                    )
+                }
+            }
+        }
+        
+        return increase.toShort()
+    }
+
     override fun onStart() {
         when (getCommandConfirmationFromState()) {
             CommandConfirmationSuccess, CommandConfirmationDenied -> {
@@ -589,25 +706,100 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         }
     }
 
+    private fun updatePodState(
+        deliveryStatus: DeliveryStatus,
+        podStatus: PodStatus,
+        totalPulsesDelivered: Short,
+        reservoirPulsesRemaining: Short,
+        sequenceNumberOfLastProgrammingCommand: Short,
+        minutesSinceActivation: Short,
+        activeAlerts: EnumSet<AlertType>,
+        bolusPulsesRemaining: Short
+    ) {
+        // Capture current state for tracking calculations
+        val now = System.currentTimeMillis()
+        val nowRealtime = SystemClock.elapsedRealtime()
+        val previousBolusPulsesRemaining = podState.lastBolus?.let {
+            Round.roundTo(
+                it.bolusUnitsRemaining / PodConstants.POD_PULSE_BOLUS_UNITS,
+                1.0
+            ).toInt().toShort()
+        }
+
+        // Update basal expected delivery
+        podState.basalExpected = podState.basalExpected?.let {
+            integrateExpectedDelivery(podState.lastUpdatedSystem, now)?.let { delta ->
+                it + delta
+            }
+        } ?: basalDelivered.takeIf { isActivationCompleted }
+        
+        // Update bolus pulses delivered
+        podState.bolusPulsesDelivered = podState.bolusPulsesDelivered?.let {
+            podState.pulsesDelivered
+                ?.takeIf { podState.lastBolus?.deliveryComplete == false }
+                ?.let { previousTotalPulses ->
+                    (it + calculateBolusPulseIncrease(
+                        previousTotalPulses,
+                        totalPulsesDelivered,
+                        previousBolusPulsesRemaining,
+                        bolusPulsesRemaining
+                    )).toShort()
+                } ?: it
+        } ?: totalPulsesDelivered.takeIf { isActivationCompleted }
+
+        // Update pod state from response
+        podState.deliveryStatus = deliveryStatus
+        podState.podStatus = podStatus
+        podState.pulsesDelivered = totalPulsesDelivered
+        if (reservoirPulsesRemaining < 1023) {
+            podState.pulsesRemaining = reservoirPulsesRemaining
+        }
+        podState.sequenceNumberOfLastProgrammingCommand = sequenceNumberOfLastProgrammingCommand
+        podState.minutesSinceActivation = minutesSinceActivation
+        podState.activeAlerts = activeAlerts
+
+        podState.lastUpdatedSystem = now
+        podState.lastStatusResponseReceived = nowRealtime
+        updateLastBolusFromResponse(bolusPulsesRemaining)
+    }
+
+    private inline fun logBasalTracking(block: () -> Unit) {
+        val driftBefore = basalDrift.takeIf { isActivationCompleted } ?: 0.0
+        block()
+        if (isActivationCompleted) {
+            logger.info(
+                LTag.PUMP,
+                "PUMP_BASAL act=%.2fU (tot=%.2fU bol=%.2fU) exp=%.4fU err=%+.4fU dErr=%+.4fU".format(
+                    basalDelivered,
+                    (pulsesDelivered ?: 0) * PodConstants.POD_PULSE_BOLUS_UNITS,
+                    (bolusPulsesDelivered ?: 0) * PodConstants.POD_PULSE_BOLUS_UNITS,
+                    podState.basalExpected ?: 0.0,
+                    basalDrift,
+                    basalDrift - driftBefore
+                )
+            )
+        }
+    }
+
     override fun updateFromDefaultStatusResponse(response: DefaultStatusResponse) {
         logger.debug(LTag.PUMPCOMM, "Default status response :$response")
-        podState.deliveryStatus = response.deliveryStatus
-        podState.podStatus = response.podStatus
-        podState.pulsesDelivered = response.totalPulsesDelivered
-        if (response.reservoirPulsesRemaining < 1023) {
-            podState.pulsesRemaining = response.reservoirPulsesRemaining
+        
+        logBasalTracking {
+            updatePodState(
+                response.deliveryStatus,
+                response.podStatus,
+                response.totalPulsesDelivered,
+                response.reservoirPulsesRemaining,
+                response.sequenceNumberOfLastProgrammingCommand,
+                response.minutesSinceActivation,
+                response.activeAlerts,
+                response.bolusPulsesRemaining
+            )
+            if (podState.activationTime == null) {
+                podState.activationTime = podState.lastUpdatedSystem - (response.minutesSinceActivation * 60_000)
+            }
         }
-        podState.sequenceNumberOfLastProgrammingCommand = response.sequenceNumberOfLastProgrammingCommand
-        podState.minutesSinceActivation = response.minutesSinceActivation
-        podState.activeAlerts = response.activeAlerts
-
-        podState.lastUpdatedSystem = System.currentTimeMillis()
-        podState.lastStatusResponseReceived = SystemClock.elapsedRealtime()
-        updateLastBolusFromResponse(response.bolusPulsesRemaining)
-        if (podState.activationTime == null) {
-            podState.activationTime = System.currentTimeMillis() - (response.minutesSinceActivation * 60_000)
-        }
-
+        
         store()
         rxBus.send(EventOmnipodDashPumpValuesChanged())
     }
@@ -660,26 +852,22 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     }
 
     override fun updateFromAlarmStatusResponse(response: AlarmStatusResponse) {
-        logger.info(
-            LTag.PUMPCOMM,
-            "Received AlarmStatusResponse: $response"
-        )
-        podState.deliveryStatus = response.deliveryStatus
-        podState.podStatus = response.podStatus
-        podState.pulsesDelivered = response.totalPulsesDelivered
-
-        if (response.reservoirPulsesRemaining < 1023) {
-            podState.pulsesRemaining = response.reservoirPulsesRemaining
+        logger.info(LTag.PUMPCOMM, "Received AlarmStatusResponse: $response")
+        
+        logBasalTracking {
+            updatePodState(
+                response.deliveryStatus,
+                response.podStatus,
+                response.totalPulsesDelivered,
+                response.reservoirPulsesRemaining,
+                response.sequenceNumberOfLastProgrammingCommand,
+                response.minutesSinceActivation,
+                response.activeAlerts,
+                response.bolusPulsesRemaining
+            )
+            podState.alarmType = response.alarmType
         }
-        podState.sequenceNumberOfLastProgrammingCommand = response.sequenceNumberOfLastProgrammingCommand
-        podState.minutesSinceActivation = response.minutesSinceActivation
-        podState.activeAlerts = response.activeAlerts
-        podState.alarmType = response.alarmType
-
-        podState.lastUpdatedSystem = System.currentTimeMillis()
-        podState.lastStatusResponseReceived = SystemClock.elapsedRealtime()
-        updateLastBolusFromResponse(response.bolusPulsesRemaining)
-
+        
         store()
         rxBus.send(EventOmnipodDashPumpValuesChanged())
     }
@@ -776,6 +964,9 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var basalProgram: BasalProgram? = null,
         var tempBasal: OmnipodDashPodStateManager.TempBasal? = null,
         var activeCommand: OmnipodDashPodStateManager.ActiveCommand? = null,
-        var lastBolus: OmnipodDashPodStateManager.LastBolus? = null
+        var lastBolus: OmnipodDashPodStateManager.LastBolus? = null,
+
+        var bolusPulsesDelivered: Short? = null,  // Cumulative count of bolus pulses for basal tracking
+        var basalExpected: Double? = null  // Initialized to actual on first drift calculation
     ) : Serializable
 }

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/queue/command/CommandDeliverBasalCorrection.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/queue/command/CommandDeliverBasalCorrection.kt
@@ -1,0 +1,8 @@
+package app.aaps.pump.omnipod.common.queue.command
+
+import app.aaps.core.interfaces.queue.CustomCommand
+
+class CommandDeliverBasalCorrection : CustomCommand {
+
+    override val statusDescription = "BASAL COMPENSATION BOLUS"
+}

--- a/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/CalculateBolusPulseIncreaseTest.kt
+++ b/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/CalculateBolusPulseIncreaseTest.kt
@@ -1,0 +1,94 @@
+package app.aaps.pump.omnipod.common.bledriver.pod.state
+
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+
+/**
+ * Tests for [OmnipodDashPodStateManagerImpl.calculateBolusPulseIncrease].
+ *
+ * This function decides how many of the newly delivered pulses should be attributed to the
+ * active bolus vs. basal. Key scenarios:
+ *  - No bolus in progress → all pulses attributed to bolus tracker (caller uses them for total)
+ *  - Normal bolus delivery → total increase matches expected bolus decrease exactly
+ *  - Concurrent basal delivery → total increase > bolus decrease, capped to bolus portion
+ *  - Anomaly (fewer total pulses than expected) → returns actual increase and logs warning
+ */
+class CalculateBolusPulseIncreaseTest : TestBase() {
+
+    @Mock lateinit var preferences: Preferences
+    @Mock lateinit var config: Config
+
+    private lateinit var sut: OmnipodDashPodStateManagerImpl
+
+    @BeforeEach fun setUp() {
+        sut = OmnipodDashPodStateManagerImpl(aapsLogger, rxBus, preferences, config)
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private fun increase(
+        prevTotal: Int,
+        newTotal: Int,
+        prevBolusPulsesRemaining: Int?,
+        newBolusPulsesRemaining: Int
+    ): Short = sut.calculateBolusPulseIncrease(
+        previousTotalPulses       = prevTotal.toShort(),
+        newTotalPulses            = newTotal.toShort(),
+        previousBolusPulsesRemaining = prevBolusPulsesRemaining?.toShort(),
+        newBolusPulsesRemaining   = newBolusPulsesRemaining.toShort()
+    )
+
+    // ---- no previous bolus tracking -----------------------------------------------------------
+
+    @Test fun `no previous tracking — full pulse increase returned`() {
+        // previousBolusPulsesRemaining = null means we have no reference point;
+        // return raw increase so the caller can record it
+        assertThat(increase(100, 103, null, 0)).isEqualTo(3.toShort())
+    }
+
+    @Test fun `no previous tracking, zero increase — returns zero`() {
+        assertThat(increase(100, 100, null, 0)).isEqualTo(0.toShort())
+    }
+
+    // ---- normal bolus delivery ----------------------------------------------------------------
+
+    @Test fun `normal bolus delivery — increase matches expected bolus decrease`() {
+        // 3 total pulses, 3 bolus pulses remaining → 0 now: clean match
+        assertThat(increase(100, 103, 3, 0)).isEqualTo(3.toShort())
+    }
+
+    @Test fun `bolus still in progress — partial delivery tracked correctly`() {
+        // 1 total pulse added, bolus remaining went from 2 → 1: expected 1 bolus pulse
+        assertThat(increase(100, 101, 2, 1)).isEqualTo(1.toShort())
+    }
+
+    @Test fun `zero increase during active bolus — returns zero`() {
+        assertThat(increase(100, 100, 3, 3)).isEqualTo(0.toShort())
+    }
+
+    // ---- concurrent basal delivery ------------------------------------------------------------
+
+    @Test fun `concurrent basal — total increase capped to bolus portion`() {
+        // 5 total pulses added, but bolus only accounted for 3 → 2 were basal corrections
+        // Result must be capped at 3 to avoid over-attributing to bolus
+        assertThat(increase(100, 105, 3, 0)).isEqualTo(3.toShort())
+    }
+
+    @Test fun `concurrent basal, partial bolus remaining — capped correctly`() {
+        // 4 total pulses, bolus remaining went 3 → 1 (2 bolus pulses expected), 2 basal
+        assertThat(increase(100, 104, 3, 1)).isEqualTo(2.toShort())
+    }
+
+    // ---- anomaly (total < expected) -----------------------------------------------------------
+
+    @Test fun `anomaly — fewer total pulses than expected bolus decrease — returns actual increase`() {
+        // Bolus remaining went 3 → 0 (expected 3), but only 2 total pulses added.
+        // We return the actual increase (2) and log a warning — do not over-attribute.
+        assertThat(increase(100, 102, 3, 0)).isEqualTo(2.toShort())
+    }
+}

--- a/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/IntegrateExpectedDeliveryTest.kt
+++ b/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/IntegrateExpectedDeliveryTest.kt
@@ -1,0 +1,316 @@
+package app.aaps.pump.omnipod.common.bledriver.pod.state
+
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.BasalProgram
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.TimeZone
+
+/**
+ * Tests for [OmnipodDashPodStateManagerImpl.integrateExpectedDelivery].
+ *
+ * All timestamps are constructed from a fixed UTC anchor (2026-01-01T00:00:00Z) so tests are
+ * calendar-layout-independent and deterministic. Device timezone is set/restored around each test
+ * to isolate [BasalProgram.rateAt] behaviour.
+ */
+class IntegrateExpectedDeliveryTest : TestBase() {
+
+    @Mock lateinit var preferences: Preferences
+    @Mock lateinit var config: Config
+
+    private lateinit var sut: OmnipodDashPodStateManagerImpl
+
+    // ---- constants ----------------------------------------------------------------------------
+
+    // 2026-01-01T00:00:00Z
+    private val JAN1_UTC = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant().toEpochMilli()
+
+    private val HOUR  = 3_600_000L
+    private val MIN30 = 1_800_000L
+
+    private val OFFSET_UTC    = 0
+    private val OFFSET_PLUS2  = 2 * 60 * 60 * 1000   // UTC+2 in ms
+    private val OFFSET_MINUS5 = -5 * 60 * 60 * 1000  // UTC-5 in ms
+
+    // ---- setup / teardown ---------------------------------------------------------------------
+
+    private lateinit var savedTz: TimeZone
+
+    @BeforeEach fun setUp() {
+        savedTz = TimeZone.getDefault()
+        sut = OmnipodDashPodStateManagerImpl(aapsLogger, rxBus, preferences, config)
+    }
+
+    @AfterEach fun restoreTz() { TimeZone.setDefault(savedTz) }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private fun seg(startSlot: Int, endSlot: Int, hundredthsPerHour: Int): BasalProgram.Segment =
+        BasalProgram.Segment(startSlot.toShort(), endSlot.toShort(), hundredthsPerHour)
+
+    /** Single-rate full-day basal program. */
+    private fun flatBasal(rateUh: Double): BasalProgram =
+        BasalProgram(listOf(seg(0, 48, (rateUh * 100).toInt())))
+
+    /** Two-segment program with [splitSlot] (0-based 30-min slots) as the split point. */
+    private fun twoSegmentBasal(rate1Uh: Double, rate2Uh: Double, splitSlot: Int): BasalProgram =
+        BasalProgram(listOf(
+            seg(0,         splitSlot, (rate1Uh * 100).toInt()),
+            seg(splitSlot, 48,        (rate2Uh * 100).toInt())
+        ))
+
+    /** TempBasal anchored to JAN1_UTC + [startOffsetMs]. */
+    private fun tempBasal(startOffsetMs: Long, durationMins: Int, rateUh: Double) =
+        OmnipodDashPodStateManager.TempBasal(
+            startTime         = JAN1_UTC + startOffsetMs,
+            durationInMinutes = durationMins.toShort(),
+            rate              = rateUh
+        )
+
+    // ---- happy path ---------------------------------------------------------------------------
+
+    @Test fun `single rate basal, period within one segment`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // 0.5h @ 1 U/h = 0.5 U
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + MIN30, OFFSET_UTC, null, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(0.5)
+    }
+
+    @Test fun `single rate basal, full 24h`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // 24h @ 1 U/h = 24 U
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + 24 * HOUR, OFFSET_UTC, null, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(24.0)
+    }
+
+    @Test fun `two-segment basal, period spans segment boundary`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Slot 16 = 08:00; period 07:00-09:00: 1h @ 1 U/h + 1h @ 2 U/h = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC + 7 * HOUR, JAN1_UTC + 9 * HOUR, OFFSET_UTC, null, prog)
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `integration window crosses midnight`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // period 23:00-01:00 (next day); slot 0 boundary at midnight must be projected to Jan2
+        // segment 16-48 = 2 U/h, segment 0-16 = 1 U/h → 1h @ 2 + 1h @ 1 = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 23 * HOUR, JAN1_UTC + 25 * HOUR,
+            OFFSET_UTC, null, prog
+        )
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    // ---- temp basal --------------------------------------------------------------------------
+
+    @Test fun `temp basal covers entire window`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp started 1h before, duration 3h → entire 1h window at 1.5 U/h = 1.5 U
+        val tb = tempBasal(-HOUR, 180, 1.5)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(1.5)
+    }
+
+    @Test fun `temp basal covers sub-period`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp starts at 30 min, lasts 30 min (rate 0); window is 2h
+        // 30 min @ 1 U/h + 30 min @ 0 U/h + 60 min @ 1 U/h = 1.5 U
+        val tb = tempBasal(MIN30, 30, 0.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + 2 * HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(1.5)
+    }
+
+    @Test fun `temp basal starts exactly at startTime`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp starts at t=0, lasts 30 min; 30 min @ 0 U/h + 30 min @ 1 U/h = 0.5 U
+        val tb = tempBasal(0L, 30, 0.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(0.5)
+    }
+
+    @Test fun `temp basal ends exactly at endTime`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp starts at t=0, ends exactly at endTime; entire 1h at temp rate 2 U/h = 2 U
+        val tb = tempBasal(0L, 60, 2.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(2.0)
+    }
+
+    @Test fun `temp basal starts before startTime and ends within window`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp started 30 min ago, ends 30 min into window; 30 min @ 0 U/h + 30 min @ 1 U/h = 0.5 U
+        val tb = tempBasal(-MIN30, 60, 0.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(0.5)
+    }
+
+    @Test fun `temp basal starts before startTime and ends after endTime — full window at temp rate`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val tb = tempBasal(-HOUR, 180, 3.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `temp basal rate zero for entire window`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val tb = tempBasal(-HOUR, 180, 0.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(0.0)
+    }
+
+    @Test fun `temp basal spans a scheduled segment boundary — entire window at temp rate`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp covers 06:00-10:00, spanning the 08:00 (slot 16) boundary; rate 0.5 over 4h = 2 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val tb = tempBasal(6 * HOUR, 240, 0.5)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 6 * HOUR, JAN1_UTC + 10 * HOUR,
+            OFFSET_UTC, tb, prog
+        )
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(2.0)
+    }
+
+    // ---- timezone: pod TZ == device TZ -------------------------------------------------------
+
+    @Test fun `pod timezone UTC, device timezone UTC — baseline`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Slot 16 boundary at 08:00 UTC; 07:00-09:00 = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 7 * HOUR, JAN1_UTC + 9 * HOUR,
+            OFFSET_UTC, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `pod timezone UTC+2, device timezone UTC+2 — segment boundaries align`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC+2"))
+        // Slot 16 boundary at 08:00 local = 06:00 UTC; window 05:00-07:00 UTC = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 5 * HOUR, JAN1_UTC + 7 * HOUR,
+            OFFSET_PLUS2, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `pod timezone UTC-5, device timezone UTC-5 — segment boundaries align`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC-5"))
+        // Slot 16 boundary at 08:00 local = 13:00 UTC; window 12:00-14:00 UTC = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 12 * HOUR, JAN1_UTC + 14 * HOUR,
+            OFFSET_MINUS5, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    // ---- timezone: pod TZ != device TZ -------------------------------------------------------
+
+    @Test fun `pod timezone UTC, device timezone UTC+2 — segment boundaries still align`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC+2"))
+        // Pod is in UTC: slot 16 boundary at 08:00 UTC.
+        // Device is UTC+2, so rateAt would see 10:00 local without the adjustment → wrong slot.
+        // With podTimeAdjustmentMs = 0 - 7200000 = -7200000 the call is shifted back 2h → correct slot.
+        // Window 07:00-09:00 UTC: 1h @ 1 U/h + 1h @ 2 U/h = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 7 * HOUR, JAN1_UTC + 9 * HOUR,
+            OFFSET_UTC, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `pod timezone UTC+2, device timezone UTC — segment boundaries still align`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Pod is in UTC+2: slot 16 boundary at 08:00 local = 06:00 UTC.
+        // Device is UTC, so rateAt would see 05:30/06:30 UTC directly → wrong slot without adjustment.
+        // With podTimeAdjustmentMs = 7200000 - 0 = +7200000 the call is shifted forward 2h → correct slot.
+        // Window 05:00-07:00 UTC: 1h @ 1 U/h + 1h @ 2 U/h = 3 U
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 5 * HOUR, JAN1_UTC + 7 * HOUR,
+            OFFSET_PLUS2, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    @Test fun `pod timezone UTC+2, device timezone UTC — window crosses pod midnight`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Pod is in UTC+2: midnight pod-local = 22:00 UTC.
+        // Window 21:00-23:00 UTC = 23:00-01:00 pod-local, crossing pod midnight.
+        // Segment split at slot 16 (08:00 pod-local): slots 0-16 = 1.0 U/h, slots 16-48 = 2.0 U/h.
+        // 21:00-22:00 UTC = 23:00-00:00 pod-local → segment 1 → 1h @ 2.0 U/h
+        // 22:00-23:00 UTC = 00:00-01:00 pod-local → segment 0 → 1h @ 1.0 U/h = 3.0 U total
+        val prog = twoSegmentBasal(1.0, 2.0, splitSlot = 16)
+        val result = sut.integrateExpectedDelivery(
+            JAN1_UTC + 21 * HOUR, JAN1_UTC + 23 * HOUR,
+            OFFSET_PLUS2, null, prog
+        )
+        assertThat(result!!).isWithin(1e-9).of(3.0)
+    }
+
+    // ---- edge cases --------------------------------------------------------------------------
+
+    @Test fun `startTime equals endTime — returns zero`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC, OFFSET_UTC, null, flatBasal(1.0))
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(0.0)
+    }
+
+    @Test fun `startTime after endTime — returns null`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val result = sut.integrateExpectedDelivery(JAN1_UTC + HOUR, JAN1_UTC, OFFSET_UTC, null, flatBasal(1.0))
+        assertThat(result).isNull()
+    }
+
+    @Test fun `null basal program and no temp basal — returns null`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, null, null)
+        assertThat(result).isNull()
+    }
+
+    @Test fun `null timezone offset — returns null`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, null, null, flatBasal(1.0))
+        assertThat(result).isNull()
+    }
+
+    @Test fun `null basal program but temp basal covers full window — returns temp rate`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        val tb = tempBasal(-HOUR, 180, 2.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, null)
+        assertThat(result).isNotNull()
+        assertThat(result!!).isWithin(1e-9).of(2.0)
+    }
+
+    @Test fun `null basal program and temp basal only covers part of window — returns null`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        // Temp covers only first 30 min; second 30 min has no rate
+        val tb = tempBasal(0L, 30, 2.0)
+        val result = sut.integrateExpectedDelivery(JAN1_UTC, JAN1_UTC + HOUR, OFFSET_UTC, tb, null)
+        assertThat(result).isNull()
+    }
+}

--- a/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/NeedsBasalCorrectionTest.kt
+++ b/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/NeedsBasalCorrectionTest.kt
@@ -1,0 +1,195 @@
+package app.aaps.pump.omnipod.common.bledriver.pod.state
+
+import app.aaps.core.data.model.BS
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.ActivationProgress
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.DeliveryStatus
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.PodStatus
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Tests for [OmnipodDashPodStateManagerImpl.needsBasalCorrection].
+ *
+ * State is set up via [OmnipodDashPodStateManagerImpl.podState] (internal), which avoids the
+ * complexity of building full response byte arrays while keeping assertions precise.
+ *
+ * Drift arithmetic (POD_PULSE_BOLUS_UNITS = 0.05 U/pulse):
+ *   basalDelivered  = (pulsesDelivered − bolusPulses) × 0.05
+ *   basalDrift      = basalDelivered − basalExpected
+ *   correctionThreshold = −0.025 U  (half a pulse under-delivery)
+ *   reset boundary      = ±0.10 U   (two full pulses)
+ */
+class NeedsBasalCorrectionTest : TestBase() {
+
+    @Mock lateinit var preferences: Preferences
+    @Mock lateinit var config: Config
+
+    private lateinit var sut: OmnipodDashPodStateManagerImpl
+
+    // ---- setup --------------------------------------------------------------------------------
+
+    @BeforeEach fun setUp() {
+        `when`(config.enableOmnipodDriftCompensation()).thenReturn(true)
+        sut = OmnipodDashPodStateManagerImpl(aapsLogger, rxBus, preferences, config)
+        sut.activationProgress = ActivationProgress.COMPLETED
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    /**
+     * Configures pulse counters and basalExpected to produce a known drift:
+     *   drift = (totalPulses − bolusPulses) × 0.05 − expectedUnits
+     */
+    private fun setDrift(totalPulses: Int, bolusPulses: Int, expectedUnits: Double) {
+        sut.podState.pulsesDelivered = totalPulses.toShort()
+        sut.podState.bolusPulsesDelivered = bolusPulses.toShort()
+        sut.podState.basalExpected = expectedUnits
+    }
+
+    // ---- prerequisite checks ------------------------------------------------------------------
+
+    @Test fun `drift compensation disabled — returns false`() {
+        `when`(config.enableOmnipodDriftCompensation()).thenReturn(false)
+        setDrift(10, 0, 0.0)    // drift = +0.5, would reset if enabled
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `activation not completed — returns false`() {
+        sut.activationProgress = ActivationProgress.NOT_STARTED
+        setDrift(10, 0, 0.55)   // drift = -0.05, in correction zone if activated
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `pod suspended — returns false`() {
+        sut.podState.deliveryStatus = DeliveryStatus.SUSPENDED
+        setDrift(10, 0, 0.55)
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `pod kaput (ALARM) — returns false`() {
+        sut.podState.podStatus = PodStatus.ALARM
+        setDrift(10, 0, 0.55)
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `pod kaput (DEACTIVATED) — returns false`() {
+        sut.podState.podStatus = PodStatus.DEACTIVATED
+        setDrift(10, 0, 0.55)
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `within cooldown window — returns false`() {
+        sut.lastBasalCorrectionTime = System.currentTimeMillis() - 30_000L  // 30 s ago, < 2 min
+        setDrift(10, 0, 0.55)
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    // ---- initialisation state ---------------------------------------------------------------
+
+    @Test fun `basalExpected null (first status after activation) — drift is zero, returns false`() {
+        // When basalExpected is null the basalDrift getter falls back to basalDelivered,
+        // making drift = 0. No correction should trigger in this initialisation state.
+        sut.podState.pulsesDelivered = 10
+        sut.podState.bolusPulsesDelivered = 0
+        sut.podState.basalExpected = null
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    // ---- drift magnitude checks ---------------------------------------------------------------
+
+    @Test fun `bolus pulses non-zero — only basal portion drives drift`() {
+        // 20 total pulses, 10 bolus pulses → 10 basal pulses delivered = 0.50 U.
+        // Expected 0.55 U → drift = -0.05, in correction zone.
+        setDrift(totalPulses = 20, bolusPulses = 10, expectedUnits = 0.55)
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+
+    @Test fun `non-zero TBR active, drift in zone — returns true`() {
+        // A running non-zero TBR should not suppress correction (only zero-rate TBR does).
+        sut.tempBasal = OmnipodDashPodStateManager.TempBasal(
+            startTime         = System.currentTimeMillis() - 10 * 60_000L,
+            durationInMinutes = 30,
+            rate              = 1.0
+        )
+        setDrift(10, 0, 0.55)   // drift = -0.05
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+
+    @Test fun `zero drift — returns false`() {
+        setDrift(10, 0, 0.50)   // delivered = 0.50, expected = 0.50 → drift = 0
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `small over-delivery (positive drift) — returns false`() {
+        setDrift(10, 0, 0.45)   // drift = +0.05; over-delivery not compensated
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `drift slightly above correction threshold — returns false`() {
+        setDrift(10, 0, 0.52)   // drift = -0.02, above -0.025 threshold
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `drift slightly below correction threshold — returns true`() {
+        setDrift(10, 0, 0.53)   // drift = -0.03, below -0.025 threshold
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+
+    @Test fun `drift in correction zone (one full pulse) — returns true`() {
+        setDrift(10, 0, 0.55)   // drift = -0.05 (1 pulse under-delivery)
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+
+    @Test fun `drift exceeds lower boundary — resets expected and returns false`() {
+        // 3 pulses = 0.15U under-delivery: clearly beyond the 2-pulse (0.10U) reset boundary.
+        // Using a margin avoids IEEE 754 round-trip errors that arise at the exact boundary.
+        setDrift(10, 0, 0.65)   // drift = 0.5 - 0.65 = -0.15
+        assertThat(sut.needsBasalCorrection()).isFalse()
+        assertThat(sut.podState.basalExpected).isEqualTo(0.5)  // reset to actual
+    }
+
+    @Test fun `drift exceeds upper boundary — resets expected and returns false`() {
+        // 3 pulses = 0.15U over-delivery: clearly beyond the 2-pulse (0.10U) reset boundary.
+        setDrift(10, 0, 0.35)   // drift = 0.5 - 0.35 = +0.15
+        assertThat(sut.needsBasalCorrection()).isFalse()
+        assertThat(sut.podState.basalExpected).isEqualTo(0.5)  // reset to actual
+    }
+
+    // ---- zero-TBR safety check ----------------------------------------------------------------
+
+    @Test fun `drift in zone, zero TBR, no recent bolus — returns false`() {
+        sut.tempBasal = OmnipodDashPodStateManager.TempBasal(
+            startTime         = System.currentTimeMillis() - 10 * 60_000L,
+            durationInMinutes = 30,
+            rate              = 0.0
+        )
+        setDrift(10, 0, 0.55)   // drift = -0.05
+        assertThat(sut.needsBasalCorrection()).isFalse()
+    }
+
+    @Test fun `drift in zone, zero TBR, but recent bolus — returns true`() {
+        sut.tempBasal = OmnipodDashPodStateManager.TempBasal(
+            startTime         = System.currentTimeMillis() - 10 * 60_000L,
+            durationInMinutes = 30,
+            rate              = 0.0
+        )
+        // createLastBolus sets startTime = now, satisfying the < 5 min recency check
+        sut.createLastBolus(requestedUnits = 1.0, historyId = 1L, bolusType = BS.Type.NORMAL)
+        setDrift(10, 0, 0.55)   // drift = -0.05
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+
+    // ---- cooldown expiry ----------------------------------------------------------------------
+
+    @Test fun `past cooldown window — does not block correction`() {
+        sut.lastBasalCorrectionTime = System.currentTimeMillis() - 3 * 60_000L  // 3 min ago, > 2 min
+        setDrift(10, 0, 0.55)   // drift = -0.05
+        assertThat(sut.needsBasalCorrection()).isTrue()
+    }
+}

--- a/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/UpdatePodStateBolusTrackingTest.kt
+++ b/pump/omnipod/common/src/test/kotlin/app/aaps/pump/omnipod/common/bledriver/pod/state/UpdatePodStateBolusTrackingTest.kt
@@ -1,0 +1,183 @@
+package app.aaps.pump.omnipod.common.bledriver.pod.state
+
+import app.aaps.core.data.model.BS
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.ActivationProgress
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.AlertType
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.BasalProgram
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.DeliveryStatus
+import app.aaps.pump.omnipod.common.bledriver.pod.definition.PodStatus
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import java.util.EnumSet
+import java.util.TimeZone
+
+/**
+ * Tests for the bolus-pulse attribution logic inside [OmnipodDashPodStateManagerImpl.updatePodState].
+ *
+ * The core invariant: new pulses are attributed to the bolus counter only when
+ *   - an incomplete bolus is in progress ([PodState.lastBolus.deliveryComplete] == false), AND
+ *   - a basal correction is NOT currently delivering ([PodState.basalCorrectionInProgress] == false).
+ *
+ * When a basal correction is in progress its pulses must NOT be counted as bolus pulses,
+ * otherwise [basalDelivered] (= total − bolus) would decrease and mask the correction
+ * against [basalExpected], corrupting the drift calculation.
+ */
+class UpdatePodStateBolusTrackingTest : TestBase() {
+
+    @Mock lateinit var preferences: Preferences
+    @Mock lateinit var config: Config
+
+    private lateinit var sut: OmnipodDashPodStateManagerImpl
+
+    // ---- setup --------------------------------------------------------------------------------
+
+    @BeforeEach fun setUp() {
+        sut = OmnipodDashPodStateManagerImpl(aapsLogger, rxBus, preferences, config)
+        sut.activationProgress = ActivationProgress.COMPLETED
+
+        // Baseline: 100 total pulses, 60 attributed as bolus → 40 basal pulses
+        sut.podState.pulsesDelivered        = 100
+        sut.podState.bolusPulsesDelivered   = 60
+        sut.podState.basalExpected          = 40 * 0.05   // 2.0 U
+        sut.podState.lastUpdatedSystem      = System.currentTimeMillis() - 1000
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    /**
+     * Calls [updatePodState] with a minimal set of parameters.
+     * [totalPulsesDelivered] and [bolusPulsesRemaining] are the only values that vary per test.
+     */
+    private fun statusUpdate(totalPulsesDelivered: Int, bolusPulsesRemaining: Int = 0) {
+        sut.updatePodState(
+            deliveryStatus                      = DeliveryStatus.BASAL_ACTIVE,
+            podStatus                           = PodStatus.RUNNING_ABOVE_MIN_VOLUME,
+            totalPulsesDelivered                = totalPulsesDelivered.toShort(),
+            reservoirPulsesRemaining            = 1000,
+            sequenceNumberOfLastProgrammingCommand = 0,
+            minutesSinceActivation              = 60,
+            activeAlerts                        = EnumSet.noneOf(AlertType::class.java),
+            bolusPulsesRemaining                = bolusPulsesRemaining.toShort()
+        )
+    }
+
+    // ---- no bolus in progress -----------------------------------------------------------------
+
+    @Test fun `no active bolus — new pulses not counted as bolus`() {
+        // lastBolus is null (no bolus has ever run); bolus counter must stay unchanged
+        statusUpdate(totalPulsesDelivered = 103)
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(60)
+    }
+
+    @Test fun `completed bolus — new pulses not counted as bolus`() {
+        sut.createLastBolus(requestedUnits = 1.0, historyId = 1L, bolusType = BS.Type.NORMAL)
+        sut.markLastBolusComplete()
+        statusUpdate(totalPulsesDelivered = 103)
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(60)
+    }
+
+    // ---- active bolus in progress -------------------------------------------------------------
+
+    @Test fun `active bolus, no concurrent basal — pulses attributed to bolus`() {
+        sut.createLastBolus(requestedUnits = 0.15, historyId = 1L, bolusType = BS.Type.NORMAL)
+        // 3 new total pulses, 3 bolus pulses remaining → 0 now: clean bolus delivery
+        statusUpdate(totalPulsesDelivered = 103, bolusPulsesRemaining = 0)
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(63)
+    }
+
+    @Test fun `active bolus with concurrent basal pulse — only bolus portion attributed`() {
+        // 5 total new pulses: 3 from bolus (remaining 3→0) + 2 from basal running in parallel.
+        // bolusPulsesDelivered must increase by 3 only; the 2 basal pulses must NOT be counted.
+        sut.createLastBolus(requestedUnits = 0.15, historyId = 1L, bolusType = BS.Type.NORMAL)
+        // Set bolus remaining so previousBolusPulsesRemaining = 3
+        sut.podState.lastBolus!!.bolusUnitsRemaining = 3 * 0.05
+        statusUpdate(totalPulsesDelivered = 105, bolusPulsesRemaining = 0)
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(63)  // 60 + 3, not 60 + 5
+    }
+
+    // ---- basal correction in progress ---------------------------------------------------------
+
+    @Test fun `basal correction in progress — pulse increase NOT attributed to bolus`() {
+        // Simulate the correction scenario: an incomplete bolus exists (the correction
+        // bolus itself), but basalCorrectionInProgress prevents those pulses from
+        // being counted as bolus pulses. This keeps basalDelivered correct.
+        sut.createLastBolus(requestedUnits = 0.05, historyId = 1L, bolusType = BS.Type.NORMAL)
+        sut.basalCorrectionInProgress = true
+
+        statusUpdate(totalPulsesDelivered = 102, bolusPulsesRemaining = 0)
+
+        // bolus counter must be unchanged: the correction pulse is basal, not bolus
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(60)
+        // total went up by 2, bolus unchanged → basal pulses = 42 → basalDelivered = 2.10 U
+        assertThat(sut.podState.pulsesDelivered).isEqualTo(102)
+    }
+
+    @Test fun `basal correction flag cleared after correction — subsequent bolus pulses tracked again`() {
+        sut.createLastBolus(requestedUnits = 0.05, historyId = 1L, bolusType = BS.Type.NORMAL)
+        sut.basalCorrectionInProgress = true
+        statusUpdate(totalPulsesDelivered = 101, bolusPulsesRemaining = 0)
+        // correction delivered; flag cleared
+        sut.basalCorrectionInProgress = false
+
+        // Now a new bolus starts
+        sut.createLastBolus(requestedUnits = 0.10, historyId = 2L, bolusType = BS.Type.NORMAL)
+        statusUpdate(totalPulsesDelivered = 103, bolusPulsesRemaining = 0)
+
+        // 2 new pulses from the second bolus should be attributed
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(62)
+    }
+
+    // ---- counter seeding and accumulation ----------------------------------------------------
+
+    @Test fun `bolusPulsesDelivered null — seeded from totalPulsesDelivered on first update`() {
+        // On the very first status response after activation, bolusPulsesDelivered is null.
+        // The ?: branch seeds it with totalPulsesDelivered so future delta tracking starts
+        // from the correct baseline (i.e. no bolus pulses assumed yet).
+        sut.podState.bolusPulsesDelivered = null
+
+        statusUpdate(totalPulsesDelivered = 42)
+
+        assertThat(sut.podState.bolusPulsesDelivered).isEqualTo(42)
+        // basalExpected is seeded to 0.0 U: because bolusPulsesDelivered was null at seeding time,
+        // basalPulsesDelivered can't be computed and basalDelivered falls back to 0.0 U. Both
+        // counters therefore start from zero together, so initial drift = 0.
+        assertThat(sut.podState.basalExpected).isEqualTo(0.0)
+    }
+
+    @Test fun `basalExpected null — seeded from basalDelivered on first update`() {
+        // On the very first status response, basalExpected is null.
+        // The ?: branch seeds it with the current basalDelivered so drift starts at zero.
+        // setUp: pulsesDelivered=100 bolusPulsesDelivered=60 → basalDelivered=(100−60)×0.05=2.0 U
+        sut.podState.basalExpected = null
+
+        statusUpdate(totalPulsesDelivered = 100)
+
+        // Seeded to 2.0 U = (100 − 60 pulses) × 0.05 U/pulse → initial drift = 0.
+        assertThat(sut.podState.basalExpected).isEqualTo(2.0)
+    }
+
+    @Test fun `basalExpected accumulates delta from integrateExpectedDelivery`() {
+        // Verify that the basalExpected += delta wiring works end-to-end:
+        // 1 hour at 1.0 U/h → delta ≈ 1.0 U → basalExpected goes from 2.0 to ≈ 3.0.
+        val savedTz = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+            sut.podState.timeZoneOffset    = 0
+            sut.podState.basalProgram      = BasalProgram(listOf(BasalProgram.Segment(0, 48, 100)))
+            sut.podState.lastUpdatedSystem = System.currentTimeMillis() - 3_600_000L
+            sut.podState.basalExpected     = 2.0
+
+            statusUpdate(totalPulsesDelivered = 100)
+
+            // Allow ±10 ms worth of basal (≈ 0.0003 U) for scheduling jitter
+            assertThat(sut.podState.basalExpected!!).isWithin(0.001).of(3.0)
+        } finally {
+            TimeZone.setDefault(savedTz)
+        }
+    }
+}

--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -48,6 +48,7 @@ import app.aaps.pump.omnipod.common.definition.OmnipodCommandType
 import app.aaps.pump.omnipod.common.keys.OmnipodBooleanPreferenceKey
 import app.aaps.pump.omnipod.common.keys.OmnipodIntPreferenceKey
 import app.aaps.pump.omnipod.common.queue.command.CommandDeactivatePod
+import app.aaps.pump.omnipod.common.queue.command.CommandDeliverBasalCorrection
 import app.aaps.pump.omnipod.common.queue.command.CommandDisableSuspendAlerts
 import app.aaps.pump.omnipod.common.queue.command.CommandHandleTimeChange
 import app.aaps.pump.omnipod.common.queue.command.CommandPlayTestBeep
@@ -502,6 +503,64 @@ class OmnipodDashPumpPlugin @Inject constructor(
     override fun onStop() {
         super.onStop()
         disposables.clear()
+    }
+
+    private fun deliverBasalCorrection(): PumpEnactResult {
+        if (!podStateManager.needsBasalCorrection()) {
+            aapsLogger.info(LTag.PUMP, "Basal correction no longer appropriate")
+            return pumpEnactResultProvider.get().success(true).enacted(false).comment("Basal correction no longer appropriate")
+        }
+        
+        // Set cooldown to prevent duplicate corrections
+        podStateManager.lastBasalCorrectionTime = System.currentTimeMillis()
+        
+        val requestedInsulinAmount = PodConstants.POD_PULSE_BOLUS_UNITS
+
+        if (requestedInsulinAmount > reservoirLevel) {
+            aapsLogger.info(LTag.PUMP, "Basal correction skipped: not enough insulin in reservoir ($requestedInsulinAmount > $reservoirLevel)")
+            return pumpEnactResultProvider.get().success(false).enacted(false).comment("Not enough insulin in reservoir")
+        }
+        if (podStateManager.deliveryStatus?.bolusDeliveringActive() == true) {
+            aapsLogger.info(LTag.PUMP, "Basal correction skipped: bolus already in progress")
+            return pumpEnactResultProvider.get().success(false).enacted(false).comment("Bolus already in progress")
+        }
+        try {
+            bolusDeliveryInProgress = true
+            podStateManager.basalCorrectionInProgress = true
+            aapsLogger.info(LTag.PUMP, "Delivering basal correction")
+
+            return executeProgrammingCommand(
+                historyEntry = history.createRecord(
+                    commandType = OmnipodCommandType.SET_BOLUS,
+                    bolusRecord = BolusRecord(
+                        requestedInsulinAmount,
+                        BolusType.DEFAULT
+                    )
+                ),
+                activeCommandEntry = { historyId ->
+                    podStateManager.createActiveCommand(
+                        historyId,
+                        requestedBolus = requestedInsulinAmount
+                    )
+                },
+                command = omnipodManager.bolus(
+                    requestedInsulinAmount,
+                    confirmationBeeps = false,
+                    completionBeeps = false
+                ).filter { podEvent -> podEvent.isCommandSent() }
+                    .ignoreElements(),
+                post = waitForBolusDeliveryToComplete(requestedInsulinAmount, BS.Type.NORMAL)
+                    .doOnSuccess { delivered ->
+                        aapsLogger.info(LTag.PUMP, "Basal correction delivered: $delivered U")
+                    }
+                    .ignoreElement()
+            ).doOnError { e ->
+                aapsLogger.error(LTag.PUMP, "Basal correction delivery failed", e)
+            }.toPumpEnactResultImpl()
+        } finally {
+            bolusDeliveryInProgress = false
+            podStateManager.basalCorrectionInProgress = false
+        }
     }
 
     private fun observeDeliverySuspended(): Completable = Completable.defer {
@@ -1002,6 +1061,9 @@ class OmnipodDashPumpPlugin @Inject constructor(
             is CommandDisableSuspendAlerts     ->
                 disableSuspendAlerts()
 
+            is CommandDeliverBasalCorrection   ->
+                deliverBasalCorrection()
+
             else                               -> {
                 aapsLogger.warn(LTag.PUMP, "Unsupported custom command: " + customCommand.javaClass.name)
                 pumpEnactResultProvider.get().success(false).enacted(false).comment(
@@ -1273,6 +1335,11 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     )
                     aapsLogger.info(LTag.PUMP, "syncStopTemporaryBasalWithPumpId ret=$ret pumpId=${historyEntry.pumpId()}")
                     podStateManager.tempBasal = null
+
+                    // Evaluate basal drift correction after confirmed temp basal cancel
+                    if (podStateManager.needsBasalCorrection()) {
+                        commandQueue.customCommand(CommandDeliverBasalCorrection(), null)
+                    }
                 }
                 rxBus.send(EventDismissNotification(Notification.OMNIPOD_TBR_ALERTS))
             }
@@ -1331,6 +1398,13 @@ class OmnipodDashPumpPlugin @Inject constructor(
                     )
                 } else {
                     podStateManager.tempBasal = command.tempBasal
+
+                    // Evaluate basal drift correction after confirmed temp basal set
+                    if (!commandQueue.isCustomCommandInQueue(CommandDeliverBasalCorrection::class.java) &&
+                        podStateManager.needsBasalCorrection()
+                    ) {
+                        commandQueue.customCommand(CommandDeliverBasalCorrection(), null)
+                    }
                 }
                 rxBus.send(EventDismissNotification(Notification.OMNIPOD_TBR_ALERTS))
             }


### PR DESCRIPTION
## Omnipod Dash basal drift resolution

This pull request introduces a new "basal correction" feature for the Omnipod Dash pump integration. The main goal is to detect under-delivery of basal insulin and automatically trigger a small correction bolus when needed. The implementation tracks delivered basal and bolus pulses, calculates expected vs. actual insulin delivery, and manages correction logic with safety checks and cooldowns. 

## Recap of the issue

The Omnipod Dash pump exhibits behavior that causes it to deliver less basal insulin than AAPS expects (issue #4158). This is effectively a hardware limitation of the pump.

The Dash uses an internal timer to determine when a basal pulse of 0.05 U is delivered. Once the timer interval elapses, the pulse is delivered. However, this timer is restarted whenever a basal rate change occurs (and possibly also when a bolus or SMB is delivered).

When used in combination with looping, this leads to structural under-delivery of basal insulin, as the algorithm adjusts the basal rate frequently. While the Medtrum pump compensates for this behavior internally, the Dash does not, and neither does the current Dash driver implementation in AAPS.

The issue is most apparent during the night. During daytime operation, SMBs often result in a basal rate of 0, which masks the effect. In observed usage, this results in approximately 10% of the expected Total Daily Dose (TDD) not being delivered over a 24-hour period. Additionally, glucose targets are often not reached overnight, particularly after meals with prolonged glucose impact (e.g. pasta).

## Approach

This pull request introduces automatic basal drift compensation by correcting the pump lag with small correction boluses. A correction bolus of 0.05 U is delivered as soon as the detected basal deficit reaches 0.025 U. Several safety constraints are applied. For example, corrections are not delivered during a temporary basal of 0 unless that temporary basal is the direct result of a recently delivered bolus.

With this approach, the deviation between expected and delivered basal insulin is kept within a bounded range of approximately −0.050 U to +0.025 U.

With this fix applied:
- The TDD reported by AAPS (under *Statistics*) matches the total amount actually delivered by the pump (Dash menu → *Pod management* → *History*).
- Overnight glucose targets are consistently reached.

Without this fix, a clear discrepancy between reported and delivered TDD can be observed.

## Main Changes

### Basal Correction Feature

- Added a new custom command, `CommandDeliverBasalCorrection`, and integrated it into the command queue and handling logic in `OmnipodDashPumpPlugin` to trigger a basal correction bolus when under-delivery is detected.
- Implemented the `deliverBasalCorrection` method to handle the actual delivery of the correction bolus, including safety checks (reservoir level, bolus in progress, cooldowns, etc.).

### Basal Delivery Tracking and Drift Calculation

- Added logic in `OmnipodDashPodStateManagerImpl` to track basal and bolus pulses separately, compute actual delivered basal, and calculate "drift" (difference between expected and actual basal delivery). This includes new fields in the pod state and methods for integrating expected delivery over time. 
- The `needsBasalCorrection` method determines when a correction is needed based on drift, cooldowns, and other safety criteria.

### Pod State Update and Logging Refactor

- Refactored pod state update logic to centralize updates in a new `updatePodState` method, which also updates basal tracking fields and logs basal delivery/drift for debugging. This method is now used in both default and alarm status response handlers and removes code duplication from these methods. 

Logging example:

```text
PUMP_BASAL act=8,10U (tot=33,25U bol=25,15U) exp=9,42U err=-1,32U dErr=-0,02U
```

Legend for the log fields:

| Field | Description |
|------|------------|
| `act` | Actual basal units delivered (`tot` − `bol`) |
| `tot` | Total units delivered |
| `bol` | Bolus units delivered |
| `exp` | Expected basal units delivered |
| `err` | Error / cumulative basal drift (`act` - `exp`) |
| `dErr` | Delta of `err` on this pump status response |

### Interface and State Enhancements

- Updated the `OmnipodDashPodStateManager` interface and its implementation to support new fields and methods for basal correction tracking (`lastBasalCorrectionTime`, `basalCorrectionInProgress`, `needsBasalCorrection`). 

These changes together enable the system to automatically detect and correct small basal under-deliveries, improving insulin delivery reliability and safety.

## Tests Performed

To verify the fix, we compared the total insulin delivered at 00:00 at the start of a day with the total at 00:00 at the end of the same day. 

Before this fix, the difference consistently resulted in a lower number than the TDD reported by AAPS, confirming under-delivery. After applying the fix, this discrepancy no longer occurs: AAPS TDD matches the pump’s delivered total.
