### PR TITLE
fix/Notify UI on cloud storage error state change

### DIFF
--- a/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/cloud/providers/googledrive/GoogleDriveManager.kt
+++ b/plugins/configuration/src/main/kotlin/app/aaps/plugins/configuration/maintenance/cloud/providers/googledrive/GoogleDriveManager.kt
@@ -926,6 +926,8 @@ class GoogleDriveManager @Inject constructor(
             // TODO: Implement logic to clear notification
         }
         errorNotificationId = null
+        // Notify UI to update cloud storage error state immediately
+        rxBus.send(EventCloudStorageStatusChanged())
     }
 
     /**


### PR DESCRIPTION
Fix PR #4481: 
After a connection failure and subsequent successful reconnection, the status indicator (red exclamation mark) should be updated.

@MilosKozak please review

![Screenshot_20260214_201213](https://github.com/user-attachments/assets/effe30ec-f5ee-4546-9d2c-d29c88a53724)
