### PR TITLE
Wear: Show autosens-adjusted target distinctly in LoopStatus and BgGraph

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusData.kt
@@ -10,6 +10,7 @@ data class LoopStatusData(
     val lastRun: Long?,
     val lastEnact: Long?,
     val tempTarget: TempTargetInfo?,
+    val autosensTarget: String? = null,
     val defaultRange: TargetRange,
     val oapsResult: OapsResultInfo?
 ) {

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -517,6 +517,18 @@ class DataHandlerMobile @Inject constructor(
             )
         }
 
+        // Build autosens-adjusted target (only when no TT active)
+        val autosensTarget = if (tempTarget == null && profile != null) {
+            val targetUsed =
+                if (config.APS) loop.lastRun?.constraintsProcessed?.targetBG ?: 0.0
+                else if (config.AAPSCLIENT) processedDeviceStatusData.getAPSResult()?.targetBG ?: 0.0
+                else 0.0
+            if (targetUsed != 0.0 && abs(profile.getTargetMgdl() - targetUsed) > 0.01) {
+                val units = if (profileUtil.units == GlucoseUnit.MGDL) "mg/dL" else "mmol/L"
+                "${profileUtil.fromMgdlToStringInUnits(targetUsed)} $units"
+            } else null
+        } else null
+
         // Build default range
         val defaultRange = if (profile != null) {
             val units = if (profileUtil.units == GlucoseUnit.MGDL) "mg/dL" else "mmol/L"
@@ -612,6 +624,7 @@ class DataHandlerMobile @Inject constructor(
             lastRun = lastRunTimestamp,
             lastEnact = lastEnactTimestamp,
             tempTarget = tempTargetInfo,
+            autosensTarget = autosensTarget,
             defaultRange = defaultRange,
             oapsResult = oapsResultInfo
         )

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphActivity.kt
@@ -66,7 +66,8 @@ private val IobColor       = Color(0xFF1E88E5)
 private val CarbsColor     = Color(0xFFFF6D00)
 private val BasalColor      = Color(0xFF90CAF9)
 private val SecondaryText   = Color(0xFFAAAAAA)
-private val TempTargetColor = Color(0xFFFDD835)
+private val TempTargetColor     = Color(0xFFFDD835)
+private val AutosensTargetColor = Color(0xFF77DD77)
 
 private val historyHoursCycle = listOf(3, 6, 1)
 
@@ -221,7 +222,11 @@ private fun BgGraphScreen(repository: ComplicationDataRepository, displayFormat:
                     Text(text = "${statusData.iobSum}$insulinUnit", fontSize = statsFontSize, color = IobColor)
                     Text(text = statusData.cob, fontSize = statsFontSize, color = CarbsColor)
                     Text(text = basalText, fontSize = statsFontSize, color = BasalColor)
-                    Text(text = targetText, fontSize = statsFontSize, color = if (hasTT) TempTargetColor else SecondaryText)
+                    Text(text = targetText, fontSize = statsFontSize, color = when (statusData.tempTargetLevel) {
+                        1    -> AutosensTargetColor
+                        2    -> TempTargetColor
+                        else -> SecondaryText
+                    })
                 }
             }
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
@@ -75,8 +75,10 @@ private val LoopSuperbolusColor   = Color(0xFFFFAE01)
 private val TempBasalColor        = Color(0xFFFF9800)
 private val IobColor              = Color(0xFF1E88E5)
 private val BolusColor            = Color(0xFF1EA3E5)
-private val TempTargetActiveColor = Color(0xFFF4D700)
-private val TempTargetBg          = Color(0x1AF4D700)
+private val TempTargetActiveColor  = Color(0xFFF4D700)
+private val TempTargetBg           = Color(0x1AF4D700)
+private val AutosensTargetColor    = Color(0xFF77DD77)
+private val AutosensTargetBg       = Color(0x1A77DD77)
 private val White70               = Color(0xB3FFFFFF)
 private val White20               = Color(0x33FFFFFF)
 private val CardBg                = Color(0xFF1A1A1A)
@@ -216,7 +218,7 @@ private fun LoopStatusContent(
             oapsResult = data.oapsResult,
             dateUtil = dateUtil
         )
-        TargetsCard(tempTarget = data.tempTarget, defaultRange = data.defaultRange, dateUtil = dateUtil)
+        TargetsCard(tempTarget = data.tempTarget, autosensTarget = data.autosensTarget, defaultRange = data.defaultRange, dateUtil = dateUtil)
         RefreshButton(onClick = onRefresh)
     }
 }
@@ -544,6 +546,7 @@ private fun OapsResultSection(
 @Composable
 private fun TargetsCard(
     tempTarget: TempTargetInfo?,
+    autosensTarget: String?,
     defaultRange: TargetRange,
     dateUtil: DateUtil
 ) {
@@ -594,16 +597,45 @@ private fun TargetsCard(
             Spacer(Modifier.height(6.dp))
         }
 
-        if (defaultRange.lowDisplay != defaultRange.highDisplay) {
+        if (autosensTarget != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(AutosensTargetBg)
+                    .padding(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.loop_status_adjusted_target),
+                        color = AutosensTargetColor,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = autosensTarget,
+                        color = AutosensTargetColor,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        } else {
+            if (defaultRange.lowDisplay != defaultRange.highDisplay) {
+                InfoRow(
+                    label = stringResource(R.string.loop_status_target_range),
+                    value = "${defaultRange.lowDisplay} - ${defaultRange.highDisplay} ${defaultRange.units}"
+                )
+                Spacer(Modifier.height(4.dp))
+            }
             InfoRow(
-                label = stringResource(R.string.loop_status_target_range),
-                value = "${defaultRange.lowDisplay} - ${defaultRange.highDisplay} ${defaultRange.units}"
+                label = stringResource(R.string.loop_status_target),
+                value = "${defaultRange.targetDisplay} ${defaultRange.units}"
             )
-            Spacer(Modifier.height(4.dp))
         }
-        InfoRow(
-            label = stringResource(R.string.loop_status_target),
-            value = "${defaultRange.targetDisplay} ${defaultRange.units}"
-        )
     }
 }

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -350,6 +350,7 @@
     <string name="loop_status_temp_target">Temp Target</string>
     <string name="loop_status_target_range">Range</string>
     <string name="loop_status_target">Target</string>
+    <string name="loop_status_adjusted_target">Adjusted target</string>
     <string name="loop_status">Loop status</string>
     <string name="loop_status_refresh">Refresh</string>
     <string name="confirm">Confirm</string>


### PR DESCRIPTION
When the algorithm adjusts the target (e.g. via autosens), the Loop Status and BG Graph now shows it distinctly in green rather than displaying the unchanged profile target for Loop Status or adjusted target with white color in BgGraph — matching the color already used in Custom Watchface or adjusted target in phone app.                                                                                                         
                                                                                                                                                                                                                                                                                                                                             
  - LoopStatusActivity: replaces the profile target row with a green "Adjusted target" box when the algorithm target differs from the profile target                                                                                                                                                                                         
  - BgGraphActivity: colors the target text by level — white (profile), green (autosens-adjusted), yellow (temp target)  
  
Screenshots:

| Before | After |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/d572a977-4d3e-43c1-982b-13417b16811a" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/0de82f10-a73b-4cba-9c84-8e76afd1fda1" /> | 
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/3b0b8e4b-70ae-4ffa-87ab-f37358de318b" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/9ddbd658-c704-4596-a735-1d9433669185" /> | 

mg/dL:
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/50012d79-c62b-4bd0-9c39-3333c84473ad" />

