### PR TITLE
Wear: let users pick which scenes show on the Scenes tile

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -609,6 +609,9 @@
             </intent-filter>
 
             <meta-data
+                android:name="com.google.android.clockwork.tiles.PROVIDER_CONFIG_ACTION"
+                android:value="tile_settings_scene" />
+            <meta-data
                 android:name="androidx.wear.tiles.PREVIEW"
                 android:resource="@drawable/scene_tile" />
         </service>
@@ -802,6 +805,18 @@
             android:theme="@style/WearAppCompatDark">
             <intent-filter>
                 <action android:name="tile_settings_bg_graph" />
+
+                <category android:name="com.google.android.clockwork.tiles.category.PROVIDER_CONFIG" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".tile.SceneTileSettingsActivity"
+            android:exported="true"
+            android:theme="@style/WearAppCompatDark">
+            <intent-filter>
+                <action android:name="tile_settings_scene" />
 
                 <category android:name="com.google.android.clockwork.tiles.category.PROVIDER_CONFIG" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/wear/src/main/kotlin/app/aaps/wear/di/WearActivitiesModule.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/di/WearActivitiesModule.kt
@@ -5,6 +5,7 @@ import app.aaps.wear.interaction.ConfigurationActivity
 import app.aaps.wear.interaction.WatchfaceConfigurationActivity
 import app.aaps.wear.tile.ActionsTileSettingsActivity
 import app.aaps.wear.tile.BgGraphTileSettingsActivity
+import app.aaps.wear.tile.SceneTileSettingsActivity
 import app.aaps.wear.tile.TempTargetTileSettingsActivity
 import app.aaps.wear.interaction.actions.AcceptActivity
 import app.aaps.wear.interaction.actions.BackgroundActionActivity
@@ -35,6 +36,7 @@ abstract class WearActivitiesModule {
     @ContributesAndroidInjector abstract fun contributesActionsTileSettingsActivity(): ActionsTileSettingsActivity
     @ContributesAndroidInjector abstract fun contributesTempTargetTileSettingsActivity(): TempTargetTileSettingsActivity
     @ContributesAndroidInjector abstract fun contributesBgGraphTileSettingsActivity(): BgGraphTileSettingsActivity
+    @ContributesAndroidInjector abstract fun contributesSceneTileSettingsActivity(): SceneTileSettingsActivity
     @ContributesAndroidInjector abstract fun contributesConfigurationActivity(): ConfigurationActivity
     @ContributesAndroidInjector abstract fun contributesWatchfaceConfigurationActivity(): WatchfaceConfigurationActivity
     @ContributesAndroidInjector abstract fun contributesComplicationTapActivity(): ComplicationTapActivity

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/TileMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/TileMenuActivity.kt
@@ -6,6 +6,7 @@ import app.aaps.wear.R
 import app.aaps.wear.interaction.utils.MenuListActivity
 import app.aaps.wear.tile.ActionsTileSettingsActivity
 import app.aaps.wear.tile.BgGraphTileSettingsActivity
+import app.aaps.wear.tile.SceneTileSettingsActivity
 import app.aaps.wear.tile.TempTargetTileSettingsActivity
 
 class TileMenuActivity : MenuListActivity() {
@@ -20,6 +21,7 @@ class TileMenuActivity : MenuListActivity() {
             MenuItem(R.drawable.action_tile_preview, getString(R.string.label_actions_tile)),
             MenuItem(R.drawable.temp_target_tile_preview, getString(R.string.label_temp_target_tile)),
             MenuItem(R.drawable.bg_graph_tile, getString(R.string.label_bg_graph_tile)),
+            MenuItem(R.drawable.scene_tile, getString(R.string.label_scene_tile)),
         )
 
     override fun doAction(position: String) {
@@ -27,6 +29,7 @@ class TileMenuActivity : MenuListActivity() {
             getString(R.string.label_actions_tile)     -> startActivity(Intent(this, ActionsTileSettingsActivity::class.java))
             getString(R.string.label_temp_target_tile) -> startActivity(Intent(this, TempTargetTileSettingsActivity::class.java))
             getString(R.string.label_bg_graph_tile)    -> startActivity(Intent(this, BgGraphTileSettingsActivity::class.java))
+            getString(R.string.label_scene_tile)       -> startActivity(Intent(this, SceneTileSettingsActivity::class.java))
         }
     }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/tile/SceneTileSettingsActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/SceneTileSettingsActivity.kt
@@ -23,11 +23,10 @@ class SceneTileSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        val options = sceneSource.getSceneEntries().map { TileSettingOption(it.id, it.title) } +
-            TileSettingOption("none", getString(R.string.tile_none))
+        val liveOptions = sceneSource.getSceneEntries().map { TileSettingOption(it.id, it.title) }
         setContent {
             MaterialTheme {
-                SceneTileSettingsScreen(sp = sp, options = options)
+                SceneTileSettingsScreen(sp = sp, liveOptions = liveOptions)
             }
         }
     }
@@ -39,9 +38,9 @@ class SceneTileSettingsActivity : AppCompatActivity() {
 }
 
 @Composable
-private fun SceneTileSettingsScreen(sp: SP, options: List<TileSettingOption>) {
+private fun SceneTileSettingsScreen(sp: SP, liveOptions: List<TileSettingOption>) {
     val slots = remember {
-        (1..4).map { i -> mutableStateOf(sp.getString("tile_scene_$i", "none")) }
+        (1..4).map { i -> mutableStateOf(sp.getString("tile_scene_$i", SceneSource.SLOT_AUTO)) }
     }
     val labels = listOf(
         stringResource(R.string.tile_scene_1),
@@ -49,10 +48,19 @@ private fun SceneTileSettingsScreen(sp: SP, options: List<TileSettingOption>) {
         stringResource(R.string.tile_scene_3),
         stringResource(R.string.tile_scene_4)
     )
+    val baseOptions = listOf(TileSettingOption(SceneSource.SLOT_AUTO, stringResource(R.string.tile_scene_auto))) +
+        liveOptions +
+        TileSettingOption(SceneSource.SLOT_NONE, stringResource(R.string.tile_none))
+    val unavailableLabel = stringResource(R.string.tile_scene_unavailable)
     val rows = (0..3).map { i ->
+        val currentValue = slots[i].value
+        // A slot pinned to a scene that's since been deleted/disabled won't be in baseOptions —
+        // add a synthetic entry so the picker shows "Unavailable" instead of the raw id.
+        val options = if (baseOptions.any { it.value == currentValue }) baseOptions
+                      else baseOptions + TileSettingOption(currentValue, unavailableLabel)
         TileSettingRow(
             label = labels[i],
-            currentValue = slots[i].value,
+            currentValue = currentValue,
             options = options,
             onSelect = { value ->
                 slots[i].value = value

--- a/wear/src/main/kotlin/app/aaps/wear/tile/SceneTileSettingsActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/SceneTileSettingsActivity.kt
@@ -1,0 +1,64 @@
+package app.aaps.wear.tile
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.tiles.TileService
+import app.aaps.core.interfaces.sharedPreferences.SP
+import app.aaps.wear.R
+import app.aaps.wear.tile.source.SceneSource
+import dagger.android.AndroidInjection
+import javax.inject.Inject
+
+class SceneTileSettingsActivity : AppCompatActivity() {
+
+    @Inject lateinit var sp: SP
+    @Inject lateinit var sceneSource: SceneSource
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
+        super.onCreate(savedInstanceState)
+        val options = sceneSource.getSceneEntries().map { TileSettingOption(it.id, it.title) } +
+            TileSettingOption("none", getString(R.string.tile_none))
+        setContent {
+            MaterialTheme {
+                SceneTileSettingsScreen(sp = sp, options = options)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        TileService.getUpdater(applicationContext).requestUpdate(SceneTileService::class.java)
+    }
+}
+
+@Composable
+private fun SceneTileSettingsScreen(sp: SP, options: List<TileSettingOption>) {
+    val slots = remember {
+        (1..4).map { i -> mutableStateOf(sp.getString("tile_scene_$i", "none")) }
+    }
+    val labels = listOf(
+        stringResource(R.string.tile_scene_1),
+        stringResource(R.string.tile_scene_2),
+        stringResource(R.string.tile_scene_3),
+        stringResource(R.string.tile_scene_4)
+    )
+    val rows = (0..3).map { i ->
+        TileSettingRow(
+            label = labels[i],
+            currentValue = slots[i].value,
+            options = options,
+            onSelect = { value ->
+                slots[i].value = value
+                sp.putString("tile_scene_${i + 1}", value)
+            }
+        )
+    }
+    TileSettingsScreen(title = stringResource(R.string.tile_settings), rows = rows)
+}

--- a/wear/src/main/kotlin/app/aaps/wear/tile/source/SceneSource.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/source/SceneSource.kt
@@ -29,11 +29,19 @@ class SceneSource @Inject constructor(private val context: Context, private val 
             )
         }
         val sceneData = getSceneData(sp)
-        seedDefaultSlotsIfNeeded(sceneData)
+        val slotValues = (1..4).map { sp.getString(preferenceKey(it), SLOT_AUTO) }
 
-        val selectedEntries = (1..4).mapNotNull { i ->
-            val id = sp.getString(preferenceKey(i), "none")
-            if (id == "none") null else sceneData.entries.find { it.id == id }
+        // Slots explicitly pinned to a scene id are resolved first and removed from the auto pool,
+        // so an "Automatic" slot never duplicates a scene another slot already claims.
+        val explicitIds = slotValues.filterNot { it == SLOT_AUTO || it == SLOT_NONE }.toSet()
+        val autoPool = sceneData.entries.filterNot { it.id in explicitIds }.iterator()
+
+        val selectedEntries = slotValues.mapNotNull { value ->
+            when (value) {
+                SLOT_NONE -> null
+                SLOT_AUTO -> if (autoPool.hasNext()) autoPool.next() else null
+                else      -> sceneData.entries.find { it.id == value }
+            }
         }
         return selectedEntries.map { entry ->
             Action(
@@ -53,15 +61,6 @@ class SceneSource @Inject constructor(private val context: Context, private val 
 
     private fun preferenceKey(index: Int) = "tile_scene_$index"
 
-    // Seeds the 4 slots with the first scenes in phone order, once — mirrors StaticTileSource's
-    // setDefaultSettings(). Deferred until real scene data exists so a watch that hasn't synced
-    // yet doesn't permanently lock all slots to "none" before any scenes ever arrived.
-    private fun seedDefaultSlotsIfNeeded(sceneData: EventData.SceneList) {
-        if (sp.contains(preferenceKey(1)) || sceneData.entries.isEmpty()) return
-        val ids = sceneData.entries.map { it.id }
-        for (i in 1..4) sp.putString(preferenceKey(i), ids.getOrElse(i - 1) { "none" })
-    }
-
     private fun getSceneData(sp: SP): EventData.SceneList =
         EventData.deserialize(sp.getString(R.string.key_scene_data, EventData.SceneList(arrayListOf()).serialize())) as EventData.SceneList
 
@@ -72,4 +71,12 @@ class SceneSource @Inject constructor(private val context: Context, private val 
     }
 
     override fun getResourceReferences(resources: Resources): List<Int> = listOf(R.drawable.ic_scene_purple, R.drawable.ic_cancel_red)
+
+    companion object {
+        /** Slot not deliberately touched by the user — auto-fills with the next unclaimed scene. */
+        const val SLOT_AUTO = "auto"
+
+        /** Slot deliberately emptied by the user in the settings screen — stays empty. */
+        const val SLOT_NONE = "none"
+    }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/tile/source/SceneSource.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/source/SceneSource.kt
@@ -28,27 +28,39 @@ class SceneSource @Inject constructor(private val context: Context, private val 
                 )
             )
         }
-        val sceneList = mutableListOf<Action>()
         val sceneData = getSceneData(sp)
+        seedDefaultSlotsIfNeeded(sceneData)
 
-        for (entry in sceneData.entries) {
-            if (sceneList.size < 4) {
-                sceneList.add(
-                    Action(
-                        buttonText = entry.title,
-                        iconRes = R.drawable.ic_scene_purple,
-                        activityClass = BackgroundActionActivity::class.java.name,
-                        action = EventData.ActionScenePreCheck(entry.id, entry.title),
-                        message = context.resources.getString(R.string.action_scene_confirmation),
-                    )
-                )
-                aapsLogger.info(LTag.WEAR, """getSelectedActions: scene ${entry.title} id=${entry.id}""")
-            }
+        val selectedEntries = (1..4).mapNotNull { i ->
+            val id = sp.getString(preferenceKey(i), "none")
+            if (id == "none") null else sceneData.entries.find { it.id == id }
         }
-        return sceneList
+        return selectedEntries.map { entry ->
+            Action(
+                buttonText = entry.title,
+                iconRes = R.drawable.ic_scene_purple,
+                activityClass = BackgroundActionActivity::class.java.name,
+                action = EventData.ActionScenePreCheck(entry.id, entry.title),
+                message = context.resources.getString(R.string.action_scene_confirmation),
+            ).also { aapsLogger.info(LTag.WEAR, """getSelectedActions: scene ${entry.title} id=${entry.id}""") }
+        }
     }
 
     override fun getValidFor(): Long? = null
+
+    /** Scene entries currently known to the watch, for the tile settings picker. */
+    fun getSceneEntries(): List<EventData.SceneList.SceneEntry> = getSceneData(sp).entries
+
+    private fun preferenceKey(index: Int) = "tile_scene_$index"
+
+    // Seeds the 4 slots with the first scenes in phone order, once — mirrors StaticTileSource's
+    // setDefaultSettings(). Deferred until real scene data exists so a watch that hasn't synced
+    // yet doesn't permanently lock all slots to "none" before any scenes ever arrived.
+    private fun seedDefaultSlotsIfNeeded(sceneData: EventData.SceneList) {
+        if (sp.contains(preferenceKey(1)) || sceneData.entries.isEmpty()) return
+        val ids = sceneData.entries.map { it.id }
+        for (i in 1..4) sp.putString(preferenceKey(i), ids.getOrElse(i - 1) { "none" })
+    }
 
     private fun getSceneData(sp: SP): EventData.SceneList =
         EventData.deserialize(sp.getString(R.string.key_scene_data, EventData.SceneList(arrayListOf()).serialize())) as EventData.SceneList

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="tile_scene_2">Scene 2</string>
     <string name="tile_scene_3">Scene 3</string>
     <string name="tile_scene_4">Scene 4</string>
+    <string name="tile_scene_auto">Automatic</string>
+    <string name="tile_scene_unavailable">Unavailable</string>
     <string name="datalayer_notification_title">Data Layer Foreground Service</string>
     <string name="datalayer_notification_text">AAPS is running in the foreground. To hide notification go to Developer options, App notifications, Allowed watch apps, select AAPS, Turn off Data Layer Foreground Service Channel notification.</string>
     <string name="on">ON</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -261,6 +261,10 @@
     <string name="tile_action_2">Action 2</string>
     <string name="tile_action_3">Action 3</string>
     <string name="tile_action_4">Action 4</string>
+    <string name="tile_scene_1">Scene 1</string>
+    <string name="tile_scene_2">Scene 2</string>
+    <string name="tile_scene_3">Scene 3</string>
+    <string name="tile_scene_4">Scene 4</string>
     <string name="datalayer_notification_title">Data Layer Foreground Service</string>
     <string name="datalayer_notification_text">AAPS is running in the foreground. To hide notification go to Developer options, App notifications, Allowed watch apps, select AAPS, Turn off Data Layer Foreground Service Channel notification.</string>
     <string name="on">ON</string>

--- a/wear/src/test/kotlin/app/aaps/wear/tile/source/SceneSourceTest.kt
+++ b/wear/src/test/kotlin/app/aaps/wear/tile/source/SceneSourceTest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -32,6 +33,10 @@ class SceneSourceTest {
     private val endText = "End scene"
     private val confirmationText = "Run this scene?"
 
+    // In-memory backing store for tile_scene_N slot prefs, so getString/putString/contains behave
+    // like real prefs (mirrors the pattern in ActionSourceTest).
+    private val store: MutableMap<String, String> = mutableMapOf()
+
     private lateinit var sceneSource: SceneSource
 
     private fun sceneListRaw(vararg entries: EventData.SceneList.SceneEntry): String =
@@ -50,11 +55,26 @@ class SceneSourceTest {
         whenever(sp.getString(eq(R.string.key_scene_data), any())).thenReturn(raw)
     }
 
+    /** Pins tile slot [index] (1-4) to [value] — a scene id, SLOT_NONE, or SLOT_AUTO. */
+    private fun stubSlot(index: Int, value: String) {
+        store["tile_scene_$index"] = value
+    }
+
     @BeforeEach
     fun setup() {
         whenever(context.resources).thenReturn(resources)
         whenever(resources.getString(R.string.scene_end)).thenReturn(endText)
         whenever(resources.getString(R.string.action_scene_confirmation)).thenReturn(confirmationText)
+
+        // sp backed by the in-memory map for String-keyed slot prefs — an unset key falls through
+        // to the caller-supplied default (SLOT_AUTO), matching real SharedPreferences behavior.
+        // Individual tests override via stubSlot().
+        doAnswer { invocation ->
+            val key = invocation.getArgument<String>(0)
+            val default = invocation.getArgument<String>(1)
+            store[key] ?: default
+        }.whenever(sp).getString(any<String>(), any<String>())
+
         // Default: no active scene, empty scene list. Individual tests override as needed.
         stubActiveSceneState("")
         stubSceneData(sceneListRaw())
@@ -147,6 +167,54 @@ class SceneSourceTest {
 
         assertThat(actions).hasSize(4)
         assertThat(actions.map { it.buttonText }).containsExactly("One", "Two", "Three", "Four").inOrder()
+    }
+
+    @Test
+    fun explicitSlotPinsSpecificScene() {
+        stubActiveSceneState("")
+        stubSceneData(sceneListRaw(entry("1", "One"), entry("2", "Two"), entry("3", "Three")))
+        stubSlot(1, "3") // pin slot 1 to "Three" instead of auto order
+
+        val actions = sceneSource.getSelectedActions()
+
+        // Slot 1 = pinned "Three"; slots 2-4 = auto, filling with the remaining unclaimed scenes in order.
+        assertThat(actions.map { it.buttonText }).containsExactly("Three", "One", "Two").inOrder()
+    }
+
+    @Test
+    fun noneSlotStaysEmptyEvenWithScenesAvailable() {
+        stubActiveSceneState("")
+        stubSceneData(sceneListRaw(entry("1", "One"), entry("2", "Two")))
+        stubSlot(1, SceneSource.SLOT_NONE)
+
+        val actions = sceneSource.getSelectedActions()
+
+        // Slot 1 deliberately empty; slots 2-4 auto-fill from the remaining scenes.
+        assertThat(actions.map { it.buttonText }).containsExactly("One", "Two").inOrder()
+    }
+
+    @Test
+    fun stalePinnedIdIsDroppedGracefully() {
+        stubActiveSceneState("")
+        stubSceneData(sceneListRaw(entry("1", "One")))
+        stubSlot(1, "deleted-scene-id") // previously pinned scene no longer exists
+
+        val actions = sceneSource.getSelectedActions()
+
+        // Slot 1's stale id resolves to nothing (dropped, not crashed); slot 2 auto-fills with "One".
+        assertThat(actions.map { it.buttonText }).containsExactly("One")
+    }
+
+    @Test
+    fun autoSlotsNeverDuplicateAnExplicitlyPinnedScene() {
+        stubActiveSceneState("")
+        stubSceneData(sceneListRaw(entry("1", "One"), entry("2", "Two")))
+        stubSlot(3, "1") // pin slot 3 to "One"
+
+        val actions = sceneSource.getSelectedActions()
+
+        // Slots 1-2 auto-fill; "One" is already claimed by slot 3, so only "Two" is left for auto.
+        assertThat(actions.map { it.buttonText }).containsExactly("Two", "One").inOrder()
     }
 
     @Test


### PR DESCRIPTION
The Scenes tile only showed the first 4 scenes in phone order, with no way to choose which ones once more than 4 are saved. 

This adds a tile settings screen with 4 slots, each Automatic (fills with the next unused scene), None (deliberately empty), or a specific scene — so a deleted/disabled scene's slot shows "Unavailable" instead of a raw id, without losing the selection if it comes back.

Tested OK on AAPS and AAPSClient wear.

Screenshots:
<img width="1360" height="630" alt="image" src="https://github.com/user-attachments/assets/0eb87cf6-a965-4cca-9c63-7ab67e57cac8" />
