### PR TITLE
Medtrum: Improve BLE connection recovery using handler thread

### DIFF
--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/BLEComm.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/BLEComm.kt
@@ -187,7 +187,6 @@ class BLEComm @Inject internal constructor(
         } else {
             aapsLogger.debug(LTag.PUMPBTCOMM, "Not connected, closing gatt")
             close()
-            isConnected = false
             mCallback?.onBLEDisconnected()
         }
     }
@@ -198,6 +197,8 @@ class BLEComm @Inject internal constructor(
         mBluetoothGatt?.close()
         SystemClock.sleep(100)
         mBluetoothGatt = null
+        isConnected = false
+        isConnecting = false
     }
 
     /** Scan callback  */
@@ -390,8 +391,6 @@ class BLEComm @Inject internal constructor(
             // CLosing asynchronously to avoid deadlocks or silent failures in the Android BLE callback thread during disconnect.
             handler.post {
                 close()
-                isConnected = false
-                isConnecting = false
                 mCallback?.onBLEDisconnected()
                 aapsLogger.debug(LTag.PUMPBTCOMM, "Device was disconnected " + gatt.device.name) //Device was disconnected
             }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/BLEComm.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/BLEComm.kt
@@ -387,11 +387,14 @@ class BLEComm @Inject internal constructor(
                 // Wait a bit before retrying
                 SystemClock.sleep(2000)
             }
-            close()
-            isConnected = false
-            isConnecting = false
-            mCallback?.onBLEDisconnected()
-            aapsLogger.debug(LTag.PUMPBTCOMM, "Device was disconnected " + gatt.device.name) //Device was disconnected
+            // CLosing asynchronously to avoid deadlocks or silent failures in the Android BLE callback thread during disconnect.
+            handler.post {
+                close()
+                isConnected = false
+                isConnecting = false
+                mCallback?.onBLEDisconnected()
+                aapsLogger.debug(LTag.PUMPBTCOMM, "Device was disconnected " + gatt.device.name) //Device was disconnected
+            }
         }
     }
 


### PR DESCRIPTION
This PR resolves "Pump unreachable" issues where the Medtrum driver stays stuck in the `CONNECTING` state, often following a GATT status 133 error. While other drivers (like Dash) recover correctly on the same hardware, the Medtrum implementation can fail to trigger `mCallback?.onBLEDisconnected()`. This causes the `QueueWorker` to stall and skip new connection attempts.

The root cause is performing a `close()` and state updates directly on the Bluetooth callback (Binder) thread, which can lead to deadlocks or silent connection stalls. Wrapping the GATT cleanup and state updates in a Handler.post() ensures these operations are executed asynchronously. This allows the onConnectionStateChange thread to finalize its lifecycle without being blocked.

In my testing, this change eliminated the "Pump unreachable" connection issues on my Xiaomi device. Additional testing by other Medtrum users would be appreciated to confirm correct behavior across different Android devices.