### PR TITLE
Fix: Omnipod Eros infinite connecting loop after pod deactivation

### DIFF
--- a/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/OmnipodErosPumpPlugin.kt
+++ b/pump/omnipod/eros/src/main/java/app/aaps/pump/omnipod/eros/OmnipodErosPumpPlugin.kt
@@ -455,8 +455,11 @@ class OmnipodErosPumpPlugin @Inject constructor(
         return false
     }
 
-    // TODO is this correct?
-    override fun isBusy(): Boolean = busy || rileyLinkOmnipodService == null || !podStateManager.isPodRunning
+    override fun isBusy(): Boolean {
+        val progress = podStateManager.getActivationProgress()
+        return busy || rileyLinkOmnipodService == null ||
+            (progress != ActivationProgress.NONE && !progress.isCompleted())
+    }
 
     override fun setBusy(busy: Boolean) {
         this.busy = busy


### PR DESCRIPTION
When no pod is active (`ActivationProgress == NONE`), `isBusy()` was returning `true` because `isPodRunning()` returns `false`. This caused the `QueueWorker` to loop indefinitely showing 'connecting' even with no active pod.

Fix mirrors the Dash fix from PR #4852: only return busy when activation is in progress (`progress != NONE && !isCompleted()`), not when there is simply no active pod.

Fixes #4932

**Disclaimer:** I don’t have an Eros, so I haven’t been able to test this change myself. If someone with an Eros could verify that this resolves the issue, confirmation is appreciated. The PR is on dev but it should merge cleanly with master and dev3 as well.