### PR TITLE
Fix Tidepool basal upload mapping

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunk.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunk.kt
@@ -22,9 +22,11 @@ import app.aaps.plugins.sync.tidepool.elements.WizardElement
 import app.aaps.plugins.sync.tidepool.events.EventTidepoolStatus
 import app.aaps.plugins.sync.tidepool.keys.TidepoolLongNonKey
 import app.aaps.plugins.sync.tidepool.utils.GsonInstance
+import java.util.Calendar
 import java.util.LinkedList
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
@@ -41,6 +43,9 @@ class UploadChunk @Inject constructor(
 ) {
 
     private val maxUploadSize = T.days(7).msecs() // don't change this
+    private val basalSegmentStep = T.mins(1).msecs()
+    private val scheduledBasalGapTolerance = T.mins(2).msecs()
+    private val basalRateTolerance = 0.001
 
     fun getNext(session: Session?): String? {
         session ?: return null
@@ -129,20 +134,110 @@ class UploadChunk @Inject constructor(
 
     private fun fromTemporaryBasals(tbrList: List<TB>, start: Long, end: Long): List<BasalElement> {
         val results = LinkedList<BasalElement>()
+        val calendar = Calendar.getInstance()
         for (tbr in tbrList) {
-            if (tbr.timestamp in start..end)
-                profileFunction.getProfile(tbr.timestamp)?.let {
-                    results.add(BasalElement(tbr, it, dateUtil))
+            var cursor = max(tbr.timestamp, start)
+            val tbrEnd = min(tbr.timestamp + tbr.duration, end)
+            while (cursor < tbrEnd) {
+                val profile = profileFunction.getProfile(cursor)
+                if (profile == null) {
+                    cursor = min(cursor + basalSegmentStep, tbrEnd)
+                    continue
                 }
+
+                val scheduledRate = profile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, cursor))
+                var segmentEnd = min(cursor + basalSegmentStep, tbrEnd)
+
+                while (segmentEnd < tbrEnd) {
+                    val nextProfile = profileFunction.getProfile(segmentEnd) ?: break
+                    val nextScheduledRate = nextProfile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, segmentEnd))
+                    if (abs(nextScheduledRate - scheduledRate) > basalRateTolerance)
+                        break
+                    segmentEnd = min(segmentEnd + basalSegmentStep, tbrEnd)
+                }
+
+                if (segmentEnd > cursor)
+                    results.add(BasalElement(tbr, cursor, segmentEnd - cursor, profile, dateUtil))
+                cursor = segmentEnd
+            }
         }
         return results
     }
 
+    private fun secondsFromMidnight(calendar: Calendar, timestamp: Long): Int {
+        calendar.timeInMillis = timestamp
+        return calendar.get(Calendar.HOUR_OF_DAY) * 3600 + calendar.get(Calendar.MINUTE) * 60 + calendar.get(Calendar.SECOND)
+    }
+
+    private fun activeTemporaryBasalEnd(tbrList: List<TB>, timestamp: Long): Long? {
+        for (tbr in tbrList) {
+            val tbrEnd = tbr.timestamp + tbr.duration
+            if (tbr.timestamp <= timestamp && tbrEnd > timestamp)
+                return tbrEnd
+        }
+        return null
+    }
+
+    private fun nextTemporaryBasalStart(tbrList: List<TB>, timestamp: Long, end: Long): Long {
+        var next = end
+        for (tbr in tbrList) {
+            if (tbr.timestamp > timestamp && tbr.timestamp < next)
+                next = tbr.timestamp
+        }
+        return next
+    }
+
+    private fun fromScheduledBasals(tbrList: List<TB>, start: Long, end: Long): List<BasalElement> {
+        val results = LinkedList<BasalElement>()
+        val sortedTbrs = tbrList.sortedBy { it.timestamp }
+        val calendar = Calendar.getInstance()
+        var cursor = start
+
+        while (cursor < end) {
+            val tbrEnd = activeTemporaryBasalEnd(sortedTbrs, cursor)
+            if (tbrEnd != null) {
+                cursor = min(tbrEnd, end)
+                continue
+            }
+
+            val profile = profileFunction.getProfile(cursor)
+            if (profile == null) {
+                cursor = min(cursor + basalSegmentStep, end)
+                continue
+            }
+
+            val rate = profile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, cursor))
+            val nextTbrStart = nextTemporaryBasalStart(sortedTbrs, cursor, end)
+            if (nextTbrStart < end && nextTbrStart - cursor <= scheduledBasalGapTolerance) {
+                cursor = nextTbrStart
+                continue
+            }
+            var segmentEnd = min(cursor + basalSegmentStep, nextTbrStart)
+
+            while (segmentEnd < nextTbrStart) {
+                val nextProfile = profileFunction.getProfile(segmentEnd) ?: break
+                val nextRate = nextProfile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, segmentEnd))
+                if (abs(nextRate - rate) > basalRateTolerance)
+                    break
+                segmentEnd = min(segmentEnd + basalSegmentStep, nextTbrStart)
+            }
+
+            if (segmentEnd > cursor)
+                results.add(BasalElement(cursor, segmentEnd - cursor, rate, dateUtil))
+            cursor = segmentEnd
+        }
+
+        return results
+    }
+
     private fun getBasals(start: Long, end: Long): List<BasalElement> {
-        val temporaryBasals = persistenceLayer.getTemporaryBasalsStartingFromTimeToTime(start, end, true)
-        val selection = fromTemporaryBasals(temporaryBasals, start, end)
+        // Include TBRs that started before this upload window but are still active at start.
+        val temporaryBasals = persistenceLayer.getTemporaryBasalsStartingFromTimeToTime(max(0L, start - T.days(1).msecs()), end, true)
+        val selection = LinkedList<BasalElement>()
+        selection.addAll(fromScheduledBasals(temporaryBasals, start, end))
+        selection.addAll(fromTemporaryBasals(temporaryBasals, start, end))
         if (selection.isNotEmpty())
-            rxBus.send(EventTidepoolStatus("${selection.size} TBRs selected for upload"))
+            rxBus.send(EventTidepoolStatus("${selection.size} basal records selected for upload"))
         return selection
     }
 

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunk.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/comm/UploadChunk.kt
@@ -146,15 +146,7 @@ class UploadChunk @Inject constructor(
                 }
 
                 val scheduledRate = profile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, cursor))
-                var segmentEnd = min(cursor + basalSegmentStep, tbrEnd)
-
-                while (segmentEnd < tbrEnd) {
-                    val nextProfile = profileFunction.getProfile(segmentEnd) ?: break
-                    val nextScheduledRate = nextProfile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, segmentEnd))
-                    if (abs(nextScheduledRate - scheduledRate) > basalRateTolerance)
-                        break
-                    segmentEnd = min(segmentEnd + basalSegmentStep, tbrEnd)
-                }
+                val segmentEnd = findTemporaryBasalSegmentEnd(calendar, cursor, tbrEnd, scheduledRate)
 
                 if (segmentEnd > cursor)
                     results.add(BasalElement(tbr, cursor, segmentEnd - cursor, profile, dateUtil))
@@ -162,6 +154,18 @@ class UploadChunk @Inject constructor(
             }
         }
         return results
+    }
+
+    private fun findTemporaryBasalSegmentEnd(calendar: Calendar, cursor: Long, tbrEnd: Long, scheduledRate: Double): Long {
+        var segmentEnd = min(cursor + basalSegmentStep, tbrEnd)
+        while (segmentEnd < tbrEnd) {
+            val nextProfile = profileFunction.getProfile(segmentEnd) ?: break
+            val nextScheduledRate = nextProfile.getBasalTimeFromMidnight(secondsFromMidnight(calendar, segmentEnd))
+            if (abs(nextScheduledRate - scheduledRate) > basalRateTolerance)
+                break
+            segmentEnd = min(segmentEnd + basalSegmentStep, tbrEnd)
+        }
+        return segmentEnd
     }
 
     private fun secondsFromMidnight(calendar: Calendar, timestamp: Long): Int {

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/elements/BasalElement.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/tidepool/elements/BasalElement.kt
@@ -5,14 +5,15 @@ import app.aaps.core.interfaces.profile.Profile
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.objects.extensions.convertedToAbsolute
 import com.google.gson.annotations.Expose
+import java.util.Calendar
 import java.util.UUID
 
-class BasalElement(tbr: TB, profile: Profile, dateUtil: DateUtil) : BaseElement(tbr.timestamp, UUID.nameUUIDFromBytes(("AAPS-basal" + tbr.timestamp).toByteArray()).toString(), dateUtil) {
+class BasalElement : BaseElement {
 
     internal var timestamp: Long = 0 // not exposed
 
     @Expose
-    internal var deliveryType = "automated"
+    internal var deliveryType = "temp"
 
     @Expose
     internal var duration: Long = 0
@@ -24,15 +25,50 @@ class BasalElement(tbr: TB, profile: Profile, dateUtil: DateUtil) : BaseElement(
     internal var scheduleName = "AAPS"
 
     @Expose
+    internal var suppressed: SuppressedBasal? = null
+
+    @Expose
     internal var clockDriftOffset: Long = 0
 
     @Expose
     internal var conversionOffset: Long = 0
 
-    init {
+    constructor(tbr: TB, profile: Profile, dateUtil: DateUtil) :
+        this(tbr, tbr.timestamp, tbr.duration, profile, dateUtil)
+
+    constructor(tbr: TB, timestamp: Long, duration: Long, profile: Profile, dateUtil: DateUtil) :
+        super(timestamp, UUID.nameUUIDFromBytes(("AAPS-basal" + tbr.timestamp + "-" + timestamp).toByteArray()).toString(), dateUtil) {
         type = "basal"
-        timestamp = tbr.timestamp
-        rate = tbr.convertedToAbsolute(tbr.timestamp, profile)
-        duration = tbr.duration
+        this.timestamp = timestamp
+        rate = tbr.convertedToAbsolute(timestamp, profile)
+        this.duration = duration
+        val suppressedRate = profile.getBasalTimeFromMidnight(secondsFromMidnight(timestamp))
+        suppressed = SuppressedBasal(suppressedRate)
     }
+
+    constructor(timestamp: Long, duration: Long, rate: Double, dateUtil: DateUtil) :
+        super(timestamp, UUID.nameUUIDFromBytes(("AAPS-basal-scheduled$timestamp").toByteArray()).toString(), dateUtil) {
+        type = "basal"
+        this.timestamp = timestamp
+        deliveryType = "scheduled"
+        this.duration = duration
+        this.rate = rate
+    }
+
+    private fun secondsFromMidnight(timestamp: Long): Int {
+        val calendar = Calendar.getInstance()
+        calendar.timeInMillis = timestamp
+        return calendar.get(Calendar.HOUR_OF_DAY) * 3600 + calendar.get(Calendar.MINUTE) * 60 + calendar.get(Calendar.SECOND)
+    }
+
+    class SuppressedBasal internal constructor(
+        @field:Expose
+        internal var rate: Double,
+        @field:Expose
+        internal var type: String = "basal",
+        @field:Expose
+        internal var deliveryType: String = "scheduled",
+        @field:Expose
+        internal var scheduleName: String = "AAPS"
+    )
 }


### PR DESCRIPTION
## Summary

This fixes Tidepool basal upload so normal profile basal is represented in Tidepool, and temp basal records include the scheduled basal they suppress.

## Changes

- Uploads normal profile basal as Tidepool `basal` records with `deliveryType = "scheduled"`.
- Uploads AAPS temporary basal records as Tidepool `deliveryType = "temp"`.
- Adds `suppressed` scheduled basal data to temp basal records, so Tidepool can render the scheduled/profile basal line during temp basal delivery.
- Splits temp basal records when the underlying scheduled basal rate changes, so each segment has the correct `suppressed.rate`.
- Avoids short scheduled basal spikes between immediately replaced temp basal records by ignoring gaps of 2 minutes or less.

## Implementation note

The previous uploader used `deliveryType = "automated"` for AAPS temporary basal records. This patch uses Tidepool `deliveryType = "temp"` because the temp basal data type supports `suppressed`, which is needed for Tidepool to render the scheduled/profile basal line during temporary basal delivery.

AAPS stores most temporary basal records as `TB.Type.NORMAL`, so this uploader cannot reliably distinguish user-requested temp basals from loop-requested temp basals at this layer. Because of that, this patch maps normal AAPS temporary basal records consistently to Tidepool `deliveryType = "temp"` and includes the suppressed scheduled basal data needed for Tidepool rendering.

## Manual test notes

- Uploaded AAPS data to Tidepool.
- Verified that profile basal is visible when no temp basal is active.
- Verified that temp basal periods show the suppressed scheduled basal line.
- Verified that short stop/start gaps between temp basals no longer create a visible profile-basal spike.
<img width="893" height="110" alt="BR_after" src="https://github.com/user-attachments/assets/410c832c-ed1f-428b-8dd7-5cad7a0832b6" />

## Related

- Related historical report: https://github.com/nightscout/AndroidAPS/issues/3040
- Tidepool basal docs: https://tidepool.redocly.app/docs/device-data/data-types/basal
