### PR TITLE
Fix Insulin Migration

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainApp.kt
+++ b/app/src/main/kotlin/app/aaps/MainApp.kt
@@ -12,6 +12,7 @@ import android.os.HandlerThread
 import androidx.lifecycle.ProcessLifecycleOwner
 import app.aaps.core.data.configuration.Constants
 import app.aaps.core.data.model.GlucoseUnit
+import app.aaps.core.data.model.ICfg
 import app.aaps.core.data.model.RM
 import app.aaps.core.data.model.TE
 import app.aaps.core.data.model.TT
@@ -27,6 +28,7 @@ import app.aaps.core.interfaces.configuration.ExternalOptions
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
 import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.insulin.InsulinManager
 import app.aaps.core.interfaces.insulin.InsulinType
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
@@ -137,14 +139,17 @@ class MainApp : Application(), HasAndroidInjector {
     @Inject lateinit var hardLimits: HardLimits
     @Inject lateinit var activePlugin: ActivePlugin
     @Inject lateinit var localProfileManager: LocalProfileManager
+    @Inject lateinit var localInsulinManager: InsulinManager
     @Inject lateinit var constraintChecker: ConstraintsChecker
     @Inject lateinit var signatureVerifierPlugin: SignatureVerifierPlugin
     @Inject lateinit var fileListProvider: FileListProvider
     @Inject lateinit var cryptoUtil: CryptoUtil
     @Inject lateinit var exportPasswordDataStore: ExportPasswordDataStore
     @Inject @ApplicationScope lateinit var appScope: CoroutineScope
-    lateinit var insulinLabel: String
-    var insulinPeakTime: Long = 0L
+
+    private lateinit var insulinLabel: String
+    private var insulinPeakTime: Long = 0L
+    private var profileNameToDia: Map<String, Double> = emptyMap()
 
     private var handler = Handler(HandlerThread(this::class.simpleName + "Handler").also { it.start() }.looper)
     private lateinit var refreshWidget: Runnable
@@ -467,6 +472,8 @@ class MainApp : Application(), HasAndroidInjector {
             }
         }
         // Migrate Profile
+        val indexToName = mutableMapOf<Int, String>()
+        val indexToDia = mutableMapOf<Int, Double>()
         for ((key, value) in keys) {
             if (key.startsWith(Constants.LOCAL_PROFILE + "_") && key.endsWith("_mgdl")) {
                 val number = key.split("_")[1]
@@ -505,16 +512,28 @@ class MainApp : Application(), HasAndroidInjector {
             }
             if (key.startsWith(Constants.LOCAL_PROFILE + "_") && key.endsWith("_name")) {
                 val number = key.split("_")[1]
-                preferences.put(ProfileComposedStringKey.LocalProfileNumberedName, SafeParse.stringToInt(number), value = value as String)
+                indexToName[SafeParse.stringToInt(number)] = value as String
+                preferences.put(ProfileComposedStringKey.LocalProfileNumberedName, SafeParse.stringToInt(number), value = value)
                 sp.remove(key)
             }
+            if (key.startsWith(Constants.LOCAL_PROFILE + "_name_")) {
+                val number = key.split("_")[2]
+                indexToName[SafeParse.stringToInt(number)] = value as String
+            }
             if (key.startsWith(Constants.LOCAL_PROFILE + "_") && key.endsWith("_dia")) {
+                val number = SafeParse.stringToInt(key.split("_")[1])
+                indexToDia[number] = SafeParse.stringToDouble(value.toString())
                 sp.remove(key)
             }
             if (key.startsWith(Constants.LOCAL_PROFILE + "_dia_")) {
+                val number = SafeParse.stringToInt(key.split("_")[2])
+                indexToDia[number] = SafeParse.stringToDouble(value.toString())
                 sp.remove(key)
             }
         }
+        profileNameToDia = indexToDia.mapNotNull { (index, dia) ->
+            indexToName[index]?.let { name -> name to dia }
+        }.toMap()
 
         // Migrate Tidepool from username/password to OAuth2
         if (sp.contains("tidepool_username") || sp.contains("tidepool_password")) {
@@ -589,8 +608,6 @@ class MainApp : Application(), HasAndroidInjector {
             sp.remove("ConfigBuilder_Enabled_INSULIN_InsulinLyumjevPlugin")
             sp.remove("insulin_oref_peak")
         }
-        // TODO Migrate insulin configurations
-
     }
 
     /**
@@ -673,12 +690,22 @@ class MainApp : Application(), HasAndroidInjector {
     private suspend fun dataMigrations() {
         // Migrate to database 33 (ICfg)
         // Grab default value first
-        val dia = (profileFunction.getProfile() as ProfileSealed.EPS?)?.profileName?.let { profileName ->
-            localProfileManager.profile?.getSpecificProfile(profileName)?.iCfg?.dia
-        }
-        val insulinEndTime = ((dia ?: hardLimits.maxDia()) * 3600 * 1000).toLong()
+        var runningICfg = if (profileNameToDia.size == 0) // no migration, get running iCfg from running Profile
+                profileFunction.getProfile()?.iCfg ?: localInsulinManager.iCfg
+            else {  // migration, create running iCfg from previous runningProfile dia and slected InsulinPlugin for peak
+                val dia = (profileFunction.getProfile() as ProfileSealed.EPS?)?.profileName?.let { profileName ->
+                    profileNameToDia[profileName]
+                }
+                val insulinEndTime = ((dia ?: hardLimits.maxDia()) * 3600 * 1000).toLong()
+                ICfg("", insulinEndTime, insulinPeakTime, 1.0).also {
+                    it.insulinNickname = insulinLabel
+                    it.insulinLabel = "$insulinLabel ${localInsulinManager.buildSuffix(it.peak, it.dia, it.concentration)}"
+                }
+            }
 
-        val concentration = 1.0
+        if (!localInsulinManager.insulinAlreadyExists(runningICfg)) { // Add running insulin in InsulinManager if missing
+            localInsulinManager.addNewInsulin(runningICfg, keepName = true)
+        }
 
         var totalMigrated = 0
 
@@ -690,10 +717,10 @@ class MainApp : Application(), HasAndroidInjector {
             val step = rh.get().gs(R.string.migrating_profile_switches)
             config.updateInitProgress(step, 0, total)
             unmigrated.forEachIndexed { index, ps ->
-                ps.iCfg.insulinLabel = insulinLabel
-                ps.iCfg.insulinEndTime = insulinEndTime
-                ps.iCfg.insulinPeakTime = insulinPeakTime
-                ps.iCfg.concentration = concentration
+                ps.iCfg.insulinLabel = runningICfg.insulinLabel
+                ps.iCfg.insulinEndTime = runningICfg.insulinEndTime
+                ps.iCfg.insulinPeakTime = runningICfg.insulinPeakTime
+                ps.iCfg.concentration = runningICfg.concentration
                 persistenceLayer.updateProfileSwitchNoLogging(ps)
                 if ((index + 1) % PROGRESS_UPDATE_INTERVAL == 0 || index + 1 == total)
                     config.updateInitProgress(step, index + 1, total)
@@ -709,10 +736,10 @@ class MainApp : Application(), HasAndroidInjector {
             val step = rh.get().gs(R.string.migrating_effective_profile_switches)
             config.updateInitProgress(step, 0, total)
             unmigratedEps.forEachIndexed { index, eps ->
-                eps.iCfg.insulinLabel = insulinLabel
-                eps.iCfg.insulinEndTime = insulinEndTime
-                eps.iCfg.insulinPeakTime = insulinPeakTime
-                eps.iCfg.concentration = concentration
+                eps.iCfg.insulinLabel = runningICfg.insulinLabel
+                eps.iCfg.insulinEndTime = runningICfg.insulinEndTime
+                eps.iCfg.insulinPeakTime = runningICfg.insulinPeakTime
+                eps.iCfg.concentration = runningICfg.concentration
                 persistenceLayer.updateEffectiveProfileSwitchNoLogging(eps)
                 if ((index + 1) % PROGRESS_UPDATE_INTERVAL == 0 || index + 1 == total)
                     config.updateInitProgress(step, index + 1, total)
@@ -728,10 +755,10 @@ class MainApp : Application(), HasAndroidInjector {
             val step = rh.get().gs(R.string.migrating_boluses)
             config.updateInitProgress(step, 0, total)
             unmigratedBoluses.forEachIndexed { index, bolus ->
-                bolus.iCfg.insulinLabel = insulinLabel
-                bolus.iCfg.insulinEndTime = insulinEndTime
-                bolus.iCfg.insulinPeakTime = insulinPeakTime
-                bolus.iCfg.concentration = concentration
+                bolus.iCfg.insulinLabel = runningICfg.insulinLabel
+                bolus.iCfg.insulinEndTime = runningICfg.insulinEndTime
+                bolus.iCfg.insulinPeakTime = runningICfg.insulinPeakTime
+                bolus.iCfg.concentration = runningICfg.concentration
                 persistenceLayer.updateBolusNoLogging(bolus)
                 if ((index + 1) % PROGRESS_UPDATE_INTERVAL == 0 || index + 1 == total)
                     config.updateInitProgress(step, index + 1, total)

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/InsulinManager.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/insulin/InsulinManager.kt
@@ -9,6 +9,11 @@ import app.aaps.core.data.model.ICfg
  */
 interface InsulinManager {
 
+    /**
+     * Provide default Insulin
+     */
+    val iCfg: ICfg
+
     /** All configured insulins */
     val insulins: ArrayList<ICfg>
 
@@ -22,7 +27,7 @@ interface InsulinManager {
     fun storeSettings()
 
     /** Add a new insulin to the list. Returns the stored copy. */
-    fun addNewInsulin(newICfg: ICfg, ue: Boolean = true): ICfg
+    fun addNewInsulin(newICfg: ICfg, ue: Boolean = true, keepName: Boolean = false): ICfg
 
     /** Remove the insulin at [currentInsulinIndex] */
     fun removeCurrentInsulin()
@@ -38,6 +43,18 @@ interface InsulinManager {
      * @param excludeIndex index to exclude for duplicated name identification (-1 for none)
      */
     fun buildFullName(nickname: String, peak: Int, dia: Double, concentration: Double, excludeIndex: Int = -1): String
+
+    /**
+     * Calculate the suffix for insulin migration.
+     */
+    fun buildSuffix(peak: Int, dia: Double, concentration: Double): String
+
+    /**
+     * Check if an iCfg already exists in the list.
+     * @param iCfg
+     * @param excludeIndex index to exclude for duplicated name identification (-1 for none)
+     */
+    fun insulinAlreadyExists(iCfg: ICfg, excludeIndex: Int = -1): Boolean
 
     /**
      * Calculate the suffix to be shown in UI (include potential index to prevent duplication names).

--- a/implementation/src/main/kotlin/app/aaps/implementation/insulin/InsulinImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/insulin/InsulinImpl.kt
@@ -91,7 +91,7 @@ class InsulinImpl @Inject constructor(
     )
 
     @Synchronized
-    override fun addNewInsulin(newICfg: ICfg, ue: Boolean): ICfg {
+    override fun addNewInsulin(newICfg: ICfg, ue: Boolean, keepName: Boolean): ICfg {
         val template = InsulinType.fromPeak(newICfg.insulinPeakTime)
         val nickname = newICfg.insulinNickname.ifBlank { rh.gs(template.label) }
         val fullName = buildFullName(
@@ -101,7 +101,7 @@ class InsulinImpl @Inject constructor(
             concentration = newICfg.concentration,
             excludeIndex = -1
         )
-        newICfg.insulinLabel = fullName
+        newICfg.insulinLabel = if (keepName) newICfg.insulinLabel.ifBlank { fullName } else fullName
         newICfg.insulinNickname = nickname
         val newInsulin = deepClone(newICfg)
         insulins.add(newInsulin)
@@ -123,7 +123,7 @@ class InsulinImpl @Inject constructor(
         storeSettings()
     }
 
-    fun buildSuffix(peak: Int, dia: Double, concentration: Double): String {
+    override fun buildSuffix(peak: Int, dia: Double, concentration: Double): String {
         val concLabel = rh.gs(ConcentrationType.fromDouble(concentration).label)
         val diaLabel = if (dia % 1.0 == 0.0) "${dia.toInt()}h" else "${dia}h"
         return "${peak}m $diaLabel $concLabel"
@@ -149,9 +149,9 @@ class InsulinImpl @Inject constructor(
         return fullName.removePrefix(nickname).trim()
     }
 
-    private fun insulinAlreadyExists(iCfg: ICfg, currentIndex: Int = -1): Boolean {
+    override fun insulinAlreadyExists(iCfg: ICfg, excludeIndex: Int): Boolean {
         insulins.forEachIndexed { index, insulin ->
-            if (index != currentIndex) {
+            if (index != excludeIndex) {
                 if (iCfg.isEqual(insulin)) {
                     return true
                 }


### PR DESCRIPTION
- for migration, map ProfileNames with dia before removal of dia key
- Create the running iCfg with dia (from current running Profile and map), and peak from previous selected insulin plugin (using template as nickname and standard suffix)
- Check if Current Running iCfg (migration or not) exists within InsulinManager and create it if missing

After several tests (from 3.4.2.1 only), Running Profile is ok (with correct insulin fullname), and running insulin is create (in addition to default Novorapid insulin) within InsulinManager