### PR TITLE
Wear: Accelerating hold-to-repeat on input buttons + curved category title in AcceptActivity

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
@@ -126,7 +126,16 @@ class AcceptActivity : DaggerAppCompatActivity() {
                     HorizontalPager(state = pagerState) { page ->
                         when (page) {
                             0    -> {
-                                if (hasStructuredData) {
+                                val curvedTitle = when {
+                                    hasStructuredData  -> stringResource(R.string.menu_treatment)
+                                    hasTempTargetData  -> stringResource(R.string.loop_status_temp_target)
+                                    hasProfileData     -> stringResource(R.string.status_profile_switch)
+                                    hasRunningModeData -> stringResource(R.string.status_running_mode)
+                                    else               -> null
+                                }
+                                Box(modifier = Modifier.fillMaxSize()) {
+                                    if (curvedTitle != null) CurvedTitle(curvedTitle)
+                                    if (hasStructuredData) {
                                     // Bolus / Carbs / eCarbs structured summary
                                     Column(
                                         modifier = Modifier
@@ -362,6 +371,7 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                             textAlign = if (isError) TextAlign.Center else TextAlign.Start,
                                         )
                                     }
+                                }
                                 }
                             }
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/PlusMinusInputScreen.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/PlusMinusInputScreen.kt
@@ -290,10 +290,11 @@ private fun StepButton(
                                 delay(100)          // allow pager to claim swipe gestures first
                                 stepped = true
                                 onStep(delta)
-                                delay(200)          // hold-to-repeat: 300ms total from press
+                                var repeatDelay = 300L
                                 while (true) {
+                                    delay(repeatDelay)
                                     onStep(delta)
-                                    delay(150)
+                                    repeatDelay = maxOf(40L, (repeatDelay * 0.75).toLong())
                                 }
                             }
                             val released = tryAwaitRelease()  // false if pager cancelled the gesture
@@ -320,6 +321,18 @@ private fun StepButton(
                 modifier = Modifier.size(28.dp)
             )
         }
+    }
+}
+
+@Composable
+internal fun CurvedTitle(title: String) {
+    val fontSize = when {
+        title.length <= 15 -> 12.sp
+        title.length <= 19 -> 10.sp
+        else               -> 9.sp
+    }
+    CurvedLayout(anchor = 270f, anchorType = AnchorType.Center) {
+        curvedText(text = title, color = WearSecondaryText, fontSize = fontSize)
     }
 }
 


### PR DESCRIPTION
- PlusMinusInputScreen: hold-to-repeat now starts at 300 ms and accelerates to 40 ms, instead of a fixed 150 ms interval. 

- AcceptActivity: "Confirm"-page now shows a curved title at the top of the screen indicating the action category — "Treatment", "Temp Target", "Profile switch", or "Running mode" — matching the style used on input pages.

Screenshots:
<img width="897" height="227" alt="image" src="https://github.com/user-attachments/assets/be765616-f88c-426b-b722-832c921819ce" />
