### PR TITLE
Wear: Add Blood Glucose (large) complication

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -194,6 +194,24 @@
         </service>
 
         <service
+            android:name=".complications.SgvLargeComplication"
+            android:exported="true"
+            android:icon="@drawable/ic_sgv"
+            android:label="@string/complication_blood_glucose_large"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="SHORT_TEXT" />
+            <meta-data
+                android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+                android:value="300" />
+        </service>
+
+        <service
             android:name=".complications.SgvComplicationExt1"
             android:exported="true"
             android:icon="@drawable/ic_sgv"

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
@@ -46,6 +46,7 @@ import app.aaps.wear.complications.LongStatusFlippedComplication
 import app.aaps.wear.complications.SgvComplication
 import app.aaps.wear.complications.SgvComplicationExt1
 import app.aaps.wear.complications.SgvComplicationExt2
+import app.aaps.wear.complications.SgvLargeComplication
 import app.aaps.wear.complications.UploaderBatteryComplication
 import app.aaps.wear.data.ComplicationDataRepository
 import app.aaps.wear.interaction.WatchfaceConfigurationActivity
@@ -474,6 +475,7 @@ class DataHandlerWear @Inject constructor(
             SgvComplication::class.java,
             SgvComplicationExt1::class.java,
             SgvComplicationExt2::class.java,
+            SgvLargeComplication::class.java,
             // Long status complications (show detailed glucose + status info)
             LongStatusComplication::class.java,
             LongStatusFlippedComplication::class.java,

--- a/wear/src/main/kotlin/app/aaps/wear/complications/SgvLargeComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/SgvLargeComplication.kt
@@ -1,0 +1,73 @@
+package app.aaps.wear.complications
+
+import android.app.PendingIntent
+import androidx.wear.watchface.complications.data.ComplicationData
+import androidx.wear.watchface.complications.data.ComplicationType
+import androidx.wear.watchface.complications.data.CountUpTimeReference
+import androidx.wear.watchface.complications.data.PlainComplicationText
+import androidx.wear.watchface.complications.data.ShortTextComplicationData
+import androidx.wear.watchface.complications.data.TimeDifferenceComplicationText
+import androidx.wear.watchface.complications.data.TimeDifferenceStyle
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.rx.weardata.EventData
+import dagger.android.AndroidInjection
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+/**
+ * SGV Large Complication
+ *
+ * Shows BG value as large as possible with trend and auto-updating age.
+ * Display format: "6.8" (large) with "3m ↗" above
+ * - No delta — trend arrow conveys direction, age conveys freshness
+ * - Time auto-updates every minute (battery efficient)
+ */
+class SgvLargeComplication : ModernBaseComplicationProviderService() {
+
+    override fun onCreate() {
+        AndroidInjection.inject(this)
+        super.onCreate()
+    }
+
+    override fun buildComplicationData(
+        type: ComplicationType,
+        data: app.aaps.wear.data.ComplicationData,
+        complicationPendingIntent: PendingIntent
+    ): ComplicationData? {
+        val bgData = data.bgData
+        aapsLogger.debug(LTag.WEAR, "SgvLargeComplication building: sgv=${bgData.sgvString} arrow=${bgData.slopeArrow}")
+
+        return when (type) {
+            ComplicationType.SHORT_TEXT -> buildShortTextComplication(bgData, complicationPendingIntent)
+            else -> {
+                aapsLogger.warn(LTag.WEAR, "SgvLargeComplication unexpected type: $type")
+                null
+            }
+        }
+    }
+
+    private fun buildShortTextComplication(
+        bgData: EventData.SingleBg,
+        pendingIntent: PendingIntent
+    ): ShortTextComplicationData {
+        val titleText = TimeDifferenceComplicationText.Builder(
+            style = TimeDifferenceStyle.SHORT_SINGLE_UNIT,
+            countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp))
+        )
+            .setMinimumTimeUnit(TimeUnit.MINUTES)
+            .setText("^1 ${bgData.slopeArrow}\uFE0E")
+            .build()
+
+        return ShortTextComplicationData.Builder(
+            text = PlainComplicationText.Builder(text = bgData.sgvString).build(),
+            contentDescription = PlainComplicationText.Builder(text = "Glucose ${bgData.sgvString}").build()
+        )
+            .setTitle(titleText)
+            .setTapAction(pendingIntent)
+            .build()
+    }
+
+    override fun getComplicationAction(): ComplicationAction = ComplicationAction.BG_GRAPH
+
+    override fun getProviderCanonicalName(): String = SgvLargeComplication::class.java.canonicalName!!
+}

--- a/wear/src/main/kotlin/app/aaps/wear/di/WearServicesModule.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/di/WearServicesModule.kt
@@ -18,6 +18,7 @@ import app.aaps.wear.complications.LongStatusFlippedComplication
 import app.aaps.wear.complications.SgvComplication
 import app.aaps.wear.complications.SgvComplicationExt1
 import app.aaps.wear.complications.SgvComplicationExt2
+import app.aaps.wear.complications.SgvLargeComplication
 import app.aaps.wear.complications.UploaderBatteryComplication
 import app.aaps.wear.complications.WallpaperComplication
 import app.aaps.wear.heartrate.HeartRateListener
@@ -59,6 +60,7 @@ abstract class WearServicesModule {
     @ContributesAndroidInjector abstract fun contributesSgvComplication(): SgvComplication
     @ContributesAndroidInjector abstract fun contributesSgvComplicationExt1(): SgvComplicationExt1
     @ContributesAndroidInjector abstract fun contributesSgvComplicationExt2(): SgvComplicationExt2
+    @ContributesAndroidInjector abstract fun contributesSgvLargeComplication(): SgvLargeComplication
     @ContributesAndroidInjector abstract fun contributesUploaderBatteryComplication(): UploaderBatteryComplication
     @ContributesAndroidInjector abstract fun contributesWallpaperComplication(): WallpaperComplication
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -279,6 +279,7 @@
     <string name="complication_full_status">Full Status</string>
     <string name="complication_full_status_flipped">Full Status (flipped)</string>
     <string name="complication_blood_glucose">Blood Glucose</string>
+    <string name="complication_blood_glucose_large">Blood Glucose (large)</string>
     <string name="complication_blood_glucose_ext1">Blood Glucose Ext1</string>
     <string name="complication_blood_glucose_ext2">Blood Glucose Ext2</string>
     <string name="complication_br_cob_iob">BR, CoB &amp; IoB</string>


### PR DESCRIPTION
New complication showing the BG value as large as possible, for users who find the standard BG complication text too small. Some users have reported that certain languages also aren't able to display the delta correctly due to total text length.
Trades delta for more space, keeping trend arrow and auto-updating age in the title slot.                                                                                                                      
                                                                                                                                                                                                                                                                                                                                             
  - Text: BG value only — maximizes display size                                                                                                                                                                                                                                                                                             
  - Title: trend arrow + auto-updating age ("3m ↗") — no delta
  - Tap opens BG graph (same as standard BG complication)                                                                                                                                                                                                                                                                                    
  - Appears as "Blood Glucose (large)" in the complication picker    
  
Screenshots:
<img width="1045" height="263" alt="image" src="https://github.com/user-attachments/assets/be418f0c-b5a1-41a7-8698-10967cdd2911" />
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/b1c532b2-1c44-4786-87f5-b1eb6f0e3c20" />
