### PR TITLE
Dev3 medtrum handle patch reset

### DIFF
--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPlugin.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPlugin.kt
@@ -56,6 +56,7 @@ import app.aaps.core.validators.preferences.AdaptiveSwitchPreference
 import app.aaps.pump.medtrum.comm.enums.MedtrumPumpState
 import app.aaps.pump.medtrum.comm.enums.ModelType
 import app.aaps.pump.medtrum.keys.MedtrumBooleanKey
+import app.aaps.pump.medtrum.keys.MedtrumBooleanNonKey
 import app.aaps.pump.medtrum.keys.MedtrumDoubleNonKey
 import app.aaps.pump.medtrum.keys.MedtrumIntKey
 import app.aaps.pump.medtrum.keys.MedtrumIntNonKey
@@ -101,7 +102,8 @@ class MedtrumPlugin @Inject constructor(
         .description(R.string.medtrum_pump_description),
     ownPreferences = listOf(
         MedtrumStringKey::class.java, MedtrumIntKey::class.java, MedtrumBooleanKey::class.java,
-        MedtrumIntNonKey::class.java, MedtrumLongNonKey::class.java, MedtrumStringNonKey::class.java, MedtrumDoubleNonKey::class.java
+        MedtrumIntNonKey::class.java, MedtrumLongNonKey::class.java, MedtrumStringNonKey::class.java, MedtrumDoubleNonKey::class.java,
+        MedtrumBooleanNonKey::class.java
     ),
     aapsLogger, rh, preferences, commandQueue
 ), Pump, Medtrum {

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
@@ -22,6 +22,7 @@ import app.aaps.pump.medtrum.comm.enums.ModelType
 import app.aaps.pump.medtrum.extension.toByteArray
 import app.aaps.pump.medtrum.extension.toInt
 import app.aaps.pump.medtrum.keys.MedtrumBooleanKey
+import app.aaps.pump.medtrum.keys.MedtrumBooleanNonKey
 import app.aaps.pump.medtrum.keys.MedtrumDoubleNonKey
 import app.aaps.pump.medtrum.keys.MedtrumIntKey
 import app.aaps.pump.medtrum.keys.MedtrumIntNonKey
@@ -68,6 +69,11 @@ class MedtrumPump @Inject constructor(
         set(value) {
             _pumpState.value = value
             preferences.put(MedtrumIntNonKey.PumpState, value.state.toInt())
+            // Maintain patchPrimed flag: set once we reach PRIMED, clear only on STOPPED/NONE
+            when {
+                value >= MedtrumPumpState.PRIMED && value < MedtrumPumpState.STOPPED -> patchPrimed = true
+                value == MedtrumPumpState.STOPPED || value == MedtrumPumpState.NONE  -> patchPrimed = false
+            }
         }
 
     // Active alarms
@@ -94,6 +100,17 @@ class MedtrumPump @Inject constructor(
         get() = _primeProgress.value
         set(value) {
             _primeProgress.value = value
+        }
+
+    // Tracks that the patch was primed at least once during the current activation session.
+    // Set when pumpState reaches PRIMED; cleared only by STOPPED or NONE.
+    // Used to detect an unexpected patch reset and block ACTIVATION in that case.
+    private var _patchPrimed = false
+    var patchPrimed: Boolean
+        get() = _patchPrimed
+        set(value) {
+            _patchPrimed = value
+            preferences.put(MedtrumBooleanNonKey.PatchPrimed, value)
         }
 
     private var _lastBasalType: MutableStateFlow<BasalType> = MutableStateFlow(BasalType.NONE)
@@ -324,6 +341,7 @@ class MedtrumPump @Inject constructor(
         _pumpTimeZoneOffset = preferences.get(MedtrumIntNonKey.PumpTimezoneOffset)
         _bolusStartTime = preferences.get(MedtrumLongNonKey.BolusStartTime)
         _bolusAmountToBeDelivered = preferences.get(MedtrumDoubleNonKey.BolusAmountToBeDelivered)
+        _patchPrimed = preferences.get(MedtrumBooleanNonKey.PatchPrimed)
 
         loadActiveAlarms()
 

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
@@ -69,10 +69,10 @@ class MedtrumPump @Inject constructor(
         set(value) {
             _pumpState.value = value
             preferences.put(MedtrumIntNonKey.PumpState, value.state.toInt())
-            // Maintain patchPrimed flag: set once we reach PRIMED, clear only on STOPPED/NONE
+            // Maintain patchPrimed flag: set once we reach PRIMING, clear only on STOPPED
             when {
-                value >= MedtrumPumpState.PRIMED && value < MedtrumPumpState.STOPPED -> patchPrimed = true
-                value == MedtrumPumpState.STOPPED || value == MedtrumPumpState.NONE  -> patchPrimed = false
+                value >= MedtrumPumpState.PRIMING && value < MedtrumPumpState.STOPPED -> patchPrimed = true
+                value == MedtrumPumpState.STOPPED                                     -> patchPrimed = false
             }
         }
 
@@ -102,9 +102,9 @@ class MedtrumPump @Inject constructor(
             _primeProgress.value = value
         }
 
-    // Tracks that the patch was primed at least once during the current activation session.
-    // Set when pumpState reaches PRIMED; cleared only by STOPPED or NONE.
-    // Used to detect an unexpected patch reset and block ACTIVATION in that case.
+    // Tracks that the patch has started priming at least once during the current activation session.
+    // Set when pumpState reaches PRIMING; cleared only by STOPPED or NONE.
+    // Used to detect an unexpected patch reset and block activation in that case.
     private var _patchPrimed = false
     var patchPrimed: Boolean
         get() = _patchPrimed

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/MedtrumPump.kt
@@ -67,13 +67,14 @@ class MedtrumPump @Inject constructor(
     var pumpState: MedtrumPumpState
         get() = _pumpState.value
         set(value) {
-            _pumpState.value = value
-            preferences.put(MedtrumIntNonKey.PumpState, value.state.toInt())
             // Maintain patchPrimed flag: set once we reach PRIMING, clear only on STOPPED
             when {
                 value >= MedtrumPumpState.PRIMING && value < MedtrumPumpState.STOPPED -> patchPrimed = true
                 value == MedtrumPumpState.STOPPED                                     -> patchPrimed = false
             }
+            
+            _pumpState.value = value
+            preferences.put(MedtrumIntNonKey.PumpState, value.state.toInt())
         }
 
     // Active alarms

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/keys/MedtrumBooleanNonKey.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/keys/MedtrumBooleanNonKey.kt
@@ -1,0 +1,12 @@
+package app.aaps.pump.medtrum.keys
+
+import app.aaps.core.keys.interfaces.BooleanNonPreferenceKey
+
+enum class MedtrumBooleanNonKey(
+    override val key: String,
+    override val defaultValue: Boolean,
+    override val exportable: Boolean = true
+) : BooleanNonPreferenceKey {
+
+    PatchPrimed("patch_primed_flag", defaultValue = false),
+}

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/MedtrumService.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/services/MedtrumService.kt
@@ -640,7 +640,31 @@ class MedtrumService : DaggerService(), BLECommCallback {
             }
 
             MedtrumPumpState.IDLE,
-            MedtrumPumpState.FILLED,
+            MedtrumPumpState.FILLED               -> {
+                rxBus.send(EventDismissNotification(Notification.PUMP_ERROR))
+                rxBus.send(EventDismissNotification(Notification.PUMP_SUSPENDED))
+                medtrumPump.setFakeTBRIfNotSet()
+                medtrumPump.clearAlarmState()
+
+                if (medtrumPump.patchPrimed) {
+                    aapsLogger.error(LTag.PUMP, "handlePumpStateUpdate: Unexpected patch state drop while primed! state: $state")
+
+                    pumpSync.insertAnnouncement(
+                        rh.gs(R.string.patch_reset_after_primed_error),
+                        null,
+                        medtrumPump.pumpType(),
+                        medtrumPump.pumpSN.toString(radix = 16)
+                    )
+
+                    uiInteraction.addNotificationWithSound(
+                        Notification.PUMP_ERROR,
+                        rh.gs(R.string.patch_reset_after_primed_error),
+                        Notification.URGENT,
+                        app.aaps.core.ui.R.raw.alarm
+                    )
+                }
+            }
+
             MedtrumPumpState.PRIMING,
             MedtrumPumpState.PRIMED,
             MedtrumPumpState.EJECTING,

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumActivateCompleteFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumActivateCompleteFragment.kt
@@ -10,8 +10,10 @@ import app.aaps.core.interfaces.logging.LTag
 import app.aaps.core.interfaces.logging.UserEntryLogger
 import app.aaps.core.interfaces.maintenance.ImportExportPrefs
 import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.ui.dialogs.OKDialog
 import app.aaps.core.ui.toast.ToastUtils
 import app.aaps.pump.medtrum.R
+import app.aaps.pump.medtrum.code.PatchStep
 import app.aaps.pump.medtrum.databinding.FragmentMedtrumActivateCompleteBinding
 import app.aaps.pump.medtrum.ui.viewmodel.MedtrumViewModel
 import javax.inject.Inject
@@ -42,8 +44,15 @@ class MedtrumActivateCompleteFragment : MedtrumBaseFragment<FragmentMedtrumActiv
                         MedtrumViewModel.SetupStep.ACTIVATED -> btnPositive.visibility = View.VISIBLE
 
                         else                                 -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumActivateFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumActivateFragment.kt
@@ -37,15 +37,16 @@ class MedtrumActivateFragment : MedtrumBaseFragment<FragmentMedtrumActivateBindi
                         MedtrumViewModel.SetupStep.PRIMED    -> Unit // Nothing to do here, previous state
                         MedtrumViewModel.SetupStep.ACTIVATED -> moveStep(PatchStep.ACTIVATE_COMPLETE)
 
-                        MedtrumViewModel.SetupStep.ERROR     -> {
-                            updateSetupStep(MedtrumViewModel.SetupStep.PRIMED) // Reset setup step
-                            binding.textActivatingPump.text = rh.gs(R.string.activating_error)
-                            binding.btnPositive.visibility = View.VISIBLE
-                        }
-
                         else                                 -> {
-                            ToastUtils.errorToast(requireContext(), "Unexpected state: $it")
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumAttachPatchFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumAttachPatchFragment.kt
@@ -38,8 +38,15 @@ class MedtrumAttachPatchFragment : MedtrumBaseFragment<FragmentMedtrumAttachPatc
                         MedtrumViewModel.SetupStep.PRIMED -> Unit // Nothing to do here, previous state
 
                         else                              -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumDeactivatePatchFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumDeactivatePatchFragment.kt
@@ -33,18 +33,32 @@ class MedtrumDeactivatePatchFragment : MedtrumBaseFragment<FragmentMedtrumDeacti
             viewModel?.apply {
                 setupStep.observe(viewLifecycleOwner) {
                     when (it) {
-                        MedtrumViewModel.SetupStep.STOPPED -> {
+                        MedtrumViewModel.SetupStep.INITIAL,
+                        MedtrumViewModel.SetupStep.START_DEACTIVATION -> Unit // Nothing to do here, previous state
+                        MedtrumViewModel.SetupStep.STOPPED            -> {
                             moveStep(PatchStep.DEACTIVATION_COMPLETE)
                         }
 
-                        MedtrumViewModel.SetupStep.ERROR   -> {
+                        // Error is handled by showing force activate button
+                        MedtrumViewModel.SetupStep.ERROR              -> {
                             updateSetupStep(MedtrumViewModel.SetupStep.START_DEACTIVATION) // Reset setup step
                             binding.textDeactivatingPump.text = rh.gs(R.string.deactivating_error)
                             binding.btnNegative.visibility = View.VISIBLE
                             binding.btnPositive.visibility = View.VISIBLE
                         }
 
-                        else                               -> Unit // Nothing to do here
+                        // Catch other unexpected states
+                        else                                          -> {
+                            aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
+                        }
                     }
                 }
                 deactivatePatch()

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
@@ -52,7 +52,7 @@ class MedtrumOverviewFragment : MedtrumBaseFragment<FragmentMedtrumOverviewBindi
                                         medtrumPump.pumpState in listOf(MedtrumPumpState.STOPPED, MedtrumPumpState.NONE) ->
                                             PatchStep.PREPARE_PATCH
 
-                                        medtrumPump.pumpState <= MedtrumPumpState.EJECTED && !(medtrumPump.pumpState < MedtrumPumpState.PRIMED && medtrumPump.patchPrimed) ->
+                                        medtrumPump.pumpState <= MedtrumPumpState.EJECTED && !(medtrumPump.pumpState < MedtrumPumpState.PRIMING && medtrumPump.patchPrimed) ->
                                             PatchStep.RETRY_ACTIVATION
 
                                         else ->

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
@@ -49,13 +49,16 @@ class MedtrumOverviewFragment : MedtrumBaseFragment<FragmentMedtrumOverviewBindi
                                 ProtectionCheck.Protection.PREFERENCES,
                                 {
                                     val nextStep = when {
-                                        medtrumPump.pumpState in listOf(MedtrumPumpState.STOPPED, MedtrumPumpState.NONE) ->
+                                        medtrumPump.pumpState == MedtrumPumpState.STOPPED                                                                                   ->
+                                            PatchStep.PREPARE_PATCH
+
+                                        medtrumPump.pumpState == MedtrumPumpState.NONE && !medtrumPump.patchPrimed                                                          ->
                                             PatchStep.PREPARE_PATCH
 
                                         medtrumPump.pumpState <= MedtrumPumpState.EJECTED && !(medtrumPump.pumpState < MedtrumPumpState.PRIMING && medtrumPump.patchPrimed) ->
                                             PatchStep.RETRY_ACTIVATION
 
-                                        else ->
+                                        else                                                                                                                                ->
                                             PatchStep.START_DEACTIVATION
                                     }
                                     startActivity(MedtrumActivity.createIntentFromMenu(this, nextStep))

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumOverviewFragment.kt
@@ -49,17 +49,14 @@ class MedtrumOverviewFragment : MedtrumBaseFragment<FragmentMedtrumOverviewBindi
                                 ProtectionCheck.Protection.PREFERENCES,
                                 {
                                     val nextStep = when {
-                                        medtrumPump.pumpState > MedtrumPumpState.EJECTED && medtrumPump.pumpState < MedtrumPumpState.STOPPED -> {
-                                            PatchStep.START_DEACTIVATION
-                                        }
-
-                                        medtrumPump.pumpState in listOf(MedtrumPumpState.STOPPED, MedtrumPumpState.NONE)                     -> {
+                                        medtrumPump.pumpState in listOf(MedtrumPumpState.STOPPED, MedtrumPumpState.NONE) ->
                                             PatchStep.PREPARE_PATCH
-                                        }
 
-                                        else                                                                                                 -> {
+                                        medtrumPump.pumpState <= MedtrumPumpState.EJECTED && !(medtrumPump.pumpState < MedtrumPumpState.PRIMED && medtrumPump.patchPrimed) ->
                                             PatchStep.RETRY_ACTIVATION
-                                        }
+
+                                        else ->
+                                            PatchStep.START_DEACTIVATION
                                     }
                                     startActivity(MedtrumActivity.createIntentFromMenu(this, nextStep))
                                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPreparePatchConnectFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPreparePatchConnectFragment.kt
@@ -34,15 +34,22 @@ class MedtrumPreparePatchConnectFragment : MedtrumBaseFragment<FragmentMedtrumPr
             viewModel?.apply {
                 setupStep.observe(viewLifecycleOwner) {
                     when (it) {
-                        MedtrumViewModel.SetupStep.INITIAL -> btnPositive.visibility = View.GONE
+                        MedtrumViewModel.SetupStep.INITIAL,
+                        MedtrumViewModel.SetupStep.STOPPED -> btnPositive.visibility = View.GONE
+
                         MedtrumViewModel.SetupStep.FILLED  -> btnPositive.visibility = View.VISIBLE
 
-                        MedtrumViewModel.SetupStep.ERROR   -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
-                            moveStep(PatchStep.CANCEL)
+                        else                               -> {
+                            aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
-
-                        else                               -> Unit
                     }
                 }
                 preparePatchConnect()

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimeCompleteFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimeCompleteFragment.kt
@@ -37,8 +37,15 @@ class MedtrumPrimeCompleteFragment : MedtrumBaseFragment<FragmentMedtrumPrimeCom
                         MedtrumViewModel.SetupStep.PRIMED -> Unit // Nothing to do here, previous state
 
                         else                              -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimeFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimeFragment.kt
@@ -37,8 +37,15 @@ class MedtrumPrimeFragment : MedtrumBaseFragment<FragmentMedtrumPrimeBinding>() 
                         MedtrumViewModel.SetupStep.FILLED -> Unit // Nothing to do here, previous state
 
                         else                              -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimingFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumPrimingFragment.kt
@@ -38,16 +38,16 @@ class MedtrumPrimingFragment : MedtrumBaseFragment<FragmentMedtrumPrimingBinding
                         MedtrumViewModel.SetupStep.PRIMING -> Unit // Nothing to do here
                         MedtrumViewModel.SetupStep.PRIMED  -> moveStep(PatchStep.PRIME_COMPLETE)
 
-                        MedtrumViewModel.SetupStep.ERROR   -> {
-                            updateSetupStep(MedtrumViewModel.SetupStep.FILLED) // Reset setup step
-                            binding.textWaitForPriming.text = rh.gs(R.string.priming_error)
-                            binding.btnNegative.visibility = View.VISIBLE
-                            binding.btnPositive.visibility = View.VISIBLE
-                        }
-
                         else                               -> {
-                            ToastUtils.errorToast(requireContext(), rh.gs(R.string.unexpected_state, it.toString()))
                             aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                            OKDialog.show(
+                                requireActivity(),
+                                rh.gs(app.aaps.core.ui.R.string.error),
+                                rh.gs(R.string.unexpected_state, it.toString()),
+                                runOnDismiss = true
+                            ) {
+                                viewModel?.moveStep(PatchStep.CANCEL)
+                            }
                         }
                     }
                 }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumRetryActivationConnectFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumRetryActivationConnectFragment.kt
@@ -36,14 +36,7 @@ class MedtrumRetryActivationConnectFragment : MedtrumBaseFragment<FragmentMedtru
                     if (patchStep.value != PatchStep.CANCEL) {
                         when (it) {
                             MedtrumViewModel.SetupStep.INITIAL   -> Unit // Nothing to do here
-                            MedtrumViewModel.SetupStep.FILLED    -> {
-                                aapsLogger.error(LTag.PUMP, "Pump reports FILLED during retry activation. Blocking re-prime to prevent insulin delivery into already-inserted patch.")
-                                OKDialog.show(requireActivity(), rh.gs(app.aaps.core.ui.R.string.error), rh.gs(R.string.retry_activation_filled_error)) {
-                                    viewModel?.apply {
-                                        moveStep(PatchStep.CANCEL)
-                                    }
-                                }
-                            }
+                            MedtrumViewModel.SetupStep.FILLED    -> forceMoveStep(PatchStep.PRIME)
                             MedtrumViewModel.SetupStep.PRIMING   -> forceMoveStep(PatchStep.PRIMING)
                             MedtrumViewModel.SetupStep.PRIMED    -> forceMoveStep(PatchStep.PRIME_COMPLETE)
                             MedtrumViewModel.SetupStep.ACTIVATED -> forceMoveStep(PatchStep.ACTIVATE_COMPLETE)

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumRetryActivationConnectFragment.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/MedtrumRetryActivationConnectFragment.kt
@@ -43,6 +43,14 @@ class MedtrumRetryActivationConnectFragment : MedtrumBaseFragment<FragmentMedtru
 
                             else                                 -> {
                                 aapsLogger.error(LTag.PUMP, "Unexpected state: $it")
+                                OKDialog.show(
+                                    requireActivity(),
+                                    rh.gs(app.aaps.core.ui.R.string.error),
+                                    rh.gs(R.string.unexpected_state, it.toString()),
+                                    runOnDismiss = true
+                                ) {
+                                    viewModel?.moveStep(PatchStep.CANCEL)
+                                }
                             }
                         }
                     }

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
@@ -91,31 +91,35 @@ class MedtrumViewModel @Inject constructor(
                 aapsLogger.debug(LTag.PUMP, "MedtrumViewModel pumpStateFlow: $state")
                 if (patchStep.value != null) {
                     when {
-                        (state == MedtrumPumpState.NONE || state == MedtrumPumpState.IDLE) && !medtrumPump.patchPrimed -> {
+                        state == MedtrumPumpState.NONE                                           -> {
                             updateSetupStep(SetupStep.INITIAL)
                         }
 
-                        state == MedtrumPumpState.FILLED && !medtrumPump.patchPrimed                                   -> {
+                        state == MedtrumPumpState.IDLE && !medtrumPump.patchPrimed               -> {
+                            updateSetupStep(SetupStep.INITIAL)
+                        }
+
+                        state == MedtrumPumpState.FILLED && !medtrumPump.patchPrimed             -> {
                             updateSetupStep(SetupStep.FILLED)
                         }
 
-                        state == MedtrumPumpState.PRIMING                                                              -> {
+                        state == MedtrumPumpState.PRIMING                                        -> {
                             updateSetupStep(SetupStep.PRIMING)
                         }
 
-                        state == MedtrumPumpState.PRIMED || state == MedtrumPumpState.EJECTED                          -> {
+                        state == MedtrumPumpState.PRIMED || state == MedtrumPumpState.EJECTED    -> {
                             updateSetupStep(SetupStep.PRIMED)
                         }
 
-                        state == MedtrumPumpState.ACTIVE || state == MedtrumPumpState.ACTIVE_ALT                       -> {
+                        state == MedtrumPumpState.ACTIVE || state == MedtrumPumpState.ACTIVE_ALT -> {
                             updateSetupStep(SetupStep.ACTIVATED)
                         }
 
-                        state == MedtrumPumpState.STOPPED                                                              -> {
+                        state == MedtrumPumpState.STOPPED                                        -> {
                             updateSetupStep(SetupStep.STOPPED)
                         }
 
-                        else                                                                                           -> {
+                        else                                                                     -> {
                             updateSetupStep(SetupStep.ERROR)
                         }
                     }
@@ -196,8 +200,15 @@ class MedtrumViewModel @Inject constructor(
             while (medtrumService?.isConnecting == true || medtrumService?.isConnected == true) {
                 SystemClock.sleep(100)
             }
-            // Set pump state to FILLED, so user will be able to retry activation again
-            medtrumPump.pumpState = MedtrumPumpState.FILLED
+            // Set pump state to to a proper state, (at beginning of retry state is reset to NONE)
+            // This is to ensure user can retry activation again
+            if (medtrumPump.pumpState == MedtrumPumpState.NONE) {
+                if (medtrumPump.patchPrimed) {
+                    medtrumPump.pumpState = MedtrumPumpState.PRIMING
+                } else {
+                    medtrumPump.pumpState = MedtrumPumpState.FILLED
+                }
+            }
         }
     }
 

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
@@ -256,24 +256,28 @@ class MedtrumViewModel @Inject constructor(
     }
 
     fun deactivatePatch() {
-        commandQueue.deactivate(object : Callback() {
-            override fun run() {
-                if (this.result.success) {
-                    // Do nothing, state change will handle this
-                } else {
-                    if (medtrumPump.pumpState >= MedtrumPumpState.OCCLUSION && medtrumPump.pumpState <= MedtrumPumpState.NO_CALIBRATION) {
-                        // We are in a fault state, we need to force deactivation
-                        aapsLogger.info(LTag.PUMP, "deactivatePatch: force deactivation")
-                        medtrumService?.disconnect("ForceDeactivation")
-                        SystemClock.sleep(1000)
-                        medtrumPump.pumpState = MedtrumPumpState.STOPPED
+        if ((medtrumPump.pumpState >= MedtrumPumpState.OCCLUSION && medtrumPump.pumpState <= MedtrumPumpState.NO_CALIBRATION)
+            || medtrumPump.pumpState <= MedtrumPumpState.FILLED
+        ) {
+            // We are in a fault state, we need to force deactivation 
+            // Connection can be skipped as its useless anyways
+            // (deactivation command will not work in fault state)
+            aapsLogger.info(LTag.PUMP, "deactivatePatch: force deactivation")
+            medtrumService?.disconnect("ForceDeactivation")
+            SystemClock.sleep(1000)
+            medtrumPump.pumpState = MedtrumPumpState.STOPPED
+        } else {
+            commandQueue.deactivate(object : Callback() {
+                override fun run() {
+                    if (this.result.success) {
+                        // Do nothing, state change will handle this
                     } else {
                         aapsLogger.info(LTag.PUMP, "deactivatePatch: failure!")
                         updateSetupStep(SetupStep.ERROR)
                     }
                 }
-            }
-        })
+            })
+        }
     }
 
     fun retryActivationConnect() {
@@ -322,8 +326,7 @@ class MedtrumViewModel @Inject constructor(
         return newStep
     }
 
-    enum class SetupStep { INITIAL, FILLED, PRIMING, PRIMED, ACTIVATED, ERROR, START_DEACTIVATION, STOPPED
-    }
+    enum class SetupStep { INITIAL, FILLED, PRIMING, PRIMED, ACTIVATED, ERROR, START_DEACTIVATION, STOPPED }
 
     val setupStep = MutableLiveData<SetupStep>()
 

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/ui/viewmodel/MedtrumViewModel.kt
@@ -90,32 +90,32 @@ class MedtrumViewModel @Inject constructor(
             medtrumPump.pumpStateFlow.collect { state ->
                 aapsLogger.debug(LTag.PUMP, "MedtrumViewModel pumpStateFlow: $state")
                 if (patchStep.value != null) {
-                    when (state) {
-                        MedtrumPumpState.NONE, MedtrumPumpState.IDLE         -> {
+                    when {
+                        (state == MedtrumPumpState.NONE || state == MedtrumPumpState.IDLE) && !medtrumPump.patchPrimed -> {
                             updateSetupStep(SetupStep.INITIAL)
                         }
 
-                        MedtrumPumpState.FILLED                              -> {
+                        state == MedtrumPumpState.FILLED && !medtrumPump.patchPrimed                                   -> {
                             updateSetupStep(SetupStep.FILLED)
                         }
 
-                        MedtrumPumpState.PRIMING                             -> {
+                        state == MedtrumPumpState.PRIMING                                                              -> {
                             updateSetupStep(SetupStep.PRIMING)
                         }
 
-                        MedtrumPumpState.PRIMED, MedtrumPumpState.EJECTED    -> {
+                        state == MedtrumPumpState.PRIMED || state == MedtrumPumpState.EJECTED                          -> {
                             updateSetupStep(SetupStep.PRIMED)
                         }
 
-                        MedtrumPumpState.ACTIVE, MedtrumPumpState.ACTIVE_ALT -> {
+                        state == MedtrumPumpState.ACTIVE || state == MedtrumPumpState.ACTIVE_ALT                       -> {
                             updateSetupStep(SetupStep.ACTIVATED)
                         }
 
-                        MedtrumPumpState.STOPPED                             -> {
+                        state == MedtrumPumpState.STOPPED                                                              -> {
                             updateSetupStep(SetupStep.STOPPED)
                         }
 
-                        else                                                 -> {
+                        else                                                                                           -> {
                             updateSetupStep(SetupStep.ERROR)
                         }
                     }

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_activate.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_activate.xml
@@ -53,23 +53,9 @@
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/cancel"
                     android:text="@string/cancel"
-                    app:layout_constraintEnd_toStartOf="@id/btn_positive"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <Button
-                    android:id="@+id/btn_positive"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="6dp"
-                    android:contentDescription="@string/retry"
-                    android:text="@string/retry"
-                    android:visibility="gone"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/btn_negative"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:onSafeClick="@{() -> viewModel.moveStep(PatchStep.ACTIVATE)}"
-                    tools:visibility="visible" />
+                    app:layout_constraintTop_toTopOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/pump/medtrum/src/main/res/layout/fragment_medtrum_priming.xml
+++ b/pump/medtrum/src/main/res/layout/fragment_medtrum_priming.xml
@@ -81,23 +81,10 @@
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/cancel"
                     android:text="@string/cancel"
-                    app:layout_constraintEnd_toStartOf="@id/btn_positive"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <Button
-                    android:id="@+id/btn_positive"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="6dp"
-                    android:contentDescription="@string/retry"
-                    android:text="@string/retry"
-                    android:visibility="gone"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/btn_negative"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:onSafeClick="@{() -> viewModel.moveStep(PatchStep.PRIMING)}"
-                    tools:visibility="visible" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="patch_not_active">Patch not activated</string>
     <string name="pump_setting_failed">Setting user settings to pump failed!</string>
     <string name="pump_sync_error">Error while syncing history from pump, a record has been skipped. Check treatment tab to check if bolus is synced correctly. Snooze and if error keep coming back change patch or pumpbase.</string>
+    <string name="patch_reset_after_primed_error">Patch reset detected after priming! Remove the patch and start a new patch.</string>
 
     <!-- overview fragment -->
     <string name="ble_status_label">BLE Status</string>
@@ -110,7 +111,6 @@
 
     <string name="activation_in_progress">Oops! Something went wrong, it seems there is already an activation in progress.</string>
     <string name="press_retry_or_discard">Press <b>Next</b> to resume the activation or <b>Discard</b> to reset the activation status.</string>
-    <string name="retry_activation_filled_error">Activation cannot be resumed. The pump state has been lost. Do NOT re-prime, as the patch may already be inserted. Please discard the patch and start a new activation.</string>
     <string name="reading_activation_status">Please wait, reading activation status from pump.</string>
 
     <!-- settings-->


### PR DESCRIPTION
https://github.com/nightscout/AndroidAPS/issues/4676

PR to dev3
Will port to dev4 asap after merge, and will double check dev4 activation process (some things are different)

## Changes
- Give error when patch goes from primed state to FILLED or IDLE state (both local and NS)
- Block retry activation on primed patches
- Deactivate patch: Skip connection when in fault state instead force deactivation
- Activation/deactivation: Handle errors with OKDialog returning to overview, instead of toast and staying in activation process

## Manual tests

- patch reset (state set to FILLED or IDLE) during activation, after prime:
    - EXPECTED: Gives error (pop up dialog) and further activation blocked
    - EXPECTED: Retry-activation also not possible (not presented to user at all)
- Patch reset during priming
    - EXPECTED: Gives error and further activation blocked
    - EXPECTED: Retry-activation also not possible (not presented to user at all)
- Reset during normal operation
    - EXPECTED: Gives error and pressing change patch goes straight to deactivation screen
- Start retry activation when after primed but patch reset (when state has not been read back)
    - Note: This can be tested by exiting the activation screen (press cancel), then reset patch and press "Change Patch" in overview
    - Note2: To speed up, you can export the settings when in PRIMED state when doing another test, and import when you do this test
    - EXPECTED: retry-activation should throw error (pop up dialog), and retry is blocked
- Force close app when in activation process pre-prime but patch has not been primed yet (fresh activation)
    - EXPECTED: retry-activation is allowed, and goes to correct screen (fill patch)
- Force close app when in activation process during priming
    - EXPECTED: retry-activation is allowed, and goes to correct screen (priming progress)
- Force close app when in activation process after priming
    - EXPECTED: retry-activation is allowed, and goes to correct screen (filling completed)


**Test instructions:**
To force reset to FILLED/IDLE state: Remove pumpbase, wait for 15 seconds, reattach pumpbase. (confirm 4 beeps when reattaching pumpbase)
Depending on the reservoir level this will move the state back to FILLED or IDLE



Tested OK with 300U by myself
Requesting at least one tester with Nano (200U), my own 200U nano is broken, and I want another person to test it.
