### PR TITLE
Move Site Location step before Attach

### DIFF
--- a/pump/equil/src/main/kotlin/app/aaps/pump/equil/compose/EquilWizardStep.kt
+++ b/pump/equil/src/main/kotlin/app/aaps/pump/equil/compose/EquilWizardStep.kt
@@ -46,9 +46,9 @@ enum class EquilWorkflow {
             add(EquilWizardStep.PASSWORD)
             if (insulinSelectionEnabled) add(EquilWizardStep.SELECT_INSULIN)
             add(EquilWizardStep.FILL)
+            if (siteRotationEnabled) add(EquilWizardStep.SITE_LOCATION)
             add(EquilWizardStep.ATTACH)
             add(EquilWizardStep.AIR)
-            if (siteRotationEnabled) add(EquilWizardStep.SITE_LOCATION)
             add(EquilWizardStep.CONFIRM)
         }
 
@@ -57,9 +57,9 @@ enum class EquilWorkflow {
             add(EquilWizardStep.ASSEMBLE)
             if (insulinSelectionEnabled) add(EquilWizardStep.SELECT_INSULIN)
             add(EquilWizardStep.FILL)
+            if (siteRotationEnabled) add(EquilWizardStep.SITE_LOCATION)
             add(EquilWizardStep.ATTACH)
             add(EquilWizardStep.AIR)
-            if (siteRotationEnabled) add(EquilWizardStep.SITE_LOCATION)
             add(EquilWizardStep.CONFIRM)
         }
 

--- a/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/ui/wizard/compose/OmnipodWizardViewModel.kt
+++ b/pump/omnipod/common/src/main/kotlin/app/aaps/pump/omnipod/common/ui/wizard/compose/OmnipodWizardViewModel.kt
@@ -255,8 +255,8 @@ abstract class OmnipodWizardViewModel(
                 if (showInsulinStep) add(OmnipodWizardStep.SELECT_INSULIN)
                 add(OmnipodWizardStep.INITIALIZE_POD)
             }
-            add(OmnipodWizardStep.ATTACH_POD)
             if (showSiteLocationStep) add(OmnipodWizardStep.SITE_LOCATION)
+            add(OmnipodWizardStep.ATTACH_POD)
             add(OmnipodWizardStep.INSERT_CANNULA)
             add(OmnipodWizardStep.POD_ACTIVATED)
         }

--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/wizard/compose/DashOmnipodWizardViewModel.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/ui/wizard/compose/DashOmnipodWizardViewModel.kt
@@ -290,8 +290,8 @@ class DashOmnipodWizardViewModel @Inject constructor(
         OmnipodWizardStep.START_POD_ACTIVATION   -> CommonR.string.omnipod_common_pod_activation_wizard_start_pod_activation_title
         OmnipodWizardStep.SELECT_INSULIN         -> app.aaps.core.ui.R.string.select_insulin
         OmnipodWizardStep.INITIALIZE_POD         -> CommonR.string.omnipod_common_pod_activation_wizard_initialize_pod_title
-        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_title
         OmnipodWizardStep.SITE_LOCATION          -> app.aaps.core.ui.R.string.site_location
+        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_title
         OmnipodWizardStep.INSERT_CANNULA         -> CommonR.string.omnipod_common_pod_activation_wizard_insert_cannula_title
         OmnipodWizardStep.POD_ACTIVATED          -> CommonR.string.omnipod_common_pod_activation_wizard_pod_activated_title
         OmnipodWizardStep.START_POD_DEACTIVATION -> CommonR.string.omnipod_common_pod_deactivation_wizard_start_pod_deactivation_title
@@ -307,8 +307,8 @@ class DashOmnipodWizardViewModel @Inject constructor(
         OmnipodWizardStep.START_POD_ACTIVATION   -> R.string.omnipod_dash_pod_activation_wizard_start_pod_activation_text
         OmnipodWizardStep.SELECT_INSULIN         -> app.aaps.core.ui.R.string.select_insulin_description
         OmnipodWizardStep.INITIALIZE_POD         -> R.string.omnipod_dash_pod_activation_wizard_initialize_pod_text
-        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_text
         OmnipodWizardStep.SITE_LOCATION          -> app.aaps.core.ui.R.string.select_site_location
+        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_text
         OmnipodWizardStep.INSERT_CANNULA         -> CommonR.string.omnipod_common_pod_activation_wizard_insert_cannula_text
         OmnipodWizardStep.POD_ACTIVATED          -> CommonR.string.omnipod_common_pod_activation_wizard_pod_activated_text
         OmnipodWizardStep.START_POD_DEACTIVATION -> CommonR.string.omnipod_common_pod_deactivation_wizard_start_pod_deactivation_text

--- a/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/wizard/compose/ErosOmnipodWizardViewModel.kt
+++ b/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/ui/wizard/compose/ErosOmnipodWizardViewModel.kt
@@ -154,8 +154,8 @@ class ErosOmnipodWizardViewModel @Inject constructor(
         OmnipodWizardStep.START_POD_ACTIVATION   -> CommonR.string.omnipod_common_pod_activation_wizard_start_pod_activation_title
         OmnipodWizardStep.SELECT_INSULIN         -> app.aaps.core.ui.R.string.select_insulin
         OmnipodWizardStep.INITIALIZE_POD         -> CommonR.string.omnipod_common_pod_activation_wizard_initialize_pod_title
-        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_title
         OmnipodWizardStep.SITE_LOCATION          -> app.aaps.core.ui.R.string.site_location
+        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_title
         OmnipodWizardStep.INSERT_CANNULA         -> CommonR.string.omnipod_common_pod_activation_wizard_insert_cannula_title
         OmnipodWizardStep.POD_ACTIVATED          -> CommonR.string.omnipod_common_pod_activation_wizard_pod_activated_title
         OmnipodWizardStep.START_POD_DEACTIVATION -> CommonR.string.omnipod_common_pod_deactivation_wizard_start_pod_deactivation_title
@@ -171,8 +171,8 @@ class ErosOmnipodWizardViewModel @Inject constructor(
         OmnipodWizardStep.START_POD_ACTIVATION   -> R.string.omnipod_eros_pod_activation_wizard_start_pod_activation_text
         OmnipodWizardStep.SELECT_INSULIN         -> app.aaps.core.ui.R.string.select_insulin_description
         OmnipodWizardStep.INITIALIZE_POD         -> R.string.omnipod_eros_pod_activation_wizard_initialize_pod_text
-        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_text
         OmnipodWizardStep.SITE_LOCATION          -> app.aaps.core.ui.R.string.select_site_location
+        OmnipodWizardStep.ATTACH_POD             -> CommonR.string.omnipod_common_pod_activation_wizard_attach_pod_text
         OmnipodWizardStep.INSERT_CANNULA         -> CommonR.string.omnipod_common_pod_activation_wizard_insert_cannula_text
         OmnipodWizardStep.POD_ACTIVATED          -> CommonR.string.omnipod_common_pod_activation_wizard_pod_activated_text
         OmnipodWizardStep.START_POD_DEACTIVATION -> CommonR.string.omnipod_common_pod_deactivation_wizard_start_pod_deactivation_text


### PR DESCRIPTION
I started with Medtrum pump a few days ago, but I think modification should also be done on all Patch pumps

I was not able to test the modification (and for Equil and omnipod, the step management is a bit different compare to Medtrum)