### PR TITLE
GraphImprovement

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -519,8 +519,7 @@ fun SecondaryGraphCompose(
     val secondaryAxisLine = remember(secondaryAxisColor) {
         LineCartesianLayer.Line(
             fill = LineCartesianLayer.LineFill.single(Fill(secondaryAxisColor)),
-            areaFill = LineCartesianLayer.AreaFill.single(
-                Fill(Brush.verticalGradient(listOf(secondaryAxisColor.copy(alpha = 0.3f), Color.Transparent)))
+            areaFill = LineCartesianLayer.AreaFill.single(fill = Fill(Color.Transparent)
             )
         )
     }


### PR DESCRIPTION
Remove areaFill with gradient for secondary curve
Especially if combined with DEV graph, gradient make color identification more difficult
Graph is I think cleaner with one less gradient if primary curve have one (like COB)