### PR TITLE
Fix(Omnipod): validate profile before pod activation to prevent wasting pods (Issue #4534)

### DIFF
--- a/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/ErosPodManagementActivity.kt
+++ b/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/ErosPodManagementActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.queue.Callback
 import app.aaps.core.interfaces.queue.CommandQueue
 import app.aaps.core.interfaces.resources.ResourceHelper
@@ -57,6 +58,7 @@ class ErosPodManagementActivity : TranslatedDaggerAppCompatActivity() {
     @Inject lateinit var uiInteraction: UiInteraction
     @Inject lateinit var rh: ResourceHelper
     @Inject lateinit var rxBus: RxBus
+    @Inject lateinit var profileFunction: ProfileFunction
     @Inject lateinit var resetRileyLinkConfigurationTaskProvider: Provider<ResetRileyLinkConfigurationTask>
 
     private var disposables: CompositeDisposable = CompositeDisposable()
@@ -75,6 +77,16 @@ class ErosPodManagementActivity : TranslatedDaggerAppCompatActivity() {
         supportActionBar?.setDisplayShowHomeEnabled(true)
 
         binding.buttonActivatePod.setOnClickListener {
+            val profile = profileFunction.getProfile()
+            if (profile == null) {
+                OKDialog.show(
+                    this,
+                    rh.gs(app.aaps.pump.omnipod.common.R.string.omnipod_common_warning),
+                    rh.gs(app.aaps.pump.omnipod.common.R.string.omnipod_common_error_failed_to_set_profile_empty_profile)
+                )
+                return@setOnClickListener
+            }
+
             val type: PodActivationWizardActivity.Type = if (podStateManager.isPodInitialized
                 and podStateManager.activationProgress.isAtLeast(ActivationProgress.PRIMING_COMPLETED)
             ) {


### PR DESCRIPTION
Closes #4534

### Problem
As reported in Issue #4534, users are unable to insert the cannula on an Omnipod. After priming, the "Insert Cannula" step immediately shows a "Retry" button that does nothing when clicked. This occurs when the user's basal profile is missing or invalid (e.g., Dash requires basal rates in 30-minute increments).

By the time this error surfaces at the "Insert Cannula" step, the pod has already been primed and is wasted.

### Solution
This PR adds profile validation at the "Activate Pod" button click — **before the activation wizard starts** — in both `DashPodManagementActivity` and `ErosPodManagementActivity`:

- **Dash**: Checks for a null profile and validates the basal program format via `mapProfileToBasalProgram()`. If either fails, an `OKDialog` warning is shown and the wizard is blocked.
- **Eros**: Checks for a null profile. If missing, an `OKDialog` warning is shown and the wizard is blocked.

This prevents users from wasting pods on invalid or missing profiles.
