### PR TITLE
Cleanup Workflow AAPS CI: keep_runs=20, keep_threshold=5. Uses cleanu…

### DIFF
--- a/.github/workflows/aaps-ci.yml
+++ b/.github/workflows/aaps-ci.yml
@@ -354,3 +354,15 @@ jobs:
           upload_to_gdrive "aaps-wear-${VERSION}${VERSION_SUFFIX}.apk" "aaps-wear-${VERSION}${VERSION_SUFFIX}.apk"
 
           echo "🎉 APKs successfully uploaded to Google Drive!"
+
+  # Configuration: Threshold-based cleanup
+  # Clean up only occurs when total runs exceed: keep_runs + keep_threshold (e.g., 20 + 5 = 25)
+  cleanup:
+    name: Cleanup Old Workflow Runs
+    needs: build
+    if: always()
+    uses: ./.github/workflows/cleanup-workflow-runs.yml
+    with:
+      workflow_name: 'AAPS CI'
+      keep_runs: 20
+      keep_threshold: 5


### PR DESCRIPTION
Adding 'AAPS CI' workflow (see also PR#4821)
Depend on cleanup-workflow-runs.yml