### PR TITLE
Fix site rotation manage pump setting not being used

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/FillDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/FillDialog.kt
@@ -172,7 +172,7 @@ class FillDialog(val fm: FragmentManager) : DialogFragmentWithDate() {
                                 ValueWithUnit.TEType(TE.Type.CANNULA_CHANGE)
                             ).filterNotNull()
                         ).subscribe()
-                        if (preferences.get(BooleanKey.SiteRotationManageCgm)) {
+                        if (preferences.get(BooleanKey.SiteRotationManagePump)) {
                             SiteRotationDialog().also { srd ->
                                 srd.arguments = Bundle().also { args ->
                                     args.putLong("time", eventTime)


### PR DESCRIPTION
Looks like the code accidentally used the CGM setting instead of the pump setting.