### PR TITLE
fix extendedBolus bug.

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/pump/defs/PumpDescription.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/pump/defs/PumpDescription.kt
@@ -34,7 +34,7 @@ class PumpDescription {
     var isPatchPump = false
     var maxResorvoirReading = 50
     var useHardwareLink = false
-
+    var extendedBolusMinAmount = 0.0
     fun resetSettings() {
         isBolusCapable = true
         bolusStep = 0.1
@@ -64,6 +64,7 @@ class PumpDescription {
         needsManualTDDLoad = true
         hasCustomUnreachableAlertCheck = false
         useHardwareLink = false
+        extendedBolusMinAmount = extendedBolusStep
     }
 
     companion object {

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/defs/PumpDescriptionExtension.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/defs/PumpDescriptionExtension.kt
@@ -41,6 +41,7 @@ fun PumpDescription.fillFor(pumpType: PumpType): PumpDescription {
     isPatchPump = pumpType.isPatchPump()
     maxResorvoirReading = pumpType.maxReservoirReading()
     useHardwareLink = pumpType.useHardwareLink
+    pumpType.extendedBolusSettings()?.minDose?.let { extendedBolusMinAmount = it }
 
     return this
 }

--- a/ui/src/main/kotlin/app/aaps/ui/dialogs/ExtendedBolusDialog.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/dialogs/ExtendedBolusDialog.kt
@@ -30,6 +30,7 @@ import java.text.DecimalFormat
 import java.util.LinkedList
 import javax.inject.Inject
 import kotlin.math.abs
+import kotlin.math.max
 
 class ExtendedBolusDialog : DialogFragmentWithDate() {
 
@@ -70,9 +71,10 @@ class ExtendedBolusDialog : DialogFragmentWithDate() {
 
         val maxInsulin = constraintChecker.getMaxExtendedBolusAllowed().value()
         val extendedStep = pumpDescription.extendedBolusStep
+        val minInsulin = pumpDescription.extendedBolusMinAmount
         binding.insulin.setParams(
             savedInstanceState?.getDouble("insulin")
-                ?: extendedStep, extendedStep, maxInsulin, extendedStep, DecimalFormat("0.00"), false, binding.okcancel.ok
+                ?: minInsulin, minInsulin, maxInsulin, extendedStep, DecimalFormat("0.00"), false, binding.okcancel.ok
         )
 
         val extendedDurationStep = pumpDescription.extendedBolusDurationStep


### PR DESCRIPTION
using VirtualPumpPlugin, pumpType = CELLNOVO, the initial value of the ExtendedBolusDialog is lower than the minimum value