### PR TITLE
fix (medtronic): same encoding type displayed in MT pump settings dialog

### DIFF
--- a/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/MedtronicPumpPlugin.kt
+++ b/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/MedtronicPumpPlugin.kt
@@ -1274,7 +1274,7 @@ class MedtronicPumpPlugin @Inject constructor(
         if (requiredKey != null) return
 
         val batteryEntries = mutableListOf<CharSequence>().also { list -> BatteryType.entries.forEach { list.add(rh.gs(it.friendlyName)) } }.toTypedArray()
-        val encodingEntries = arrayOf<CharSequence>(rh.gs(RileyLinkEncodingType.FourByteSixByteLocal.friendlyName!!), rh.gs(RileyLinkEncodingType.FourByteSixByteLocal.friendlyName!!))
+        val encodingEntries = arrayOf<CharSequence>(rh.gs(RileyLinkEncodingType.FourByteSixByteLocal.friendlyName!!), rh.gs(RileyLinkEncodingType.FourByteSixByteRileyLink.friendlyName!!))
 
         val pumpTypeEntries = arrayOf<CharSequence>(
             "Other (unsupported)",


### PR DESCRIPTION
Fixes displaying same values in dialog of choosing Encoding type introduced in 3.4.0.0 version (commit ebb4994)

Friendly names of the encoding types in line 1277 should repeat the sequence of values in line 1267.

Related to #4519