### PR TITLE
fix: Allow insulin delivery while loop is suspended but pump is available

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/model/RM.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/model/RM.kt
@@ -63,6 +63,7 @@ data class RM(
         fun isClosedLoopOrLgs() = this == CLOSED_LOOP || this == CLOSED_LOOP_LGS
         fun isLoopRunning() = this == OPEN_LOOP || this == CLOSED_LOOP || this == CLOSED_LOOP_LGS
         fun isSuspended() = this == DISCONNECTED_PUMP || this == SUSPENDED_BY_PUMP || this == SUSPENDED_BY_USER || this == SUSPENDED_BY_DST || this == SUPER_BOLUS
+        fun isPumpSuspended() = this == DISCONNECTED_PUMP || this == SUSPENDED_BY_PUMP
         // DISABLED_LOOP is added to "mustBeTemporary" to be properly rendered in NS
         fun mustBeTemporary() = this == DISCONNECTED_PUMP || this == SUSPENDED_BY_PUMP || this == SUSPENDED_BY_USER || this == SUSPENDED_BY_DST || this == SUPER_BOLUS || this == DISABLED_LOOP
 

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/InsulinDialog.kt
@@ -128,7 +128,7 @@ class InsulinDialog : DialogFragmentWithDate() {
         }
         val maxInsulin = constraintChecker.getMaxBolusAllowed().value()
 
-        if (loop.runningMode.isSuspended() || !pump.isInitialized()) {
+        if (loop.runningMode.isPumpSuspended() || !pump.isInitialized()) {
             binding.recordOnly.isChecked = true
             binding.recordOnly.isEnabled = false
             binding.recordOnly.setTextColor(rh.gac(app.aaps.core.ui.R.attr.warningColor))


### PR DESCRIPTION
In certain cases, the Insulin dialog goes yellow and only allows entering "record-only" boluses, as implemented in #3254. Before 3.4.0.0/the running mode rework of loop status, these cases were limited to when there was no pump ready to run a bolus. With the rework, the condition was mistakenly changed from "is the pump suspended" to "is the _loop_ suspended", which is why 3.4.0.0 will let you set basal rates but will not let you bolus as long as the loop is suspended: it's perfectly possible behind the scenes, but the insulin dialog will not allow it. This PR restores the 3.3.2.1 behavior, showing the correct insulin dialog when the loop is suspended but the pump is available.

As the other uses for RM's `isSuspended()` function do intentionally look at all loop suspension reasons, I added a separate function called `isPumpSuspended()` and use that to determine whether pump-boluses should be allowed. This way, pump suspension/disconnection should still lead to the yellow insulin dialog, but loop suspension should not prevent boluses anymore.

Tested with Omnipod Dash, confirmed the insulin dialog shows the right version in the following cases:
* No pod active (record-only)
* Active pod, pump disconnected (record-only)
* Loop suspended (regular, on 3.4.0.0 this is record-only)
* Loop enabled (regular)
* Loop disabled (regular)

PS: this is my first time contributing to this repo, so if this is the wrong place/way to make this happen, let me know and I'll do my best to accommodate!

Fixes #4468, fixes #4517