### PR TITLE
Fix persistent notification icon layout for phone vs Android Auto

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -228,7 +228,6 @@ class PersistentNotificationPlugin @Inject constructor(
         builder.setOnlyAlertOnce(true)
         builder.setCategory(NotificationCompat.CATEGORY_STATUS)
         builder.setSmallIcon(iconsProvider.getNotificationIcon())
-        builder.setLargeIcon(rh.decodeResource(iconsProvider.getIcon()))
         builder.setContentTitle(line1)
         if (line2 != null) builder.setContentText(line2)
         if (line3 != null) builder.setSubText(line3)
@@ -236,6 +235,7 @@ class PersistentNotificationPlugin @Inject constructor(
         if (unreadConversationBuilder != null) {
             builder.extend(
                 NotificationCompat.CarExtender()
+                    .setLargeIcon(rh.decodeResource(iconsProvider.getIcon()))
                     .setUnreadConversation(unreadConversationBuilder.build())
             )
         }


### PR DESCRIPTION
  On the phone notification, having both `setSmallIcon` and `setLargeIcon` set caused
  icons to appear on both sides of the notification content, making it visually cluttered.

  In Android Auto, the small icon alone is too small to identify the app clearly, so the
  large icon is needed there for visibility.

  Fix: remove `setLargeIcon` from the base notification builder and move it into the
  `CarExtender` block, so it only applies when the notification is rendered in Android Auto.

| Before | After |
|--------|--------|
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/6e9dab7b-d0bc-411e-9438-fc399ae12fc0" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/d1e57c57-056f-43b3-8aa5-0391e29bf2d5" /> | 

Android auto tested OK:
<img width="999" height="641" alt="image" src="https://github.com/user-attachments/assets/ba065781-2824-49e7-909a-0937f26f0370" />
