### PR TITLE
SgvComplication: simplify delta display

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/SgvComplication.kt
@@ -9,24 +9,19 @@ import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import androidx.wear.watchface.complications.data.TimeDifferenceComplicationText
 import androidx.wear.watchface.complications.data.TimeDifferenceStyle
 import app.aaps.core.interfaces.logging.LTag
-import app.aaps.core.interfaces.sharedPreferences.SP
-import app.aaps.wear.interaction.utils.SmallestDoubleString
 import dagger.android.AndroidInjection
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
 
 /**
  * SGV (Sensor Glucose Value) Complication
  *
  * Shows current blood glucose with arrow, auto-updating time, and delta
- * Display format: "6.8↘" with "5m Δ-3" above
+ * Display format: "6.8↘" with "5m +0.1" above (mmol/L) or "5m +1" (mg/dL)
  * - Time auto-updates every minute (battery efficient)
  * - Delta is static until new BG reading
  */
 class SgvComplication : ModernBaseComplicationProviderService() {
-
-    @Inject lateinit var sp: SP
 
     // Not derived from DaggerService, do injection here
     override fun onCreate() {
@@ -59,10 +54,9 @@ class SgvComplication : ModernBaseComplicationProviderService() {
         bgData: app.aaps.core.interfaces.rx.weardata.EventData.SingleBg,
         pendingIntent: PendingIntent
     ): ShortTextComplicationData {
-        // Main text: BG value + arrow (with variation selector to prevent emoji)
-        val mainText = bgData.sgvString + bgData.slopeArrow + "\uFE0E"
+        val mainText = bgData.sgvString + bgData.slopeArrow
 
-        // Title: auto-updating time + delta (e.g., "5m Δ-3")
+        // Title: auto-updating time + delta (e.g., "5m +0.1")
         val titleText = buildDeltaAndTimeTitle(bgData)
 
         return ShortTextComplicationData.Builder(
@@ -75,37 +69,20 @@ class SgvComplication : ModernBaseComplicationProviderService() {
     }
 
     /**
-     * Build combined delta and time title (e.g., "5m Δ-3")
-     * Time auto-updates, delta is static
+     * Build combined delta and time title (e.g., "5m +0.1" mmol/L or "5m +1" mg/dL)
+     * Time auto-updates, delta is static until new BG reading
      * Uses ^1 placeholder which is replaced with the time difference
      */
-    private fun buildDeltaAndTimeTitle(bgData: app.aaps.core.interfaces.rx.weardata.EventData.SingleBg): TimeDifferenceComplicationText {
-        // Use detailed delta if preference is enabled, otherwise use simple delta
-        val rawDelta = if (sp.getBoolean(app.aaps.wear.R.string.key_show_detailed_delta, false)) {
-            bgData.deltaDetailed
-        } else {
-            bgData.delta
-        }
-
-        // Add delta symbol if Unicode complications are enabled
-        val useUnicode = sp.getBoolean("complication_unicode", true)
-        val deltaSymbol = if (useUnicode) "\u0394" else ""
-
-        // Minimize delta to leave room for time (max 7 chars total for SHORT_TEXT title)
-        val deltaText = deltaSymbol + SmallestDoubleString(rawDelta).minimise(4)
-
-        // ^1 is replaced with auto-updating time (e.g., "5m")
-        // Format: "5m Δ-3" where time auto-updates every minute
-        return TimeDifferenceComplicationText.Builder(
+    private fun buildDeltaAndTimeTitle(bgData: app.aaps.core.interfaces.rx.weardata.EventData.SingleBg): TimeDifferenceComplicationText =
+        // SHORT_SINGLE_UNIT rounds to nearest; adding 30_000ms makes it round down instead,
+        // matching CWF, AAPS overview, and BgGraphActivity
+        TimeDifferenceComplicationText.Builder(
             style = TimeDifferenceStyle.SHORT_SINGLE_UNIT,
-            // SHORT_SINGLE_UNIT rounds to nearest; adding 30_000ms makes it round down instead,
-            // matching CWF, AAPS overview, and BgGraphActivity
             countUpTimeReference = CountUpTimeReference(Instant.ofEpochMilli(bgData.timeStamp + 30_000L))
         )
             .setMinimumTimeUnit(TimeUnit.MINUTES)
-            .setText("^1 $deltaText")
+            .setText("^1 ${bgData.delta}")
             .build()
-    }
 
     override fun getComplicationAction(): ComplicationAction = ComplicationAction.BG_GRAPH
 


### PR DESCRIPTION
Simplifies the SGV complication delta display to match the phone overview and BgGraphActivity format (+0.1 mmol/L / +1 mg/dL).

Changes:
  - Remove SmallestDoubleString — no longer needed since bgData.delta is already compact and correctly formatted
  - Remove key_show_detailed_delta and complication_unicode SP preferences — the complication now always shows the clean delta format, consistent with the rest of the app
  - Remove delta symbol (Δ) to save space and align with phone display
  - Remove unnecessary U+FE0E variation selector — the arrow characters used (U+2191–U+21CA) are text-only glyphs with no emoji presentation
  
  Screenshots:
  
| Before | After |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/40f013d1-6d98-43d8-9f28-cc1b8e1fd0b2" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/659af3c1-1e63-4cc6-b70a-37b8d714d0f3" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/8b42e2fa-ada9-481a-bcee-c1b830453b18" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/a2d456fe-ec0a-4808-8234-fa574a322fbd" /> | 