### PR TITLE
Improve temp target confirmation dialog: formatting, colors, and layout

### DIFF
--- a/core/data/src/main/kotlin/app/aaps/core/data/ui/ConfirmationLine.kt
+++ b/core/data/src/main/kotlin/app/aaps/core/data/ui/ConfirmationLine.kt
@@ -10,7 +10,7 @@ package app.aaps.core.data.ui
  */
 enum class ConfirmationRole {
 
-    NORMAL, PRIMARY, BOLUS, CARBS, COB, WARNING, INFO
+    NORMAL, PRIMARY, BOLUS, CARBS, COB, WARNING, INFO, TEMP_TARGET
 }
 
 /**

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/FormatUtils.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/FormatUtils.kt
@@ -10,7 +10,7 @@ import kotlin.math.roundToInt
 import app.aaps.core.keys.R as KeysR
 
 /**
- * Formats minutes as duration string: "Xh Ym" when >= 60, "X mins" otherwise.
+ * Formats minutes as duration string: "X h Y min" when >= 60 (omits minutes if zero), "X min" otherwise.
  * Composable version using stringResource.
  */
 @Composable
@@ -20,14 +20,15 @@ fun formatMinutesAsDuration(minutes: Int): String {
     return if (abs >= 60) {
         val hours = abs / 60
         val mins = abs % 60
-        sign + stringResource(R.string.format_hour_minute, hours, mins)
+        sign + if (mins == 0) stringResource(R.string.format_hours_only, hours)
+        else stringResource(R.string.format_hour_minute, hours, mins)
     } else {
         stringResource(R.string.format_mins, minutes)
     }
 }
 
 /**
- * Formats minutes as duration string: "Xh Ym" when >= 60, "X mins" otherwise.
+ * Formats minutes as duration string: "X h Y min" when >= 60 (omits minutes if zero), "X min" otherwise.
  * Non-composable version using ResourceHelper.
  */
 fun formatMinutesAsDuration(minutes: Int, rh: ResourceHelper): String {
@@ -36,7 +37,8 @@ fun formatMinutesAsDuration(minutes: Int, rh: ResourceHelper): String {
     return if (abs >= 60) {
         val hours = abs / 60
         val mins = abs % 60
-        sign + rh.gs(R.string.format_hour_minute, hours, mins)
+        sign + if (mins == 0) rh.gs(R.string.format_hours_only, hours)
+        else rh.gs(R.string.format_hour_minute, hours, mins)
     } else {
         rh.gs(R.string.format_mins, minutes)
     }
@@ -47,7 +49,7 @@ fun formatMinutesAsDuration(minutes: Int, rh: ResourceHelper): String {
  * unit labels, and plain value formatting.
  *
  * Priority order:
- * 1. Minutes unit (unitLabelResId == units_min) → "Xh Ym" or "X mins"
+ * 1. Minutes unit (unitLabelResId == units_min) → "X h Y min" or "X min"
  * 2. valueFormatResId → stringResource with value (as Int if formatAsInt, else Double)
  * 3. unitLabel non-empty → "formatted_value unitLabel"
  * 4. Plain → valueFormat.format(value)

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/dialogs/ConfirmationMessage.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/dialogs/ConfirmationMessage.kt
@@ -26,14 +26,16 @@ fun List<ConfirmationLine>.toAnnotatedString(primaryColor: Color): AnnotatedStri
     val cob = AapsTheme.elementColors.cob
     val warning = MaterialTheme.colorScheme.error
     val info = AapsTheme.elementColors.tempTarget
+    val tempTarget = AapsTheme.generalColors.inProgress
     fun color(role: ConfirmationRole): Color? = when (role) {
-        ConfirmationRole.NORMAL  -> null
-        ConfirmationRole.PRIMARY -> primaryColor
-        ConfirmationRole.BOLUS   -> insulin
-        ConfirmationRole.CARBS   -> carbs
-        ConfirmationRole.COB     -> cob
-        ConfirmationRole.WARNING -> warning
-        ConfirmationRole.INFO    -> info
+        ConfirmationRole.NORMAL      -> null
+        ConfirmationRole.PRIMARY     -> primaryColor
+        ConfirmationRole.BOLUS       -> insulin
+        ConfirmationRole.CARBS       -> carbs
+        ConfirmationRole.COB         -> cob
+        ConfirmationRole.WARNING     -> warning
+        ConfirmationRole.INFO        -> info
+        ConfirmationRole.TEMP_TARGET -> tempTarget
     }
     return buildAnnotatedString {
         this@toAnnotatedString.forEachIndexed { index, confirmationLine ->

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -37,10 +37,10 @@
     <string name="loop_disabled">LOOP DISABLED BY CONSTRAINTS</string>
     <string name="loop_disabled_by_user">Loop disabled by user</string>
     <string name="event_type">Event type</string>
-    <string name="mgdl">mg/dl</string>
-    <string name="mmol">mmol/l</string>
-    <string name="bg_mgdl">%1$d mg/dl</string>
-    <string name="bg_mmol">%1$.1f mmol/l</string>
+    <string name="mgdl">mg/dL</string>
+    <string name="mmol">mmol/L</string>
+    <string name="bg_mgdl">%1$d mg/dL</string>
+    <string name="bg_mmol">%1$.1f mmol/L</string>
     <string name="save">Save</string>
     <string name="skip">Skip</string>
     <string name="switch_to_edit">Edit</string>
@@ -108,7 +108,7 @@
     <string name="formatsignedinsulinunits">%1$+.2f U</string>
     <string name="format_carbs">%1$d g</string>
     <string name="format_hours">%1$.2f h</string>
-    <string name="format_mins">%1$d mins</string>
+    <string name="format_mins">%1$d min</string>
     <string name="confirmation_line" comment="Confirmation-summary line, joins a label and an already-formatted value. %1$s = label, %2$s = value with its unit. Example: Bolus: 1.50 U">%1$s: %2$s</string>
     <string name="value_with_unit" comment="A numeric value followed by its unit, when no dedicated value template exists. %1$s = value, %2$s = unit. Example: 120 mg/dl">%1$s %2$s</string>
     <string name="objectives">Objectives</string>
@@ -925,7 +925,8 @@
     <string name="cloud_auth_success">Cloud storage authentication successful</string>
     <string name="authorization_status">Authorization Status</string>
 
-    <string name="format_hour_minute">%1$dh %2$dm</string>
+    <string name="format_hour_minute" comment="%1$d=hours, %2$d=minutes. Example: 1 h 23 min">%1$d h %2$d min</string>
+    <string name="format_hours_only" comment="%1$d=hours, when minutes are zero. Example: 4 h">%1$d h</string>
 
     <!-- datetime layout -->
     <string name="event_time_label">Event time</string>

--- a/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
@@ -49,6 +49,7 @@ import app.aaps.core.objects.wizard.BolusWizard
 import app.aaps.core.objects.wizard.QuickWizard
 import app.aaps.core.objects.wizard.QuickWizardEntry
 import app.aaps.core.ui.R
+import app.aaps.core.ui.compose.formatMinutesAsDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
@@ -367,8 +368,9 @@ class WizardBolusExecutorImpl @Inject constructor(
         )
         // The master is the SOLE author of the confirmation: build the MERGED lines for the whole batch here, so the
         // client renders the master's exact string and a master-local dialog renders the identical one (decision 1).
+        val isTtOnly = bolus == null && ps == null && rm == null && cappedTb == null && cappedEb == null && ctb == null && ceb == null && ia == null
         val lines = buildFixedLines(bolus, insulin, carbs, recordOnly) +
-            (tt?.let { buildTtLine(it) } ?: emptyList()) +
+            (tt?.let { buildTtLine(it, isTtOnly) } ?: emptyList()) +
             (ps?.let { buildPsLine(it) } ?: emptyList()) +
             (rm?.let { buildRmLine(it) } ?: emptyList()) +
             (cappedTb?.let { buildTempBasalLine(it, tb) } ?: emptyList()) +
@@ -601,7 +603,7 @@ class WizardBolusExecutorImpl @Inject constructor(
      * reason line, or a "cancel" line when [durationMinutes] is 0. [lowMgdl]/[highMgdl] in mg/dL; [reasonDisplay]
      * already localized (or "").
      */
-    private fun buildTempTargetLines(reasonDisplay: String, lowMgdl: Double, highMgdl: Double, durationMinutes: Int): List<ConfirmationLine> {
+    private fun buildTempTargetLines(reasonDisplay: String, lowMgdl: Double, highMgdl: Double, durationMinutes: Int, standalone: Boolean = false): List<ConfirmationLine> {
         val out = mutableListOf<ConfirmationLine>()
         if (durationMinutes == 0) {
             out += ConfirmationLine(ConfirmationRole.NORMAL, rh.gs(R.string.confirmation_line, rh.gs(R.string.temporary_target), rh.gs(R.string.cancel)))
@@ -610,9 +612,15 @@ class WizardBolusExecutorImpl @Inject constructor(
             val unitLabel = if (units == GlucoseUnit.MMOL) rh.gs(R.string.mmol) else rh.gs(R.string.mgdl)
             val low = decimalFormatter.to1Decimal(profileUtil.fromMgdlToUnits(lowMgdl, units))
             val target = if (lowMgdl == highMgdl) low else low + " – " + decimalFormatter.to1Decimal(profileUtil.fromMgdlToUnits(highMgdl, units))
+            val durationText = formatMinutesAsDuration(durationMinutes, rh)
+            val targetLabel = if (standalone) rh.gs(R.string.target_label) else rh.gs(R.string.temporary_target)
+            out += ConfirmationLine(
+                ConfirmationRole.TEMP_TARGET,
+                rh.gs(R.string.confirmation_line, targetLabel, rh.gs(R.string.value_with_unit, target, unitLabel))
+            )
             out += ConfirmationLine(
                 ConfirmationRole.NORMAL,
-                rh.gs(R.string.confirmation_line, rh.gs(R.string.temporary_target), rh.gs(R.string.value_with_unit, target, unitLabel) + " (" + rh.gs(R.string.format_mins, durationMinutes) + ")")
+                rh.gs(R.string.confirmation_line, rh.gs(R.string.duration), durationText)
             )
             if (reasonDisplay.isNotEmpty())
                 out += ConfirmationLine(ConfirmationRole.NORMAL, rh.gs(R.string.confirmation_line, rh.gs(R.string.reason), reasonDisplay))
@@ -621,8 +629,8 @@ class WizardBolusExecutorImpl @Inject constructor(
     }
 
     /** The TT line(s) for any batch (wear / client / phone) — range + duration + a localized reason, or a cancel line. */
-    private fun buildTtLine(tt: BatchAction.TempTarget): List<ConfirmationLine> =
-        buildTempTargetLines(localizeTtReason(tt.reason), tt.lowMgdl, tt.highMgdl, tt.durationMinutes)
+    private fun buildTtLine(tt: BatchAction.TempTarget, standalone: Boolean = false): List<ConfirmationLine> =
+        buildTempTargetLines(localizeTtReason(tt.reason), tt.lowMgdl, tt.highMgdl, tt.durationMinutes, standalone)
 
     /**
      * Apply a batch ProfileSwitch via the dialog-free domain path. [profileName] non-null → switch to that named

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
@@ -156,6 +156,7 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                                         "CARBS", "COB"   -> CarbsOrange
                                                         "WARNING"        -> WearWarningAmber
                                                         "INFO"           -> WearSecondaryText
+                                                        "TEMP_TARGET"    -> TempTargetYellow
                                                         "NORMAL", "PRIMARY" -> Color.White
                                                         else             -> Color.White
                                                     },


### PR DESCRIPTION
  - Fix unit casing: mmol/L and mg/dL throughout (format_mins, bg_mgdl, bg_mmol)
  - Fix duration display: "4 h" instead of "4h 0m", "45 min" instead of "45 mins"
    (formatMinutesAsDuration now omits zero components; format_hour_minute uses spaces)
  - Add TEMP_TARGET ConfirmationRole mapped to yellow on both phone and wear
  - Split TT confirmation into separate lines: target value (yellow), duration, reason
  - Use shorter "Target:" label in standalone TT dialog (to avoid repeating title), "Temporary target:" in batch with carbs, insulin etc.
  
  Some screenshots before/after:
  
| Before | After |
|--------|--------|
| <img width="501" height="737" alt="image" src="https://github.com/user-attachments/assets/248b876c-47aa-4596-8f2e-713f4c900013" /> | <img width="638" height="940" alt="image" src="https://github.com/user-attachments/assets/7fd16dfa-19cc-4bd0-a2cb-2cae97bfc37e" /> |
| <img width="582" height="701" alt="image" src="https://github.com/user-attachments/assets/440b6145-7c84-4821-94cf-d5a8dca02ab3" /> | <img width="506" height="697" alt="image" src="https://github.com/user-attachments/assets/85b4ccbc-aaa8-4393-aab1-bb99d2e881fc" /> |
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/54ce7c08-7c11-4555-94f5-60cd91afbaa2" />l | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/a475f241-954c-4442-b793-ce353c038fa4" /> | 

Watch:
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/86d25ee5-9694-4ba3-a41f-7702c337c416" />
