### PR TITLE
Wear: Improve IOB formatting in CobIob, IobIcon and BrIob complications

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/complications/BrIobComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/BrIobComplication.kt
@@ -6,15 +6,14 @@ import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.PlainComplicationText
 import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import app.aaps.core.interfaces.logging.LTag
-import app.aaps.wear.interaction.utils.DisplayFormat
-import app.aaps.wear.interaction.utils.SmallestDoubleString
+import app.aaps.wear.R
 import dagger.android.AndroidInjection
 
 /**
  * Basal Rate + IOB Complication
  *
  * Shows insulin on board (IOB) and basal rate
- * Text: IOB value (minimized to fit)
+ * Text: IOB value
  * Title: Basal rate with symbol
  *
  */
@@ -35,13 +34,13 @@ class BrIobComplication : ModernBaseComplicationProviderService() {
 
         return when (type) {
             ComplicationType.SHORT_TEXT      -> {
-                val iob = SmallestDoubleString(statusData.iobSum, SmallestDoubleString.Units.USE).minimise(DisplayFormat.MIN_FIELD_LEN_IOB)
+                val iob = statusData.iobSum + getString(R.string.insulin_unit_short)
 
                 ShortTextComplicationData.Builder(
                     text = PlainComplicationText.Builder(text = iob).build(),
                     contentDescription = PlainComplicationText.Builder(text = "IOB, Basal Rate").build()
                 )
-                    .setTitle(PlainComplicationText.Builder(text = displayFormat.basalRateSymbol() + statusData.currentBasal).build())
+                    .setTitle(PlainComplicationText.Builder(text = displayFormat.basalRateSymbol().trimEnd() + statusData.currentBasal.replaceFirst(" ", "")).build())
                     .setTapAction(complicationPendingIntent)
                     .build()
             }

--- a/wear/src/main/kotlin/app/aaps/wear/complications/CobIobComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/CobIobComplication.kt
@@ -6,16 +6,15 @@ import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.PlainComplicationText
 import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import app.aaps.core.interfaces.logging.LTag
-import app.aaps.wear.interaction.utils.DisplayFormat
-import app.aaps.wear.interaction.utils.SmallestDoubleString
+import app.aaps.wear.R
 import dagger.android.AndroidInjection
 
 /**
  * COB+IOB Complication
  *
  * Shows both carbs on board (COB) and insulin on board (IOB)
- * Text: COB value
- * Title: IOB value (minimized to fit)
+ * Text: IOB value
+ * Title: COB value
  *
  */
 class CobIobComplication : ModernBaseComplicationProviderService() {
@@ -36,13 +35,13 @@ class CobIobComplication : ModernBaseComplicationProviderService() {
         return when (type) {
             ComplicationType.SHORT_TEXT      -> {
                 val cob = statusData.cob
-                val iob = SmallestDoubleString(statusData.iobSum, SmallestDoubleString.Units.USE).minimise(DisplayFormat.MAX_FIELD_LEN_SHORT)
+                val iob = statusData.iobSum + getString(R.string.insulin_unit_short)
 
                 ShortTextComplicationData.Builder(
-                    text = PlainComplicationText.Builder(text = cob).build(),
-                    contentDescription = PlainComplicationText.Builder(text = "COB $cob IOB $iob").build()
+                    text = PlainComplicationText.Builder(text = iob).build(),
+                    contentDescription = PlainComplicationText.Builder(text = "IOB $iob COB $cob").build()
                 )
-                    .setTitle(PlainComplicationText.Builder(text = iob).build())
+                    .setTitle(PlainComplicationText.Builder(text = cob).build())
                     .setTapAction(complicationPendingIntent)
                     .build()
             }

--- a/wear/src/main/kotlin/app/aaps/wear/complications/IobIconComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/IobIconComplication.kt
@@ -9,15 +9,12 @@ import androidx.wear.watchface.complications.data.PlainComplicationText
 import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.wear.R
-import app.aaps.wear.interaction.utils.DisplayFormat
-import app.aaps.wear.interaction.utils.SmallestDoubleString
 import dagger.android.AndroidInjection
 
 /**
  * IOB Icon Complication
  *
  * Shows insulin on board (IOB) with insulin icon
- * Uses SmallestDoubleString for optimal display in limited space
  * Tap action opens bolus wizard
  *
  */
@@ -38,7 +35,7 @@ class IobIconComplication : ModernBaseComplicationProviderService() {
 
         return when (type) {
             ComplicationType.SHORT_TEXT      -> {
-                val iob = SmallestDoubleString(statusData.iobSum, SmallestDoubleString.Units.USE).minimise(DisplayFormat.MAX_FIELD_LEN_SHORT)
+                val iob = statusData.iobSum + getString(R.string.insulin_unit_short)
 
                 ShortTextComplicationData.Builder(
                     text = PlainComplicationText.Builder(text = iob).build(),


### PR DESCRIPTION
Aligns IOB display with phone formatting — the complications have enough space to show the full value.                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                             
  - IOB now shows as "0.02U" instead of ",02" (leading zero preserved, unit from insulin_unit_short resource)
  - Replaced SmallestDoubleString with direct formatting since space is not a constraint here                                                                                                                                                                                                                                                
  - BrIob: BR title compact formatting consistent with BrTt complication (so 0,00 U/h can be shown without being cut)
  - CobIob: swapped order — IOB in text (larger slot), COB in title
  
  Before:
  
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/d5a4a475-42df-4290-a60a-c52855bff4e7" />

After:
| Header | Header |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/8e13961f-27cf-420f-9d9e-3816785a9c39" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/87f9452d-7b59-45dc-a7ed-98faaee48148" /> | 