### PR TITLE
RileyLink encoding fix (#4519)

### DIFF
--- a/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/defs/RileyLinkEncodingType.kt
+++ b/pump/rileylink/src/main/kotlin/app/aaps/pump/common/hw/rileylink/ble/defs/RileyLinkEncodingType.kt
@@ -6,8 +6,8 @@ import app.aaps.pump.common.hw.rileylink.R
 enum class RileyLinkEncodingType(val value: Byte, val key: String?, @StringRes val friendlyName: Int? = null) {
     None(0x00, null),  // No encoding on RL
     Manchester(0x01, null),  // Manchester encoding on RL (for Omnipod)
-    FourByteSixByteLocal(0x00, "medtronic_pump_encoding_4b6b_local", R.string.medtronic_pump_encoding_4b6b_rileylink),
-    FourByteSixByteRileyLink(0x02, "medtronic_pump_encoding_4b6b_rileylink", R.string.medtronic_pump_encoding_4b6b_local),  // 4b6b encoding on RL (for Medtronic)
+    FourByteSixByteLocal(0x00, "medtronic_pump_encoding_4b6b_local", R.string.medtronic_pump_encoding_4b6b_local),
+    FourByteSixByteRileyLink(0x02, "medtronic_pump_encoding_4b6b_rileylink", R.string.medtronic_pump_encoding_4b6b_rileylink),  // 4b6b encoding on RL (for Medtronic)
     ; // No encoding on RL, but 4b6b encoding in code
 
     companion object {


### PR DESCRIPTION
Fix of wrong enum mapping for RileyLinkEncodingType enum introduced in 3.4.0.0 version (commit ebb4994)