### PR TITLE
InsulinManagementScreen

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementScreen.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.AutoFixHigh
-import androidx.compose.material.icons.filled.AutoFixOff
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PlayArrow
@@ -315,20 +313,7 @@ fun InsulinManagementScreen(
                                     modifier = Modifier.weight(1f)
                                 )
 
-                                Spacer(modifier = Modifier.width(4.dp))
-
-                                IconButton(
-                                    onClick = { viewModel.toggleAutoName() },
-                                    enabled = editorEnabled
-                                ) {
-                                    Icon(
-                                        imageVector = if (uiState.autoNameEnabled) Icons.Default.AutoFixHigh else Icons.Default.AutoFixOff,
-                                        contentDescription = null,
-                                        tint = if (uiState.autoNameEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-                                    )
-                                }
-
-                                Spacer(modifier = Modifier.width(4.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
 
                                 Surface(
                                     shape = RoundedCornerShape(4.dp),

--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinManagement/InsulinManagementViewModel.kt
@@ -150,8 +150,6 @@ class InsulinManagementViewModel @Inject constructor(
         }
     }
 
-
-
     fun updateEditorConcentration(concentration: ConcentrationType) {
         uiState.update { it.copy(editorConcentration = concentration) }
     }
@@ -178,7 +176,8 @@ class InsulinManagementViewModel @Inject constructor(
             it.copy(
                 editorTemplate = preset,
                 editorPeakMinutes = preset.iCfg.peak,
-                editorNickname = rh.gs(preset.label)
+                editorNickname = rh.gs(preset.label),
+                autoNameEnabled = true
             )
         }
     }
@@ -188,19 +187,6 @@ class InsulinManagementViewModel @Inject constructor(
         uiState.update { it.copy(editorNickname = newDefaultNickname) }
     }
 
-    fun toggleAutoName() {
-        val autoNameEnabled = !uiState.value.autoNameEnabled
-        val newDefaultNickname = if (autoNameEnabled)
-            rh.gs((uiState.value.editorTemplate ?: InsulinType.fromPeak(uiState.value.editorPeakMinutes.toLong() * 60_000L)).label)
-        else
-            uiState.value.editorNickname
-        uiState.update {
-            it.copy(
-                autoNameEnabled = autoNameEnabled,
-                editorNickname = newDefaultNickname
-            )
-        }
-    }
     // CRUD operations
 
     fun saveCurrentInsulin(): Boolean {

--- a/ui/src/main/kotlin/app/aaps/ui/compose/profileManagement/ProfileViewerContent.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/profileManagement/ProfileViewerContent.kt
@@ -92,7 +92,7 @@ fun ProfileSingleContent(
                 ElevatedCard(
                     modifier = Modifier.weight(1f),
                     elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
-                    onClick = { /*TODO*/ }
+                    onClick = { /* TODO Open Insulin Management on current running insulin */ }
                 ) {
                     Column(modifier = Modifier.padding(16.dp)) {
                         ProfileRow(


### PR DESCRIPTION
- Remove AutoFix
- Simplify Insulin Card in ProfileViewerContent

I propose to include a quick access to InsulinManagement (with of course Running Insulin selected by default) from ProfileManagement when the user click on Running Insulin (`onClick = { /* TODO */ }` added)