### PR TITLE
Medtrum Status String

### DIFF
--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/comm/enums/MedtrumPumpState.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/comm/enums/MedtrumPumpState.kt
@@ -1,31 +1,34 @@
 package app.aaps.pump.medtrum.comm.enums
 
-enum class MedtrumPumpState(val state: Byte) {
-    NONE(0),
-    IDLE(1),
-    FILLED(2),
-    PRIMING(3),
-    PRIMED(4),
-    EJECTING(5),
-    EJECTED(6),
-    ACTIVE(32),
-    ACTIVE_ALT(33),
-    LOW_BG_SUSPENDED(64),
-    LOW_BG_SUSPENDED2(65),
-    AUTO_SUSPENDED(66),
-    HOURLY_MAX_SUSPENDED(67),
-    DAILY_MAX_SUSPENDED(68),
-    SUSPENDED(69),
-    PAUSED(70),
-    OCCLUSION(96),
-    EXPIRED(97),
-    RESERVOIR_EMPTY(98),
-    PATCH_FAULT(99),
-    PATCH_FAULT2(100),
-    BASE_FAULT(101),
-    BATTERY_OUT(102),
-    NO_CALIBRATION(103),
-    STOPPED(128.toByte());
+import androidx.annotation.StringRes
+import app.aaps.pump.medtrum.R
+
+enum class MedtrumPumpState(val state: Byte, @StringRes val label: Int) {
+    NONE(0, R.string.alarm_none),
+    IDLE(1, R.string.status_idle),
+    FILLED(2, R.string.status_filled),
+    PRIMING(3, R.string.status_priming),
+    PRIMED(4, R.string.status_primed),
+    EJECTING(5, R.string.status_ejecting),
+    EJECTED(6, R.string.status_ejected),
+    ACTIVE(32, R.string.status_active),
+    ACTIVE_ALT(33, R.string.status_active),
+    LOW_BG_SUSPENDED(64, R.string.alarm_low_bg_suspended),
+    LOW_BG_SUSPENDED2(65, R.string.alarm_low_bg_suspended2),
+    AUTO_SUSPENDED(66, R.string.alarm_auto_suspended),
+    HOURLY_MAX_SUSPENDED(67, R.string.alarm_hourly_max_suspended),
+    DAILY_MAX_SUSPENDED(68, R.string.alarm_daily_max_suspended),
+    SUSPENDED(69, R.string.alarm_suspended),
+    PAUSED(70, R.string.alarm_paused),
+    OCCLUSION(96, R.string.alarm_occlusion),
+    EXPIRED(97, R.string.alarm_expired),
+    RESERVOIR_EMPTY(98, R.string.alarm_reservoir_empty),
+    PATCH_FAULT(99, R.string.alarm_patch_fault),
+    PATCH_FAULT2(100, R.string.alarm_patch_fault),
+    BASE_FAULT(101, R.string.alarm_base_fault),
+    BATTERY_OUT(102, R.string.alarm_battery_out),
+    NO_CALIBRATION(103, R.string.alarm_no_calibration),
+    STOPPED(128.toByte(), R.string.status_stopped);
 
     fun isSuspendedByPump(): Boolean {
         return this in LOW_BG_SUSPENDED..SUSPENDED

--- a/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/MedtrumOverviewViewModel.kt
+++ b/pump/medtrum/src/main/kotlin/app/aaps/pump/medtrum/compose/MedtrumOverviewViewModel.kt
@@ -249,7 +249,7 @@ class MedtrumOverviewViewModel @Inject constructor(
         // Medtrum-specific rows
         val specificRows = buildList {
             // Pump state
-            add(PumpInfoRow(label = rh.gs(R.string.pump_state_label), value = pumpState.toString()))
+            add(PumpInfoRow(label = rh.gs(R.string.pump_state_label), value = rh.gs(pumpState.label)))
             // tempBasal rate
             add(PumpInfoRow(label = rh.gs(CoreUiR.string.base_basal_rate_label), value = ch.basalRateString(PumpRate(basalRate), true)))
             tempBasalRate?.let {

--- a/pump/medtrum/src/main/res/values/strings.xml
+++ b/pump/medtrum/src/main/res/values/strings.xml
@@ -53,6 +53,16 @@
     <string name="pump_time_update_failed">Failed to update pump timezone, snooze message and refresh manually.</string>
     <string name="bolus_error">Bolus error</string>
 
+    <!-- Status strings -->
+    <string name="status_idle">Idle</string>
+    <string name="status_filled">Filled</string>
+    <string name="status_priming">Priming</string>
+    <string name="status_primed">Primed</string>
+    <string name="status_ejecting">Ejecting</string>
+    <string name="status_ejected">Ejected</string>
+    <string name="status_active">Active</string>
+    <string name="status_stopped">Stopped</string>
+
     <!-- wizard-->
     <string name="retry">Retry</string>
 


### PR DESCRIPTION
Add string for Pump status to allow translation
- I reused alarm strings to be consistent and only created new strings for status without alarm