### PR TITLE
Client: fix error dialogs and HTTP 410 command lockout

### DIFF
--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -975,7 +975,7 @@
     <string name="reorder">Reorder</string>
     <string name="status">Status</string>
     <string name="pump_actions">Pump actions</string>
-    <string name="tempbasal_button">TempBasal</string>
+    <string name="tempbasal_button">Temp Basal</string>
     <string name="extended_bolus_button">Extended Bolus</string>
     <string name="device_maintenance">Device Maintenance</string>
     <string name="from_label">From</string>

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/services/NSClientV3Service.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/services/NSClientV3Service.kt
@@ -318,7 +318,9 @@ class NSClientV3Service : DaggerService() {
                         nsClientV3Plugin.handleClientControlProgressEvent(docJson)
                     // Master-side: route client-control envelopes (paired-client → master commands)
                     // to the receiver. The plugin gates on the master toggle internally.
-                    identifier.startsWith(ClientControlPublisher.IDENTIFIER_PREFIX)                               ->
+                    // !config.AAPSCLIENT: NS WS echoes every write back to the sender too — a client must not
+                    // self-process its own outgoing commands (unknown clientId → deleteSettings → HTTP 410 tombstone).
+                    !config.AAPSCLIENT && identifier.startsWith(ClientControlPublisher.IDENTIFIER_PREFIX) ->
                         nsClientV3Plugin.handleClientControlSettingsEvent(identifier, docJson)
                 }
             }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/carbsDialog/CarbsDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/carbsDialog/CarbsDialogViewModel.kt
@@ -17,6 +17,8 @@ import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
 import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.iob.GlucoseStatusProvider
 import app.aaps.core.interfaces.iob.IobCobCalculator
 import app.aaps.core.interfaces.profile.ProfileUtil
@@ -56,6 +58,7 @@ class CarbsDialogViewModel @Inject constructor(
     val config: Config,
     val rh: ResourceHelper,
     val dateUtil: DateUtil,
+    private val rxBus: RxBus,
     @ApplicationScope private val appScope: CoroutineScope
 ) : ViewModel() {
 
@@ -273,10 +276,13 @@ class CarbsDialogViewModel @Inject constructor(
             when (val prepared = batchExecutor.prepare(actions, Sources.CarbDialog, rh.gs(app.aaps.core.ui.R.string.carbs))) {
                 is ActionProgress.Prepared -> _sideEffect.tryEmit(SideEffect.ShowConfirmation(prepared.id, prepared.lines))
                 is ActionProgress.Rejected -> when (prepared.reason) {
-                    FailureReason.NotReachable -> _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                    FailureReason.NotReachable -> rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.carbs), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
                     // No-op (e.g. nothing left to remove after a COB-shrink between open and confirm): neutral message, NOT the bolus-error alarm.
                     FailureReason.NoAction     -> _sideEffect.tryEmit(SideEffect.ShowNoActionDialog)
-                    else                       -> prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    else                       -> prepared.detail?.let { detail ->
+                        if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.carbs), message = detail))
+                        else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                    }
                 }
 
                 else                       -> Unit // Unconfirmed → app-level modal
@@ -296,8 +302,11 @@ class CarbsDialogViewModel @Inject constructor(
             // NoPendingBolus, …) → the master's detail. Unconfirmed (state unknown) rides the round-trip's app-level modal.
             if (result is ActionProgress.Rejected) {
                 if (result.reason == FailureReason.NotReachable)
-                    _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.carbs), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.carbs), message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                }
             }
             automation.removeAutomationEventEatReminder()
             // Device-local "time to eat" alarm — on confirm, when configured.

--- a/ui/src/main/kotlin/app/aaps/ui/compose/extendedBolusDialog/ExtendedBolusDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/extendedBolusDialog/ExtendedBolusDialogViewModel.kt
@@ -10,7 +10,10 @@ import app.aaps.core.interfaces.bolus.BatchExecutor
 import app.aaps.core.interfaces.clientcontrol.ActionProgress
 import app.aaps.core.interfaces.clientcontrol.FailureReason
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
+import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.resources.ResourceHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,8 +34,10 @@ import javax.inject.Inject
 class ExtendedBolusDialogViewModel @Inject constructor(
     private val constraintChecker: ConstraintsChecker,
     activePlugin: ActivePlugin,
+    private val config: Config,
     private val rh: ResourceHelper,
     private val batchExecutor: BatchExecutor,
+    private val rxBus: RxBus,
     @ApplicationScope private val appScope: CoroutineScope
 ) : ViewModel() {
 
@@ -119,8 +124,11 @@ class ExtendedBolusDialogViewModel @Inject constructor(
                     is ActionProgress.Prepared -> _sideEffect.tryEmit(SideEffect.ShowConfirmation(prepared.id, prepared.lines))
                     // Offline block (and a master-local failure) surface here; a client round-trip failure already showed on the modal.
                     is ActionProgress.Rejected ->
-                        if (prepared.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                        else prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                        if (prepared.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.extended_bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                        else prepared.detail?.let { detail ->
+                            if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.extended_bolus), message = detail))
+                            else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                        }
 
                     else                       -> Unit // Unconfirmed → app-level modal
                 }
@@ -135,8 +143,11 @@ class ExtendedBolusDialogViewModel @Inject constructor(
         appScope.launch {
             val result = batchExecutor.commit(bolusId, Sources.ExtendedBolusDialog, rh.gs(app.aaps.core.ui.R.string.extended_bolus), pumpDirect = true)
             if (result is ActionProgress.Rejected)
-                if (result.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                if (result.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.extended_bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.extended_bolus), message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                }
         }
     }
 }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/insulinDialog/InsulinDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/insulinDialog/InsulinDialogViewModel.kt
@@ -16,6 +16,8 @@ import app.aaps.core.interfaces.clientcontrol.FailureReason
 import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.insulin.InsulinManager
 import app.aaps.core.interfaces.plugin.ActivePlugin
@@ -63,6 +65,7 @@ class InsulinDialogViewModel @Inject constructor(
     val dateUtil: DateUtil,
     hardLimits: HardLimits,
     private val batchExecutor: BatchExecutor,
+    private val rxBus: RxBus,
     @ApplicationScope private val appScope: CoroutineScope
 ) : ViewModel() {
 
@@ -232,10 +235,13 @@ class InsulinDialogViewModel @Inject constructor(
                 // Offline block (and a master-local failure) surface here; a client round-trip failure already showed
                 // on the app-level modal, so only re-surface NotReachable or a master-side detail message.
                 is ActionProgress.Rejected -> when (prepared.reason) {
-                    FailureReason.NotReachable -> _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                    FailureReason.NotReachable -> rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
                     // No-op after caps (e.g. the bolus was constraint-capped to 0): neutral message, NOT the bolus-error alarm.
                     FailureReason.NoAction     -> _sideEffect.tryEmit(SideEffect.ShowNoActionDialog)
-                    else                       -> prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    else                       -> prepared.detail?.let { detail ->
+                        if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = detail))
+                        else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                    }
                 }
 
                 else                       -> Unit // Unconfirmed → app-level modal
@@ -255,8 +261,11 @@ class InsulinDialogViewModel @Inject constructor(
             // NoPendingBolus, …) → the master's detail. Unconfirmed (state unknown) rides the round-trip's app-level modal.
             if (result is ActionProgress.Rejected) {
                 if (result.reason == FailureReason.NotReachable)
-                    _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                }
             }
         }
     }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/manageSheet/ManageViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/manageSheet/ManageViewModel.kt
@@ -28,6 +28,7 @@ import app.aaps.core.interfaces.resources.ResourceHelper
 import app.aaps.core.interfaces.rx.bus.RxBus
 import app.aaps.core.interfaces.rx.events.EventCustomActionsChanged
 import app.aaps.core.interfaces.rx.events.EventInitializationChanged
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.sync.NsClient
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.keys.BooleanKey
@@ -219,8 +220,11 @@ class ManageViewModel @Inject constructor(
                 is ActionProgress.Prepared -> _sideEffect.tryEmit(SideEffect.ShowConfirmation(elementType, prepared.id, prepared.lines, label))
                 // Offline block (and a master-local failure) surface here; a client round-trip failure already showed on the modal.
                 is ActionProgress.Rejected ->
-                    if (prepared.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowError(elementType, rh.gs(R.string.clientcontrol_fail_not_reachable)))
-                    else prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowError(elementType, it)) }
+                    if (prepared.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = label, message = rh.gs(R.string.clientcontrol_fail_not_reachable)))
+                    else prepared.detail?.let { detail ->
+                        if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = label, message = detail))
+                        else _sideEffect.tryEmit(SideEffect.ShowError(elementType, detail))
+                    }
 
                 else                       -> Unit // Unconfirmed → app-level modal
             }
@@ -233,8 +237,11 @@ class ManageViewModel @Inject constructor(
             // NoPendingBolus (a double-tapped dialog already consumed it) stays silent — the cancel ran once.
             val result = batchExecutor.commit(bolusId, Sources.Actions, label, pumpDirect = true)
             if (result is ActionProgress.Rejected)
-                if (result.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowError(elementType, rh.gs(R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowError(elementType, it)) }
+                if (result.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = label, message = rh.gs(R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = label, message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowError(elementType, detail))
+                }
         }
     }
 

--- a/ui/src/main/kotlin/app/aaps/ui/compose/profileManagement/viewmodels/ProfileManagementViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/profileManagement/viewmodels/ProfileManagementViewModel.kt
@@ -481,9 +481,18 @@ class ProfileManagementViewModel @Inject constructor(
                         title = label, message = "", confirmationLines = prepared.lines, icon = IcProfile,
                         onOk = {
                             appScope.launch {
-                                if (batchExecutor.commit(prepared.id, Sources.ProfileSwitchDialog, label) is ActionProgress.Applied) {
-                                    if (percentage == 90 && durationMinutes == 10) preferences.put(BooleanNonKey.ObjectivesProfileSwitchUsed, true)
-                                    withContext(Dispatchers.Main) { onSuccess() }
+                                when (val result = batchExecutor.commit(prepared.id, Sources.ProfileSwitchDialog, label)) {
+                                    is ActionProgress.Applied -> {
+                                        if (percentage == 90 && durationMinutes == 10) preferences.put(BooleanNonKey.ObjectivesProfileSwitchUsed, true)
+                                        withContext(Dispatchers.Main) { onSuccess() }
+                                    }
+                                    is ActionProgress.Rejected ->
+                                        if (result.reason == FailureReason.NotReachable)
+                                            rxBus.send(EventShowDialog.Ok(title = label, message = rh.gs(R.string.clientcontrol_fail_not_reachable)))
+                                        else result.detail?.let { detail ->
+                                            rxBus.send(EventShowDialog.Ok(title = label, message = detail))
+                                        }
+                                    else                      -> Unit // Unconfirmed → app-level modal
                                 }
                             }
                         }
@@ -494,8 +503,11 @@ class ProfileManagementViewModel @Inject constructor(
 
             // Master-local pre-check failure, or a client offline; a client round-trip failure already showed on the app modal.
             is ActionProgress.Rejected -> {
-                if (!config.AAPSCLIENT || prepared.reason == FailureReason.NotReachable)
-                    _snackbarEvent.tryEmit(prepared.detail ?: rh.gs(R.string.clientcontrol_fail_not_reachable))
+                if (prepared.reason == FailureReason.NotReachable)
+                    rxBus.send(EventShowDialog.Ok(title = label, message = rh.gs(R.string.clientcontrol_fail_not_reachable)))
+                else prepared.detail?.let { detail ->
+                    rxBus.send(EventShowDialog.Ok(title = label, message = detail))
+                }
                 false
             }
 

--- a/ui/src/main/kotlin/app/aaps/ui/compose/tempBasalDialog/TempBasalDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/tempBasalDialog/TempBasalDialogViewModel.kt
@@ -10,7 +10,10 @@ import app.aaps.core.interfaces.bolus.BatchAction
 import app.aaps.core.interfaces.bolus.BatchExecutor
 import app.aaps.core.interfaces.clientcontrol.ActionProgress
 import app.aaps.core.interfaces.clientcontrol.FailureReason
+import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.profile.ProfileFunction
 import app.aaps.core.interfaces.resources.ResourceHelper
@@ -32,8 +35,10 @@ import javax.inject.Inject
 class TempBasalDialogViewModel @Inject constructor(
     private val profileFunction: ProfileFunction,
     private val activePlugin: ActivePlugin,
+    private val config: Config,
     private val rh: ResourceHelper,
     private val batchExecutor: BatchExecutor,
+    private val rxBus: RxBus,
     @ApplicationScope private val appScope: CoroutineScope
 ) : ViewModel() {
 
@@ -119,8 +124,11 @@ class TempBasalDialogViewModel @Inject constructor(
                     is ActionProgress.Prepared -> _sideEffect.tryEmit(SideEffect.ShowConfirmation(prepared.id, prepared.lines))
                     // Offline block (and a master-local failure) surface here; a client round-trip failure already showed on the modal.
                     is ActionProgress.Rejected ->
-                        if (prepared.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                        else prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                        if (prepared.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.tempbasal_label), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                        else prepared.detail?.let { detail ->
+                            if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.tempbasal_label), message = detail))
+                            else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                        }
 
                     else                       -> Unit // Unconfirmed → app-level modal
                 }
@@ -135,8 +143,11 @@ class TempBasalDialogViewModel @Inject constructor(
         appScope.launch {
             val result = batchExecutor.commit(bolusId, Sources.TempBasalDialog, rh.gs(app.aaps.core.ui.R.string.tempbasal_label), pumpDirect = true)
             if (result is ActionProgress.Rejected)
-                if (result.reason == FailureReason.NotReachable) _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                if (result.reason == FailureReason.NotReachable) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.tempbasal_label), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.tempbasal_label), message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                }
         }
     }
 }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/treatmentDialog/TreatmentDialogViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/treatmentDialog/TreatmentDialogViewModel.kt
@@ -13,6 +13,8 @@ import app.aaps.core.interfaces.clientcontrol.FailureReason
 import app.aaps.core.interfaces.configuration.Config
 import app.aaps.core.interfaces.constraints.ConstraintsChecker
 import app.aaps.core.interfaces.di.ApplicationScope
+import app.aaps.core.interfaces.rx.bus.RxBus
+import app.aaps.core.interfaces.rx.events.EventShowDialog
 import app.aaps.core.interfaces.insulin.Insulin
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.profile.ProfileFunction
@@ -39,13 +41,14 @@ class TreatmentDialogViewModel @Inject constructor(
     constraintChecker: ConstraintsChecker,
     activePlugin: ActivePlugin,
     private val activeInsulin: Insulin,
-    config: Config,
+    private val config: Config,
     val decimalFormatter: DecimalFormatter,
     private val rh: ResourceHelper,
     private val profileFunction: ProfileFunction,
     hardLimits: HardLimits,
     private val loop: Loop,
     private val batchExecutor: BatchExecutor,
+    private val rxBus: RxBus,
     @ApplicationScope private val appScope: CoroutineScope
 ) : ViewModel() {
 
@@ -128,10 +131,13 @@ class TreatmentDialogViewModel @Inject constructor(
             when (val prepared = batchExecutor.prepare(actions, Sources.TreatmentDialog, rh.gs(app.aaps.core.ui.R.string.bolus))) {
                 is ActionProgress.Prepared -> _sideEffect.tryEmit(SideEffect.ShowConfirmation(prepared.id, prepared.lines))
                 is ActionProgress.Rejected -> when (prepared.reason) {
-                    FailureReason.NotReachable -> _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                    FailureReason.NotReachable -> rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
                     // No-op after caps (e.g. the bolus was constraint-capped to 0): neutral message, NOT the bolus-error alarm.
                     FailureReason.NoAction     -> _sideEffect.tryEmit(SideEffect.ShowNoActionDialog)
-                    else                       -> prepared.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    else                       -> prepared.detail?.let { detail ->
+                        if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = detail))
+                        else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                    }
                 }
 
                 else                       -> Unit // Unconfirmed → app-level modal
@@ -147,8 +153,11 @@ class TreatmentDialogViewModel @Inject constructor(
             // NoPendingBolus, …) → the master's detail. Unconfirmed (state unknown) rides the round-trip's app-level modal.
             if (result is ActionProgress.Rejected) {
                 if (result.reason == FailureReason.NotReachable)
-                    _sideEffect.tryEmit(SideEffect.ShowDeliveryError(rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
-                else result.detail?.let { _sideEffect.tryEmit(SideEffect.ShowDeliveryError(it)) }
+                    rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = rh.gs(app.aaps.core.ui.R.string.clientcontrol_fail_not_reachable)))
+                else result.detail?.let { detail ->
+                    if (config.AAPSCLIENT) rxBus.send(EventShowDialog.Ok(title = rh.gs(app.aaps.core.ui.R.string.bolus), message = detail))
+                    else _sideEffect.tryEmit(SideEffect.ShowDeliveryError(detail))
+                }
             }
         }
     }


### PR DESCRIPTION
#### Proposal to fix two bugs in AAPSClient remote command handling:
  
**"Scary" alarm on offline master** — When the master had "Allow client control" disabled, or Nightscout was unreachable, treatment dialogs (Carbs, Insulin, TBR, Extended Bolus, Profile Activate, Cancel TBR) triggered the bolus delivery alarm with sound on AAPSClient. These now show a simple dismissable dialog instead.

**HTTP 410 command lockout after Cancel TBR** — NS WebSocket echoes every write back to all subscribers, including the sender. The client was processing its own outgoing command echoes through `verifyAndAck`, which has no authorized clients on the client side and called `deleteSettings()` on the identifier — tombstoning it. Subsequent commands then got HTTP 410 until the user re-paired. Fixed by skipping the master-side receiver on `config.AAPSCLIENT`.