### PR TITLE
Add BgGraphActivity — full-screen BG history graph for Wear OS

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -645,6 +645,10 @@
             android:exported="false"
             android:theme="@style/WearAppCompatDark" />
         <activity
+            android:name=".interaction.activities.BgGraphActivity"
+            android:exported="false"
+            android:theme="@style/WearAppCompatDark" />
+        <activity
             android:name=".interaction.menus.PreferenceMenuActivity"
             android:exported="true"
             android:label="@string/menu_settings"

--- a/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationAction.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationAction.kt
@@ -52,6 +52,12 @@ enum class ComplicationAction {
     TEMP_TARGET,
 
     /**
+     * Opens the BG graph activity.
+     * Shows 3h (default) BG history with predictions; tap cycles the window up to 8h.
+     */
+    BG_GRAPH,
+
+    /**
      * Opens warning dialog about watch-phone sync issues.
      * Displayed when data hasn't updated from phone recently.
      */

--- a/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationTapActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationTapActivity.kt
@@ -17,6 +17,7 @@ import app.aaps.wear.interaction.actions.ECarbActivity
 import app.aaps.wear.interaction.actions.TempTargetActivity
 import app.aaps.wear.interaction.actions.TreatmentActivity
 import app.aaps.wear.interaction.actions.WizardActivity
+import app.aaps.wear.interaction.activities.BgGraphActivity
 import app.aaps.wear.interaction.menus.MainMenuActivity
 import app.aaps.wear.interaction.menus.StatusMenuActivity
 import app.aaps.wear.interaction.utils.Constants
@@ -148,6 +149,7 @@ class ComplicationTapActivity : DaggerAppCompatActivity() {
             ComplicationAction.BOLUS -> intentOpen = Intent(this, TreatmentActivity::class.java)
             ComplicationAction.E_CARB -> intentOpen = Intent(this, ECarbActivity::class.java)
             ComplicationAction.TEMP_TARGET -> intentOpen = Intent(this, TempTargetActivity::class.java)
+            ComplicationAction.BG_GRAPH -> intentOpen = Intent(this, BgGraphActivity::class.java)
             ComplicationAction.STATUS -> intentOpen = Intent(this, StatusMenuActivity::class.java)
 
             ComplicationAction.WARNING_OLD, ComplicationAction.WARNING_SYNC -> {
@@ -181,6 +183,7 @@ class ComplicationTapActivity : DaggerAppCompatActivity() {
                 "bolus" -> ComplicationAction.BOLUS
                 "ecarb" -> ComplicationAction.E_CARB
                 "status" -> ComplicationAction.STATUS
+                "bg_graph" -> ComplicationAction.BG_GRAPH
                 "none" -> ComplicationAction.NONE
                 "default" -> originalAction
                 else -> originalAction

--- a/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
@@ -105,5 +105,7 @@ class SgvComplication : ModernBaseComplicationProviderService() {
             .build()
     }
 
+    override fun getComplicationAction(): ComplicationAction = ComplicationAction.BG_GRAPH
+
     override fun getProviderCanonicalName(): String = SgvComplication::class.java.canonicalName!!
 }

--- a/wear/src/main/kotlin/app/aaps/wear/di/WearActivitiesModule.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/di/WearActivitiesModule.kt
@@ -17,6 +17,7 @@ import app.aaps.wear.interaction.actions.TempTargetActivity
 import app.aaps.wear.interaction.actions.TreatmentActivity
 import app.aaps.wear.interaction.actions.WizardActivity
 import app.aaps.wear.interaction.actions.WizardResultActivity
+import app.aaps.wear.interaction.activities.BgGraphActivity
 import app.aaps.wear.interaction.activities.LoopStatusActivity
 import app.aaps.wear.interaction.menus.FillMenuActivity
 import app.aaps.wear.interaction.menus.MainMenuActivity
@@ -54,4 +55,5 @@ abstract class WearActivitiesModule {
     @ContributesAndroidInjector abstract fun contributesQuickSnoozeActivity(): QuickSnoozeActivity
     @ContributesAndroidInjector abstract fun contributesRunningModeTimedActivity(): RunningModeTimedActivity
     @ContributesAndroidInjector abstract fun contributesLoopStatusActivity(): LoopStatusActivity
+    @ContributesAndroidInjector abstract fun contributesBgGraphActivity(): BgGraphActivity
 }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
@@ -55,6 +56,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.abs
 
 // Colors matching CustomWatchFace defaults
 private val BgInRangeColor = Color(0xFF00FF00)
@@ -376,5 +378,63 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
             radius = predRadius,
             center = Offset(timeToX(pred.timeStamp), sgvToY(pred.sgv.toFloat()))
         )
+    }
+
+    val boluses = data.treatmentData.boluses
+    val triSize   = dotRadius * 1.4f   // base half-width for bolus/carb triangles
+    val triHeight = dotRadius * 2.4f   // height for bolus/carb triangles
+    val smbTriSize = dotRadius * 1.2f  // smaller for SMB
+
+    val bottom = pad + graphH
+
+    // Pass 1: carb triangles (upward, orange) — drawn first so bolus covers them
+    for (treatment in boluses) {
+        if (!treatment.isValid || treatment.isSMB) continue
+        if (treatment.carbs <= 0 || treatment.date !in startTime..endTime) continue
+        val x = timeToX(treatment.date)
+        drawPath(
+            Path().apply {
+                moveTo(x, bottom - triHeight)
+                lineTo(x - triSize, bottom)
+                lineTo(x + triSize, bottom)
+                close()
+            },
+            CarbsColor
+        )
+    }
+
+    // Pass 2: bolus triangles (downward, blue) — drawn on top of carbs
+    for (treatment in boluses) {
+        if (!treatment.isValid) continue
+        if (treatment.bolus <= 0 || treatment.date !in startTime..endTime) continue
+        val x = timeToX(treatment.date)
+        if (treatment.isSMB) {
+            // Small downward triangle above the nearest BG entry
+            val nearestEntry = entries.filter { it.sgv > 0 }
+                .minByOrNull { abs(it.timeStamp - treatment.date) }
+            if (nearestEntry != null && abs(nearestEntry.timeStamp - treatment.date) < 10 * 60_000L) {
+                val bgY = sgvToY(nearestEntry.sgv.toFloat())
+                val tipY = bgY - dotRadius * 1.5f
+                drawPath(
+                    Path().apply {
+                        moveTo(x, tipY)
+                        lineTo(x - smbTriSize, tipY - smbTriSize * 1.8f)
+                        lineTo(x + smbTriSize, tipY - smbTriSize * 1.8f)
+                        close()
+                    },
+                    IobColor.copy(alpha = 0.85f)
+                )
+            }
+        } else {
+            drawPath(
+                Path().apply {
+                    moveTo(x, bottom)
+                    lineTo(x - triSize, bottom - triHeight)
+                    lineTo(x + triSize, bottom - triHeight)
+                    close()
+                },
+                IobColor
+            )
+        }
     }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -1,5 +1,6 @@
 package app.aaps.wear.interaction.activities
 
+import android.content.Intent
 import android.graphics.Paint
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -7,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,9 +32,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.foundation.AnchorType
@@ -44,6 +47,8 @@ import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.wear.R
 import app.aaps.wear.data.ComplicationData
 import app.aaps.wear.data.ComplicationDataRepository
+import app.aaps.wear.interaction.menus.MainMenuActivity
+import app.aaps.wear.interaction.utils.DisplayFormat
 import dagger.android.AndroidInjection
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -57,15 +62,27 @@ private val BgHighColor    = Color(0xFFFFFF00)
 private val BgLowColor     = Color(0xFFFF0000)
 private val IobColor       = Color(0xFF1E88E5)
 private val CarbsColor     = Color(0xFFFF6D00)
-private val BasalColor     = Color(0xFF90CAF9)
-private val SecondaryText  = Color(0xFFAAAAAA)
+private val BasalColor      = Color(0xFF90CAF9)
+private val SecondaryText   = Color(0xFFAAAAAA)
+private val TempTargetColor = Color(0xFFFDD835)
 
-private val historyHoursCycle = listOf(3, 4, 5, 6, 7, 8)
+private val historyHoursCycle = listOf(3, 6, 9, 12, 24, 1)
 
 private fun bgColor(sgvLevel: Long): Color = when (sgvLevel.toInt()) {
     -1   -> BgLowColor
     1    -> BgHighColor
     else -> BgInRangeColor
+}
+
+private fun formatTtDuration(durationMs: Long): String {
+    val totalMinutes = (durationMs / 60_000).toInt().coerceAtLeast(0)
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return when {
+        hours > 0 && minutes > 0 -> "${hours}h ${minutes}'"
+        hours > 0                -> "${hours}h"
+        else                     -> "${minutes}'"
+    }
 }
 
 private fun ageColor(ageMs: Long): Color {
@@ -80,6 +97,7 @@ private fun ageColor(ageMs: Long): Color {
 class BgGraphActivity : AppCompatActivity() {
 
     @Inject lateinit var complicationDataRepository: ComplicationDataRepository
+    @Inject lateinit var displayFormat: DisplayFormat
     @Inject lateinit var aapsLogger: AAPSLogger
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -87,14 +105,17 @@ class BgGraphActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
-                BgGraphScreen(repository = complicationDataRepository)
+                BgGraphScreen(
+                    repository = complicationDataRepository,
+                    displayFormat = displayFormat
+                )
             }
         }
     }
 }
 
 @Composable
-private fun BgGraphScreen(repository: ComplicationDataRepository) {
+private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat: DisplayFormat) {
     val data by repository.complicationData.collectAsState(initial = ComplicationData())
     var windowIdx by remember { mutableIntStateOf(0) }
     val historyHours = historyHoursCycle[windowIdx]
@@ -124,61 +145,69 @@ private fun BgGraphScreen(repository: ComplicationDataRepository) {
                 .padding(horizontal = 4.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(20.dp))
+            val context = LocalContext.current
 
-            // BG value + trend + delta + age
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = "${bgData.sgvString}${bgData.slopeArrow}\uFE0E",
-                    fontSize = 32.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = bgColor(bgData.sgvLevel)
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Column(horizontalAlignment = Alignment.Start) {
-                    Text(
-                        text = bgData.delta,
-                        fontSize = 12.sp,
-                        color = SecondaryText
-                    )
-                    Text(
-                        text = "${ageMin}m",
-                        fontSize = 12.sp,
-                        color = ageColor(ageMs)
-                    )
-                }
-            }
-
-            // IOB / COB / Basal above graph so they aren't clipped by circular bezel
-            val insulinUnit = stringResource(R.string.insulin_unit_short)
-            Row(
+            // Top area: BG + stats — double-tap opens main menu
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 2.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
+                    .pointerInput(Unit) {
+                        detectTapGestures(onDoubleTap = {
+                            context.startActivity(
+                                Intent(context, MainMenuActivity::class.java).apply {
+                                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                                }
+                            )
+                        })
+                    },
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = "IOB ${statusData.iobSum}$insulinUnit",
-                    fontSize = 11.sp,
-                    color = IobColor,
-                    textAlign = TextAlign.Center
-                )
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = "COB ${statusData.cob}",
-                    fontSize = 11.sp,
-                    color = CarbsColor,
-                    textAlign = TextAlign.Center
-                )
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = statusData.currentBasal,
-                    fontSize = 11.sp,
-                    color = BasalColor,
-                    textAlign = TextAlign.Center
-                )
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // BG value + trend + delta + age
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "${bgData.sgvString}${bgData.slopeArrow}\uFE0E",
+                        fontSize = 32.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = bgColor(bgData.sgvLevel)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Column(horizontalAlignment = Alignment.Start) {
+                        Text(
+                            text = bgData.delta,
+                            fontSize = 12.sp,
+                            color = SecondaryText
+                        )
+                        Text(
+                            text = "${ageMin}m",
+                            fontSize = 12.sp,
+                            color = ageColor(ageMs)
+                        )
+                    }
+                }
+
+                // IOB / COB / Basal / Target
+                val hasTT = statusData.tempTargetDuration >= 0
+                val targetText = if (hasTT) {
+                    "${statusData.tempTarget} (${formatTtDuration(statusData.tempTargetDuration)})"
+                } else {
+                    statusData.tempTarget
+                }
+                val insulinUnit = stringResource(R.string.insulin_unit_short)
+                val basalText = displayFormat.basalRateSymbol().trimEnd() + statusData.currentBasal.replaceFirst(" ", "")
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 2.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = "${statusData.iobSum}$insulinUnit", fontSize = 11.sp, color = IobColor)
+                    Text(text = statusData.cob, fontSize = 11.sp, color = CarbsColor)
+                    Text(text = basalText, fontSize = 11.sp, color = BasalColor)
+                    Text(text = targetText, fontSize = 11.sp, color = if (hasTT) TempTargetColor else SecondaryText)
+                }
             }
 
             // Graph — tap cycles history window

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -45,7 +45,6 @@ import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.curvedText
-import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.wear.R
 import app.aaps.wear.data.ComplicationData
 import app.aaps.wear.data.ComplicationDataRepository
@@ -101,7 +100,6 @@ class BgGraphActivity : AppCompatActivity() {
 
     @Inject lateinit var complicationDataRepository: ComplicationDataRepository
     @Inject lateinit var displayFormat: DisplayFormat
-    @Inject lateinit var aapsLogger: AAPSLogger
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -326,7 +324,6 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
             isAntiAlias = true
         }
         for (hourMs in hourMarks) {
-            val hour = Calendar.getInstance().apply { timeInMillis = hourMs }.get(Calendar.HOUR_OF_DAY)
             canvas.nativeCanvas.drawText(
                 hourFormat.format(Date(hourMs)),
                 timeToX(hourMs),

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.wear.compose.foundation.AnchorType
 import androidx.wear.compose.foundation.CurvedLayout
+import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.curvedText
@@ -130,11 +131,18 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
     val hourUnit = stringResource(R.string.hour_short)
     val minUnit = stringResource(R.string.minute_short)
 
+    val isLoading = bgData.timeStamp == 0L
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.Black)
     ) {
+        if (isLoading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            return@Box
+        }
+
         CurvedLayout(anchor = 270f, anchorType = AnchorType.Center) {
             curvedText(
                 text = "${historyHours}$hourUnit",

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -295,8 +295,8 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     )
 
     // Text labels: hour numbers at bottom, current time at top of "now" line
-    val nowLabel = SimpleDateFormat("H:mm", Locale.getDefault()).format(Date(now))
-    val hourFormat = SimpleDateFormat("H", Locale.getDefault())
+    val nowLabel = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(now))
+    val hourFormat = SimpleDateFormat("HH", Locale.getDefault())
     drawIntoCanvas { canvas ->
         val hourPaint = Paint().apply {
             color = android.graphics.Color.argb(140, 170, 170, 170)

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -251,11 +251,14 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     val predictions = data.treatmentData.predictions
 
     // Dynamic Y range: top adapts to data, bottom fixed at 40
-    val visibleSgvValues = buildList {
-        entries.forEach { if (it.timeStamp in startTime..now) add(it.sgv.toFloat()) }
-        predictions.forEach { if (it.timeStamp in (now + 1)..endTime) add(it.sgv.toFloat()) }
-    }.filter { it > 0 }
-    val dataMax = visibleSgvValues.maxOrNull() ?: 200f
+    // Predictions are capped at actualMax + 50 mg/dL to avoid compressing the BG history
+    val actualMax = entries
+        .filter { it.timeStamp in startTime..now && it.sgv > 0 }
+        .maxOfOrNull { it.sgv.toFloat() } ?: 200f
+    val predMax = predictions
+        .filter { it.timeStamp in (now + 1)..endTime && it.sgv > 0 }
+        .maxOfOrNull { it.sgv.toFloat() } ?: 0f
+    val dataMax = predMax.coerceAtMost(actualMax + 50f).coerceAtLeast(actualMax)
     val yMin = 40f
     val yMax = maxOf(dataMax, bgData.high.toFloat()) + 30f
     val ySpan = yMax - yMin
@@ -347,11 +350,11 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
         )
     }
 
-    val dotRadius = w * 0.016f
+    val dotRadius = w * 0.013f
 
     // BG history dots
     for (entry in entries) {
-        if (entry.timeStamp < startTime || entry.timeStamp > now) continue
+        if (entry.timeStamp !in startTime..now) continue
         drawCircle(
             color = bgColor(entry.sgvLevel),
             radius = dotRadius,
@@ -360,9 +363,9 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     }
 
     // Prediction dots (slightly smaller)
-    val predRadius = dotRadius * 0.8f
+    val predRadius = dotRadius * 0.6f
     for (pred in predictions) {
-        if (pred.timeStamp <= now || pred.timeStamp > endTime) continue
+        if (pred.timeStamp !in (now + 1)..endTime) continue
         val color = if (pred.color != 0) {
             Color(pred.color).copy(alpha = 0.7f)
         } else {

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -197,7 +197,7 @@ private fun BgGraphScreen(repository: ComplicationDataRepository) {
 private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     val now = System.currentTimeMillis()
     val historyMs = historyHours * 60 * 60 * 1000L
-    val predictionMs = 30 * 60 * 1000L
+    val predictionMs = 90 * 60 * 1000L
     val startTime = now - historyMs
     val endTime = now + predictionMs
     val timeSpan = (endTime - startTime).toFloat()
@@ -208,18 +208,25 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     val drawW = w - 2 * pad
     val drawH = h - 2 * pad
 
+    val bgData      = data.bgData
+    val entries     = data.graphData.entries
+    val predictions = data.treatmentData.predictions
+
+    // Dynamic Y range: top adapts to data, bottom fixed at 40
+    val visibleSgvValues = buildList {
+        entries.forEach { if (it.timeStamp in startTime..now) add(it.sgv.toFloat()) }
+        predictions.forEach { if (it.timeStamp in (now + 1)..endTime) add(it.sgv.toFloat()) }
+    }.filter { it > 0 }
+    val dataMax = visibleSgvValues.maxOrNull() ?: 200f
     val yMin = 40f
-    val yMax = 360f
+    val yMax = maxOf(dataMax, bgData.high.toFloat()) + 30f
     val ySpan = yMax - yMin
 
     fun timeToX(t: Long) = pad + drawW * ((t - startTime).toFloat() / timeSpan)
     fun sgvToY(sgv: Float) = pad + drawH * (1f - (sgv.coerceIn(yMin, yMax) - yMin) / ySpan)
 
-    val bgData      = data.bgData
-    val entries     = data.graphData.entries
-    val predictions = data.treatmentData.predictions
-
-    // Hour grid lines (subtle)
+    // Collect hour marks for grid lines and labels
+    val hourMarks = mutableListOf<Long>()
     val cal = Calendar.getInstance().apply {
         timeInMillis = startTime
         set(Calendar.MINUTE, 0)
@@ -228,17 +235,21 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
         add(Calendar.HOUR_OF_DAY, 1)
     }
     while (cal.timeInMillis <= endTime) {
-        val x = timeToX(cal.timeInMillis)
-        drawLine(
-            color = Color.White.copy(alpha = 0.12f),
-            start = Offset(x, pad),
-            end = Offset(x, pad + drawH),
-            strokeWidth = 0.5.dp.toPx()
-        )
+        hourMarks.add(cal.timeInMillis)
         cal.add(Calendar.HOUR_OF_DAY, 1)
     }
 
-    // "Now" line with current time label
+    // Hour grid lines
+    for (hourMs in hourMarks) {
+        drawLine(
+            color = Color.White.copy(alpha = 0.12f),
+            start = Offset(timeToX(hourMs), pad),
+            end = Offset(timeToX(hourMs), pad + drawH),
+            strokeWidth = 0.5.dp.toPx()
+        )
+    }
+
+    // "Now" line
     val nowX = timeToX(now)
     drawLine(
         color = Color.White.copy(alpha = 0.35f),
@@ -246,15 +257,32 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
         end = Offset(nowX, pad + drawH),
         strokeWidth = 1.dp.toPx()
     )
+
+    // Text labels: hour numbers at bottom, current time at top of "now" line
     val nowLabel = SimpleDateFormat("H:mm", Locale.getDefault()).format(Date(now))
+    val hourFormat = SimpleDateFormat("H", Locale.getDefault())
     drawIntoCanvas { canvas ->
-        val textPaint = Paint().apply {
+        val hourPaint = Paint().apply {
+            color = android.graphics.Color.argb(140, 170, 170, 170)
+            textSize = 8.dp.toPx()
+            textAlign = Paint.Align.CENTER
+            isAntiAlias = true
+        }
+        val nowPaint = Paint().apply {
             color = android.graphics.Color.argb(178, 255, 255, 255)
             textSize = 8.dp.toPx()
             textAlign = Paint.Align.CENTER
             isAntiAlias = true
         }
-        canvas.nativeCanvas.drawText(nowLabel, nowX, pad + textPaint.textSize + 2f, textPaint)
+        for (hourMs in hourMarks) {
+            canvas.nativeCanvas.drawText(
+                hourFormat.format(Date(hourMs)),
+                timeToX(hourMs),
+                pad + drawH - 4f,
+                hourPaint
+            )
+        }
+        canvas.nativeCanvas.drawText(nowLabel, nowX, pad + nowPaint.textSize + 2f, nowPaint)
     }
 
     // High/low threshold lines

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -1,0 +1,308 @@
+package app.aaps.wear.interaction.activities
+
+import android.graphics.Paint
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.foundation.AnchorType
+import androidx.wear.compose.foundation.CurvedLayout
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.curvedText
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.wear.R
+import app.aaps.wear.data.ComplicationData
+import app.aaps.wear.data.ComplicationDataRepository
+import dagger.android.AndroidInjection
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+// Colors matching CustomWatchFace defaults
+private val BgInRangeColor = Color(0xFF00FF00)
+private val BgHighColor    = Color(0xFFFFFF00)
+private val BgLowColor     = Color(0xFFFF0000)
+private val IobColor       = Color(0xFF1E88E5)
+private val CarbsColor     = Color(0xFFFF6D00)
+private val BasalColor     = Color(0xFF90CAF9)
+private val SecondaryText  = Color(0xFFAAAAAA)
+
+private val historyHoursCycle = listOf(3, 4, 5, 6, 7, 8)
+
+private fun bgColor(sgvLevel: Long): Color = when (sgvLevel.toInt()) {
+    -1   -> BgLowColor
+    1    -> BgHighColor
+    else -> BgInRangeColor
+}
+
+private fun ageColor(ageMs: Long): Color {
+    val minutes = ageMs / 60_000
+    return when {
+        minutes < 4  -> BgInRangeColor
+        minutes < 10 -> Color(0xFFFF9800)
+        else         -> BgLowColor
+    }
+}
+
+class BgGraphActivity : AppCompatActivity() {
+
+    @Inject lateinit var complicationDataRepository: ComplicationDataRepository
+    @Inject lateinit var aapsLogger: AAPSLogger
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                BgGraphScreen(repository = complicationDataRepository)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BgGraphScreen(repository: ComplicationDataRepository) {
+    val data by repository.complicationData.collectAsState(initial = ComplicationData())
+    var windowIdx by remember { mutableIntStateOf(0) }
+    val historyHours = historyHoursCycle[windowIdx]
+
+    val bgData = data.bgData
+    val statusData = data.statusData
+    val now = System.currentTimeMillis()
+    val ageMs = now - bgData.timeStamp
+    val ageMin = ageMs / 60_000
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        CurvedLayout(anchor = 270f, anchorType = AnchorType.Center) {
+            curvedText(
+                text = "${historyHours}h",
+                color = SecondaryText,
+                fontSize = 11.sp
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // BG value + trend + delta + age
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "${bgData.sgvString}${bgData.slopeArrow}\uFE0E",
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = bgColor(bgData.sgvLevel)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Column(horizontalAlignment = Alignment.Start) {
+                    Text(
+                        text = bgData.delta,
+                        fontSize = 12.sp,
+                        color = SecondaryText
+                    )
+                    Text(
+                        text = "${ageMin}m",
+                        fontSize = 12.sp,
+                        color = ageColor(ageMs)
+                    )
+                }
+            }
+
+            // IOB / COB / Basal above graph so they aren't clipped by circular bezel
+            val insulinUnit = stringResource(R.string.insulin_unit_short)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 2.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = "IOB ${statusData.iobSum}$insulinUnit",
+                    fontSize = 11.sp,
+                    color = IobColor,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = "COB ${statusData.cob}",
+                    fontSize = 11.sp,
+                    color = CarbsColor,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = statusData.currentBasal,
+                    fontSize = 11.sp,
+                    color = BasalColor,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            // Graph — tap cycles history window
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .clickable { windowIdx = (windowIdx + 1) % historyHoursCycle.size }
+            ) {
+                renderBgGraph(data, historyHours)
+            }
+        }
+    }
+}
+
+private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
+    val now = System.currentTimeMillis()
+    val historyMs = historyHours * 60 * 60 * 1000L
+    val predictionMs = 30 * 60 * 1000L
+    val startTime = now - historyMs
+    val endTime = now + predictionMs
+    val timeSpan = (endTime - startTime).toFloat()
+
+    val w = size.width
+    val h = size.height
+    val pad = w * 0.03f
+    val drawW = w - 2 * pad
+    val drawH = h - 2 * pad
+
+    val yMin = 40f
+    val yMax = 360f
+    val ySpan = yMax - yMin
+
+    fun timeToX(t: Long) = pad + drawW * ((t - startTime).toFloat() / timeSpan)
+    fun sgvToY(sgv: Float) = pad + drawH * (1f - (sgv.coerceIn(yMin, yMax) - yMin) / ySpan)
+
+    val bgData      = data.bgData
+    val entries     = data.graphData.entries
+    val predictions = data.treatmentData.predictions
+
+    // Hour grid lines (subtle)
+    val cal = Calendar.getInstance().apply {
+        timeInMillis = startTime
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+        add(Calendar.HOUR_OF_DAY, 1)
+    }
+    while (cal.timeInMillis <= endTime) {
+        val x = timeToX(cal.timeInMillis)
+        drawLine(
+            color = Color.White.copy(alpha = 0.12f),
+            start = Offset(x, pad),
+            end = Offset(x, pad + drawH),
+            strokeWidth = 0.5.dp.toPx()
+        )
+        cal.add(Calendar.HOUR_OF_DAY, 1)
+    }
+
+    // "Now" line with current time label
+    val nowX = timeToX(now)
+    drawLine(
+        color = Color.White.copy(alpha = 0.35f),
+        start = Offset(nowX, pad),
+        end = Offset(nowX, pad + drawH),
+        strokeWidth = 1.dp.toPx()
+    )
+    val nowLabel = SimpleDateFormat("H:mm", Locale.getDefault()).format(Date(now))
+    drawIntoCanvas { canvas ->
+        val textPaint = Paint().apply {
+            color = android.graphics.Color.argb(178, 255, 255, 255)
+            textSize = 8.dp.toPx()
+            textAlign = Paint.Align.CENTER
+            isAntiAlias = true
+        }
+        canvas.nativeCanvas.drawText(nowLabel, nowX, pad + textPaint.textSize + 2f, textPaint)
+    }
+
+    // High/low threshold lines
+    val high = bgData.high.toFloat()
+    if (high in yMin..yMax) {
+        drawLine(
+            color = BgHighColor.copy(alpha = 0.35f),
+            start = Offset(pad, sgvToY(high)),
+            end = Offset(pad + drawW, sgvToY(high)),
+            strokeWidth = 1.dp.toPx()
+        )
+    }
+
+    val low = bgData.low.toFloat()
+    if (low in yMin..yMax) {
+        drawLine(
+            color = BgLowColor.copy(alpha = 0.35f),
+            start = Offset(pad, sgvToY(low)),
+            end = Offset(pad + drawW, sgvToY(low)),
+            strokeWidth = 1.dp.toPx()
+        )
+    }
+
+    val dotRadius = w * 0.016f
+
+    // BG history dots
+    for (entry in entries) {
+        if (entry.timeStamp < startTime || entry.timeStamp > now) continue
+        drawCircle(
+            color = bgColor(entry.sgvLevel),
+            radius = dotRadius,
+            center = Offset(timeToX(entry.timeStamp), sgvToY(entry.sgv.toFloat()))
+        )
+    }
+
+    // Prediction dots (slightly smaller)
+    val predRadius = dotRadius * 0.8f
+    for (pred in predictions) {
+        if (pred.timeStamp <= now || pred.timeStamp > endTime) continue
+        val color = if (pred.color != 0) {
+            Color(pred.color).copy(alpha = 0.7f)
+        } else {
+            bgColor(pred.sgvLevel).copy(alpha = 0.6f)
+        }
+        drawCircle(
+            color = color,
+            radius = predRadius,
+            center = Offset(timeToX(pred.timeStamp), sgvToY(pred.sgv.toFloat()))
+        )
+    }
+}

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -69,7 +69,7 @@ private val BasalColor      = Color(0xFF90CAF9)
 private val SecondaryText   = Color(0xFFAAAAAA)
 private val TempTargetColor = Color(0xFFFDD835)
 
-private val historyHoursCycle = listOf(3, 6, 9, 12, 24, 1)
+private val historyHoursCycle = listOf(3, 6, 1)
 
 private fun bgColor(sgvLevel: Long): Color = when (sgvLevel.toInt()) {
     -1   -> BgLowColor
@@ -325,10 +325,8 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
             textAlign = Paint.Align.CENTER
             isAntiAlias = true
         }
-        val labelStep = if (historyHours >= 18) 2 else 1
         for (hourMs in hourMarks) {
             val hour = Calendar.getInstance().apply { timeInMillis = hourMs }.get(Calendar.HOUR_OF_DAY)
-            if (hour % labelStep != 0) continue
             canvas.nativeCanvas.drawText(
                 hourFormat.format(Date(hourMs)),
                 timeToX(hourMs),

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -198,6 +198,11 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                 }
                 val insulinUnit = stringResource(R.string.insulin_unit_short)
                 val basalText = displayFormat.basalRateSymbol().trimEnd() + statusData.currentBasal.replaceFirst(" ", "")
+                val combinedLen = "${statusData.iobSum}$insulinUnit".length +
+                    statusData.cob.length +
+                    basalText.length +
+                    targetText.length
+                val statsFontSize = if (combinedLen > 30) 11.sp else 12.sp
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -205,10 +210,10 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = "${statusData.iobSum}$insulinUnit", fontSize = 12.sp, color = IobColor)
-                    Text(text = statusData.cob, fontSize = 12.sp, color = CarbsColor)
-                    Text(text = basalText, fontSize = 12.sp, color = BasalColor)
-                    Text(text = targetText, fontSize = 12.sp, color = if (hasTT) TempTargetColor else SecondaryText)
+                    Text(text = "${statusData.iobSum}$insulinUnit", fontSize = statsFontSize, color = IobColor)
+                    Text(text = statusData.cob, fontSize = statsFontSize, color = CarbsColor)
+                    Text(text = basalText, fontSize = statsFontSize, color = BasalColor)
+                    Text(text = targetText, fontSize = statsFontSize, color = if (hasTT) TempTargetColor else SecondaryText)
                 }
             }
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -74,13 +74,13 @@ private fun bgColor(sgvLevel: Long): Color = when (sgvLevel.toInt()) {
     else -> BgInRangeColor
 }
 
-private fun formatTtDuration(durationMs: Long): String {
+private fun formatTtDuration(durationMs: Long, hourUnit: String): String {
     val totalMinutes = (durationMs / 60_000).toInt().coerceAtLeast(0)
     val hours = totalMinutes / 60
     val minutes = totalMinutes % 60
     return when {
-        hours > 0 && minutes > 0 -> "${hours}h ${minutes}'"
-        hours > 0                -> "${hours}h"
+        hours > 0 && minutes > 0 -> "${hours}$hourUnit ${minutes}'"
+        hours > 0                -> "${hours}$hourUnit"
         else                     -> "${minutes}'"
     }
 }
@@ -125,6 +125,8 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
     val now = System.currentTimeMillis()
     val ageMs = now - bgData.timeStamp
     val ageMin = ageMs / 60_000
+    val hourUnit = stringResource(R.string.hour_short)
+    val minUnit = stringResource(R.string.minute_short)
 
     Box(
         modifier = Modifier
@@ -133,7 +135,7 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
     ) {
         CurvedLayout(anchor = 270f, anchorType = AnchorType.Center) {
             curvedText(
-                text = "${historyHours}h",
+                text = "${historyHours}$hourUnit",
                 color = SecondaryText,
                 fontSize = 11.sp
             )
@@ -155,7 +157,7 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                         detectTapGestures(onDoubleTap = {
                             context.startActivity(
                                 Intent(context, MainMenuActivity::class.java).apply {
-                                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
                                 }
                             )
                         })
@@ -180,7 +182,7 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                             color = SecondaryText
                         )
                         Text(
-                            text = "${ageMin}m",
+                            text = "${ageMin}$minUnit",
                             fontSize = 12.sp,
                             color = ageColor(ageMs)
                         )
@@ -190,7 +192,7 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                 // IOB / COB / Basal / Target
                 val hasTT = statusData.tempTargetDuration >= 0
                 val targetText = if (hasTT) {
-                    "${statusData.tempTarget} (${formatTtDuration(statusData.tempTargetDuration)})"
+                    "${statusData.tempTarget} (${formatTtDuration(statusData.tempTargetDuration, hourUnit)})"
                 } else {
                     statusData.tempTarget
                 }
@@ -199,14 +201,14 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 2.dp),
+                        .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = "${statusData.iobSum}$insulinUnit", fontSize = 11.sp, color = IobColor)
-                    Text(text = statusData.cob, fontSize = 11.sp, color = CarbsColor)
-                    Text(text = basalText, fontSize = 11.sp, color = BasalColor)
-                    Text(text = targetText, fontSize = 11.sp, color = if (hasTT) TempTargetColor else SecondaryText)
+                    Text(text = "${statusData.iobSum}$insulinUnit", fontSize = 12.sp, color = IobColor)
+                    Text(text = statusData.cob, fontSize = 12.sp, color = CarbsColor)
+                    Text(text = basalText, fontSize = 12.sp, color = BasalColor)
+                    Text(text = targetText, fontSize = 12.sp, color = if (hasTT) TempTargetColor else SecondaryText)
                 }
             }
 
@@ -303,7 +305,10 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
             textAlign = Paint.Align.CENTER
             isAntiAlias = true
         }
+        val labelStep = if (historyHours >= 18) 2 else 1
         for (hourMs in hourMarks) {
+            val hour = Calendar.getInstance().apply { timeInMillis = hourMs }.get(Calendar.HOUR_OF_DAY)
+            if (hour % labelStep != 0) continue
             canvas.nativeCanvas.drawText(
                 hourFormat.format(Date(hourMs)),
                 timeToX(hourMs),

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -243,6 +243,8 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     val pad = w * 0.03f
     val drawW = w - 2 * pad
     val drawH = h - 2 * pad
+    val bottomReserve = 12.dp.toPx()
+    val graphH = drawH - bottomReserve
 
     val bgData      = data.bgData
     val entries     = data.graphData.entries
@@ -259,7 +261,7 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     val ySpan = yMax - yMin
 
     fun timeToX(t: Long) = pad + drawW * ((t - startTime).toFloat() / timeSpan)
-    fun sgvToY(sgv: Float) = pad + drawH * (1f - (sgv.coerceIn(yMin, yMax) - yMin) / ySpan)
+    fun sgvToY(sgv: Float) = pad + graphH * (1f - (sgv.coerceIn(yMin, yMax) - yMin) / ySpan)
 
     // Collect hour marks for grid lines and labels
     val hourMarks = mutableListOf<Long>()
@@ -280,7 +282,7 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
         drawLine(
             color = Color.White.copy(alpha = 0.12f),
             start = Offset(timeToX(hourMs), pad),
-            end = Offset(timeToX(hourMs), pad + drawH),
+            end = Offset(timeToX(hourMs), pad + graphH),
             strokeWidth = 0.5.dp.toPx()
         )
     }
@@ -290,7 +292,7 @@ private fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int) {
     drawLine(
         color = Color.White.copy(alpha = 0.35f),
         start = Offset(nowX, pad),
-        end = Offset(nowX, pad + drawH),
+        end = Offset(nowX, pad + graphH),
         strokeWidth = 1.dp.toPx()
     )
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
@@ -36,7 +36,7 @@ class MainMenuActivity : MenuListActivity() {
                 add(MenuItem(R.drawable.ic_sync, getString(R.string.menu_resync)))
             } else {
                 add(MenuItem(R.drawable.ic_loop_closed, getString(R.string.loop_status)))
-                add(MenuItem(R.drawable.ic_graph, getString(R.string.menu_bg_graph)))
+                add(MenuItem(R.drawable.ic_bg_graph, getString(R.string.menu_bg_graph)))
                 if (sp.getBoolean(R.string.key_show_wizard, true))
                     add(MenuItem(R.drawable.ic_calculator, getString(R.string.menu_wizard)))
                 add(MenuItem(R.drawable.ic_carbs_orange, getString(R.string.menu_ecarb)))

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
@@ -12,6 +12,7 @@ import app.aaps.wear.interaction.actions.ECarbActivity
 import app.aaps.wear.interaction.actions.TempTargetActivity
 import app.aaps.wear.interaction.actions.TreatmentActivity
 import app.aaps.wear.interaction.actions.WizardActivity
+import app.aaps.wear.interaction.activities.BgGraphActivity
 import app.aaps.wear.interaction.activities.LoopStatusActivity
 import app.aaps.wear.interaction.utils.MenuListActivity
 
@@ -35,6 +36,7 @@ class MainMenuActivity : MenuListActivity() {
                 add(MenuItem(R.drawable.ic_sync, getString(R.string.menu_resync)))
             } else {
                 add(MenuItem(R.drawable.ic_loop_closed, getString(R.string.loop_status)))
+                add(MenuItem(R.drawable.ic_graph, getString(R.string.menu_bg_graph)))
                 if (sp.getBoolean(R.string.key_show_wizard, true))
                     add(MenuItem(R.drawable.ic_calculator, getString(R.string.menu_wizard)))
                 add(MenuItem(R.drawable.ic_carbs_orange, getString(R.string.menu_ecarb)))
@@ -51,6 +53,7 @@ class MainMenuActivity : MenuListActivity() {
     override fun doAction(position: String) {
         when (position) {
             getString(R.string.loop_status)             -> startActivity(Intent(this, LoopStatusActivity::class.java))
+            getString(R.string.menu_bg_graph)           -> startActivity(Intent(this, BgGraphActivity::class.java))
             getString(R.string.menu_wizard)             -> startActivity(Intent(this, WizardActivity::class.java))
             getString(R.string.menu_ecarb)              -> startActivity(Intent(this, ECarbActivity::class.java))
             getString(R.string.menu_treatment)          -> startActivity(Intent(this, TreatmentActivity::class.java))

--- a/wear/src/main/res/drawable/ic_bg_graph.xml
+++ b/wear/src/main/res/drawable/ic_bg_graph.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+  <!-- High threshold line (yellow) -->
+  <path
+      android:fillColor="#00000000"
+      android:strokeColor="#60FFFF00"
+      android:strokeWidth="0.5"
+      android:pathData="M1,8 L23,8"/>
+
+  <!-- Low threshold line (red) -->
+  <path
+      android:fillColor="#00000000"
+      android:strokeColor="#60FF0000"
+      android:strokeWidth="0.5"
+      android:pathData="M1,18 L23,18"/>
+
+  <!-- Dots: in range (green) -->
+  <path android:fillColor="#FF00FF00" android:pathData="M2,15 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FF00FF00" android:pathData="M4,13 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FF00FF00" android:pathData="M6,10 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FF00FF00" android:pathData="M12,8 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FF00FF00" android:pathData="M14.5,12 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FF00FF00" android:pathData="M17,16 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+
+  <!-- Dots: high (yellow) -->
+  <path android:fillColor="#FFFFFF00" android:pathData="M8,6 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FFFFFF00" android:pathData="M10,5 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+
+  <!-- Dots: low (red) -->
+  <path android:fillColor="#FFFF0000" android:pathData="M19.5,19 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+  <path android:fillColor="#FFFF0000" android:pathData="M22,20 m-1,0 a1,1 0,1 1,2,0 a1,1 0,1 1,-2,0"/>
+
+</vector>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="week_short">w</string>
     <string name="day_short">d</string>
     <string name="hour_short">h</string>
+    <string name="minute_short">m</string>
     <string name="hour_minute">%1$s:%2$s</string>
     <string name="hour_minute_second">%1$s:%2$s:%3$s</string>
     <string name="old">old</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="menu_ecarb">eCarbs</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_status">Status</string>
+    <string name="menu_bg_graph">BG graph</string>
     <string name="menu_resync">Re-Sync</string>
     <string name="menu_prime_fill">Prime/Fill</string>
     <string name="menu_none">None</string>


### PR DESCRIPTION
  Adds a new Compose activity showing a BG graph, accessible by tapping the Blood Glucose complication or via the main menu.

  Features:
  - BG value, trend arrow, delta and reading age at top
  - IOB / COB / basal / target stats row (font auto-shrinks for long values)
  - Graph with CWF-matching colors, tapping cycles time window (3h → 6h → 1h)
  - Hour grid lines with time labels, "now" line, high/low threshold lines
  - BG history dots + prediction dots (capped to avoid compressing the Y axis)
  - Bolus and carb triangles at graph bottom; SMB triangles above their BG reading
  - Double-tap top area opens main menu
  - Curved label showing active time window

Screenshots:
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/5ef58cfa-6774-4fd5-bbdc-1ead944db546" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/bd110975-19a6-4562-8a6a-75f2162b544a" /> |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/5568adbb-aa72-45ec-84c2-840e9acd760f" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/5a77a5ac-9e5c-413a-b8ac-a301389a8aa7" /> | 
