### PR TITLE
Wear: Enable Running mode tile for AAPSClient

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -1172,17 +1172,16 @@ class DataHandlerMobile @Inject constructor(
     private var lastRunningModes: List<AvailableRunningMode>? = null
 
     private fun handleAvailableRunningModes() {
-        // See LoopDialog for states list building logic
-        if (config.AAPSCLIENT) return
-
-        val pump = activePlugin.activePump
-        val pumpDescription = pump.pumpDescription
         if (!runBlocking { profileFunction.isProfileValid("WearDataHandler_LoopChangeState") }) return
 
-        val disconnectDurs = arrayListOf<Int>()
-        if (pumpDescription.tempDurationStep15mAllowed) disconnectDurs.add(15)
-        if (pumpDescription.tempDurationStep30mAllowed) disconnectDurs.add(30)
-        for (i in listOf(1, 2, 3)) disconnectDurs.add(i * 60)
+        val disconnectDurs = if (!config.AAPSCLIENT) {
+            val pumpDescription = activePlugin.activePump.pumpDescription
+            arrayListOf<Int>().apply {
+                if (pumpDescription.tempDurationStep15mAllowed) add(15)
+                if (pumpDescription.tempDurationStep30mAllowed) add(30)
+                for (i in listOf(1, 2, 3)) add(i * 60)
+            }
+        } else emptyList()
 
         fun mapMode(mode: RM.Mode): AvailableRunningMode? =
             when (mode) {
@@ -1191,7 +1190,8 @@ class DataHandlerMobile @Inject constructor(
                 RM.Mode.OPEN_LOOP         -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_OPEN)
                 RM.Mode.DISABLED_LOOP     -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_DISABLE)
                 RM.Mode.SUPER_BOLUS       -> null
-                RM.Mode.DISCONNECTED_PUMP -> AvailableRunningMode(AvailableRunningMode.RunningMode.PUMP_DISCONNECT, disconnectDurs)
+                RM.Mode.DISCONNECTED_PUMP -> if (config.AAPSCLIENT) null
+                                             else AvailableRunningMode(AvailableRunningMode.RunningMode.PUMP_DISCONNECT, disconnectDurs)
                 RM.Mode.SUSPENDED_BY_PUMP -> null
                 RM.Mode.SUSPENDED_BY_USER -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND, listOf(1, 2, 3, 10).map { it * 60 })
                 RM.Mode.SUSPENDED_BY_DST  -> null
@@ -1202,7 +1202,9 @@ class DataHandlerMobile @Inject constructor(
             }
 
         val allStates = loop.allowedNextModes().mapNotNull { mapMode(it) }
-        val states = if (allStates.any { it.state == AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND })
+        // LOOP_DISABLE is dropped when LOOP_USER_SUSPEND is present to fit within 4 tile slots.
+        // AAPSClient has no PUMP_DISCONNECT, so the slot is free and both can be shown.
+        val states = if (!config.AAPSCLIENT && allStates.any { it.state == AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND })
             allStates.filter { it.state != AvailableRunningMode.RunningMode.LOOP_DISABLE }
         else allStates
         lastAuthorizedRunningModeChangeTS = System.currentTimeMillis()


### PR DESCRIPTION
Running mode tile was silently blocked for AAPSClient. This removes the guard and adapts the available modes: 
<img width="535" height="250" alt="image" src="https://github.com/user-attachments/assets/1158d8a5-481d-40a9-a644-8214e20e5fd8" />
