### PR TITLE
Wear: distinguish AAPS, AAPSClient(s) and Pumpcontrol by name in tile picker, app drawer and complications picker

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -66,6 +66,7 @@ android {
             applicationId = "info.nightscout.androidaps"
             dimension = "standard"
             resValue("string", "app_name", "AAPS")
+            resValue("string", "label_actions_activity", "AAPS")
             versionName = Versions.appVersion
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
         }
@@ -73,6 +74,7 @@ android {
             applicationId = "info.nightscout.aapspumpcontrol"
             dimension = "standard"
             resValue("string", "app_name", "Pumpcontrol")
+            resValue("string", "label_actions_activity", "Pumpcontrol")
             versionName = Versions.appVersion + "-pumpcontrol"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_pumpcontrol"
         }
@@ -80,6 +82,7 @@ android {
             applicationId = "info.nightscout.aapsclient"
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient")
+            resValue("string", "label_actions_activity", "AAPSClient")
             versionName = Versions.appVersion + "-aapsclient"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_yellowowl"
         }
@@ -87,6 +90,7 @@ android {
             applicationId = "info.nightscout.aapsclient2"
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient2")
+            resValue("string", "label_actions_activity", "AAPSClient2")
             versionName = Versions.appVersion + "-aapsclient2"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_blueowl"
         }
@@ -94,6 +98,7 @@ android {
             applicationId = "info.nightscout.aapsclient3"
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient3")
+            resValue("string", "label_actions_activity", "AAPSClient3")
             versionName = Versions.appVersion + "-aapsclient3"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_greenowl"
         }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
@@ -6,7 +6,6 @@ import app.aaps.core.interfaces.rx.events.EventWearToMobile
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.rx.weardata.EventData.ActionResendData
 import app.aaps.core.keys.BooleanKey
-import app.aaps.wear.BuildConfig
 import app.aaps.wear.R
 import app.aaps.wear.interaction.actions.ECarbActivity
 import app.aaps.wear.interaction.actions.TempTargetActivity
@@ -18,13 +17,7 @@ import app.aaps.wear.interaction.utils.MenuListActivity
 class MainMenuActivity : MenuListActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        when (BuildConfig.FLAVOR) {
-            "full"        -> setTitle(R.string.app_name)
-            "aapsclient"  -> setTitle("AAPSClient")
-            "aapsclient2" -> setTitle("AAPSClient2")
-            "aapsclient3" -> setTitle("AAPSClient3")
-            "pumpcontrol" -> setTitle("Pumpcontrol")
-        }
+        setTitle(R.string.app_name)
         super.onCreate(savedInstanceState)
         rxBus.send(EventWearToMobile(ActionResendData("MainMenuListActivity")))
     }

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">AAPS</string>
-    <string name="label_actions_activity">AAPS</string>
     <string name="label_watchface_circle">AAPS(Circle)</string>
     <string name="label_watchface_digital_style">AAPS(DigitalStyle)</string>
     <string name="label_watchface_custom">AAPS(Custom)</string>


### PR DESCRIPTION
In old implementation it is hard to distinguish AAPS tiles from AAPSClient etc because they all gather under the same AAPS category name. Now all flavors get their own name/category for tiles, complications and app drawer. This will improve user experience when multiple AAPSClients are installed.

<img width="998" height="462" alt="image" src="https://github.com/user-attachments/assets/07134297-fc0d-40e7-8473-055343625747" />
