### PR TITLE
Add xDrip to notification parser plugin

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/model/SourceSensor.kt
@@ -8,6 +8,7 @@ enum class SourceSensor(val text: String) {
     DEXCOM_G6_NATIVE_XDRIP("G6 Native"),
     DEXCOM_G7_NATIVE_XDRIP("G7 Native"),
     DEXCOM_G7_XDRIP("G7"),
+    XDRIP("xDrip"),
     LIBRE_1_OTHER("Other App"),
     LIBRE_1_NET("Network libre"),
     LIBRE_1_BLUE("BlueReader"),

--- a/database/impl/src/main/kotlin/app/aaps/database/entities/GlucoseValue.kt
+++ b/database/impl/src/main/kotlin/app/aaps/database/entities/GlucoseValue.kt
@@ -102,6 +102,8 @@ data class GlucoseValue(
         SYAI_TAG,
 
         INSTARA,
+
+        XDRIP,
         IOB_PREDICTION,
         A_COB_PREDICTION,
         COB_PREDICTION,

--- a/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourceSensorExtension.kt
+++ b/database/persistence/src/main/kotlin/app/aaps/database/persistence/converters/SourceSensorExtension.kt
@@ -40,6 +40,7 @@ fun GlucoseValue.SourceSensor.fromDb(): SourceSensor =
         GlucoseValue.SourceSensor.SIBIONIC               -> SourceSensor.SIBIONIC
         GlucoseValue.SourceSensor.SINO                   -> SourceSensor.SINO
         GlucoseValue.SourceSensor.INSTARA                -> SourceSensor.INSTARA
+        GlucoseValue.SourceSensor.XDRIP                  -> SourceSensor.XDRIP
 
         GlucoseValue.SourceSensor.IOB_PREDICTION         -> SourceSensor.IOB_PREDICTION
         GlucoseValue.SourceSensor.A_COB_PREDICTION       -> SourceSensor.A_COB_PREDICTION
@@ -85,6 +86,7 @@ fun SourceSensor.toDb(): GlucoseValue.SourceSensor =
         SourceSensor.SIBIONIC               -> GlucoseValue.SourceSensor.SIBIONIC
         SourceSensor.SINO                   -> GlucoseValue.SourceSensor.SINO
         SourceSensor.INSTARA                -> GlucoseValue.SourceSensor.INSTARA
+        SourceSensor.XDRIP                  -> GlucoseValue.SourceSensor.XDRIP
 
         SourceSensor.IOB_PREDICTION         -> GlucoseValue.SourceSensor.IOB_PREDICTION
         SourceSensor.A_COB_PREDICTION       -> GlucoseValue.SourceSensor.A_COB_PREDICTION

--- a/plugins/source/src/main/assets/notification_reader_packages.json
+++ b/plugins/source/src/main/assets/notification_reader_packages.json
@@ -235,6 +235,11 @@
       "package": "com.suswel.ai",
       "sensor": "Unknown",
       "intervalMinutes": 5
+    },
+    {
+      "package": "com.eveningoutpost.dexdrip",
+      "sensor": "xDrip",
+      "intervalMinutes": 5
     }
   ]
 }

--- a/plugins/source/src/main/kotlin/app/aaps/plugins/source/notificationreader/NotificationParser.kt
+++ b/plugins/source/src/main/kotlin/app/aaps/plugins/source/notificationreader/NotificationParser.kt
@@ -63,6 +63,7 @@ class NotificationParser(private val packageConfig: PackageConfig) {
             '\u2700'..'\u27BF', // Dingbats
             '\u2900'..'\u297F', // Supplemental Arrows-B
             '\u2B00'..'\u2BFF', // Misc Symbols and Arrows
+            '\uFE00'..'\uFE0F', // Variation Selectors
         )
 
         private val UNIT_LABELS = Regex("m(?:g/d|mol/)l", RegexOption.IGNORE_CASE)

--- a/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/NotificationParserTest.kt
+++ b/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/NotificationParserTest.kt
@@ -19,7 +19,7 @@ class NotificationParserTest {
                 "com.dexcom.dexcomone", "com.dexcom.stelo", "com.camdiab.fx_alert.mmoll",
                 "com.medtronic.diabetes.guardian", "com.medtronic.diabetes.minimedmobile.eu",
                 "com.senseonics.gen12androidapp", "com.microtech.aidexx",
-                "com.ottai.seas", "com.sinocare.cgm.ce",
+                "com.ottai.seas", "com.sinocare.cgm.ce", "com.eveningoutpost.dexdrip"
             ),
             packageToSensor = mapOf(
                 "com.dexcom.g7" to SourceSensor.DEXCOM_G7_NATIVE,
@@ -34,6 +34,7 @@ class NotificationParserTest {
                 "com.microtech.aidexx" to SourceSensor.AIDEX,
                 "com.ottai.seas" to SourceSensor.OTTAI,
                 "com.sinocare.cgm.ce" to SourceSensor.SINO,
+                "com.eveningoutpost.dexdrip" to SourceSensor.XDRIP,
             )
         )
     }
@@ -107,6 +108,13 @@ class NotificationParserTest {
         fun `dingbats removed`() {
             // U+2764 is in Dingbats range
             assertThat(parser.cleanText("142\u2764")).isEqualTo("142")
+        }
+
+        @Test
+        fun `Variation selectors removed`() {
+            // Variation Selectors \uFE00-\uFE0F appear in xDrip notifications
+            assertThat(parser.cleanText("9.3 →\uFE00")).isEqualTo("9.3")
+            assertThat(parser.cleanText("9.1 →\uFE0F")).isEqualTo("9.1")
         }
     }
 
@@ -233,6 +241,14 @@ class NotificationParserTest {
             assertThat(result).isNotNull()
             assertThat(result!!.glucoseMgdl).isIn(149..150)
             assertThat(result.sourceSensor).isEqualTo(SourceSensor.MM_600_SERIES)
+        }
+
+        @Test
+        fun `mmol-L from xDrip`() {
+            val result = parser.extractGlucose(listOf("9.1 →︎", "Delta: -0.2 mmol/l"), "com.eveningoutpost.dexdrip", useMgdl = false)
+            assertThat(result).isNotNull()
+            assertThat(result!!.glucoseMgdl).isIn(163..164)
+            assertThat(result.sourceSensor).isEqualTo(SourceSensor.XDRIP)
         }
 
         @Test

--- a/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/PackageConfigTest.kt
+++ b/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/PackageConfigTest.kt
@@ -28,7 +28,8 @@ class PackageConfigTest {
             "com.dexcom.g6",
             "com.medtronic.diabetes.guardian",
             "com.senseonics.gen12androidapp",
-            "com.unknown.future.app"
+            "com.unknown.future.app",
+            "com.eveningoutpost.dexdrip"
         )
     }
 
@@ -39,6 +40,7 @@ class PackageConfigTest {
         assertThat(config.sensorForPackage("com.dexcom.g6")).isEqualTo(SourceSensor.DEXCOM_G6_NATIVE)
         assertThat(config.sensorForPackage("com.medtronic.diabetes.guardian")).isEqualTo(SourceSensor.MM_600_SERIES)
         assertThat(config.sensorForPackage("com.senseonics.gen12androidapp")).isEqualTo(SourceSensor.EVERSENSE)
+        assertThat(config.sensorForPackage("com.eveningoutpost.dexdrip")).isEqualTo(SourceSensor.XDRIP)
     }
 
     @Test

--- a/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/PackageConfigTest.kt
+++ b/plugins/source/src/test/kotlin/app/aaps/plugins/source/notificationreader/PackageConfigTest.kt
@@ -14,7 +14,8 @@ class PackageConfigTest {
             { "package": "com.dexcom.g6", "sensor": "AAPS-DexcomG6" },
             { "package": "com.medtronic.diabetes.guardian", "sensor": "MM600Series" },
             { "package": "com.senseonics.gen12androidapp", "sensor": "Eversense" },
-            { "package": "com.unknown.future.app", "sensor": "SomeUnknownSensor" }
+            { "package": "com.unknown.future.app", "sensor": "SomeUnknownSensor" },
+            { "package": "com.eveningoutpost.dexdrip", "sensor": "xDrip" }
           ]
         }
     """.trimIndent()


### PR DESCRIPTION
This PR adds support for xDrip notification parsing.

xDrip notifications contain a variant selector character after the trend arrow. So, this PR introduces those to the `SYMBOL_RANGES` list in the notification parser.

