### PR TITLE
feat: Expand insulin pump compatibility by serial number prefix #4510

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGet.kt
@@ -174,7 +174,14 @@ class CmdDevicesOldGet(
         }
     }
 
-    fun isSupport(): Boolean = firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL
+    fun isSupport(serialNumber: String): Boolean {
+        val firstChar = serialNumber.firstOrNull()?.uppercaseChar()
+        val needsVersionCheck = setOf('0', '1', '3', 'A', 'D')
+        return when (firstChar) {
+            in needsVersionCheck -> firmwareVersion >= EquilConst.EQUIL_SUPPORT_LEVEL
+            else -> true
+        }
+    }
 
     override fun getEventType(): EquilHistoryRecord.EventType? = null
 }

--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/ui/pair/EquilPairSerialNumberFragment.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/ui/pair/EquilPairSerialNumberFragment.kt
@@ -275,7 +275,7 @@ class EquilPairSerialNumberFragment : EquilPairFragmentBase() {
                 if (activity == null) return
                 aapsLogger.debug(LTag.PUMPCOMM, "result====" + result.success + "===" + result.enacted)
                 if (result.success) {
-                    if (cmdDevicesOldGet.isSupport()) {
+                    if (cmdDevicesOldGet.isSupport(serialNumber)) {
                         SystemClock.sleep(EquilConst.EQUIL_BLE_NEXT_CMD)
                         pair(scanResult)
                     } else {

--- a/pump/equil/src/test/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGetTest.kt
+++ b/pump/equil/src/test/kotlin/app/aaps/pump/equil/manager/command/CmdDevicesOldGetTest.kt
@@ -97,8 +97,8 @@ class CmdDevicesOldGetTest : TestBaseWithProfile() {
     @Test
     fun `isSupport should check firmware version`() {
         val cmd = CmdDevicesOldGet("00:11:22:33:44:55", aapsLogger, preferences, equilManager)
-        // Initially firmware version is 0.0
-        assertFalse(cmd.isSupport())
+        // Initially firmware version is 0.0, serial starting with '0' needs version check
+        assertFalse(cmd.isSupport("0ABC12"))
     }
 
     @Test
@@ -162,7 +162,7 @@ class CmdDevicesOldGetTest : TestBaseWithProfile() {
         thread.join(1000)
 
         assertTrue(cmd.cmdSuccess)
-        assertTrue(cmd.isSupport()) // 5.5 should be supported (>= 5.3)
+        assertTrue(cmd.isSupport("0ABC12")) // 5.5 should be supported (>= 5.3)
     }
 
     @Test


### PR DESCRIPTION
I have confirmed with their developers that this configuration supports all pump models, and the serial numbers comply with their naming conventions.

Add serial number-based support check for insulin pumps. Only pumps with serial numbers starting with '0', '1', '3', 'A', or 'D' require firmware version validation. All other pump models are now supported by default.

I submitted this once before, but found that the latest dev branch doesn't include this content.