### PR TITLE
Wear: AAPSClient running mode parity + tile refresh on enter

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -1194,14 +1194,12 @@ class DataHandlerMobile @Inject constructor(
     private fun handleAvailableRunningModes() {
         if (!runBlocking { profileFunction.isProfileValid("WearDataHandler_LoopChangeState") }) return
 
-        val disconnectDurs = if (!config.AAPSCLIENT) {
-            val pumpDescription = activePlugin.activePump.pumpDescription
-            arrayListOf<Int>().apply {
-                if (pumpDescription.tempDurationStep15mAllowed) add(15)
-                if (pumpDescription.tempDurationStep30mAllowed) add(30)
-                for (i in listOf(1, 2, 3)) add(i * 60)
-            }
-        } else emptyList()
+        val pumpDescription = activePlugin.activePump.pumpDescription
+        val disconnectDurs = arrayListOf<Int>().apply {
+            if (pumpDescription.tempDurationStep15mAllowed) add(15)
+            if (pumpDescription.tempDurationStep30mAllowed) add(30)
+            for (i in listOf(1, 2, 3)) add(i * 60)
+        }
 
         fun mapMode(mode: RM.Mode): AvailableRunningMode? =
             when (mode) {
@@ -1210,9 +1208,7 @@ class DataHandlerMobile @Inject constructor(
                 RM.Mode.OPEN_LOOP         -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_OPEN)
                 RM.Mode.DISABLED_LOOP     -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_DISABLE)
                 RM.Mode.SUPER_BOLUS       -> null
-                RM.Mode.DISCONNECTED_PUMP -> if (config.AAPSCLIENT) null
-                else AvailableRunningMode(AvailableRunningMode.RunningMode.PUMP_DISCONNECT, disconnectDurs)
-
+                RM.Mode.DISCONNECTED_PUMP -> AvailableRunningMode(AvailableRunningMode.RunningMode.PUMP_DISCONNECT, disconnectDurs)
                 RM.Mode.SUSPENDED_BY_PUMP -> null
                 RM.Mode.SUSPENDED_BY_USER -> AvailableRunningMode(AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND, listOf(1, 2, 3, 10).map { it * 60 })
                 RM.Mode.SUSPENDED_BY_DST  -> null
@@ -1224,8 +1220,7 @@ class DataHandlerMobile @Inject constructor(
 
         val allStates = loop.allowedNextModes().mapNotNull { mapMode(it) }
         // LOOP_DISABLE is dropped when LOOP_USER_SUSPEND is present to fit within 4 tile slots.
-        // AAPSClient has no PUMP_DISCONNECT, so the slot is free and both can be shown.
-        val states = if (!config.AAPSCLIENT && allStates.any { it.state == AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND })
+        val states = if (allStates.any { it.state == AvailableRunningMode.RunningMode.LOOP_USER_SUSPEND })
             allStates.filter { it.state != AvailableRunningMode.RunningMode.LOOP_DISABLE }
         else allStates
         lastAuthorizedRunningModeChangeTS = System.currentTimeMillis()

--- a/wear/src/main/kotlin/app/aaps/wear/tile/RunningModeTileService.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/RunningModeTileService.kt
@@ -1,5 +1,9 @@
 package app.aaps.wear.tile
 
+import androidx.wear.tiles.EventBuilders.TileEnterEvent
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventWearToMobile
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.wear.tile.source.RunningModeSource
 import dagger.android.AndroidInjection
 import javax.inject.Inject
@@ -7,6 +11,7 @@ import javax.inject.Inject
 class RunningModeTileService : TileBase() {
 
     @Inject lateinit var runningModeSource: RunningModeSource
+    @Inject lateinit var rxBus: RxBus
 
     // Not derived from DaggerService, do injection here
     override fun onCreate() {
@@ -16,6 +21,11 @@ class RunningModeTileService : TileBase() {
 
     override val resourceVersion = "RunningModeTileService"
     override val source get() = runningModeSource
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onTileEnterEvent(requestParams: TileEnterEvent) {
+        rxBus.send(EventWearToMobile(EventData.RunningModeRequest(System.currentTimeMillis())))
+    }
 }
 
 


### PR DESCRIPTION
Follow up on: 30b42289
- AAPSClient wear app now shows the same running mode options as AAPS, including pump disconnect (previously hidden)                                                                                                                                                                                                                                                                                            
- Running mode tile requests fresh state from phone when the user navigates to it, so mode changes made on the phone are reflected without a manual resync

All running modes tested OK on phone/wear AAPS/AAPSClient