### PR TITLE
Add CI workflows to support tag and branch builds

### DIFF
--- a/.github/jdk-map.json
+++ b/.github/jdk-map.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "AAPS version wildcard patterns → JDK version. Patterns are matched in order, first match wins. To support a new AAPS release, add an entry to mappings.",
+  "mappings": [
+    { "pattern": "2.*",   "jdk": 11 },
+    { "pattern": "3.0.*", "jdk": 11 },
+    { "pattern": "3.1.*", "jdk": 17 },
+    { "pattern": "3.2.*", "jdk": 17 },
+    { "pattern": "3.3.*", "jdk": 21 },
+    { "pattern": "3.4.*", "jdk": 21 }
+  ],
+  "default": 21
+}

--- a/.github/workflows/aaps-ci.yml
+++ b/.github/workflows/aaps-ci.yml
@@ -3,6 +3,42 @@ name: AAPS CI
 on:
   workflow_dispatch:
     inputs:
+      tagName:
+        description: 'Select AAPS Version'
+        required: true
+        default: '3.4.2.1'
+        type: choice
+        options:
+          # ── 3.4.x (JDK 21) ──────────────────────────────
+          - 3.4.2.1
+          - 3.4.2.0
+          - 3.4.1.0
+          - 3.4.0.0
+          # ── 3.3.x (JDK 21) ──────────────────────────────
+          - 3.3.2.1
+          - 3.3.2.0
+          - 3.3.1.3
+          # ── 3.2.x (JDK 17) ──────────────────────────────
+          - 3.2.0.4
+          - 3.2.0.3
+          - 3.2.0.2
+          - 3.2.0.1
+          - 3.2.0.0
+          # ── 3.1.x (JDK 17) ──────────────────────────────
+          - 3.1.0.3
+          - 3.1.0.2
+          - 3.1.0.1
+          - 3.1.0
+          # ── 3.0.x (JDK 11) ──────────────────────────────
+          - 3.0.0.2
+          - 3.0.0.1
+          - 3.0.0
+          # ── 2.x (build not supported) ────────────────────
+          # ⚠️  2.x versions depend on packages such as
+          #     com.google.android:flexbox that were only published
+          #     on JCenter. JCenter shut down in 2022 and these
+          #     dependencies can no longer be resolved, causing
+          #     the build to fail.
       buildVariant:
         description: 'Select Build Variant'
         required: true
@@ -68,7 +104,7 @@ jobs:
 
           # Check secrets
           check_secret "$GDRIVE_OAUTH2" "GDRIVE_OAUTH2"
-          
+
           check_secret "$KEYSTORE_BASE64" "KEYSTORE_BASE64"
           check_secret "$KEYSTORE_PASSWORD" "KEYSTORE_PASSWORD"
           check_secret "$KEY_ALIAS" "KEY_ALIAS"
@@ -95,7 +131,7 @@ jobs:
           echo "test" > dummy.txt
           zip -q dummy.jar dummy.txt
           rm dummy.txt
-          
+
           # Attempt to validate using jarsigner
           JARSIGNER_LOG=$(mktemp)
           if ! jarsigner \
@@ -119,16 +155,16 @@ jobs:
         run: |
           echo "🔐 Decoding GDRIVE_OAUTH2..."
           DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
-          
+
           GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
           GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-          
+
           echo "::add-mask::$GDRIVE_CLIENT_ID"
           echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-          
+
           echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
           echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
-          
+
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 
       - name: Retrieving Google Drive access token
@@ -148,8 +184,36 @@ jobs:
           echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
           echo "✅ Access token obtained."
 
-      - name: Checkout source code
-        uses: actions/checkout@v4
+      - name: Checkout source code at tag
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch selected tag from upstream
+        run: |
+          git remote add upstream https://github.com/nightscout/AndroidAPS.git || true
+          git fetch upstream refs/tags/${{ github.event.inputs.tagName }}:refs/tags/${{ github.event.inputs.tagName }}
+          echo "✅ Tag ${{ github.event.inputs.tagName }} fetched from upstream."
+
+      - name: Determine JVM version from tag
+        run: |
+          # jdk-map.json must be read before switching to the upstream tag,
+          # as the upstream tag does not contain this file.
+          TAG="${{ github.event.inputs.tagName }}"
+          JAVA_VERSION=$(jq -r '.default' .github/jdk-map.json)
+          while IFS=$'\t' read -r pattern jdk; do
+            if [[ "$TAG" == $pattern ]]; then
+              JAVA_VERSION="$jdk"
+              break
+            fi
+          done < <(jq -r '.mappings[] | "\(.pattern)\t\(.jdk)"' .github/jdk-map.json)
+          echo "JAVA_VERSION=$JAVA_VERSION" >> $GITHUB_ENV
+          echo "ℹ️ Tag $TAG → JDK $JAVA_VERSION (from jdk-map.json)"
+
+      - name: Switch to selected tag
+        run: |
+          git checkout refs/tags/${{ github.event.inputs.tagName }}
+          echo "✅ Checked out tag ${{ github.event.inputs.tagName }}"
 
       - name: Set BUILD_VARIANT
         run: |
@@ -176,10 +240,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          # When upgrading the JDK, please update this section accordingly as well.
-          java-version: 21
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -1,17 +1,8 @@
-name: Cherry Pick CI (Pre-release Feature Backport)
+name: Branch CI
 
 on:
   workflow_dispatch:
     inputs:
-      upstream_repo:
-        description: 'Upstream repository (format: owner/repo)'
-        required: true
-        default: 'nightscout/AndroidAPS'
-
-      cherry_pick:
-        description: 'Commit hash(es) to cherry-pick (e.g. abc123 def456)'
-        required: true
-
       buildVariant:
         description: 'Select Build Variant'
         required: true
@@ -32,77 +23,6 @@ jobs:
     name: Build AAPS
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Load jdk versions
-        run: |
-          JAVA_VERSION=$(jq -r '.default' .github/jdk-map.json)
-          echo "JAVA_VERSION=$JAVA_VERSION" >> $GITHUB_ENV
-
-      - name: Fetch upstream and verify commits
-        run: |
-          git remote add upstream "https://github.com/${{ github.event.inputs.upstream_repo }}.git"
-          git fetch upstream
-          echo "✅ Upstream branches fetched."
-
-          ALL_FOUND=true
-          for HASH in ${{ github.event.inputs.cherry_pick }}; do
-            TYPE=$(git cat-file -t "$HASH" 2>/dev/null || true)
-            if [ "$TYPE" = "commit" ]; then
-              echo "✅ $HASH is reachable from a branch"
-              continue
-            fi
-
-            # Commit not on any branch — may be from a squash-merged PR.
-            # Use the GitHub API to find which PR contains this commit, then
-            # fetch that PR's preserved ref (refs/pull/<n>/head).
-            echo "ℹ️ $HASH not on any branch — looking up PR via GitHub API..."
-            PR_NUMBER=$(curl -s \
-              -H "Authorization: Bearer ${{ github.token }}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.event.inputs.upstream_repo }}/commits/$HASH/pulls" \
-              | jq -r '.[0].number // empty')
-
-            if [ -n "$PR_NUMBER" ]; then
-              echo "🔗 Found in PR #$PR_NUMBER — fetching PR ref..."
-              git fetch upstream "refs/pull/$PR_NUMBER/head:refs/remotes/upstream/pr/$PR_NUMBER"
-              TYPE2=$(git cat-file -t "$HASH" 2>/dev/null || true)
-              if [ "$TYPE2" = "commit" ]; then
-                echo "✅ $HASH now available via PR #$PR_NUMBER"
-              else
-                echo "❌ $HASH still not found after fetching PR #$PR_NUMBER"
-                ALL_FOUND=false
-              fi
-            else
-              echo "❌ $HASH is not reachable from any branch or PR in upstream."
-              echo "   Possible cause: squash-merged and PR ref no longer preserved."
-              echo "   Tip: use the merge commit SHA that landed on the target branch instead."
-              ALL_FOUND=false
-            fi
-          done
-
-          if [ "$ALL_FOUND" = "false" ]; then
-            echo "🛑 One or more commits could not be resolved. Aborting."
-            exit 1
-          fi
-          echo "✅ All commits verified and reachable."
-
-      - name: Cherry-pick commits
-        run: |
-          echo "➡️ Cherry-picking commits: ${{ github.event.inputs.cherry_pick }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
-          if ! git cherry-pick ${{ github.event.inputs.cherry_pick }}; then
-            echo "❌ Cherry-pick failed. Exiting."
-            exit 1
-          fi
-          
-          echo "✅ All commits cherry-picked."
-
       - name: Decode Secrets Keystore Set and Oauth2 to Env
         run: |
           if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
@@ -228,6 +148,14 @@ jobs:
           echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
           echo "✅ Access token obtained."
 
+      - name: Checkout source code
+        uses: actions/checkout@v5
+
+      - name: Load jdk versions
+        run: |
+          JAVA_VERSION=$(jq -r '.default' .github/jdk-map.json)
+          echo "JAVA_VERSION=$JAVA_VERSION" >> $GITHUB_ENV
+
       - name: Set BUILD_VARIANT
         run: |
           BUILD_VARIANT="${{ github.event.inputs.buildVariant }}"
@@ -265,17 +193,17 @@ jobs:
 
       - name: Build APKs
         run: |
-          ./gradlew :app:assemble${{ env.BUILD_VARIANT }} :wear:assemble${{ env.BUILD_VARIANT }} \
-            -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
-            -Dkotlin.daemon.jvm.options="-Xmx2g" \
-            -Dkotlin.compiler.execution.strategy="in-process" \
-            -Dorg.gradle.daemon=true \
-            -Dorg.gradle.workers.max=8 \
-            -Dorg.gradle.caching=true \
-            -Pandroid.injected.signing.store.file="$RUNNER_TEMP/keystore/keystore.jks" \
-            -Pandroid.injected.signing.store.password="$KEYSTORE_PASSWORD" \
-            -Pandroid.injected.signing.key.alias="$KEY_ALIAS" \
-            -Pandroid.injected.signing.key.password="$KEY_PASSWORD"
+              ./gradlew :app:assemble${{ env.BUILD_VARIANT }} :wear:assemble${{ env.BUILD_VARIANT }} \
+              -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
+              -Dkotlin.daemon.jvm.options="-Xmx2g" \
+              -Dkotlin.compiler.execution.strategy="in-process" \
+              -Dorg.gradle.daemon=true \
+              -Dorg.gradle.workers.max=8 \
+              -Dorg.gradle.caching=true \
+              -Pandroid.injected.signing.store.file="$RUNNER_TEMP/keystore/keystore.jks" \
+              -Pandroid.injected.signing.store.password="$KEYSTORE_PASSWORD" \
+              -Pandroid.injected.signing.key.alias="$KEY_ALIAS" \
+              -Pandroid.injected.signing.key.password="$KEY_PASSWORD"
 
       - name: Rename APKs with version
         run: |
@@ -361,17 +289,8 @@ jobs:
 
             echo "✅ Uploaded: $NAME"
           }
-          
-          # Sanitize cherry-pick input to create a safe filename suffix.
-          # Reason: ${{ github.event.inputs.cherry_pick }} may contain special characters,
-          # spaces, or symbols that are invalid or risky in filenames.
-          # This ensures the final name only includes letters, numbers, dash (-), and underscore (_).               
-          CHERRY_PICK_RAW="${{ github.event.inputs.cherry_pick }}"
-          CHERRY_PICK_SAFE=$(echo "$CHERRY_PICK_RAW" | sed 's/ /_/g')
-          CHERRY_PICK_SAFE=$(echo "$CHERRY_PICK_SAFE" | sed 's/[^a-zA-Z0-9_-]/_/g')
-          echo "CHERRY_PICK_SAFE=$CHERRY_PICK_SAFE" >> $GITHUB_ENV
 
-          upload_to_gdrive "aaps-${VERSION}${VERSION_SUFFIX}.apk" "aaps-${VERSION}${VERSION_SUFFIX}_CP-${CHERRY_PICK_SAFE}.apk"
-          upload_to_gdrive "aaps-wear-${VERSION}${VERSION_SUFFIX}.apk" "aaps-wear-${VERSION}${VERSION_SUFFIX}_CP-${CHERRY_PICK_SAFE}.apk"
+          upload_to_gdrive "aaps-${VERSION}${VERSION_SUFFIX}.apk" "aaps-${VERSION}${VERSION_SUFFIX}.apk"
+          upload_to_gdrive "aaps-wear-${VERSION}${VERSION_SUFFIX}.apk" "aaps-wear-${VERSION}${VERSION_SUFFIX}.apk"
 
           echo "🎉 APKs successfully uploaded to Google Drive!"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -181,11 +181,16 @@ jobs:
           echo "PR_REF_TYPE=$PR_REF_TYPE" >> $GITHUB_ENV
 
       - name: Checkout pull/${{ github.event.inputs.pr_number }}/${{ github.event.inputs.pr_ref_type }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ steps.pr_ref.outputs.ref_name }}
           fetch-depth: 1
+
+      - name: Load jdk versions
+        run: |
+          JAVA_VERSION=$(jq -r '.default' .github/jdk-map.json)
+          echo "JAVA_VERSION=$JAVA_VERSION" >> $GITHUB_ENV
 
       - name: Set BUILD_VARIANT
         run: |
@@ -212,10 +217,10 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          # When upgrading the JDK, please update this section accordingly as well.
-          java-version: 21
+          # Java version is defined in .github/versions.env
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
           cache: gradle
 


### PR DESCRIPTION
@MilosKozak 
Modify aaps-ci to support building APKs for 3.x versions.
<img width="618" height="613" alt="圖片" src="https://github.com/user-attachments/assets/8ef6f6ab-a712-48f1-bece-1a81f3323c47" />

Add branch-ci for testers who need to build the dev branch (this preserves the original aaps-ci behavior).
<img width="619" height="411" alt="圖片" src="https://github.com/user-attachments/assets/f23495a6-812b-46f5-b273-c318f1192d66" />

Upgrade setup-java from v4 to v5.

Important: Because the GitHub Actions UI cannot load options dynamically, whenever a new tag is added or the JVM mapping changes, the following files must be updated manually:
	1.	aaps-ci: add the latest tag to the dropdown menu
<img width="844" height="591" alt="圖片" src="https://github.com/user-attachments/assets/60957e13-17de-49a2-8958-52064a049700" />

	2.	jdk-map.json: add the JDK version mapping for the tag and update the latest version mapping
<img width="807" height="525" alt="圖片" src="https://github.com/user-attachments/assets/45abc327-6cd7-4cbf-91e1-a0fd6e30d59f" />

Changes to GitHub Actions only take effect after they are merged into the default branch (master).

please review
