### PR TITLE
Fix: revert timed profile switch reliably when it expires

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
@@ -12,6 +12,7 @@ import app.aaps.annotations.OpenForTesting
 import app.aaps.core.data.model.BS
 import app.aaps.core.data.model.EPS
 import app.aaps.core.data.model.PS
+import app.aaps.core.data.time.T
 import app.aaps.core.data.ue.Action
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.interfaces.alerts.LocalAlertUtils
@@ -79,6 +80,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.LinkedList
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -189,7 +191,24 @@ class CommandQueueImplementation @Inject constructor(
                     iCfg = it.iCfg
                 )
                 persistenceLayer.insertOrUpdateEffectiveProfileSwitch(eps)
+                scheduleExpiryCheck(it)
             }
+        }
+    }
+
+    // Expiry of a timed profile switch fires no event on its own and KeepAliveWorker
+    // may be delayed by Doze, so schedule an explicit check at the expiry time
+    private fun scheduleExpiryCheck(ps: PS) {
+        if (ps.duration != 0L && ps.end > dateUtil.now()) {
+            workManager.enqueueUniqueWork(
+                ProfileSwitchExpiryWorker.WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                OneTimeWorkRequest.Builder(ProfileSwitchExpiryWorker::class.java)
+                    .setInitialDelay(ps.end - dateUtil.now() + T.secs(10).msecs(), TimeUnit.MILLISECONDS)
+                    .build()
+            )
+        } else {
+            workManager.cancelUniqueWork(ProfileSwitchExpiryWorker.WORK_NAME)
         }
     }
 

--- a/implementation/src/main/kotlin/app/aaps/implementation/queue/ProfileSwitchExpiryWorker.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/queue/ProfileSwitchExpiryWorker.kt
@@ -1,0 +1,53 @@
+package app.aaps.implementation.queue
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.WorkerParameters
+import app.aaps.core.interfaces.configuration.Config
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.queue.Command
+import app.aaps.core.interfaces.queue.CommandQueue
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventProfileChangeRequested
+import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import app.aaps.core.objects.workflow.LoggingWorker
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Scheduled to fire when a timed profile switch ends.
+ *
+ * Expiry of a timed profile switch is passive: the ProfileSwitch record simply stops matching
+ * the "active" query while the loop and the UI keep using the last EffectiveProfileSwitch with
+ * the old percentage/timeshift. Without this worker the revert depends solely on
+ * KeepAliveWorker, which can be delayed indefinitely by Doze.
+ */
+@HiltWorker
+class ProfileSwitchExpiryWorker @AssistedInject internal constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    aapsLogger: AAPSLogger,
+    fabricPrivacy: FabricPrivacy,
+    private val config: Config,
+    private val profileFunction: ProfileFunction,
+    private val commandQueue: CommandQueue,
+    private val rxBus: RxBus
+) : LoggingWorker(context, params, Dispatchers.Default, aapsLogger, fabricPrivacy) {
+
+    companion object {
+
+        const val WORK_NAME = "ProfileSwitchExpiry"
+    }
+
+    override suspend fun doWorkAndLog(): Result {
+        if (config.AAPSCLIENT) return Result.success()
+        if (profileFunction.isProfileChangePending() && !commandQueue.isRunning(Command.CommandType.BASAL_PROFILE)) {
+            aapsLogger.debug(LTag.PROFILE, "Timed profile switch expired. Requesting profile update")
+            rxBus.send(EventProfileChangeRequested())
+        }
+        return Result.success()
+    }
+}

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/loop/LoopPlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/loop/LoopPlugin.kt
@@ -50,6 +50,7 @@ import app.aaps.core.interfaces.pump.PumpEnactResult
 import app.aaps.core.interfaces.pump.PumpStatusProvider
 import app.aaps.core.interfaces.pump.PumpSync
 import app.aaps.core.interfaces.pump.VirtualPump
+import app.aaps.core.interfaces.queue.Command
 import app.aaps.core.interfaces.queue.CommandQueue
 import app.aaps.core.interfaces.receivers.ReceiverStatusStore
 import app.aaps.core.interfaces.resources.ResourceHelper
@@ -58,6 +59,7 @@ import app.aaps.core.interfaces.rx.events.EventAcceptOpenLoopChange
 import app.aaps.core.interfaces.rx.events.EventLoopUpdateGui
 import app.aaps.core.interfaces.rx.events.EventMobileToWear
 import app.aaps.core.interfaces.rx.events.EventNewOpenLoopNotification
+import app.aaps.core.interfaces.rx.events.EventProfileChangeRequested
 import app.aaps.core.interfaces.rx.events.EventRefreshOverview
 import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.ui.UiInteraction
@@ -460,6 +462,14 @@ class LoopPlugin @Inject constructor(
                 aapsLogger.debug(LTag.APS, rh.gs(app.aaps.core.ui.R.string.no_profile_set))
                 rxBus.send(EventLoopSetLastRunGui(rh.gs(app.aaps.core.ui.R.string.no_profile_set)))
                 return@withContext
+            }
+
+            // An expired timed profile switch is reverted only on EventProfileChangeRequested.
+            // KeepAliveWorker fires it but can be delayed by Doze, so detect the pending
+            // change here as well: the loop runs reliably on every BG
+            if (profileFunction.isProfileChangePending() && !commandQueue.isRunning(Command.CommandType.BASAL_PROFILE)) {
+                aapsLogger.debug(LTag.APS, "Profile change pending. Requesting profile update")
+                rxBus.send(EventProfileChangeRequested())
             }
 
             if (!isEmptyQueue()) {


### PR DESCRIPTION
Expiry of a timed profile switch is passive: nothing fires at its end time and the loop keeps using the last EffectiveProfileSwitch. The only revert trigger is KeepAliveWorker.checkPump(), which Doze can delay indefinitely, leaving the expired percentage/timeshift active.

Add two independent triggers, both gated on isProfileChangePending():
- ProfileSwitchExpiryWorker, scheduled for the switch end time whenever a timed switch becomes effective (cancelled by a permanent switch)
- a pending-change check in LoopPlugin.invoke(), as the loop runs on every BG even when scheduled work is throttled