### PR TITLE
BolusWizard Source management

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/WizardBolusExecutor.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/bolus/WizardBolusExecutor.kt
@@ -220,6 +220,7 @@ interface WizardBolusExecutor {
         val eCarbsGrams: Int = 0,
         val eCarbsDelayMinutes: Int = 0,
         val eCarbsDurationHours: Int = 0,
-        val profileName: String? = null
+        val profileName: String? = null,
+        val source: Sources = Sources.WizardDialog
     )
 }

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/BolusWizard.kt
@@ -163,9 +163,9 @@ class BolusWizard @Inject constructor(
     private var useAlarm = false
     var notes: String = ""
     private var carbTime: Int = 0
-    private var quickWizard: Boolean = true
     var usePercentage: Boolean = false
     var positiveIOBOnly: Boolean = false
+    private var source: Sources = Sources.WizardDialog
 
     suspend fun doCalc(
         profile: Profile,
@@ -188,8 +188,8 @@ class BolusWizard @Inject constructor(
         carbTime: Int = 0,
         usePercentage: Boolean = false,
         totalPercentage: Double = 100.0,
-        quickWizard: Boolean = false,
-        positiveIOBOnly: Boolean = false
+        positiveIOBOnly: Boolean = false,
+        source: Sources = Sources.WizardDialog
     ): BolusWizard {
 
         this.profile = profile
@@ -210,10 +210,10 @@ class BolusWizard @Inject constructor(
         this.useAlarm = useAlarm
         this.notes = notes
         this.carbTime = carbTime
-        this.quickWizard = quickWizard
         this.usePercentage = usePercentage
         this.totalPercentage = totalPercentage
         this.positiveIOBOnly = positiveIOBOnly
+        this.source = source
 
         // Insulin from BG
         sens = profileUtil.fromMgdlToUnits(profile.getIsfMgdlForCarbs(dateUtil.now(), "BolusWizard", config, processedDeviceStatusData))
@@ -551,7 +551,7 @@ class BolusWizard @Inject constructor(
                         profile = profile,
                         newRM = RM.Mode.SUPER_BOLUS,
                         action = Action.SUPERBOLUS_TBR,
-                        source = Sources.WizardDialog
+                        source = source
                     )
                     rxBus.send(EventRefreshOverview("WizardDialog"))
                 }
@@ -561,7 +561,6 @@ class BolusWizard @Inject constructor(
                 carbs == 0                     -> Action.BOLUS
                 else                           -> Action.TREATMENT
             }
-            val source = if (quickWizard) Sources.QuickWizard else Sources.WizardDialog
             val bolusCalculatorResult = createBolusCalculatorResult()
             quickWizardEntry?.markAsUsed()
             // Schedule carb timer before bolus delivery. Scheduling in the bolus completion callback
@@ -648,7 +647,6 @@ class BolusWizard @Inject constructor(
             automation.removeAutomationEventEatReminder()
 
         if (insulinAfterConstraints > 0) {
-            val source = if (quickWizard) Sources.QuickWizard else Sources.WizardDialog
             if (forcedRecordOnly) {
                 uel.log(
                     action = Action.BOLUS_ADVISOR,

--- a/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/QuickWizardEntry.kt
+++ b/core/objects/src/main/kotlin/app/aaps/core/objects/wizard/QuickWizardEntry.kt
@@ -3,6 +3,7 @@ package app.aaps.core.objects.wizard
 import app.aaps.annotations.OpenForTesting
 import app.aaps.core.data.iob.InMemoryGlucoseValue
 import app.aaps.core.data.model.RM
+import app.aaps.core.data.ue.Sources
 import app.aaps.core.interfaces.aps.Loop
 import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.iob.GlucoseStatusProvider
@@ -190,8 +191,8 @@ class QuickWizardEntry @Inject constructor(
             useAlarm() == YES,
             buttonText(),
             carbTime(),
-            quickWizard = true,
-            positiveIOBOnly = uPositiveIOBOnly
+            positiveIOBOnly = uPositiveIOBOnly,
+            source = Sources.QuickWizard
         ) //tbc, ok if only quickwizard, but if other sources elsewhere use Sources.QuickWizard
     }
 

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/clientcontrol/ClientControlReceiver.kt
@@ -605,7 +605,7 @@ class ClientControlReceiver @Inject constructor(
             carbTime = message.carbTime, useBg = message.useBg, useCob = message.useCob, useIob = message.useIob,
             useTt = message.useTt, useTrend = message.useTrend, alarm = message.alarm, notes = message.notes,
             eCarbsGrams = message.eCarbsGrams, eCarbsDelayMinutes = message.eCarbsDelayMinutes, eCarbsDurationHours = message.eCarbsDurationHours,
-            profileName = message.profileName
+            profileName = message.profileName, source = Sources.NSClient
         )
         return when (val result = wizardBolusExecutor.prepareWizard(inputs)) {
             is WizardBolusExecutor.PrepareResult.Error   -> {

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -599,7 +599,8 @@ class DataHandlerMobile @Inject constructor(
             useTt = preferences.get(BooleanKey.WearWizardTt),
             useTrend = preferences.get(BooleanKey.WearWizardTrend),
             alarm = false,
-            notes = ""
+            notes = "",
+            source = Sources.Wear
         )
         contacting()
         shipPrepared(


### PR DESCRIPTION
Allow dedicated Source for uel logger in BolusWizard or QuickWizard (in ex `Sources.Wear`when command is launched from Wear Watch)