### PR TITLE
  QuickWizard: eCarbs support for CARBS mode, tile UX improvements

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/BatchAction.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/BatchAction.kt
@@ -26,7 +26,10 @@ sealed interface BatchAction {
         val recordOnly: Boolean,
         val notes: String,
         val timestamp: Long,
-        val iCfg: ICfg?
+        val iCfg: ICfg?,
+        val eCarbsGrams: Int = 0,
+        val eCarbsDelayMinutes: Int = 0,
+        val eCarbsDurationHours: Int = 0
     ) : BatchAction
 
     /**

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/ClientControlMessage.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/ClientControlMessage.kt
@@ -231,7 +231,11 @@ data class BatchActionDto(
     val meterType: String? = null,
     val location: String? = null,
     val arrow: String? = null,
-    val source: String? = null // round-trips for symmetry; the master ignores it (relayed events are logged as Sources.NSClient)
+    val source: String? = null, // round-trips for symmetry; the master ignores it (relayed events are logged as Sources.NSClient)
+    // bolus eCarbs split: extended carbs amount, delay, and duration (0 = no eCarbs)
+    val eCarbsGrams: Int = 0,
+    val eCarbsDelayMinutes: Int = 0,
+    val eCarbsDurationHours: Int = 0
 ) {
 
     companion object {

--- a/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
@@ -399,6 +399,7 @@ class WizardBolusExecutorImpl @Inject constructor(
             insulin = insulin, carbs = carbs, bcr = null, bolusId = bolusId, entry = null,
             carbTimeMinutes = bolus?.carbsTimeOffsetMinutes ?: 0, notes = bolus?.notes, mode = BolusMode.FIXED,
             eventType = eventType, carbsDurationHours = bolus?.carbsDurationHours ?: 0,
+            eCarbsGrams = bolus?.eCarbsGrams ?: 0, eCarbsDelayMinutes = bolus?.eCarbsDelayMinutes ?: 0, eCarbsDurationHours = bolus?.eCarbsDurationHours ?: 0,
             tempTarget = tt, profileSwitch = ps, runningMode = rm, recordOnly = recordOnly, iCfg = bolus?.iCfg, bolusTimestamp = bolus?.timestamp?.takeIf { it > 0L },
             tempBasal = cappedTb, extendedBolus = cappedEb, cancelTempBasal = ctb != null, cancelExtendedBolus = ceb != null,
             insulinActivate = ia, therapyEvents = tes
@@ -476,6 +477,12 @@ class WizardBolusExecutorImpl @Inject constructor(
                     val carbsTime = if (p.carbs > 0) dateUtil.now() + T.mins(p.carbTimeMinutes.toLong()).msecs() else null
                     deliver(p.insulin, p.carbs, carbsTime = carbsTime, carbsDuration = p.carbsDurationHours, bolusCalculatorResult = p.bcr, notes = notes, source = source, onError = wrapped, eventType = p.eventType)
                 }
+            }
+            // eCarbs split (e.g. a CARBS-mode QuickWizard entry with eCarbs configured): the immediate carbs are
+            // delivered above; the extended portion is scheduled here, mirroring the wizard path's carbs2 delivery.
+            if (p.eCarbsGrams > 0) {
+                val eCarbsTime = dateUtil.now() + T.mins(p.eCarbsDelayMinutes.toLong()).msecs()
+                deliverECarbs(p.eCarbsGrams, eCarbsTime, p.eCarbsDurationHours, p.eCarbsDelayMinutes, notes, source, wrapped)
             }
             if (tt != null && !raising && accepted) applyTempTarget(tt, source)
             // Insulin activation re-applies the active profile with the new insulin — run BEFORE any explicit PS
@@ -632,6 +639,8 @@ class WizardBolusExecutorImpl @Inject constructor(
             if (bolus.carbsDurationHours > 0)
                 out += ConfirmationLine(ConfirmationRole.NORMAL, rh.gs(R.string.confirmation_line, rh.gs(R.string.duration), rh.gs(R.string.value_with_unit, bolus.carbsDurationHours.toString(), rh.gs(app.aaps.core.interfaces.R.string.shorthour))))
         }
+        if (bolus.eCarbsGrams > 0)
+            out += ConfirmationLine(ConfirmationRole.CARBS, rh.gs(R.string.wizard_ecarbs, bolus.eCarbsGrams, bolus.eCarbsDurationHours, bolus.eCarbsDelayMinutes))
         if (bolus.notes.isNotEmpty())
             out += ConfirmationLine(ConfirmationRole.NORMAL, rh.gs(R.string.confirmation_line, rh.gs(R.string.notes_label), bolus.notes))
         return out

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/BatchActionMapping.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/BatchActionMapping.kt
@@ -17,7 +17,8 @@ internal fun BatchAction.toDto(): BatchActionDto = when (this) {
         type = BatchActionDto.TYPE_BOLUS,
         insulin = insulin, carbs = carbs, carbsTimeOffsetMinutes = carbsTimeOffsetMinutes,
         carbsDurationHours = carbsDurationHours, recordOnly = recordOnly, notes = notes, timestamp = timestamp,
-        iCfgJson = iCfg?.toJsonObject()?.toString()
+        iCfgJson = iCfg?.toJsonObject()?.toString(),
+        eCarbsGrams = eCarbsGrams, eCarbsDelayMinutes = eCarbsDelayMinutes, eCarbsDurationHours = eCarbsDurationHours
     )
 
     is BatchAction.TempTarget          -> BatchActionDto(
@@ -64,7 +65,8 @@ internal fun BatchActionDto.toDomain(): BatchAction? = when (type) {
     BatchActionDto.TYPE_BOLUS                 -> BatchAction.Bolus(
         insulin = insulin, carbs = carbs, carbsTimeOffsetMinutes = carbsTimeOffsetMinutes,
         carbsDurationHours = carbsDurationHours, recordOnly = recordOnly, notes = notes, timestamp = timestamp,
-        iCfg = iCfgJson?.let { j -> runCatching { (Json.parseToJsonElement(j) as? JsonObject)?.let { ICfg.fromJsonObject(it) } }.getOrNull() }
+        iCfg = iCfgJson?.let { j -> runCatching { (Json.parseToJsonElement(j) as? JsonObject)?.let { ICfg.fromJsonObject(it) } }.getOrNull() },
+        eCarbsGrams = eCarbsGrams, eCarbsDelayMinutes = eCarbsDelayMinutes, eCarbsDurationHours = eCarbsDurationHours
     )
 
     BatchActionDto.TYPE_TEMP_TARGET           -> reason?.let { BatchAction.TempTarget(it, lowMgdl, highMgdl, durationMinutes, startOffsetMinutes, notes.ifEmpty { null }) }

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -271,7 +271,7 @@ class DataHandlerMobile @Inject constructor(
             onCommitResult(batchExecutor.commit(it.bolusId, Sources.Wear, rh.gs(app.aaps.core.ui.R.string.overview_treatment_label))) {
                 quickWizardGuid?.let { guid ->
                     quickWizard.get(guid)?.markAsUsed()
-                    sendQuickWizardListToWear() // refresh lastUsed so the fixed-mode tile cools down (matches phone)
+                    sendQuickWizardListToWear() // refresh lastUsed in the tile entry list after delivery
                 }
             }
         }
@@ -701,14 +701,14 @@ class DataHandlerMobile @Inject constructor(
         )
     }
 
-    // Parked bolusId → QuickWizard guid for a FIXED (INSULIN/CARBS) wear quick-wizard, so the entry is marked used on a
-    // successful commit and the tile cools down for an hour (matches the phone's executeFixedBatch → markAsUsed). The
+    // Parked bolusId → QuickWizard guid for a FIXED (INSULIN/CARBS) wear quick-wizard, so the entry's lastUsed
+    // timestamp is updated on a successful commit (mirrors the phone's executeFixedBatch → markAsUsed). The
     // WIZARD path marks used inside the executor — its PendingBolus carries the entry — but a fixed batch parks entry=null.
     private val quickWizardFixedUsage = ConcurrentHashMap<Long, String>()
 
     private fun rememberQuickWizardUsage(bolusId: Long, guid: String) {
-        // Drop ids older than the tile cooldown so a prepared-then-cancelled (never committed) entry can't accumulate.
-        quickWizardFixedUsage.keys.removeAll { dateUtil.now() - it > 3_600_000L } // 1 hour (QuickWizardSource.COOLDOWN_MILLIS)
+        // Drop ids older than 1 hour so a prepared-then-cancelled (never committed) entry can't accumulate.
+        quickWizardFixedUsage.keys.removeAll { dateUtil.now() - it > 3_600_000L }
         quickWizardFixedUsage[bolusId] = guid
     }
 
@@ -729,13 +729,19 @@ class DataHandlerMobile @Inject constructor(
                 label = rh.gs(app.aaps.core.ui.R.string.bolus)
             ) { bolusId -> rememberQuickWizardUsage(bolusId, command.guid); EventData.ActionBolusConfirmed(bolusId) }
 
-            QuickWizardMode.CARBS   -> sendBatchPreCheck(
-                BatchAction.Bolus(
-                    insulin = 0.0, carbs = entry.carbs(), carbsTimeOffsetMinutes = 0, carbsDurationHours = 0,
-                    recordOnly = false, notes = entry.buttonText(), timestamp = 0L, iCfg = null
-                ),
-                label = rh.gs(app.aaps.core.ui.R.string.carbs)
-            ) { bolusId -> rememberQuickWizardUsage(bolusId, command.guid); EventData.ActionBolusConfirmed(bolusId) }
+            QuickWizardMode.CARBS   -> {
+                val hasEcarbs = entry.useEcarbs() == QuickWizardEntry.YES
+                sendBatchPreCheck(
+                    BatchAction.Bolus(
+                        insulin = 0.0, carbs = entry.carbs(), carbsTimeOffsetMinutes = 0, carbsDurationHours = 0,
+                        recordOnly = false, notes = entry.buttonText(), timestamp = 0L, iCfg = null,
+                        eCarbsGrams = if (hasEcarbs) entry.carbs2() else 0,
+                        eCarbsDelayMinutes = if (hasEcarbs) entry.time() else 0,
+                        eCarbsDurationHours = if (hasEcarbs) entry.duration() else 0
+                    ),
+                    label = rh.gs(app.aaps.core.ui.R.string.carbs)
+                ) { bolusId -> rememberQuickWizardUsage(bolusId, command.guid); EventData.ActionBolusConfirmed(bolusId) }
+            }
 
             else                    -> {
                 // Role-transparent recompute: MASTER computes + caps + parks + authors lines locally; CLIENT relays a

--- a/ui/src/main/kotlin/app/aaps/ui/compose/main/MainViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/main/MainViewModel.kt
@@ -521,9 +521,16 @@ class MainViewModel @Inject constructor(
     private suspend fun executeCarbsMode(entry: QuickWizardEntry) {
         val carbs = entry.carbs()
         if (carbs <= 0) return
+        val hasEcarbs = entry.useEcarbs() == QuickWizardEntry.YES
         executeFixedBatch(
             entry,
-            listOf(BatchAction.Bolus(insulin = 0.0, carbs = carbs, carbsTimeOffsetMinutes = 0, carbsDurationHours = 0, recordOnly = false, notes = entry.buttonText(), timestamp = 0L, iCfg = null)),
+            listOf(BatchAction.Bolus(
+                insulin = 0.0, carbs = carbs, carbsTimeOffsetMinutes = 0, carbsDurationHours = 0,
+                recordOnly = false, notes = entry.buttonText(), timestamp = 0L, iCfg = null,
+                eCarbsGrams = if (hasEcarbs) entry.carbs2() else 0,
+                eCarbsDelayMinutes = if (hasEcarbs) entry.time() else 0,
+                eCarbsDurationHours = if (hasEcarbs) entry.duration() else 0
+            )),
             rh.gs(app.aaps.core.ui.R.string.carbs),
             IcCarbs
         )

--- a/ui/src/main/kotlin/app/aaps/ui/compose/quickWizard/viewmodels/QuickWizardManagementViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/quickWizard/viewmodels/QuickWizardManagementViewModel.kt
@@ -97,25 +97,21 @@ class QuickWizardManagementViewModel @Inject constructor(
                 val showSuperBolus = preferences.get(BooleanKey.OverviewUseSuperBolus)
                 val showWear = preferences.get(BooleanKey.WearControl)
 
-                // Select first entry if exists
-                val firstEntry = entries.firstOrNull()
-
-                _uiState.update {
-                    it.copy(
+                _uiState.update { current ->
+                    // Preserve the current selection if valid (e.g. after a save on a non-first card);
+                    // fall back to 0 on initial load (current.selectedIndex == -1) or if the list shrank.
+                    val targetIndex = if (current.selectedIndex in entries.indices) current.selectedIndex else 0
+                    val targetEntry = entries.getOrNull(targetIndex)
+                    current.copy(
                         entries = entries,
-                        selectedIndex = if (entries.isNotEmpty()) 0 else -1,
-                        selectedGuid = firstEntry?.guid() ?: "",
-                        currentCardIndex = 0,
+                        selectedIndex = if (entries.isNotEmpty()) targetIndex else -1,
+                        selectedGuid = targetEntry?.guid() ?: "",
+                        currentCardIndex = if (current.currentCardIndex in entries.indices) current.currentCardIndex else 0,
                         showSuperBolusOption = showSuperBolus,
                         showWearOptions = showWear,
                         isLoading = false
                     ).let { state ->
-                        // Load first entry into editor if exists
-                        if (firstEntry != null) {
-                            loadEntryIntoEditor(state, firstEntry)
-                        } else {
-                            state
-                        }
+                        if (targetEntry != null) loadEntryIntoEditor(state, targetEntry) else state
                     }
                 }
             } catch (e: Exception) {
@@ -275,7 +271,14 @@ class QuickWizardManagementViewModel @Inject constructor(
                 quickWizard.addOrUpdate(entry)
                 rxBus.send(EventQuickWizardChange())
 
-                _uiState.update { it.copy(hasUnsavedChanges = false) }
+                // Synchronously refresh the entries list so the carousel shows the saved mode
+                // immediately, without waiting for the async RxBus → loadData() path.
+                val updatedEntries = quickWizard.list()
+                _uiState.update { state ->
+                    val savedEntry = updatedEntries.getOrNull(index)
+                    val base = state.copy(entries = updatedEntries, hasUnsavedChanges = false)
+                    if (savedEntry != null) loadEntryIntoEditor(base, savedEntry) else base
+                }
             } catch (e: Exception) {
                 aapsLogger.error(LTag.UI, "Failed to save QuickWizard entry", e)
                 rxBus.send(EventShowSnackbar(e.message ?: "Failed to save entry", EventShowSnackbar.Type.Error))

--- a/wear/src/main/kotlin/app/aaps/wear/tile/QuickWizardTileService.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/QuickWizardTileService.kt
@@ -1,5 +1,9 @@
 package app.aaps.wear.tile
 
+import androidx.wear.tiles.EventBuilders.TileEnterEvent
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventWearToMobile
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.wear.tile.source.QuickWizardSource
 import dagger.android.AndroidInjection
 import javax.inject.Inject
@@ -7,6 +11,7 @@ import javax.inject.Inject
 class QuickWizardTileService : TileBase() {
 
     @Inject lateinit var quickWizardSource: QuickWizardSource
+    @Inject lateinit var rxBus: RxBus
 
     // Not derived from DaggerService, do injection here
     override fun onCreate() {
@@ -16,4 +21,9 @@ class QuickWizardTileService : TileBase() {
 
     override val resourceVersion = "QuickWizardTileService"
     override val source get() = quickWizardSource
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onTileEnterEvent(requestParams: TileEnterEvent) {
+        rxBus.send(EventWearToMobile(EventData.ActionResendData("QuickWizardTileService")))
+    }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
@@ -34,6 +34,11 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         for (quick in quickMap.entries) {
             val isActive = sfm in quick.validFrom..quick.validTo && now - quick.lastUsed > COOLDOWN_MILLIS
             if (isActive && quick.guid.isNotEmpty()) {
+                val icon = when (quick.mode) {
+                    1    -> R.drawable.ic_bolus         // INSULIN mode
+                    2    -> R.drawable.ic_carbs_orange  // CARBS mode
+                    else -> R.drawable.ic_quick_wizard  // WIZARD mode
+                }
                 quickList.add(
                     Action(
                         buttonText = quick.buttonText,
@@ -41,7 +46,7 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
                             context.resources.getString(R.string.quick_wizard_tile_insulin, quick.insulin)
                         else
                             context.resources.getString(R.string.quick_wizard_tile_carbs, quick.carbs),
-                        iconRes = R.drawable.ic_quick_wizard,
+                        iconRes = icon,
                         activityClass = BackgroundActionActivity::class.java.name,
                         action = EventData.ActionQuickWizardPreCheck(quick.guid),
                         message = context.resources.getString(R.string.action_quick_wizard_confirmation)
@@ -96,5 +101,9 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         return (passed / 1000).toInt()
     }
 
-    override fun getResourceReferences(resources: Resources): List<Int> = listOf(R.drawable.ic_quick_wizard)
+    override fun getResourceReferences(resources: Resources): List<Int> = listOf(
+        R.drawable.ic_quick_wizard,
+        R.drawable.ic_bolus,
+        R.drawable.ic_carbs_orange
+    )
 }

--- a/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
@@ -18,8 +18,6 @@ import javax.inject.Singleton
 class QuickWizardSource @Inject constructor(private val context: Context, private val sp: SP, private val aapsLogger: AAPSLogger) : TileSource {
 
     companion object {
-        const val COOLDOWN_MILLIS = 3_600_000L // 1 hour
-
         // Mirrors QuickWizardMode in :core:objects (not a wear dependency): WIZARD(0), INSULIN(1), CARBS(2).
         // An INSULIN button shows its fixed dose in U; WIZARD/CARBS show carbs in g (the wizard's carb input).
         private const val MODE_INSULIN = 1
@@ -29,11 +27,9 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         val quickList = mutableListOf<Action>()
         val quickMap = getQuickWizardData(sp)
         val sfm = secondsFromMidnight()
-        val now = System.currentTimeMillis()
 
         for (quick in quickMap.entries) {
-            val isActive = sfm in quick.validFrom..quick.validTo && now - quick.lastUsed > COOLDOWN_MILLIS
-            if (isActive && quick.guid.isNotEmpty()) {
+            if (sfm in quick.validFrom..quick.validTo && quick.guid.isNotEmpty()) {
                 val icon = when (quick.mode) {
                     1    -> R.drawable.ic_bolus         // INSULIN mode
                     2    -> R.drawable.ic_carbs_orange  // CARBS mode
@@ -65,21 +61,12 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         if (quickMap.entries.isEmpty()) return null
 
         val sfm = secondsFromMidnight()
-        val now = System.currentTimeMillis()
         var validTill = 24 * 60 * 60
 
         for (quick in quickMap.entries) {
-            val onCooldown = now - quick.lastUsed <= COOLDOWN_MILLIS
-            val isActive = sfm in quick.validFrom..quick.validTo && !onCooldown
             if (quick.guid.isNotEmpty()) {
-                if (isActive && validTill > quick.validTo) validTill = quick.validTo
+                if (sfm in quick.validFrom..quick.validTo && validTill > quick.validTo) validTill = quick.validTo
                 if (quick.validFrom in (sfm + 1) until validTill) validTill = quick.validFrom
-                // If entry is on cooldown but within time window, refresh when cooldown expires
-                if (onCooldown && sfm in quick.validFrom..quick.validTo) {
-                    val cooldownRemainingSecs = ((quick.lastUsed + COOLDOWN_MILLIS - now) / 1000).toInt()
-                    val cooldownExpirySfm = sfm + cooldownRemainingSecs
-                    if (cooldownExpirySfm in (sfm + 1) until validTill) validTill = cooldownExpirySfm
-                }
             }
         }
 

--- a/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/source/QuickWizardSource.kt
@@ -21,6 +21,7 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         // Mirrors QuickWizardMode in :core:objects (not a wear dependency): WIZARD(0), INSULIN(1), CARBS(2).
         // An INSULIN button shows its fixed dose in U; WIZARD/CARBS show carbs in g (the wizard's carb input).
         private const val MODE_INSULIN = 1
+        private const val MODE_CARBS   = 2
     }
 
     override fun getSelectedActions(): List<Action> {
@@ -31,9 +32,9 @@ class QuickWizardSource @Inject constructor(private val context: Context, privat
         for (quick in quickMap.entries) {
             if (sfm in quick.validFrom..quick.validTo && quick.guid.isNotEmpty()) {
                 val icon = when (quick.mode) {
-                    1    -> R.drawable.ic_bolus         // INSULIN mode
-                    2    -> R.drawable.ic_carbs_orange  // CARBS mode
-                    else -> R.drawable.ic_quick_wizard  // WIZARD mode
+                    MODE_INSULIN -> R.drawable.ic_bolus
+                    MODE_CARBS   -> R.drawable.ic_carbs_orange
+                    else         -> R.drawable.ic_quick_wizard
                 }
                 quickList.add(
                     Action(


### PR DESCRIPTION
  - **Fixed so that eCarbs is applied for CARBS mode** (wear + phone): .
    Applies to both the wear tile and the phone carousel button.

  - **Tile refresh on enter**: `QuickWizardTileService` sends `ActionResendData`
    on `onTileEnterEvent`, matching the pattern used by running mode and scenes

  - **Removed 1-hour cooldown**: tile was hiding recently-used entries for 1
    hour after use — phone has no equivalent cooldown and confirmation dialog
    already prevents accidental double-delivery

  - **Mode-specific icons on tile**: INSULIN → bolus icon, CARBS → carbs icon,
    WIZARD → wizard icon 

  - **Carousel display bug** (phone): `loadData()` was always resetting to card 0
    after any data change, so saving a non-first card showed the wrong mode icon
    until the screen was reopened; carousel now preserves the current position
    and refreshes immediately after save

Tested OK on AAPSClient and AAPS phone/wear.

Some screenshots:
| Before | After |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/c2392eb7-e8fe-4d2e-8628-f1674f44f2b3" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/69b3c8a0-da28-4afb-82b0-78feea1ed94b" /> |
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/73f1c4c8-aae9-4cf4-ac3a-f20b2ee808bf" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/44e719c4-6c82-41ff-b047-af78a7811726" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/a28b4122-b632-4b12-bb05-e99280c7e8a7" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/cf76a978-9c72-47a6-83d7-efeb59415d8e" /> | 