### PR TITLE
Fix: Omnipod Dash infinite connecting loop after pod deactivation

### DIFF
--- a/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/pump/omnipod/dash/src/main/kotlin/app/aaps/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -237,7 +237,8 @@ class OmnipodDashPumpPlugin @Inject constructor(
 
     override fun isBusy(): Boolean {
         // prevents the queue from executing commands
-        return podStateManager.activationProgress.isBefore(ActivationProgress.COMPLETED)
+        return podStateManager.activationProgress != ActivationProgress.NOT_STARTED &&
+            podStateManager.activationProgress.isBefore(ActivationProgress.COMPLETED)
     }
 
     override fun isConnected(): Boolean {


### PR DESCRIPTION
## Fix: Omnipod continuously shows "Connecting" after pod deactivation

Fixes #4848, #4542

### Problem

After pod deactivation, AAPS gets stuck in an infinite "Connecting for X s" loop and never returns to a normal idle state. Battery drain increases significantly during this period. Commit 9d3bdce (since 3.4.1.0) made `isConnected()` return `true` when no pod is present to suppress spurious BLE connect attempts, but inadvertently caused `QueueWorker` to spin forever: `isBusy()` returns `true` at `NOT_STARTED`, so the queue-empty exit is never reached and a WorkManager wake lock is held indefinitely.

### Fix

Exclude `ActivationProgress.NOT_STARTED` from the busy range in `OmnipodDashPumpPlugin.isBusy()` — consistent with how the Medtrum and Eopatch drivers report this state. APS commands and activation are unaffected (guarded by `isInitialized()` and a separate code path respectively).

### Testing

Verified on a physical device — no more infinite connecting loop after deactivation.

<img width="216" height="485" alt="1000000313" src="https://github.com/user-attachments/assets/58cb1abb-1dfa-4211-8f5e-3471f6bffc40" />

### Target

Bugfix for `dev3` (AAPS 3.x). Applies as a clean cherry-pick to `dev` (AAPS 4.x) as well.