### PR TITLE
Simplify Concentration UI

### DIFF
--- a/app/src/main/kotlin/app/aaps/ComposeMainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/ComposeMainActivity.kt
@@ -527,9 +527,6 @@ class ComposeMainActivity : AppCompatActivity() {
                                 withProtection(ProtectionCheck.Protection.PREFERENCES) {
                                     insulinManagementViewModel.setScreenMode(ScreenMode.EDIT)
                                 }
-                            },
-                            onNavigateToFillDialog = {
-                                navController.navigate(AppRoute.FillDialog.createRoute(FillPreselect.CARTRIDGE_CHANGE.ordinal))
                             }
                         )
                     }

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/insulin/ConcentrationDropDown.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/insulin/ConcentrationDropDown.kt
@@ -1,0 +1,61 @@
+package app.aaps.core.ui.compose.insulin
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.aaps.core.interfaces.insulin.ConcentrationType
+import app.aaps.core.ui.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConcentrationDropdown(
+    selected: ConcentrationType,
+    concentrations: List<ConcentrationType>,
+    onSelect: (ConcentrationType) -> Unit,
+    enabled: Boolean = true
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded && enabled,
+        onExpandedChange = { if (enabled) expanded = !expanded }
+    ) {
+        OutlinedTextField(
+            value = stringResource(selected.label),
+            onValueChange = {},
+            readOnly = true,
+            enabled = enabled,
+            label = { Text(stringResource(R.string.concentration_label)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            concentrations.forEach { concentration ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(concentration.label)) },
+                    onClick = {
+                        onSelect(concentration)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/insulin/SelectInsulin.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/insulin/SelectInsulin.kt
@@ -1,0 +1,184 @@
+package app.aaps.core.ui.compose.insulin
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import app.aaps.core.data.model.ICfg
+import app.aaps.core.interfaces.insulin.ConcentrationType
+import app.aaps.core.ui.R
+
+@Composable
+fun SelectInsulin(
+    availableInsulins: List<ICfg>,
+    selectedInsulin: ICfg?,
+    activeInsulinLabel: String?,
+    onInsulinSelect: (ICfg) -> Unit,
+    initialExpanded: Boolean = false,
+    concentrationDropDownEnabled: Boolean = false
+) {
+    var expanded by rememberSaveable { mutableStateOf(initialExpanded) }
+    val allConcentrations = remember(availableInsulins) {
+        availableInsulins
+            .map { it.concentration }
+            .distinct()
+            .mapNotNull { ConcentrationType.fromDouble(it) }
+            .sortedBy { it.value }
+    }
+    var selectedConcentration by rememberSaveable { mutableStateOf<ConcentrationType?>(ConcentrationType.U100) }
+
+    LaunchedEffect(selectedInsulin) {
+        if (selectedInsulin != null) {
+            selectedConcentration = ConcentrationType.fromDouble(selectedInsulin.concentration)
+        } else if (allConcentrations.isNotEmpty()) {
+            selectedConcentration = allConcentrations.first()
+        }
+    }
+
+    val filteredInsulins = remember(selectedConcentration, availableInsulins) {
+        if (selectedConcentration != null) {
+            availableInsulins.filter { it.concentration == selectedConcentration!!.value }
+        } else {
+            availableInsulins
+        }
+    }
+
+
+        // Show current insulin with a Change button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.current_insulin),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = selectedInsulin?.insulinLabel ?: activeInsulinLabel ?: "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            FilledTonalButton(onClick = { expanded = !expanded }) {
+                Text(stringResource(R.string.change_insulin))
+            }
+        }
+
+        // Expandable insulin selection list
+        AnimatedVisibility(visible = expanded) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Spacer(modifier = Modifier.height(48.dp))
+                if (allConcentrations.isNotEmpty() && selectedConcentration != null) {
+                    ConcentrationDropdown(
+                        selected = selectedConcentration!!,
+                        concentrations = allConcentrations,
+                        onSelect = { newConcentration ->
+                            selectedConcentration = newConcentration
+                        },
+                        enabled = concentrationDropDownEnabled
+                    )
+                }
+
+                    filteredInsulins.forEach { iCfg ->
+                        val isSelected = iCfg.insulinLabel == selectedInsulin?.insulinLabel
+                        val isActive = iCfg.insulinLabel == activeInsulinLabel
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onInsulinSelect(iCfg)
+                                    expanded = false
+                                }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = isSelected,
+                                onClick = {
+                                    onInsulinSelect(iCfg)
+                                    expanded = false
+                                }
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = iCfg.insulinLabel,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
+                                )
+                                if (isActive) {
+                                    Text(
+                                        text = stringResource(R.string.current_insulin),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+
+        }
+    }
+}
+
+
+private val previewInsulins = listOf(
+    ICfg("Fiasp U100", peak = 55, dia = 5.0, concentration = 1.0),
+    ICfg("Lyumjev U200", peak = 45, dia = 5.0, concentration = 2.0),
+    ICfg("NovoRapid U100", peak = 75, dia = 5.0, concentration = 1.0)
+)
+
+@Preview(showBackground = true, name = "Select Insulin - Collapsed")
+@Composable
+private fun PreviewCollapsed() {
+    MaterialTheme {
+        SelectInsulin(
+            availableInsulins = previewInsulins,
+            selectedInsulin = previewInsulins[0],
+            activeInsulinLabel = "Fiasp U100",
+            onInsulinSelect = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Select Insulin - Expanded")
+@Composable
+private fun PreviewExpanded() {
+    MaterialTheme {
+        SelectInsulin(
+            availableInsulins = previewInsulins,
+            selectedInsulin = previewInsulins[0],
+            activeInsulinLabel = "Fiasp U100",
+            onInsulinSelect = {},
+            initialExpanded = true
+        )
+    }
+}

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="none"><![CDATA[<none>]]></string>
     <string name="remove_label">REMOVE</string>
     <string name="activate_profile">Activate profile</string>
+    <string name="activate_insulin">Activate insulin</string>
     <string name="reset">Reset</string>
     <string name="profileswitch_ismissing">ProfileSwitch missing. Please do a profile switch or press \"Activate Profile\" in the LocalProfile.</string>
     <string name="profile">Profile</string>
@@ -266,8 +267,11 @@
     <string name="reason">Reason</string>
     <string name="nochangerequested">No change requested</string>
 
-    <!--    Concentration-->
+    <!--    Insulin / Concentration-->
     <string name="ins_concentration_confirmed">Insulin %1$s confirmed</string>
+    <string name="current_insulin">Currently active</string>
+    <string name="change_insulin">Change</string>
+    <string name="select_insulin_description">Select the insulin you are filling the pump with. A profile switch will be applied after activation/prime.</string>
 
     <!--    ProfileSwitch-->
     <string name="zerovalueinprofile">Invalid profile: %1$s</string>

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/MedtrumPatchViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/MedtrumPatchViewModel.kt
@@ -11,6 +11,8 @@ import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.queue.Callback
 import app.aaps.core.interfaces.queue.CommandQueue
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.pump.medtrum.MedtrumPlugin
 import app.aaps.pump.medtrum.MedtrumPump
 import app.aaps.pump.medtrum.R
@@ -52,11 +54,13 @@ class MedtrumPatchViewModel @Inject constructor(
     private val commandQueue: CommandQueue,
     val medtrumPump: MedtrumPump,
     private val insulinManager: InsulinManager,
-    private val profileFunction: ProfileFunction
+    private val profileFunction: ProfileFunction,
+    private val preferences: Preferences
 ) : ViewModel() {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-
+    val concentrationEnabled: Boolean
+        get() = preferences.get(BooleanKey.GeneralInsulinConcentration)
     private val medtrumService: MedtrumService?
         get() = medtrumPlugin.getService()
 

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/steps/SelectInsulinStep.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/steps/SelectInsulinStep.kt
@@ -1,34 +1,21 @@
 package app.aaps.pump.medtrum.compose.steps
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.aaps.core.data.model.ICfg
+import app.aaps.core.ui.R
+import app.aaps.core.ui.compose.insulin.SelectInsulin
 import app.aaps.core.ui.compose.pump.WizardButton
 import app.aaps.core.ui.compose.pump.WizardStepLayout
-import app.aaps.pump.medtrum.R
 import app.aaps.pump.medtrum.code.PatchStep
 import app.aaps.pump.medtrum.compose.MedtrumPatchViewModel
 
@@ -41,32 +28,10 @@ fun SelectInsulinStep(
     val selectedInsulin by viewModel.selectedInsulin.collectAsStateWithLifecycle()
     val activeInsulinLabel by viewModel.activeInsulinLabel.collectAsStateWithLifecycle()
 
-    SelectInsulinStepContent(
-        availableInsulins = availableInsulins,
-        selectedInsulin = selectedInsulin,
-        activeInsulinLabel = activeInsulinLabel,
-        onInsulinSelect = viewModel::selectInsulin,
-        onNext = { viewModel.moveStep(PatchStep.PRIME) },
-        onCancel = onCancel
-    )
-}
-
-@Composable
-internal fun SelectInsulinStepContent(
-    availableInsulins: List<ICfg>,
-    selectedInsulin: ICfg?,
-    activeInsulinLabel: String?,
-    onInsulinSelect: (ICfg) -> Unit,
-    onNext: () -> Unit,
-    onCancel: () -> Unit,
-    initialExpanded: Boolean = false
-) {
-    var expanded by rememberSaveable { mutableStateOf(initialExpanded) }
-
     WizardStepLayout(
         primaryButton = WizardButton(
             text = stringResource(R.string.next),
-            onClick = onNext
+            onClick = { viewModel.moveStep(PatchStep.PRIME) }
         ),
         secondaryButton = WizardButton(
             text = stringResource(app.aaps.core.ui.R.string.cancel),
@@ -80,75 +45,17 @@ internal fun SelectInsulinStepContent(
 
         Spacer(Modifier.height(16.dp))
 
-        // Show current insulin with a Change button
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.current_insulin),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = selectedInsulin?.insulinLabel ?: activeInsulinLabel ?: "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-            FilledTonalButton(onClick = { expanded = !expanded }) {
-                Text(stringResource(R.string.change_insulin))
-            }
-        }
-
-        // Expandable insulin selection list
-        AnimatedVisibility(visible = expanded) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                availableInsulins.forEach { iCfg ->
-                    val isSelected = iCfg.insulinLabel == selectedInsulin?.insulinLabel
-                    val isActive = iCfg.insulinLabel == activeInsulinLabel
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                onInsulinSelect(iCfg)
-                                expanded = false
-                            }
-                            .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        RadioButton(
-                            selected = isSelected,
-                            onClick = {
-                                onInsulinSelect(iCfg)
-                                expanded = false
-                            }
-                        )
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = iCfg.insulinLabel,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
-                            )
-                            if (isActive) {
-                                Text(
-                                    text = stringResource(R.string.current_insulin),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        SelectInsulin(
+            availableInsulins = availableInsulins,
+            selectedInsulin = selectedInsulin,
+            activeInsulinLabel = activeInsulinLabel,
+            onInsulinSelect = viewModel::selectInsulin,
+            concentrationDropDownEnabled = viewModel.concentrationEnabled
+        )
     }
 }
+
+
 
 // region Previews
 
@@ -162,13 +69,11 @@ private val previewInsulins = listOf(
 @Composable
 private fun PreviewCollapsed() {
     MaterialTheme {
-        SelectInsulinStepContent(
+        SelectInsulin(
             availableInsulins = previewInsulins,
             selectedInsulin = previewInsulins[0],
             activeInsulinLabel = "Fiasp U100",
-            onInsulinSelect = {},
-            onNext = {},
-            onCancel = {}
+            onInsulinSelect = {}
         )
     }
 }
@@ -177,14 +82,13 @@ private fun PreviewCollapsed() {
 @Composable
 private fun PreviewExpanded() {
     MaterialTheme {
-        SelectInsulinStepContent(
+        SelectInsulin(
             availableInsulins = previewInsulins,
             selectedInsulin = previewInsulins[0],
             activeInsulinLabel = "Fiasp U100",
             onInsulinSelect = {},
-            onNext = {},
-            onCancel = {},
-            initialExpanded = true
+            initialExpanded = true,
+            concentrationDropDownEnabled = true
         )
     }
 }

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -66,9 +66,6 @@
     <string name="step_prepare_patch">Activate Patch</string>
     <string name="step_prepare_patch_connect">Connect and Fill</string>
     <string name="step_select_insulin">Select Insulin</string>
-    <string name="select_insulin_description">Select the insulin you are filling the patch with. A profile switch will be applied after activation.</string>
-    <string name="current_insulin">Currently active</string>
-    <string name="change_insulin">Change</string>
     <string name="step_prime">Prime</string>
     <string name="step_priming">Priming</string>
     <string name="step_priming_complete">Priming Complete</string>

--- a/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogScreen.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogScreen.kt
@@ -54,6 +54,7 @@ import app.aaps.core.ui.compose.AapsTopAppBar
 import app.aaps.core.ui.compose.NumberInputRow
 import app.aaps.core.ui.compose.clearFocusOnTap
 import app.aaps.core.ui.compose.dialogs.OkCancelDialog
+import app.aaps.core.ui.compose.insulin.SelectInsulin
 import app.aaps.core.ui.compose.navigation.ElementType
 import app.aaps.core.ui.compose.navigation.color
 import app.aaps.core.ui.compose.navigation.icon
@@ -302,11 +303,12 @@ private fun FillDialogContent(
 
             // Insulin change section
             AnimatedVisibility(visible = uiState.showInsulinChange) {
-                InsulinChangeSection(
+                SelectInsulin(
                     availableInsulins = uiState.availableInsulins,
                     selectedInsulin = uiState.selectedInsulin,
                     activeInsulinLabel = uiState.activeInsulinLabel,
-                    onInsulinSelect = onInsulinSelect
+                    onInsulinSelect = onInsulinSelect,
+                    concentrationDropDownEnabled = uiState.concentrationEnabled
                 )
             }
 
@@ -566,12 +568,13 @@ private fun PreviewAapsClient() {
 @Composable
 private fun PreviewInsulinSelectionExpanded() {
     MaterialTheme {
-        InsulinChangeSection(
+        SelectInsulin(
             availableInsulins = previewInsulins,
             selectedInsulin = previewInsulins[0],
             activeInsulinLabel = "Fiasp U100",
             onInsulinSelect = {},
-            initialExpanded = true
+            initialExpanded = true,
+            concentrationDropDownEnabled = true
         )
     }
 }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogUiState.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogUiState.kt
@@ -42,7 +42,8 @@ data class FillDialogUiState(
     // Config
     val showBolus: Boolean = true,
     val showNotesFromPreferences: Boolean = false,
-    val simpleMode: Boolean = true
+    val simpleMode: Boolean = true,
+    val concentrationEnabled: Boolean = false
 ) {
 
     /** Whether any actionable item is selected */

--- a/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/fillDialog/FillDialogViewModel.kt
@@ -111,7 +111,8 @@ class FillDialogViewModel @Inject constructor(
                 pumpUnitsWarning = if (!ch.isU100()) rh.gs(R.string.fill_pump_units_note, ch.insulinConcentrationString()) else null,
                 showBolus = !config.AAPSCLIENT,
                 showNotesFromPreferences = preferences.get(BooleanKey.OverviewShowNotesInDialogs),
-                simpleMode = preferences.get(BooleanKey.GeneralSimpleMode)
+                simpleMode = preferences.get(BooleanKey.GeneralSimpleMode),
+                concentrationEnabled = preferences.get(BooleanKey.GeneralInsulinConcentration)
             )
         }
     }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementScreen.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementScreen.kt
@@ -30,11 +30,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -62,10 +58,10 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.aaps.core.graph.InsulinGraphCompose
-import app.aaps.core.interfaces.insulin.ConcentrationType
 import app.aaps.core.interfaces.insulin.InsulinType
 import app.aaps.core.ui.compose.AapsFab
 import app.aaps.core.ui.compose.AapsTopAppBar
+import app.aaps.core.ui.compose.insulin.ConcentrationDropdown
 import app.aaps.core.ui.compose.NumberInputRow
 import app.aaps.core.ui.compose.ScreenMode
 import app.aaps.core.ui.compose.clearFocusOnTap
@@ -93,8 +89,7 @@ fun InsulinManagementScreen(
     viewModel: InsulinManagementViewModel,
     initialMode: ScreenMode = ScreenMode.EDIT,
     onNavigateBack: () -> Unit,
-    onRequestEditMode: () -> Unit = {},
-    onNavigateToFillDialog: () -> Unit = {}
+    onRequestEditMode: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val focusManager = LocalFocusManager.current
@@ -157,6 +152,17 @@ fun InsulinManagementScreen(
                 showDeleteDialog = false
             },
             onDismiss = { showDeleteDialog = false }
+        )
+    }
+
+    // Activate confirmation dialog
+    uiState.activationMessage?.let { message ->
+        OkCancelDialog(
+            title = stringResource(CoreUiR.string.activate_insulin),
+            message = message,
+            icon = IcPluginInsulin,
+            onConfirm = { viewModel.executeActivation() },
+            onDismiss = { viewModel.dismissActivation() }
         )
     }
 
@@ -400,22 +406,23 @@ fun InsulinManagementScreen(
                             }
                         }
                     }
-
-                    // Activate FAB — routes to FillDialog (cartridge change) for safe insulin switching
-                    AapsFab(
-                        onClick = {
-                            if (hasUnsavedChanges) {
-                                showUnsavedDialog = true
-                            } else {
-                                onNavigateToFillDialog()
+                    val currentIcfgConcentration = uiState.insulins.getOrNull(uiState.currentCardIndex)?.concentration ?: 0.0
+                    if (currentIcfgConcentration == uiState.activeConcentration)
+                    // Activate FAB
+                        AapsFab(
+                            onClick = {
+                                if (hasUnsavedChanges) {
+                                    showUnsavedDialog = true
+                                } else {
+                                    viewModel.prepareActivation()
+                                }
                             }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.PlayArrow,
+                                contentDescription = null
+                            )
                         }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.PlayArrow,
-                            contentDescription = null
-                        )
-                    }
                 }
             }
 
@@ -526,44 +533,3 @@ private fun PageIndicatorDots(
 
 // --- Concentration Dropdown ---
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ConcentrationDropdown(
-    selected: ConcentrationType,
-    concentrations: List<ConcentrationType>,
-    onSelect: (ConcentrationType) -> Unit,
-    enabled: Boolean = true
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    ExposedDropdownMenuBox(
-        expanded = expanded && enabled,
-        onExpandedChange = { if (enabled) expanded = !expanded }
-    ) {
-        OutlinedTextField(
-            value = stringResource(selected.label),
-            onValueChange = {},
-            readOnly = true,
-            enabled = enabled,
-            label = { Text(stringResource(CoreUiR.string.concentration_label)) },
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-        )
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false }
-        ) {
-            concentrations.forEach { concentration ->
-                DropdownMenuItem(
-                    text = { Text(stringResource(concentration.label)) },
-                    onClick = {
-                        onSelect(concentration)
-                        expanded = false
-                    }
-                )
-            }
-        }
-    }
-}

--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementUiState.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementUiState.kt
@@ -12,6 +12,7 @@ data class InsulinManagementUiState(
     val insulins: List<ICfg> = emptyList(),
     val currentCardIndex: Int = 0,
     val activeInsulinLabel: String? = null,
+    val activeConcentration: Double = 1.0,
 
     // Editor fields
     val editorName: String = "",
@@ -19,6 +20,9 @@ data class InsulinManagementUiState(
     val editorConcentration: ConcentrationType = ConcentrationType.U100,
     val editorPeakMinutes: Int = 75,
     val editorDiaHours: Double = 5.0,
+
+    // Activation dialog
+    val activationMessage: String? = null,
 
     // Screen mode
     val screenMode: ScreenMode = ScreenMode.EDIT,

--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementViewModel.kt
@@ -3,6 +3,7 @@ package app.aaps.ui.compose.insulinManagement
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.aaps.core.data.model.ICfg
+import app.aaps.core.data.time.T
 import app.aaps.core.data.ue.Action
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.data.ue.ValueWithUnit
@@ -11,9 +12,13 @@ import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.insulin.InsulinManager
 import app.aaps.core.interfaces.insulin.InsulinType
 import app.aaps.core.interfaces.logging.UserEntryLogger
+import app.aaps.core.interfaces.profile.LocalProfileManager
 import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.HardLimits
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.core.objects.profile.ProfileSealed
 import app.aaps.core.ui.compose.ScreenMode
 import app.aaps.core.ui.compose.SnackbarMessage
 import app.aaps.ui.R
@@ -32,7 +37,10 @@ import app.aaps.core.ui.R as CoreUiR
 class InsulinManagementViewModel @Inject constructor(
     private val insulin: Insulin,
     private val insulinManager: InsulinManager,
+    private val preferences: Preferences,
     private val profileFunction: ProfileFunction,
+    private val localProfileManager: LocalProfileManager,
+    private val dateUtil: DateUtil,
     private val hardLimits: HardLimits,
     private val uel: UserEntryLogger,
     val rh: ResourceHelper
@@ -65,6 +73,7 @@ class InsulinManagementViewModel @Inject constructor(
             if (reload) insulinManager.loadSettings()
             val insulins = insulinManager.insulins.map { it.deepClone() }
             val activeLabel = profileFunction.getProfile()?.iCfg?.insulinLabel
+            val activeConcentration = profileFunction.getProfile()?.iCfg?.concentration ?: 1.0  // Only insulin with Current Active concentration can be set from Insulin Management
 
             val currentIndex = (targetIndex ?: uiState.value.currentCardIndex).coerceIn(0, (insulins.size - 1).coerceAtLeast(0))
             val currentICfg = insulins.getOrNull(currentIndex)
@@ -76,6 +85,7 @@ class InsulinManagementViewModel @Inject constructor(
                     insulins = insulins,
                     currentCardIndex = currentIndex,
                     activeInsulinLabel = activeLabel,
+                    activeConcentration = activeConcentration,
                     editorName = currentICfg?.insulinLabel ?: "",
                     editorTemplate = template,
                     editorConcentration = currentICfg?.let { cfg -> ConcentrationType.fromDouble(cfg.concentration) } ?: ConcentrationType.U100,
@@ -236,6 +246,48 @@ class InsulinManagementViewModel @Inject constructor(
         return true
     }
 
+    fun prepareActivation() {
+        val state = uiState.value
+        val iCfg = state.insulins.getOrNull(state.currentCardIndex) ?: return
+        val profile = profileFunction.getProfile()
+        if (profile == null) {
+            showSnackbar(rh.gs(R.string.activate_insulin_no_profile))
+            return
+        }
+
+        val eps = (profile as? ProfileSealed.EPS)?.value
+        val profileName = eps?.originalProfileName ?: return
+        val percentage = eps.originalPercentage
+        val timeshiftHours = T.msecs(eps.originalTimeshift).hours().toInt()
+        val durationMs = eps.originalDuration
+
+        val details = mutableListOf<String>()
+        details.add(profileName)
+        if (percentage != 100) details.add(rh.gs(CoreUiR.string.format_percent, percentage))
+        if (timeshiftHours != 0) details.add(rh.gs(CoreUiR.string.format_hours, timeshiftHours.toDouble()))
+        if (durationMs > 0) {
+            val remaining = ((durationMs - (dateUtil.now() - eps.timestamp)) / 60_000L).coerceAtLeast(0)
+            if (remaining > 0)
+                details.add(rh.gs(R.string.activate_insulin_remaining, remaining.toInt()))
+        }
+
+        val message = rh.gs(R.string.activate_insulin_new_insulin, iCfg.insulinLabel) +
+            "\n\n" + rh.gs(R.string.activate_insulin_profile_switch, details.joinToString(", "))
+
+        uiState.update { it.copy(activationMessage = message) }
+    }
+
+    fun dismissActivation() {
+        uiState.update { it.copy(activationMessage = null) }
+    }
+
+    fun executeActivation() {
+        uiState.update { it.copy(activationMessage = null) }
+        val state = uiState.value
+        val iCfg = state.insulins.getOrNull(state.currentCardIndex) ?: return
+        profileFunction.createProfileSwitchWithNewInsulin(iCfg, Sources.Insulin)
+        refreshData()
+    }
 
     // Helpers
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -90,7 +90,11 @@
     <string name="a11y_add_new_insulin">Add new insulin</string>
     <string name="a11y_delete_current_insulin">Delete current insulin</string>
     <string name="save_or_reset_changes_first">Save or reset current changes first</string>
-<string name="load_peak_from">Load peak from</string>
+    <string name="activate_insulin_no_profile">No active profile found</string>
+    <string name="activate_insulin_new_insulin">New insulin: %1$s</string>
+    <string name="activate_insulin_remaining">Remaining: %1$d min</string>
+    <string name="activate_insulin_profile_switch">Profile switch will be created:\n\n<b>%1$s</b></string>
+    <string name="load_peak_from">Load peak from</string>
     <string name="cannot_delete_last_insulin">Cannot delete the last insulin</string>
     <string name="cannot_delete_active_insulin">Cannot delete the active insulin</string>
 


### PR DESCRIPTION
I think it's a global simplification of previous UI:
We should have in mind the number for each action and the associated risks:

- Adjustments of Peak and Dia : can be frequent, with very low risks (can be done at any time with current version)
- Insulin Switch (with U100), very few (in the past 15 years, I switched Insulin 3 times, from Novo to Fiast, then to Lyumjev U100). Should be done during a Reservoir change, but again risks are very low, only less optimized settings concerning IOB calculation)
- Concentration Switch : Very very few occurence (I did it only once 2 years ago, from Lyumjev U100 to Lyumjev U200), but here the risks are high (Under or Over dosing if an error is done)

With the proposed updates, Concentration modification can only be done when the user action comes from a Insulin Change in Pump or from a Patch/Pump Change (implemented in Medtrum)
- For Tube Pump, The user have to open the Prime/Fill User Interface
- For Patch/Pod, it's within the Patch change steps

In both (in work for patch pump), the Change Insulin Button is included
- The additionnal "DropDown concentration menu" is here to reduce risks of a wrong selection by mistake
- This DropDown concentration menu is "Disabled" when the General Insulin Concentration menu is disabled (this is to be sure the user cannot select another concentration, even if other insulins are available in Insulin management for manual Boluses with pens)

Now in Insulin management, I simplified a lot:
- No more Prime/Fill Dialog needed (here the activate Insulin is only available for insulins with the "Current Running Concentration")
- User can adjust Peak and Dia, and activate directly
- User can theoritically create Insulin with other concentration for manual boluses, these cannot be used directly from insulin management if concentration is not the running concentration.

This prevent any concentration switch outside a real insulin change in the pump
This allow an easy way to adjust Peak / Dia at any time

Even if it's possible from Insulin management, the user interface suggest to synchronize Insulin Changes (same concentration) during insulin change....

No change within Manual Bolus (for external boluses we can use all existing insulin whatever the concentration, unit will allways be in IU)

I saw you blocked the General parameter with the overall list of insulin (no other concentration allowed currently), I think we can limit the constraint to the running Insulin only which should be U100.

I created some shared Composable for insulin selection in core.ui to standardize selection