### PR TITLE
Fix dead "Don't Kill My App?" link for unknown manufacturers

### DIFF
--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -214,7 +214,7 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
                                 startActivity(
                                     Intent(
                                         Intent.ACTION_VIEW,
-                                        Uri.parse("https://dontkillmyapp.com/" + Build.MANUFACTURER.lowercase().replace(" ", "-"))
+                                        Uri.parse("https://dontkillmyapp.com/?app=AAPS")
                                     )
                                 )
                             }

--- a/app/src/main/kotlin/app/aaps/MainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/MainActivity.kt
@@ -211,13 +211,18 @@ class MainActivity : DaggerAppCompatActivityWithResult() {
                             .setMessage(messageSpanned)
                             .setPositiveButton(rh.gs(app.aaps.core.ui.R.string.ok), null)
                             .setNeutralButton(rh.gs(app.aaps.core.ui.R.string.cta_dont_kill_my_app_info)) { _, _ ->
-                                startActivity(
-                                    Intent(
-                                        Intent.ACTION_VIEW,
-                                        Uri.parse("https://dontkillmyapp.com/?app=AAPS")
-                                    )
-                                )
-                            }
+                        val knownVendors = setOf(
+                        "samsung", "huawei", "xiaomi", "oneplus", "oppo", "vivo",
+                        "realme", "meizu", "asus", "lenovo", "sony", "lg",
+                        "google", "nokia", "honor", "blackview", "wiko"
+                        )
+                        val mfr = Build.MANUFACTURER.lowercase().replace(" ", "-")
+                        val url = if (mfr in knownVendors)
+                        "https://dontkillmyapp.com/$mfr?app=AAPS"
+                        else
+                        "https://dontkillmyapp.com/?app=AAPS"
+                        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                        }
                             .create().apply {
                                 show()
                                 findViewById<TextView>(android.R.id.message)?.movementMethod = LinkMovementMethod.getInstance()


### PR DESCRIPTION
The About dialog built its target URL as
https://dontkillmyapp.com/<Build.MANUFACTURER>, which 404s for any manufacturer that does not have a dedicated page on dontkillmyapp.com (e.g. Fairphone, HMD, custom ROMs, emulator).

Link to the homepage with the ?app=AAPS query parameter instead, as recommended by DKMA's own API docs. The homepage lets the user pick their device and always resolves.