### PR TITLE
Wear: Speed up complication/watchface update when TT changes on phone

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
@@ -14,6 +14,9 @@ import app.aaps.core.interfaces.plugin.PluginDescription
 import app.aaps.core.interfaces.pump.BolusProgressData
 import app.aaps.core.interfaces.receivers.Intents
 import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.data.model.TT
+import app.aaps.core.interfaces.db.PersistenceLayer
+import app.aaps.core.interfaces.db.observeChanges
 import app.aaps.core.interfaces.rx.AapsSchedulers
 import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventAutosensCalculationFinished
@@ -24,9 +27,7 @@ import app.aaps.core.interfaces.rx.events.EventWearUpdateTiles
 import app.aaps.core.interfaces.rx.weardata.CwfData
 import app.aaps.core.interfaces.rx.weardata.CwfMetadataKey
 import app.aaps.core.interfaces.rx.weardata.EventData
-import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
-import app.aaps.core.interfaces.versionChecker.VersionCheckerUtils
 import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.DoubleKey
 import app.aaps.core.keys.IntKey
@@ -43,11 +44,13 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -68,9 +71,8 @@ class WearPlugin @Inject constructor(
     private val dataHandlerMobile: DataHandlerMobile,
     private val dataLayerListenerServiceMobileHelper: DataLayerListenerServiceMobileHelper,
     private val config: Config,
-    private val dateUtil: DateUtil,
-    private val versionCheckerUtils: VersionCheckerUtils,
     private val bolusProgressData: BolusProgressData,
+    private val persistenceLayer: PersistenceLayer,
 ) : PluginBaseWithPreferences(
     pluginDescription = PluginDescription()
         .mainType(PluginType.SYNC)
@@ -102,6 +104,7 @@ class WearPlugin @Inject constructor(
         _savedCustomWatchface.value = cwfData
     }
 
+    @OptIn(FlowPreview::class)
     override fun onStart() {
         super.onStart()
         val newScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -149,6 +152,12 @@ class WearPlugin @Inject constructor(
             .toObservable(EventLoopUpdateGui::class.java)
             .observeOn(aapsSchedulers.io)
             .subscribe({ dataHandlerMobile.resendData("EventLoopUpdateGui") }, fabricPrivacy::logException)
+        // Push status to watch quickly when a TT changes, without waiting for the loop's 10s debounce
+        persistenceLayer.observeChanges<TT>()
+            .drop(1) // Skip initial emission on collection start
+            .debounce(2_000L)
+            .onEach { dataHandlerMobile.resendData("TempTargetChange") }
+            .launchIn(newScope)
         disposable += rxBus
             .toObservable(EventWearUpdateTiles::class.java)
             .observeOn(aapsSchedulers.io)

--- a/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/wear/WearPluginTest.kt
+++ b/plugins/sync/src/test/kotlin/app/aaps/plugins/sync/wear/WearPluginTest.kt
@@ -1,7 +1,7 @@
 package app.aaps.plugins.sync.wear
 
+import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.pump.BolusProgressData
-import app.aaps.core.interfaces.versionChecker.VersionCheckerUtils
 import app.aaps.plugins.sync.tidepool.utils.RateLimit
 import app.aaps.plugins.sync.wear.wearintegration.DataHandlerMobile
 import app.aaps.plugins.sync.wear.wearintegration.DataLayerListenerServiceMobileHelper
@@ -13,13 +13,13 @@ class WearPluginTest : TestBaseWithProfile() {
 
     @Mock lateinit var dataHandlerMobile: DataHandlerMobile
     @Mock lateinit var dataLayerListenerServiceMobileHelper: DataLayerListenerServiceMobileHelper
-    @Mock lateinit var versionCheckerUtils: VersionCheckerUtils
+    @Mock lateinit var persistenceLayer: PersistenceLayer
 
     private lateinit var wearPlugin: WearPlugin
     private lateinit var rateLimit: RateLimit
 
     @BeforeEach fun prepare() {
         rateLimit = RateLimit(dateUtil)
-        wearPlugin = WearPlugin(aapsLogger, rh, aapsSchedulers, preferences, fabricPrivacy, rxBus, context, dataHandlerMobile, dataLayerListenerServiceMobileHelper, config, dateUtil, versionCheckerUtils, BolusProgressData())
+        wearPlugin = WearPlugin(aapsLogger, rh, aapsSchedulers, preferences, fabricPrivacy, rxBus, context, dataHandlerMobile, dataLayerListenerServiceMobileHelper, config, BolusProgressData(), persistenceLayer)
     }
 }


### PR DESCRIPTION
Noticed an issue with slow updating of TT/target on wear watchface/complications during work on #4720 and #4717. This is my proposal to improve this.

When a temp target is set on the phone, complications now update within ~2 seconds instead of 10-20 seconds (some times even longer).                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                             Root cause: 
LoopPlugin has a 10s debounce on TT DB changes before invoking the loop, after which EventAutosensCalculationFinished triggers the watch update. WearPlugin now observes TT DB changes directly and calls resendData() after a 2s debounce (to absorb the cancel+insert pair from setting a new TT).                           
                                                                                                                                                                                                                                                                                                                                             
  - Added PersistenceLayer injection to WearPlugin          
  - Removed unused dateUtil and versionCheckerUtils constructor params
  - Updated WearPluginTest accordingly