### PR TITLE
Fix Frozen Arrow Trial

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/CustomWatchface.kt
@@ -750,10 +750,9 @@ class CustomWatchface : BaseWatchFace() {
 
         companion object {
 
-            fun init(cwf: CustomWatchface) = entries.forEach {
-                it.cwf = cwf
-                it.arrowCustom = null
-
+            fun init(cwf: CustomWatchface) = entries.forEach { trendArrow ->
+                trendArrow.cwf = cwf
+                trendArrow.arrowCustom = trendArrow.customDrawable?.let { cwf.resDataMap[it.fileName]?.toDrawable(cwf.resources) } ?: ResourcesCompat.getDrawable(cwf.resources, trendArrow.icon, cwf.theme)
             }
 
             fun drawable() = entries.firstOrNull { it.symbol == it.cwf.singleBg[0].slopeArrow }?.arrowCustom ?: NONE.arrowCustom
@@ -766,7 +765,6 @@ class CustomWatchface : BaseWatchFace() {
 
         lateinit var cwf: CustomWatchface
         var arrowCustom: Drawable? = null
-            get() = field ?: customDrawable?.let { cwf.resDataMap[it.fileName]?.toDrawable(cwf.resources)?.also { arrowCustom = it } } ?: ResourcesCompat.getDrawable(cwf.resources, icon, cwf.theme)
     }
 
     private enum class GravityMap(val key: String, val gravity: Int) {


### PR DESCRIPTION
Just a trial to improve the management of trend arrow into CWF
- From time to time (i.e. after a firmware update of the watch), we can have trend arrow "frozen" (always the same arrow visible into CWF, whatever the arrow sent to the watch)
- This bug is very difficult to reproduce, so I was not able to test to confirm if this modification will fix or not this issue
- Instead of having arrow loaded only once, I load the arrow on each call of `TrendArrowMap.init(cwf)`, so it should be more robust...