### PR TITLE
Fix missing translation of "/h" in TempBasalDialogScreen

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/compose/tempBasalDialog/TempBasalDialogScreen.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/tempBasalDialog/TempBasalDialogScreen.kt
@@ -169,7 +169,7 @@ private fun TempBasalDialogContent(
                 if (uiState.isPercentPump && uiState.basalPercent != 100.0) {
                     Text("${DecimalFormat("0").format(uiState.basalPercent)}%")
                 } else if (!uiState.isPercentPump && uiState.basalAbsolute > 0.0) {
-                    Text("${DecimalFormat("0.00").format(uiState.basalAbsolute)} ${stringResource(CoreUiR.string.insulin_unit_shortname)}/h")
+                    Text("${DecimalFormat("0.00").format(uiState.basalAbsolute)} ${stringResource(CoreUiR.string.profile_ins_units_per_hour)}")
                 } else {
                     Text(stringResource(CoreUiR.string.ok))
                 }
@@ -216,7 +216,7 @@ private fun TempBasalDialogContent(
                             valueRange = 0.0..uiState.maxTempAbsolute,
                             step = uiState.tempAbsoluteStep,
                             valueFormat = DecimalFormat("0.00"),
-                            unitLabel = stringResource(CoreUiR.string.insulin_unit_shortname) + "/h",
+                            unitLabel = stringResource(CoreUiR.string.profile_ins_units_per_hour),
                             modifier = itemModifier
                         )
                     }


### PR DESCRIPTION
<img width="432" height="911" alt="image" src="https://github.com/user-attachments/assets/db7bd50e-a763-42dd-8f9f-43d909682cf3" />
<img width="1080" height="348" alt="image" src="https://github.com/user-attachments/assets/37e9f0a8-ef5e-43ff-8ed7-d0b8717e2366" />
