### PR TITLE
Add trailing space after basal rate to improve notification shown in Android Auto

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -149,9 +149,9 @@ class PersistentNotificationPlugin @Inject constructor(
             }
             val activeTemp = processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())
             line1 += if (activeTemp != null) {
-                " • " + activeTemp.toStringShort(rh)
+                " • " + activeTemp.toStringShort(rh) + " "
             } else {
-                " • " + rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, ch.fromPump(pump.baseBasalRate))
+                " • " + rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, ch.fromPump(pump.baseBasalRate)) + " "
             }
             val profileName = profileFunction.getProfileName()
             //IOB


### PR DESCRIPTION
Minor followup on https://github.com/nightscout/AndroidAPS/pull/4787

Android adds time ago icon or text (depending on version) automatically at the end of line 1 without adding space. Adding space like this make it look less cramped in android auto. Does not affect phone notification.

Before:
<img width="890" height="250" alt="image" src="https://github.com/user-attachments/assets/cd297bf0-c62b-46b0-9f5c-180b085f8caa" />

After:
<img width="884" height="238" alt="image" src="https://github.com/user-attachments/assets/5ff476ae-4945-4c24-92fb-e7616f3f927b" />

