### PR TITLE
 Wear: fix SGV complication time-ago to round down, matching AAPS and CWF       

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
@@ -98,7 +98,9 @@ class SgvComplication : ModernBaseComplicationProviderService() {
         // Format: "5m Δ-3" where time auto-updates every minute
         return TimeDifferenceComplicationText.Builder(
             style = TimeDifferenceStyle.SHORT_SINGLE_UNIT,
-            countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp))
+            // SHORT_SINGLE_UNIT rounds to nearest; adding 30_000ms makes it round down instead,
+            // matching CWF, AAPS overview, and BgGraphActivity
+            countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp + 30_000L))
         )
             .setMinimumTimeUnit(TimeUnit.MINUTES)
             .setText("^1 $deltaText")

--- a/wear/src/main/kotlin/app/aaps/wear/complications/SgvLargeComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/SgvLargeComplication.kt
@@ -52,7 +52,9 @@ class SgvLargeComplication : ModernBaseComplicationProviderService() {
     ): ShortTextComplicationData {
         val titleText = TimeDifferenceComplicationText.Builder(
             style = TimeDifferenceStyle.SHORT_SINGLE_UNIT,
-            countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp))
+            // SHORT_SINGLE_UNIT rounds to nearest; adding 30_000ms makes it round down instead,
+            // matching CWF, AAPS overview, and BgGraphActivity
+            countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp + 30_000L))
         )
             .setMinimumTimeUnit(TimeUnit.MINUTES)
             .setText("^1 ${bgData.slopeArrow}\uFE0E")


### PR DESCRIPTION
**Problem**                                                

  The SGV complication time-ago display uses `TimeDifferenceStyle.SHORT_SINGLE_UNIT`
  which rounds to the *nearest* minute. AAPS overview, CWF, and BgGraphActivity all
  use integer division (floor) — i.e. "how many full minutes have elapsed."

  The practical consequence: a reading that is 5m 30s old would show **6m** in the
  complication, while AAPS shows **5m**. A user seeing "6m ago" may think no BG value
  has been received and start troubleshooting their sensor or AAPS — unnecessarily.
  As long as the complication never actually reaches 6 minutes, there is nothing to
  worry about.

**Fix**

  Shift the `CountUpTimeReference` timestamp forward by `30_000ms`. This cancels out
  the 30-second rounding constant used internally by `SHORT_SINGLE_UNIT`, making it
  behave identically to floor division for all possible reading arrival times.

  As a side effect of the corrected rounding, very fresh readings (< 1 minute old)                                                                                                                                                                                                                                                           
  now display as **"Now"** instead of "1m" — a human-friendly label rendered and                                                                                                                                                                                                                                                             
  automatically translated by the Android OS. 
  
  Applied to `SgvComplication` and `SgvLargeComplication`. Tested OK with Dexcom G7, Random BG generator in AAPS and xDrip.


Screenshots: 
<img width="1453" height="326" alt="image" src="https://github.com/user-attachments/assets/4835257d-8a9a-43ec-b476-cf06af3032d7" />
