### PR TITLE
Wear: Reintroduce bolus wizard result screen with QuickWizard support

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/WizardBolusExecutor.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/WizardBolusExecutor.kt
@@ -5,6 +5,7 @@ import app.aaps.core.data.model.ICfg
 import app.aaps.core.data.model.TE
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.data.ui.ConfirmationLine
+import app.aaps.core.interfaces.rx.weardata.EventData
 
 /**
  * Transport-neutral spine for wizard / quick-wizard bolus **prepare → confirm → deliver**. Owns the
@@ -172,7 +173,8 @@ interface WizardBolusExecutor {
             val bolusId: Long,
             val lines: List<ConfirmationLine> = emptyList(),
             val advisorApplies: Boolean = false,
-            val advisorLines: List<ConfirmationLine> = emptyList()
+            val advisorLines: List<ConfirmationLine> = emptyList(),
+            val wizardDetail: EventData.WizardDetail? = null,
         ) : PrepareResult
 
         data class Error(val message: String) : PrepareResult

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/clientcontrol/ActionProgress.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/clientcontrol/ActionProgress.kt
@@ -1,6 +1,7 @@
 package app.aaps.core.interfaces.clientcontrol
 
 import app.aaps.core.data.ui.ConfirmationLine
+import app.aaps.core.interfaces.rx.weardata.EventData
 
 /**
  * Progress/outcome of an action dispatched through [ClientControlActionDispatcher]. A `dispatch`
@@ -35,7 +36,8 @@ sealed interface ActionProgress {
         val id: Long,
         val lines: List<ConfirmationLine> = emptyList(),
         val advisorApplies: Boolean = false,
-        val advisorLines: List<ConfirmationLine> = emptyList()
+        val advisorLines: List<ConfirmationLine> = emptyList(),
+        val wizardDetail: EventData.WizardDetail? = null,
     ) : ActionProgress
 
     /** Terminal: definitely not applied — master refused / failed, or it never reached NS. */

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -458,6 +458,36 @@ sealed class EventData : Event() {
     @Serializable
     data class ConfirmActionLine(val role: String, val text: String)
 
+    /**
+     * Raw bolus-wizard calculation breakdown sent alongside [ConfirmAction] for wizard/quick-wizard boluses.
+     * The watch renders a dedicated "Calculations" page so the user can inspect the full dose breakdown before
+     * confirming. Absent (null) for non-wizard actions (TT, PS, RM, scene, batch-only bolus/carbs).
+     * All insulin values are in the user's units (U); [sens] and [ic] are in profile units.
+     */
+    @Serializable
+    data class WizardDetail(
+        val totalInsulin: Double,
+        val carbs: Int,
+        val insulinFromBG: Double,
+        val insulinFromTrend: Double,
+        val insulinFromCOB: Double,
+        val insulinFromCarbs: Double,
+        val insulinFromBolusIOB: Double,
+        val insulinFromBasalIOB: Double,
+        val includeBolusIOB: Boolean,
+        val includeBasalIOB: Boolean,
+        val percentageCorrection: Int,
+        val cob: Double,
+        /** Formatted TT target string in profile units (e.g. "5.5" or "5.0-5.5"), null when no TT was used. */
+        val tempTargetLabel: String?,
+        val ic: Double,
+        val sens: Double,
+        val eCarbsGrams: Int = 0,
+        val eCarbsDelayMinutes: Int = 0,
+        val eCarbsDurationHours: Int = 0,
+        val carbTimeMinutes: Int = 0,
+    )
+
     @Serializable // returnCommand is sent back to Mobile after confirmation
     data class ConfirmAction(
         val title: String,
@@ -473,6 +503,9 @@ sealed class EventData : Event() {
         // locally, no relay) → the watch shows success immediately as before. Set from config.AAPSCLIENT, so it is
         // role-based, not per-action.
         val deferConfirm: Boolean = false,
+        // Optional wizard calculation breakdown: populated for bolus-wizard and quick-wizard prepares, null for all
+        // other actions. The watch shows an extra "Calculations" page before the confirm page when present.
+        val wizardDetail: WizardDetail? = null,
     ) : EventData()
 
     /**

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -486,6 +486,7 @@ sealed class EventData : Event() {
         val eCarbsDelayMinutes: Int = 0,
         val eCarbsDurationHours: Int = 0,
         val carbTimeMinutes: Int = 0,
+        val alarm: Boolean = false,
     )
 
     @Serializable // returnCommand is sent back to Mobile after confirmation

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/BolusPreview.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/BolusPreview.kt
@@ -46,6 +46,7 @@ data class WizardDetailDto(
     val eCarbsDelayMinutes: Int = 0,
     val eCarbsDurationHours: Int = 0,
     val carbTimeMinutes: Int = 0,
+    val alarm: Boolean = false,
 )
 
 /**

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/BolusPreview.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/localmodel/clientcontrol/BolusPreview.kt
@@ -12,13 +12,40 @@ import kotlinx.serialization.Serializable
  *
  * [advisorApplies] tells the client to offer the high-BG "correct now, eat later" choice (showing
  * [advisorLines] instead of the normal [lines]); the user's pick rides back in `BolusCommit.asAdvisor`.
+ * [wizardDetail] carries the raw calculation breakdown for wizard/quick-wizard boluses so the wear watch
+ * can show a dedicated "Calculations" page (absent for batch-only/scene prepares).
  */
 @Serializable
 data class BolusPreview(
     val bolusId: Long,
     val lines: List<ConfirmationLineDto> = emptyList(),
     val advisorApplies: Boolean = false,
-    val advisorLines: List<ConfirmationLineDto> = emptyList()
+    val advisorLines: List<ConfirmationLineDto> = emptyList(),
+    val wizardDetail: WizardDetailDto? = null,
+)
+
+/** Wire mirror of [app.aaps.core.interfaces.rx.weardata.EventData.WizardDetail] (same module-boundary pattern as [ConfirmationLineDto]). */
+@Serializable
+data class WizardDetailDto(
+    val totalInsulin: Double,
+    val carbs: Int,
+    val insulinFromBG: Double,
+    val insulinFromTrend: Double,
+    val insulinFromCOB: Double,
+    val insulinFromCarbs: Double,
+    val insulinFromBolusIOB: Double,
+    val insulinFromBasalIOB: Double,
+    val includeBolusIOB: Boolean,
+    val includeBasalIOB: Boolean,
+    val percentageCorrection: Int,
+    val cob: Double,
+    val tempTargetLabel: String?,
+    val ic: Double,
+    val sens: Double,
+    val eCarbsGrams: Int = 0,
+    val eCarbsDelayMinutes: Int = 0,
+    val eCarbsDurationHours: Int = 0,
+    val carbTimeMinutes: Int = 0,
 )
 
 /**

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
@@ -13,6 +13,7 @@ import app.aaps.core.data.ui.ConfirmationLine
 import app.aaps.core.data.ui.ConfirmationRole
 import app.aaps.core.data.ui.confirmationLines
 import app.aaps.core.interfaces.aps.GlucoseStatus
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.aps.Loop
 import app.aaps.core.interfaces.automation.Automation
 import app.aaps.core.interfaces.bolus.WizardBolusExecutor
@@ -51,6 +52,7 @@ import app.aaps.core.objects.runningMode.RunningModeGuard
 import app.aaps.core.utils.JsonHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.text.DecimalFormat
 import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.abs
@@ -446,6 +448,32 @@ class BolusWizard @Inject constructor(
                 line(ConfirmationRole.INFO, rh.gs(app.aaps.core.ui.R.string.wizard_ecarbs, eCarbsGrams, eCarbsDurationHours, eCarbsDelayMinutes))
             }
         }
+
+    fun buildWizardDetail(): EventData.WizardDetail {
+        val ttLabel = if (useTT && tempTarget != null) {
+            val fmt = DecimalFormat("0.0#")
+            val low = fmt.format(profileUtil.fromMgdlToUnits(tempTarget!!.lowTarget))
+            val high = fmt.format(profileUtil.fromMgdlToUnits(tempTarget!!.highTarget))
+            if (low == high) low else "$low-$high"
+        } else null
+        return EventData.WizardDetail(
+            totalInsulin = calculatedTotalInsulin,
+            carbs = carbs,
+            insulinFromBG = insulinFromBG,
+            insulinFromTrend = insulinFromTrend,
+            insulinFromCOB = insulinFromCOB,
+            insulinFromCarbs = insulinFromCarbs,
+            insulinFromBolusIOB = insulinFromBolusIOB,
+            insulinFromBasalIOB = insulinFromBasalIOB,
+            includeBolusIOB = includeBolusIOB,
+            includeBasalIOB = includeBasalIOB,
+            percentageCorrection = percentageCorrection,
+            cob = cob,
+            tempTargetLabel = ttLabel,
+            ic = ic,
+            sens = sens,
+        )
+    }
 
     private fun calcPercentageWithConstraints() {
         calculatedPercentage = 100

--- a/implementation/src/main/kotlin/app/aaps/implementation/bolus/RoleBranch.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/bolus/RoleBranch.kt
@@ -40,7 +40,7 @@ class RoleBranch @Inject constructor(
         }
         // Master: prepare locally — NO app-level modal (the caller renders the returned lines as the confirmation).
         return when (val r = masterPrepare()) {
-            is WizardBolusExecutor.PrepareResult.Preview -> ActionProgress.Prepared(r.bolusId, r.lines, r.advisorApplies, r.advisorLines)
+            is WizardBolusExecutor.PrepareResult.Preview -> ActionProgress.Prepared(r.bolusId, r.lines, r.advisorApplies, r.advisorLines, r.wizardDetail)
             is WizardBolusExecutor.PrepareResult.Error   -> ActionProgress.Rejected(FailureReason.ExecutionFailed, r.message)
             WizardBolusExecutor.PrepareResult.NoAction   -> ActionProgress.Rejected(FailureReason.NoAction)
         }

--- a/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
@@ -201,6 +201,7 @@ class WizardBolusExecutorImpl @Inject constructor(
                 eCarbsDelayMinutes = if (eCarbsGrams > 0) entry.time() else 0,
                 eCarbsDurationHours = if (eCarbsGrams > 0) entry.duration() else 0,
                 carbTimeMinutes = entry.carbTime(),
+                alarm = entry.useAlarm() == QuickWizardEntry.YES && entry.carbTime() > 0,
             ),
         )
     }
@@ -281,6 +282,7 @@ class WizardBolusExecutorImpl @Inject constructor(
                 eCarbsDelayMinutes = inputs.eCarbsDelayMinutes,
                 eCarbsDurationHours = inputs.eCarbsDurationHours,
                 carbTimeMinutes = inputs.carbTime,
+                alarm = inputs.alarm && inputs.carbTime > 0,
             ),
         )
     }

--- a/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/bolus/WizardBolusExecutorImpl.kt
@@ -188,13 +188,20 @@ class WizardBolusExecutorImpl @Inject constructor(
         // Build the master's color-coded confirmation lines here so the client renders the master's EXACT
         // wizard confirmation (shared builder). advisorApplies offers the high-BG "correct now, eat later" fork.
         val advisorApplies = wizard.needsBolusAdvisor()
+        val eCarbsGrams = if (entry.useEcarbs() == QuickWizardEntry.YES) entry.carbs2() else 0
         return WizardBolusExecutor.PrepareResult.Preview(
             insulin = wizard.calculatedTotalInsulin,
             carbs = wizard.carbs,
             bolusId = wizard.timeStamp,
             lines = wizard.buildConfirmationLines(advisor = false, quickWizardEntry = entry),
             advisorApplies = advisorApplies,
-            advisorLines = if (advisorApplies) wizard.buildConfirmationLines(advisor = true, quickWizardEntry = entry) else emptyList()
+            advisorLines = if (advisorApplies) wizard.buildConfirmationLines(advisor = true, quickWizardEntry = entry) else emptyList(),
+            wizardDetail = wizard.buildWizardDetail().copy(
+                eCarbsGrams = eCarbsGrams,
+                eCarbsDelayMinutes = if (eCarbsGrams > 0) entry.time() else 0,
+                eCarbsDurationHours = if (eCarbsGrams > 0) entry.duration() else 0,
+                carbTimeMinutes = entry.carbTime(),
+            ),
         )
     }
 
@@ -268,7 +275,13 @@ class WizardBolusExecutorImpl @Inject constructor(
                 eCarbsDurationHours = inputs.eCarbsDurationHours
             ),
             advisorApplies = advisorApplies,
-            advisorLines = if (advisorApplies) wizard.buildConfirmationLines(advisor = true) else emptyList()
+            advisorLines = if (advisorApplies) wizard.buildConfirmationLines(advisor = true) else emptyList(),
+            wizardDetail = wizard.buildWizardDetail().copy(
+                eCarbsGrams = inputs.eCarbsGrams,
+                eCarbsDelayMinutes = inputs.eCarbsDelayMinutes,
+                eCarbsDurationHours = inputs.eCarbsDurationHours,
+                carbTimeMinutes = inputs.carbTime,
+            ),
         )
     }
 

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
@@ -4,6 +4,7 @@ import app.aaps.core.data.ue.Action
 import app.aaps.core.data.ue.Sources
 import app.aaps.core.interfaces.bolus.WizardBolusExecutor
 import app.aaps.core.interfaces.clientcontrol.FailureReason
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.di.ApplicationScope
@@ -36,6 +37,7 @@ import app.aaps.core.nssdk.localmodel.clientcontrol.BolusPreview
 import app.aaps.core.nssdk.localmodel.clientcontrol.ClientControlMessage
 import app.aaps.core.nssdk.localmodel.clientcontrol.ClientState
 import app.aaps.core.nssdk.localmodel.clientcontrol.ConfirmationLineDto
+import app.aaps.core.nssdk.localmodel.clientcontrol.WizardDetailDto
 import app.aaps.core.nssdk.localmodel.clientcontrol.ProgressEnvelope
 import app.aaps.core.nssdk.localmodel.clientcontrol.ProgressPhase
 import app.aaps.core.nssdk.localmodel.clientcontrol.SignedEnvelope
@@ -511,7 +513,8 @@ class ClientControlReceiver @Inject constructor(
                     bolusId = result.bolusId,
                     lines = result.lines.map { ConfirmationLineDto(it.role.name, it.text) },
                     advisorApplies = result.advisorApplies,
-                    advisorLines = result.advisorLines.map { ConfirmationLineDto(it.role.name, it.text) }
+                    advisorLines = result.advisorLines.map { ConfirmationLineDto(it.role.name, it.text) },
+                    wizardDetail = result.wizardDetail?.toDto(),
                 )
                 nsClientRepository.addLog("◄ CLIENTCTL", "bolus.prepare from ${entry.name}: ${result.insulin}U ${result.carbs}g" + if (result.advisorApplies) " advisor" else "")
                 AckOutcome(AckStatus.Ok, null, json.encodeToString(BolusPreview.serializer(), preview))
@@ -600,7 +603,8 @@ class ClientControlReceiver @Inject constructor(
                     bolusId = result.bolusId,
                     lines = result.lines.map { ConfirmationLineDto(it.role.name, it.text) },
                     advisorApplies = result.advisorApplies,
-                    advisorLines = result.advisorLines.map { ConfirmationLineDto(it.role.name, it.text) }
+                    advisorLines = result.advisorLines.map { ConfirmationLineDto(it.role.name, it.text) },
+                    wizardDetail = result.wizardDetail?.toDto(),
                 )
                 nsClientRepository.addLog("◄ CLIENTCTL", "wizard.prepare from ${entry.name}: ${result.insulin}U ${result.carbs}g" + if (result.advisorApplies) " advisor" else "")
                 AckOutcome(AckStatus.Ok, null, json.encodeToString(BolusPreview.serializer(), preview))
@@ -817,3 +821,25 @@ class ClientControlReceiver @Inject constructor(
     /** Result a command handler reports back so [verifyAndAck] can write the terminal Done ack. */
     private data class AckOutcome(val status: AckStatus, val reason: String?, val payload: String? = null)
 }
+
+private fun EventData.WizardDetail.toDto() = WizardDetailDto(
+    totalInsulin = totalInsulin,
+    carbs = carbs,
+    insulinFromBG = insulinFromBG,
+    insulinFromTrend = insulinFromTrend,
+    insulinFromCOB = insulinFromCOB,
+    insulinFromCarbs = insulinFromCarbs,
+    insulinFromBolusIOB = insulinFromBolusIOB,
+    insulinFromBasalIOB = insulinFromBasalIOB,
+    includeBolusIOB = includeBolusIOB,
+    includeBasalIOB = includeBasalIOB,
+    percentageCorrection = percentageCorrection,
+    cob = cob,
+    tempTargetLabel = tempTargetLabel,
+    ic = ic,
+    sens = sens,
+    eCarbsGrams = eCarbsGrams,
+    eCarbsDelayMinutes = eCarbsDelayMinutes,
+    eCarbsDurationHours = eCarbsDurationHours,
+    carbTimeMinutes = carbTimeMinutes,
+)

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
@@ -842,4 +842,5 @@ private fun EventData.WizardDetail.toDto() = WizardDetailDto(
     eCarbsDelayMinutes = eCarbsDelayMinutes,
     eCarbsDurationHours = eCarbsDurationHours,
     carbTimeMinutes = carbTimeMinutes,
+    alarm = alarm,
 )

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlRoundTrip.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlRoundTrip.kt
@@ -454,4 +454,5 @@ private fun WizardDetailDto.toDomain() = EventData.WizardDetail(
     eCarbsDelayMinutes = eCarbsDelayMinutes,
     eCarbsDurationHours = eCarbsDurationHours,
     carbTimeMinutes = carbTimeMinutes,
+    alarm = alarm,
 )

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlRoundTrip.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlRoundTrip.kt
@@ -6,6 +6,7 @@ import app.aaps.core.interfaces.clientcontrol.ActionProgress
 import app.aaps.core.interfaces.clientcontrol.ClientControlActionDispatcher
 import app.aaps.core.interfaces.clientcontrol.FailureReason
 import app.aaps.core.interfaces.clientcontrol.PendingAction
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.di.ApplicationScope
 import app.aaps.core.interfaces.logging.AAPSLogger
@@ -24,6 +25,7 @@ import app.aaps.core.nssdk.localmodel.clientcontrol.AckStatus
 import app.aaps.core.nssdk.localmodel.clientcontrol.BolusPreview
 import app.aaps.core.nssdk.localmodel.clientcontrol.ClientControlMessage
 import app.aaps.core.nssdk.localmodel.clientcontrol.PrefEntry
+import app.aaps.core.nssdk.localmodel.clientcontrol.WizardDetailDto
 import app.aaps.core.nssdk.localmodel.clientcontrol.ProgressEnvelope
 import app.aaps.core.nssdk.localmodel.clientcontrol.ProgressPhase
 import app.aaps.core.nssdk.utils.ClientControlCrypto
@@ -406,7 +408,8 @@ class ClientControlRoundTrip @Inject constructor(
             id = preview.bolusId,
             lines = preview.lines.map { ConfirmationLine(roleOf(it.role), it.text) },
             advisorApplies = preview.advisorApplies,
-            advisorLines = preview.advisorLines.map { ConfirmationLine(roleOf(it.role), it.text) }
+            advisorLines = preview.advisorLines.map { ConfirmationLine(roleOf(it.role), it.text) },
+            wizardDetail = preview.wizardDetail?.toDomain(),
         )
     }
 
@@ -430,3 +433,25 @@ class ClientControlRoundTrip @Inject constructor(
         return doneOutcome(ack)
     }
 }
+
+private fun WizardDetailDto.toDomain() = EventData.WizardDetail(
+    totalInsulin = totalInsulin,
+    carbs = carbs,
+    insulinFromBG = insulinFromBG,
+    insulinFromTrend = insulinFromTrend,
+    insulinFromCOB = insulinFromCOB,
+    insulinFromCarbs = insulinFromCarbs,
+    insulinFromBolusIOB = insulinFromBolusIOB,
+    insulinFromBasalIOB = insulinFromBasalIOB,
+    includeBolusIOB = includeBolusIOB,
+    includeBasalIOB = includeBasalIOB,
+    percentageCorrection = percentageCorrection,
+    cob = cob,
+    tempTargetLabel = tempTargetLabel,
+    ic = ic,
+    sens = sens,
+    eCarbsGrams = eCarbsGrams,
+    eCarbsDelayMinutes = eCarbsDelayMinutes,
+    eCarbsDurationHours = eCarbsDurationHours,
+    carbTimeMinutes = carbTimeMinutes,
+)

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -813,7 +813,8 @@ class DataHandlerMobile @Inject constructor(
                     title, message = "",
                     returnCommand = returnCommand(progress.id),
                     lines = progress.lines.map { EventData.ConfirmActionLine(it.role.name, it.text) },
-                    deferConfirm = config.AAPSCLIENT
+                    deferConfirm = config.AAPSCLIENT,
+                    wizardDetail = progress.wizardDetail,
                 )
             )
 

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataHandlerWear.kt
@@ -63,6 +63,7 @@ import com.google.android.gms.wearable.WearableListenerService
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.serialization.json.Json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -133,6 +134,9 @@ class DataHandlerWear @Inject constructor(
                         // CLIENT relay: the ✓ must NOT flash success — it shows the spinner + waits for the master's
                         // real commit terminal ([RemoteDelivered] / error). False on a master (instant local success).
                         bundle.putBoolean(DataLayerListenerServiceWear.KEY_DEFER_CONFIRM, it.deferConfirm)
+                        it.wizardDetail?.let { d ->
+                            bundle.putString(DataLayerListenerServiceWear.KEY_WIZARD_DETAIL, Json.encodeToString(EventData.WizardDetail.serializer(), d))
+                        }
                     }
                 )
             })

--- a/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/comm/DataLayerListenerServiceWear.kt
@@ -283,6 +283,7 @@ class DataLayerListenerServiceWear : WearableListenerService() {
 
         //data keys
         const val KEY_ACTION_DATA = "actionData"
+        const val KEY_WIZARD_DETAIL = "wizardDetail"
 
         // Master-authored confirmation rows (parallel arrays: role name + text) rendered verbatim by AcceptActivity.
         const val KEY_LINE_ROLES = "lineRoles"

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
@@ -397,11 +397,40 @@ private fun WizardDetailPage(detail: EventData.WizardDetail) {
                         fontWeight = FontWeight.Bold,
                     )
                 }
+                val carbsFontSize = if (detail.eCarbsGrams > 0) 11.sp else 14.sp
                 if (detail.carbs > 0) {
+                    val carbsText = if (detail.carbTimeMinutes != 0) {
+                        val sign = if (detail.carbTimeMinutes > 0) "+" else ""
+                        stringResource(R.string.wizard_carbs_with_time, detail.carbs, "$sign${detail.carbTimeMinutes}")
+                    } else {
+                        stringResource(R.string.wizard_carbs_format, detail.carbs)
+                    }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        Text(
+                            text = carbsText,
+                            color = CarbsOrange,
+                            fontSize = carbsFontSize,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        if (detail.alarm && detail.carbTimeMinutes > 0) {
+                            Spacer(Modifier.width(3.dp))
+                            Icon(
+                                painter = painterResource(R.drawable.ic_alarm),
+                                contentDescription = null,
+                                tint = CarbsOrange,
+                                modifier = Modifier.size(carbsFontSize.value.dp),
+                            )
+                        }
+                    }
+                }
+                if (detail.eCarbsGrams > 0) {
                     Text(
-                        text = stringResource(R.string.wizard_carbs_format, detail.carbs),
+                        text = stringResource(R.string.wizard_result_ecarbs, detail.eCarbsGrams, detail.eCarbsDurationHours, detail.eCarbsDelayMinutes),
                         color = CarbsOrange,
-                        fontSize = 14.sp,
+                        fontSize = carbsFontSize,
                         fontWeight = FontWeight.Bold,
                         textAlign = TextAlign.Center,
                     )
@@ -485,20 +514,6 @@ private fun WizardDetailPage(detail: EventData.WizardDetail) {
                         }
                         WizardDetailDivider()
                         WizardDetailRow(stringResource(R.string.wizard_result_total), detail.totalInsulin, fmt2)
-                        if (detail.eCarbsGrams > 0) {
-                            WizardDetailDivider()
-                            Text(
-                                text = stringResource(
-                                    R.string.wizard_result_ecarbs,
-                                    detail.eCarbsGrams,
-                                    detail.eCarbsDurationHours,
-                                    detail.eCarbsDelayMinutes,
-                                ),
-                                color = CarbsOrange,
-                                fontSize = 11.sp,
-                                modifier = Modifier.padding(vertical = 2.dp),
-                            )
-                        }
                     }
                 }
             }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/AcceptActivity.kt
@@ -5,18 +5,25 @@ import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,12 +48,15 @@ import androidx.wear.compose.material3.HorizontalPageIndicator
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
+import app.aaps.core.interfaces.rx.weardata.EventData
 import app.aaps.wear.R
 import app.aaps.wear.comm.DataLayerListenerServiceWear
 import app.aaps.wear.comm.IntentCancelNotification
 import app.aaps.wear.comm.IntentWearToMobile
 import dagger.android.support.DaggerAppCompatActivity
 import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import java.text.DecimalFormat
 
 /**
  * Two-page confirmation screen for an action authored on (or relayed by) the master.
@@ -93,8 +103,10 @@ class AcceptActivity : DaggerAppCompatActivity() {
         val isError = extras?.getBoolean(DataLayerListenerServiceWear.KEY_IS_ERROR, false) ?: false
         // Curved header for the lines screen (e.g. "Treatment" / "Temporary target" / "Running mode"), authored by the master.
         val title = extras?.getString(DataLayerListenerServiceWear.KEY_TITLE, "") ?: ""
+        val wizardDetail = extras?.getString(DataLayerListenerServiceWear.KEY_WIZARD_DETAIL)
+            ?.let { runCatching { Json.decodeFromString<EventData.WizardDetail>(it) }.getOrNull() }
 
-        if (message.isEmpty() && lines.isEmpty() && !isError) {
+        if (message.isEmpty() && lines.isEmpty() && wizardDetail == null && !isError) {
             finish()
             return
         }
@@ -106,7 +118,9 @@ class AcceptActivity : DaggerAppCompatActivity() {
 
         setContent {
             MaterialTheme {
-                val pagerState = rememberPagerState(pageCount = { if (isError) 1 else 2 })
+                // Wizard flows (wizardDetail != null): page 0 = calculation result, page 1 = confirm.
+                // Non-wizard flows: page 0 = lines, page 1 = confirm (or 1 page for error with no lines).
+                val pagerState = rememberPagerState(pageCount = { if (isError && !hasLines) 1 else 2 })
                 // Hoisted above the pager pages so a page recomposition (e.g. swiping back to page 0) can never
                 // reset it and re-enable a second ✓ tap after the first already fired.
                 var confirmationSent by remember { mutableStateOf(false) }
@@ -119,13 +133,13 @@ class AcceptActivity : DaggerAppCompatActivity() {
                 Box(modifier = Modifier.fillMaxSize()) {
                     HorizontalPager(state = pagerState) { page ->
                         when (page) {
-                            0    -> {
+                            0 -> if (wizardDetail != null) {
+                                WizardDetailPage(wizardDetail)
+                            } else {
                                 val curvedTitle = if (hasLines) title.ifEmpty { null } else null
                                 Box(modifier = Modifier.fillMaxSize()) {
                                     if (curvedTitle != null) CurvedTitle(curvedTitle)
                                     if (hasLines) {
-                                        // Master-authored confirmation rows — rendered verbatim, scrollable
-                                        // (confirm lives on pager page 1, so scrolling here never blocks it).
                                         val linesScroll = rememberScrollState()
                                         Column(
                                             modifier = Modifier
@@ -135,8 +149,6 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                             horizontalAlignment = Alignment.CenterHorizontally,
                                             verticalArrangement = Arrangement.Center,
                                         ) {
-                                            // Only show the flat "Confirm" header when there is no curved title; the
-                                            // curved title already heads this page (and the confirm page keeps its own).
                                             if (curvedTitle == null) {
                                                 Text(
                                                     text = stringResource(R.string.confirm),
@@ -149,22 +161,20 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                             lines.forEach { (role, text) ->
                                                 Text(
                                                     text = text,
-                                                    // Aligned with master ConfirmationRole (core.data.ui.ConfirmationRole):
-                                                    // NORMAL/PRIMARY have no dedicated wear color → white.
                                                     color = when (role) {
-                                                        "BOLUS"             -> InsulinBlue
-                                                        "CARBS", "COB"      -> CarbsOrange
-                                                        "WARNING"           -> WearWarningAmber
-                                                        "INFO"              -> WearSecondaryText
-                                                        "TEMP_TARGET"       -> TempTargetYellow
-                                                        "SCENE"             -> ScenePurple
-                                                        "LOOP_CLOSED"       -> LoopClosedColor
-                                                        "LOOP_OPEN"         -> LoopOpenColor
-                                                        "LOOP_LGS"          -> LoopLgsColor
-                                                        "LOOP_SUSPENDED"    -> LoopSuspendedColor
-                                                        "LOOP_DISABLED"     -> LoopDisabledColor
-                                                        "LOOP_DISCONNECTED"  -> LoopDisconnectedColor
-                                                        else                -> Color.White
+                                                        "BOLUS"            -> InsulinBlue
+                                                        "CARBS", "COB"     -> CarbsOrange
+                                                        "WARNING"          -> WearWarningAmber
+                                                        "INFO"             -> WearSecondaryText
+                                                        "TEMP_TARGET"      -> TempTargetYellow
+                                                        "SCENE"            -> ScenePurple
+                                                        "LOOP_CLOSED"      -> LoopClosedColor
+                                                        "LOOP_OPEN"        -> LoopOpenColor
+                                                        "LOOP_LGS"         -> LoopLgsColor
+                                                        "LOOP_SUSPENDED"   -> LoopSuspendedColor
+                                                        "LOOP_DISABLED"    -> LoopDisabledColor
+                                                        "LOOP_DISCONNECTED" -> LoopDisconnectedColor
+                                                        else               -> Color.White
                                                     },
                                                     fontSize = 16.sp,
                                                     fontWeight = FontWeight.Bold,
@@ -173,7 +183,6 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                             }
                                         }
                                     } else {
-                                        // Fallback: plain text message (errors and non-migrated activities)
                                         val scrollState = rememberScrollState()
                                         Column(
                                             modifier = Modifier
@@ -203,43 +212,12 @@ class AcceptActivity : DaggerAppCompatActivity() {
                                 }
                             }
 
-                            else -> {
-                                // Confirm page (confirmationSent is hoisted to the setContent scope above).
-                                val haptic = LocalHapticFeedback.current
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .padding(horizontal = 24.dp, vertical = 8.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center,
-                                ) {
-                                    Text(
-                                        text = stringResource(R.string.confirm),
-                                        color = Color.White,
-                                        fontSize = 18.sp,
-                                        fontWeight = FontWeight.Bold,
-                                    )
-                                    Spacer(Modifier.height(8.dp))
-                                    Box(
-                                        modifier = Modifier
-                                            .size(90.dp)
-                                            .clip(CircleShape)
-                                            .clickable(enabled = !confirmationSent) {
-                                                confirmationSent = true
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                confirm()
-                                            },
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.ic_confirm),
-                                            contentDescription = stringResource(R.string.confirm),
-                                            tint = ConfirmGreen,
-                                            modifier = Modifier.fillMaxSize(),
-                                        )
-                                    }
-                                }
-                            }
+                            else -> WizardConfirmPage(
+                                enabled = !confirmationSent,
+                                totalInsulin = wizardDetail?.totalInsulin,
+                                carbs = wizardDetail?.carbs,
+                                onConfirm = { confirmationSent = true; confirm() },
+                            )
                         }
                     }
                     if (!isError) HorizontalPageIndicator(
@@ -284,4 +262,286 @@ class AcceptActivity : DaggerAppCompatActivity() {
         }
         finish()
     }
+}
+
+@Composable
+private fun WizardConfirmPage(enabled: Boolean, totalInsulin: Double?, carbs: Int?, onConfirm: () -> Unit) {
+    val haptic = LocalHapticFeedback.current
+    val fmt = remember { DecimalFormat("0.00") }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.confirm),
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(14.dp))
+        Box(
+            modifier = Modifier
+                .size(90.dp)
+                .clip(CircleShape)
+                .clickable(enabled = enabled) {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onConfirm()
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_confirm),
+                contentDescription = stringResource(R.string.confirm),
+                tint = ConfirmGreen,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        if (totalInsulin != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.wizard_insulin_format, fmt.format(totalInsulin)),
+                color = InsulinBlue,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        if (carbs != null && carbs > 0) {
+            Text(
+                text = stringResource(R.string.wizard_carbs_format, carbs),
+                color = CarbsOrange,
+                fontSize = 12.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WizardDetailPage(detail: EventData.WizardDetail) {
+    val fmt2 = remember { DecimalFormat("0.00") }
+    val fmt1 = remember { DecimalFormat("0.0") }
+
+    val totalIob = when {
+        detail.includeBolusIOB && detail.includeBasalIOB -> detail.insulinFromBolusIOB + detail.insulinFromBasalIOB
+        detail.includeBolusIOB                           -> detail.insulinFromBolusIOB
+        detail.includeBasalIOB                           -> detail.insulinFromBasalIOB
+        else                                             -> null
+    }
+    // New IOB = current IOB + bolus to deliver (the projected total active insulin after delivery)
+    val newIob = totalIob?.let { it + detail.totalInsulin }
+
+    data class CalcRow(val label: String, val value: Double)
+
+    val rows = buildList {
+        if (detail.insulinFromBG != 0.0) {
+            val ttLabel = detail.tempTargetLabel
+            val label = if (!ttLabel.isNullOrEmpty())
+                stringResource(R.string.wizard_result_bg_tt, ttLabel)
+            else
+                stringResource(R.string.wizard_result_bg)
+            add(CalcRow(label, detail.insulinFromBG))
+        }
+        if (detail.insulinFromTrend != 0.0)
+            add(CalcRow(stringResource(R.string.wizard_result_trend), detail.insulinFromTrend))
+        if (detail.insulinFromCOB != 0.0)
+            add(CalcRow(stringResource(R.string.wizard_result_cob, detail.cob), detail.insulinFromCOB))
+        if (detail.carbs > 0)
+            add(CalcRow(stringResource(R.string.wizard_result_carbs, detail.carbs), detail.insulinFromCarbs))
+    }
+
+    var isExpanded by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .let { if (isExpanded) it.verticalScroll(scrollState) else it }
+            .padding(horizontal = 10.dp)
+            .padding(top = 10.dp, bottom = if (isExpanded) 36.dp else 10.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Summary card
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(WearSummaryCardBg)
+                .padding(16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = stringResource(R.string.wizard_total_insulin),
+                    color = WearSecondaryText,
+                    fontSize = 12.sp,
+                    textAlign = TextAlign.Center,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = fmt2.format(detail.totalInsulin),
+                        color = Color.White,
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = stringResource(R.string.insulin_unit_short),
+                        color = Color.White,
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                if (detail.carbs > 0) {
+                    Text(
+                        text = stringResource(R.string.wizard_carbs_format, detail.carbs),
+                        color = CarbsOrange,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+
+        // Calculation card (collapsible)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(WearCalcCardBg)
+                .padding(5.dp),
+        ) {
+            Column {
+                // Header — always visible, tappable to expand/collapse
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { isExpanded = !isExpanded }
+                        .padding(vertical = 4.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.wizard_calculation),
+                            color = WearSecondaryText,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            text = if (isExpanded) "▲" else "▼",
+                            color = WearSecondaryText,
+                            fontSize = 12.sp,
+                        )
+                    }
+                    if (newIob != null) {
+                        Text(
+                            text = stringResource(R.string.wizard_result_new_iob, fmt2.format(newIob)),
+                            color = Color(0xFF90A4AE),
+                            fontSize = 11.sp,
+                        )
+                    }
+                }
+
+                // Expandable details
+                AnimatedVisibility(visible = isExpanded) {
+                    Column {
+                        if (detail.ic > 0 && detail.sens > 0) {
+                            Text(
+                                text = stringResource(R.string.wizard_settings_format, fmt1.format(detail.ic), fmt1.format(detail.sens)),
+                                color = WearSecondaryText,
+                                fontSize = 11.sp,
+                                modifier = Modifier.padding(vertical = 2.dp),
+                            )
+                        }
+                        WizardDetailDivider()
+                        rows.forEach { row -> WizardDetailRow(row.label, row.value, fmt2) }
+
+                        val subtotal = detail.insulinFromBG + detail.insulinFromTrend + detail.insulinFromCOB + detail.insulinFromCarbs
+                        val showSubtotal = rows.size > 1
+                        val showPercentage = detail.percentageCorrection != 100
+                        if (showSubtotal || showPercentage) {
+                            WizardDetailDivider()
+                            if (showSubtotal) WizardDetailRow(stringResource(R.string.wizard_result_subtotal), subtotal, fmt2)
+                            if (showPercentage) {
+                                WizardDetailRow(
+                                    stringResource(R.string.wizard_result_correction_percentage, detail.percentageCorrection),
+                                    subtotal * detail.percentageCorrection / 100.0,
+                                    fmt2,
+                                )
+                            }
+                        }
+                        if (totalIob != null && totalIob != 0.0) {
+                            WizardDetailDivider()
+                            WizardDetailRow(stringResource(R.string.wizard_result_iob), -totalIob, fmt2)
+                        }
+                        WizardDetailDivider()
+                        WizardDetailRow(stringResource(R.string.wizard_result_total), detail.totalInsulin, fmt2)
+                        if (detail.eCarbsGrams > 0) {
+                            WizardDetailDivider()
+                            Text(
+                                text = stringResource(
+                                    R.string.wizard_result_ecarbs,
+                                    detail.eCarbsGrams,
+                                    detail.eCarbsDurationHours,
+                                    detail.eCarbsDelayMinutes,
+                                ),
+                                color = CarbsOrange,
+                                fontSize = 11.sp,
+                                modifier = Modifier.padding(vertical = 2.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WizardDetailRow(label: String, value: Double, fmt: DecimalFormat) {
+    val sign = if (value >= 0) "+" else ""
+    val valueColor = when {
+        value > 0  -> WearInsulinPositive
+        value < 0  -> WearInsulinNegative
+        else       -> WearSecondaryText
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .background(if (value >= 0) WearInsulinPositive else WearInsulinNegative, CircleShape),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(text = label, color = WearSecondaryText, fontSize = 11.sp, modifier = Modifier.weight(1f))
+        Text(
+            text = "$sign${fmt.format(value)} ${stringResource(R.string.insulin_unit_short)}",
+            color = valueColor,
+            fontSize = 11.sp,
+        )
+    }
+}
+
+@Composable
+private fun WizardDetailDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp)
+            .height(1.dp)
+            .background(WearDivider),
+    )
 }

--- a/wear/src/main/res/drawable/ic_alarm.xml
+++ b/wear/src/main/res/drawable/ic_alarm.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.486,2 2,6.486 2,12s4.486,10 10,10 10,-4.486 10,-10S17.514,2 12,2zM12,20c-4.411,0 -8,-3.589 -8,-8s3.589,-8 8,-8 8,3.589 8,8 -3.589,8 -8,8zM13,11.586V7h-2v5.414l3.293,3.293 1.414,-1.414zM4.32,4.388L1.492,7.215l1.414,1.414L5.734,5.802zM22.508,7.215L19.68,4.388l-1.414,1.414 2.828,2.827z"/>
+</vector>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -340,4 +340,19 @@
     <string name="confirm">Confirm</string>
     <string name="request">Request</string>
     <string name="constraint_applied">Constraint applied!</string>
+    <string name="wizard_total_insulin" comment="Label above the total insulin amount in the wizard result summary card">Total Insulin</string>
+    <string name="wizard_calculation" comment="Header of the collapsible calculation breakdown card on the wizard result screen">Calculation</string>
+    <string name="wizard_settings_format" comment="%1$s = IC ratio (e.g. 10.0), %2$s = ISF in profile units (e.g. 2.5). Shows current IC and ISF used in the bolus calculation. Example: IC: 10.0 | ISF: 2.5">IC: %1$s | ISF: %2$s</string>
+    <string name="wizard_result_bg" comment="Bolus wizard calculation row label for the blood glucose correction component">BG</string>
+    <string name="wizard_result_bg_tt" comment="%1$s = formatted temp target value in profile units (e.g. 5.5 or 5.0-5.5). Bolus wizard BG correction row when a temp target is active. Example: BG (TT: 5.5)">BG (TT: %1$s)</string>
+    <string name="wizard_result_trend" comment="Bolus wizard calculation row label for the 15-min BG trend correction component">15\' trend</string>
+    <string name="wizard_result_iob" comment="Bolus wizard calculation row label for the IOB (insulin on board) value used in the calculation">IOB</string>
+    <string name="wizard_result_new_iob" comment="%1$s = formatted new total IOB with unit after the bolus is delivered (e.g. 1.50 U). Example: New IOB: 1.50 U">New IOB: %1$s U</string>
+    <string name="wizard_result_cob" comment="%1$.1f = COB grams (e.g. 45.0). Bolus wizard calculation row label for the COB correction component. Example: COB (45.0 g)">COB (%1$.1f g)</string>
+    <string name="wizard_result_carbs" comment="%1$d = carb grams entered (e.g. 40). Bolus wizard calculation row label for the carbs insulin component. Example: Carbs (40 g)">Carbs (%1$d g)</string>
+    <string name="wizard_result_subtotal" comment="Bolus wizard calculation row label for the subtotal before percentage correction and IOB">Subtotal</string>
+    <string name="wizard_result_total" comment="Bolus wizard calculation row label for the final calculated insulin amount to be delivered">Total</string>
+    <string name="wizard_insulin_format" comment="%1$s = formatted insulin value (e.g. 1.50). Shown on the confirm page. Example: 1.50 U">%1$s U</string>
+    <string name="wizard_result_correction_percentage" comment="%1$d = percentage value (e.g. 80). Bolus wizard calculation row label for the percentage correction applied. Example: 80%%">%1$d%%</string>
+    <string name="wizard_result_ecarbs" comment="%1$d = eCarbs grams, %2$d = duration hours, %3$d = delay minutes. Extended carbs row on wizard result. Example: eCarbs: 20g / 3h +30min">eCarbs: %1$dg / %2$dh +%3$dmin</string>
 </resources>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -340,19 +340,20 @@
     <string name="confirm">Confirm</string>
     <string name="request">Request</string>
     <string name="constraint_applied">Constraint applied!</string>
-    <string name="wizard_total_insulin" comment="Label above the total insulin amount in the wizard result summary card">Total Insulin</string>
-    <string name="wizard_calculation" comment="Header of the collapsible calculation breakdown card on the wizard result screen">Calculation</string>
-    <string name="wizard_settings_format" comment="%1$s = IC ratio (e.g. 10.0), %2$s = ISF in profile units (e.g. 2.5). Shows current IC and ISF used in the bolus calculation. Example: IC: 10.0 | ISF: 2.5">IC: %1$s | ISF: %2$s</string>
-    <string name="wizard_result_bg" comment="Bolus wizard calculation row label for the blood glucose correction component">BG</string>
-    <string name="wizard_result_bg_tt" comment="%1$s = formatted temp target value in profile units (e.g. 5.5 or 5.0-5.5). Bolus wizard BG correction row when a temp target is active. Example: BG (TT: 5.5)">BG (TT: %1$s)</string>
-    <string name="wizard_result_trend" comment="Bolus wizard calculation row label for the 15-min BG trend correction component">15\' trend</string>
-    <string name="wizard_result_iob" comment="Bolus wizard calculation row label for the IOB (insulin on board) value used in the calculation">IOB</string>
-    <string name="wizard_result_new_iob" comment="%1$s = formatted new total IOB with unit after the bolus is delivered (e.g. 1.50 U). Example: New IOB: 1.50 U">New IOB: %1$s U</string>
-    <string name="wizard_result_cob" comment="%1$.1f = COB grams (e.g. 45.0). Bolus wizard calculation row label for the COB correction component. Example: COB (45.0 g)">COB (%1$.1f g)</string>
-    <string name="wizard_result_carbs" comment="%1$d = carb grams entered (e.g. 40). Bolus wizard calculation row label for the carbs insulin component. Example: Carbs (40 g)">Carbs (%1$d g)</string>
-    <string name="wizard_result_subtotal" comment="Bolus wizard calculation row label for the subtotal before percentage correction and IOB">Subtotal</string>
-    <string name="wizard_result_total" comment="Bolus wizard calculation row label for the final calculated insulin amount to be delivered">Total</string>
-    <string name="wizard_insulin_format" comment="%1$s = formatted insulin value (e.g. 1.50). Shown on the confirm page. Example: 1.50 U">%1$s U</string>
-    <string name="wizard_result_correction_percentage" comment="%1$d = percentage value (e.g. 80). Bolus wizard calculation row label for the percentage correction applied. Example: 80%%">%1$d%%</string>
-    <string name="wizard_result_ecarbs" comment="%1$d = eCarbs grams, %2$d = duration hours, %3$d = delay minutes. Extended carbs row on wizard result. Example: eCarbs: 20g / 3h +30min">eCarbs: %1$dg / %2$dh +%3$dmin</string>
+    <string name="wizard_total_insulin">Total Insulin</string>
+    <string name="wizard_calculation">Calculation</string>
+    <string name="wizard_settings_format">IC: %1$s | ISF: %2$s</string>
+    <string name="wizard_result_bg">BG</string>
+    <string name="wizard_result_bg_tt">BG (TT: %1$s)</string>
+    <string name="wizard_result_trend">15\' trend</string>
+    <string name="wizard_result_iob">IOB</string>
+    <string name="wizard_result_new_iob">New IOB: %1$s U</string>
+    <string name="wizard_result_cob">COB (%1$.1f g)</string>
+    <string name="wizard_result_carbs">Carbs (%1$d g)</string>
+    <string name="wizard_result_subtotal">Subtotal</string>
+    <string name="wizard_result_total">Total</string>
+    <string name="wizard_insulin_format">%1$s U</string>
+    <string name="wizard_result_correction_percentage">%1$d%%</string>
+    <string name="wizard_carbs_with_time">%1$d g carbs (%2$s min)</string>
+    <string name="wizard_result_ecarbs">eCarbs: %1$d g / %2$dh (+%3$d min)</string>
 </resources>


### PR DESCRIPTION
The bolus wizard result screen was removed from Wear in a recent refactor that unified how confirmation screens work. This PR brings it back — improved — while keeping full compatibility with the new master/client relay architecture, so it works on both a master-paired watch and an AAPSClient-paired watch.

**What's new compared to the original: https://github.com/nightscout/AndroidAPS/pull/4624**
- Support for QuickWizard WIZARD preset
- QuickWizard WIZARD presets now show carb timing in the summary: "12 g carbs (+20 min)" with a small alarm clock icon when an eat-reminder alarm is set.
- Extended carbs (eCarbs) from QuickWizard presets appear in the summary card too: "eCarbs: 15 g / 1h (+40 min)".
- Works for AAPSClient watches — the calculation data travels from the master through the signed NSClient round-trip alongside the existing confirmation lines.

Tested OK with Omnipod Dash on master / client phone / app.

Some screenshots, the two first screenshots from wear is QuickWizard WIZARD preset with alarm and eCarbs and without alarm/eCarbs
<img width="902" height="606" alt="image" src="https://github.com/user-attachments/assets/a03723fa-c065-42a2-ba84-108a97f121f1" />

<img width="981" height="1023" alt="image" src="https://github.com/user-attachments/assets/185784f4-5e90-4d59-9cf3-0901bf19331a" />
