### PR TITLE
Fix excessive Android Auto pop-ups from persistent notification

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -41,8 +41,10 @@ import app.aaps.core.objects.extensions.toStringShort
 import app.aaps.core.utils.DeferredForegroundStart
 import app.aaps.plugins.main.R
 import kotlin.math.abs
+import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -111,6 +113,16 @@ class PersistentNotificationPlugin @Inject constructor(
             .toObservable(EventAutosensCalculationFinished::class.java)
             .observeOn(aapsSchedulers.io)
             .subscribe({ triggerNotificationUpdate() }, fabricPrivacy::logException)
+        /// Android Auto - debounced to prevent rapid pop-ups
+        disposable += Observable.merge(
+                rxBus.toObservable(EventRefreshOverview::class.java).map { },
+                rxBus.toObservable(EventInitializationChanged::class.java).map { },
+                rxBus.toObservable(EventAutosensCalculationFinished::class.java).map { }
+            )
+            .debounce(10, TimeUnit.SECONDS)
+            .observeOn(aapsSchedulers.io)
+            .subscribe({ triggerNotificationUpdate(includeAuto = true) }, fabricPrivacy::logException)
+        /// End Android Auto
     }
 
     override fun onStop() {
@@ -120,12 +132,12 @@ class PersistentNotificationPlugin @Inject constructor(
         super.onStop()
     }
 
-    private fun triggerNotificationUpdate() {
-        runBlocking { updateNotification() }
+    private fun triggerNotificationUpdate(includeAuto: Boolean = false) {
+        runBlocking { updateNotification(includeAuto) }
         deferredStart.start { dummyServiceHelper.startService(context) }
     }
 
-    private suspend fun updateNotification() {
+    private suspend fun updateNotification(includeAuto: Boolean = false) {
         if (!config.appInitialized) return
         val pump = activePlugins.activePump
         var line1: String?
@@ -232,7 +244,7 @@ class PersistentNotificationPlugin @Inject constructor(
         if (line2 != null) builder.setContentText(line2)
         if (line3 != null) builder.setSubText(line3)
         /// Android Auto
-        if (unreadConversationBuilder != null) {
+        if (includeAuto && unreadConversationBuilder != null) {
             builder.extend(
                 NotificationCompat.CarExtender()
                     .setLargeIcon(rh.decodeResource(iconsProvider.getIcon()))

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -97,6 +97,7 @@ class PersistentNotificationPlugin @Inject constructor(
 
     private val disposable = CompositeDisposable()
     private val deferredStart = DeferredForegroundStart()
+    private var lastAutoNotificationContent: String = ""
 
     override fun onStart() {
         super.onStart()
@@ -235,6 +236,9 @@ class PersistentNotificationPlugin @Inject constructor(
         } else {
             line1 = rh.gs(app.aaps.core.ui.R.string.no_profile_set)
         }
+        val content = "$line1|$line2|$line3"
+        if (includeAuto && content == lastAutoNotificationContent) return
+        if (includeAuto) lastAutoNotificationContent = content
         val builder = NotificationCompat.Builder(context, notificationHolder.channelID)
         builder.setOngoing(true)
         builder.setOnlyAlertOnce(true)


### PR DESCRIPTION
Android Auto displays a pop-up every time the persistent notification is  updated with a CarExtender/UnreadConversation. Since the loop runs frequently and triggers multiple events per BG cycle (BG arrival, autosens, SMB delivery confirmation), this caused rapid successive pop-ups while driving.

Changes:
- Add a dedicated Auto pipeline that debounces CarExtender updates by 10 seconds, allowing the full loop cycle (including SMB delivery at ~20s) to settle before posting a single pop-up
- Phone notification behavior is unchanged — it continues to update immediately on every event as before
- Content deduplication check is applied exclusively to the Android Auto pipeline: if BG, IOB, COB, and basal rate are unchanged since the last Auto notification, the CarExtender is not posted and no pop-up is triggered. This handles cases where the debounce fires due to background events but no meaningful data has changed. Phone notification behavior is not affected.

The result is one Android Auto pop-up per BG cycle regardless of how many loop events fire, while the phone notification remains as responsive as before.