### PR TITLE
Omnipod Hard End Date

### DIFF
--- a/pump/omnipod/common/src/main/res/values/strings.xml
+++ b/pump/omnipod/common/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="omnipod_common_overview_lot_number">LOT Number</string>
     <string name="omnipod_common_overview_pod_sequence_number">Sequence Number</string>
     <string name="omnipod_common_overview_pod_expiry_date">Pod Expires</string>
+    <string name="omnipod_common_overview_pod_hard_end_date">Pod Hard End</string>
     <string name="omnipod_common_overview_last_connection">Last Connection</string>
     <string name="omnipod_common_overview_last_bolus">Last Bolus</string>
     <string name="omnipod_common_overview_temp_basal_rate">Temp Basal Rate</string>

--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/compose/DashOverviewViewModel.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/compose/DashOverviewViewModel.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.Duration
+import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.Date
 import java.util.Locale
@@ -184,6 +185,7 @@ class DashOverviewViewModel @Inject constructor(
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_firmware_version), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_time_on_pod), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_expiry_date), value = PLACEHOLDER))
+            add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_hard_end_date), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_status), value = buildPodStatusText(), level = buildPodStatusLevel()))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_last_connection), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_last_bolus), value = PLACEHOLDER))
@@ -236,6 +238,16 @@ class DashOverviewViewModel @Inject constructor(
                 else                                                                      -> StatusLevel.NORMAL
             }
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_expiry_date), value = expiryValue, level = expiryLevel))
+
+            // Hard end date (+8 hours after expiry)
+            val hardEndAt = expiresAt?.toInstant()?.plus(Duration.ofHours(8))
+            val hardEndValue = hardEndAt?.let { dateUtil.dateAndTimeString(it.toEpochMilli()) } ?: PLACEHOLDER
+            val hardEndLevel = when {
+                hardEndAt != null && Instant.now().isAfter(hardEndAt)                          -> StatusLevel.CRITICAL
+                hardEndAt != null && Instant.now().isAfter(hardEndAt.minus(Duration.ofHours(4))) -> StatusLevel.WARNING
+                else                                                                            -> StatusLevel.NORMAL
+            }
+            add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_hard_end_date), value = hardEndValue, level = hardEndLevel))
 
             // Pod status
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_status), value = buildPodStatusText(), level = buildPodStatusLevel()))

--- a/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/compose/ErosOverviewViewModel.kt
+++ b/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/compose/ErosOverviewViewModel.kt
@@ -179,6 +179,7 @@ class ErosOverviewViewModel @Inject constructor(
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_firmware_version), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_time_on_pod), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_expiry_date), value = PLACEHOLDER))
+            add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_hard_end_date), value = PLACEHOLDER))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_status), value = buildPodStatusText(), level = buildPodStatusLevel()))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_last_connection), value = buildLastConnection().first, level = buildLastConnection().second))
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_last_bolus), value = PLACEHOLDER))
@@ -208,6 +209,12 @@ class ErosOverviewViewModel @Inject constructor(
             val expiryValue = expiresAt?.let { readableZonedTime(it) } ?: PLACEHOLDER
             val expiryLevel = if (expiresAt != null && DateTime.now().isAfter(expiresAt)) StatusLevel.CRITICAL else StatusLevel.NORMAL
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_expiry_date), value = expiryValue, level = expiryLevel))
+
+            // Hard end date (+8 hours after expiry)
+            val hardEndAt = expiresAt?.plusHours(8)
+            val hardEndValue = hardEndAt?.let { dateUtil.dateAndTimeString(it.millis) } ?: PLACEHOLDER
+            val hardEndLevel = if (hardEndAt != null && DateTime.now().isAfter(hardEndAt)) StatusLevel.CRITICAL else StatusLevel.NORMAL
+            add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_hard_end_date), value = hardEndValue, level = hardEndLevel))
 
             // Pod status
             add(PumpInfoRow(label = rh.gs(CommonR.string.omnipod_common_overview_pod_status), value = buildPodStatusText(), level = buildPodStatusLevel()))


### PR DESCRIPTION
<img width="706" height="348" alt="Screenshot from 2026-04-28 21-51-56" src="https://github.com/user-attachments/assets/1674eeb2-02c4-4bc9-9219-29626f06dd96" />

This proposes adding the end of the Omnipod grace period called the hard-end date in the Omnipod Eros and Dash tabs. It's the expiry date + 8 hours. I'm sure we all use some of the grace period in one way or another. :)

I have tested the first commit (adding the date) for a couple of months in production on both Eros and Dash. Currently testing the color treatment. I forgot to add it initially. Edit: Seeing the color treatment working correctly so far.