### PR TITLE
Wear: per-flavor header on tiles

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -67,6 +67,7 @@ android {
             dimension = "standard"
             resValue("string", "app_name", "AAPS")
             resValue("string", "label_actions_activity", "AAPS")
+            resValue("color", "flavor_header_color", "#B0BEC5")
             versionName = Versions.appVersion
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
         }
@@ -75,6 +76,7 @@ android {
             dimension = "standard"
             resValue("string", "app_name", "Pumpcontrol")
             resValue("string", "label_actions_activity", "Pumpcontrol")
+            resValue("color", "flavor_header_color", "#B0BEC5")
             versionName = Versions.appVersion + "-pumpcontrol"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_pumpcontrol"
         }
@@ -83,6 +85,7 @@ android {
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient")
             resValue("string", "label_actions_activity", "AAPSClient")
+            resValue("color", "flavor_header_color", "#E8C50C")
             versionName = Versions.appVersion + "-aapsclient"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_yellowowl"
         }
@@ -91,6 +94,7 @@ android {
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient2")
             resValue("string", "label_actions_activity", "AAPSClient2")
+            resValue("color", "flavor_header_color", "#0FBBE0")
             versionName = Versions.appVersion + "-aapsclient2"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_blueowl"
         }
@@ -99,6 +103,7 @@ android {
             dimension = "standard"
             resValue("string", "app_name", "AAPSClient3")
             resValue("string", "label_actions_activity", "AAPSClient3")
+            resValue("color", "flavor_header_color", "#64E86A")
             versionName = Versions.appVersion + "-aapsclient3"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_greenowl"
         }

--- a/wear/src/main/kotlin/app/aaps/wear/tile/BgGraphTileService.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/BgGraphTileService.kt
@@ -3,6 +3,7 @@ package app.aaps.wear.tile
 import android.graphics.Bitmap
 import android.graphics.Paint
 import androidx.compose.ui.geometry.Size
+import androidx.core.content.ContextCompat
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.unit.Density
@@ -17,6 +18,7 @@ import androidx.wear.tiles.RequestBuilders.TileRequest
 import androidx.wear.tiles.ResourceBuilders
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
+import app.aaps.wear.BuildConfig
 import app.aaps.wear.R
 import app.aaps.wear.data.ComplicationData
 import app.aaps.wear.data.ComplicationDataRepository
@@ -257,7 +259,25 @@ class BgGraphTileService : TileService() {
             else -> secondaryArgb
         }
 
-        val spacerPx = 16 * density
+        // Only AAPSClient flavors need this (distinguishing several installed side by side) — for
+        // a single-install AAPS/Pumpcontrol build it's purely decorative, and on this tile (unlike
+        // the button-grid tiles) it visibly costs graph space, so it's not worth showing there.
+        val showFlavorHeader = when (BuildConfig.FLAVOR) {
+            "aapsclient", "aapsclient2", "aapsclient3" -> true
+            else                                        -> false
+        }
+        val flavorLabelHeightPx = if (showFlavorHeader) 5 * density else 0f
+        val spacerPx = 16 * density + flavorLabelHeightPx
+        if (showFlavorHeader) {
+            val flavorColor = ContextCompat.getColor(this, R.color.flavor_header_color)
+            val flavorPaint = Paint().apply {
+                color = flavorColor
+                textSize = 9 * density
+                textAlign = Paint.Align.CENTER
+                isAntiAlias = true
+            }
+            canvas.drawText(getString(R.string.app_name), widthPx / 2f, 2 * density + flavorPaint.textSize * 0.8f, flavorPaint)
+        }
         val bgPaint = Paint().apply {
             color = bgArgb
             textSize = bgSizePx

--- a/wear/src/main/kotlin/app/aaps/wear/tile/TileBase.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/TileBase.kt
@@ -10,8 +10,11 @@ import androidx.wear.protolayout.ColorBuilders.argb
 import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
 import androidx.wear.protolayout.DeviceParametersBuilders.SCREEN_SHAPE_ROUND
 import androidx.wear.protolayout.DimensionBuilders.SpProp
+import androidx.wear.protolayout.DimensionBuilders.degrees
 import androidx.wear.protolayout.DimensionBuilders.dp
 import androidx.wear.protolayout.DimensionBuilders.sp
+import androidx.wear.protolayout.LayoutElementBuilders.Arc
+import androidx.wear.protolayout.LayoutElementBuilders.ArcText
 import androidx.wear.protolayout.LayoutElementBuilders.Box
 import androidx.wear.protolayout.LayoutElementBuilders.Column
 import androidx.wear.protolayout.LayoutElementBuilders.FONT_WEIGHT_BOLD
@@ -51,6 +54,8 @@ private const val SPACING_ACTIONS = 3f
 private const val ICON_SIZE_FRACTION = 0.4f // Percentage of button diameter
 private val BUTTON_COLOR = R.color.gray_850
 private const val LARGE_SCREEN_WIDTH_DP = 210
+private const val FLAVOR_HEADER_HEIGHT_DP = 16f
+private const val FLAVOR_HEADER_TEXT_SIZE_SP = 10f
 
 /**
  * Data source for Wear OS tiles.
@@ -237,6 +242,48 @@ abstract class TileBase : TileService() {
      * @return Layout element to render
      */
     private fun layout(wearControl: WearControl, actions: List<Action>, deviceParameters: DeviceParameters): LayoutElement {
+        val content = contentLayout(wearControl, actions, deviceParameters)
+        return if (deviceParameters.screenShape == SCREEN_SHAPE_ROUND) {
+            // Curved header hugs the round bezel's otherwise-unused corner space (circleDiameter()'s
+            // inscribed-square formula already leaves those corners empty) — overlaid, not stacked,
+            // so it costs no extra room from the button grid below.
+            Box.Builder()
+                .addContent(content)
+                .addContent(curvedFlavorHeader())
+                .build()
+        } else {
+            // No bezel curvature to hug on a square screen — fall back to a plain stacked header.
+            Column.Builder()
+                .addContent(flatFlavorHeader())
+                .addContent(content)
+                .build()
+        }
+    }
+
+    private fun curvedFlavorHeader(): LayoutElement =
+        Arc.Builder()
+            .setAnchorAngle(degrees(0f))
+            .addContent(
+                ArcText.Builder()
+                    .setText(resources.getString(R.string.app_name))
+                    .setFontStyle(flavorFontStyle())
+                    .build()
+            )
+            .build()
+
+    private fun flatFlavorHeader(): LayoutElement =
+        Text.Builder()
+            .setText(resources.getString(R.string.app_name))
+            .setFontStyle(flavorFontStyle())
+            .build()
+
+    private fun flavorFontStyle(): FontStyle =
+        FontStyle.Builder()
+            .setColor(argb(ContextCompat.getColor(baseContext, R.color.flavor_header_color)))
+            .setSize(sp(FLAVOR_HEADER_TEXT_SIZE_SP))
+            .build()
+
+    private fun contentLayout(wearControl: WearControl, actions: List<Action>, deviceParameters: DeviceParameters): LayoutElement {
         if (wearControl == WearControl.DISABLED) {
             return Text.Builder()
                 .setText(resources.getString(R.string.wear_control_not_enabled))
@@ -408,9 +455,11 @@ abstract class TileBase : TileService() {
      * @param deviceParameters Screen dimensions and shape
      * @return Button diameter in DP
      */
-    private fun circleDiameter(deviceParameters: DeviceParameters) = when (deviceParameters.screenShape) {
+    private fun circleDiameter(deviceParameters: DeviceParameters): Float = when (deviceParameters.screenShape) {
+        // Round: curved header overlays the already-unused inscribed-square corners — no reduction needed.
         SCREEN_SHAPE_ROUND -> ((sqrt(2f) - 1) * deviceParameters.screenHeightDp) - (2 * SPACING_ACTIONS)
-        else               -> 0.5f * deviceParameters.screenHeightDp - SPACING_ACTIONS
+        // Square: flat header is stacked above the grid, so it does need reserved space.
+        else               -> 0.5f * (deviceParameters.screenHeightDp - FLAVOR_HEADER_HEIGHT_DP) - SPACING_ACTIONS
     }
 
     private fun buttonTextSize(deviceParameters: DeviceParameters, text: String): SpProp {


### PR DESCRIPTION
Requested in AAPS4 thread at Discord: https://discord.com/channels/629952586895851530/1522120609792921700/1522120612837986334

Multiple flavors can be installed side by side, but their tiles looked identical — no way to tell them apart while swiping. 

Adds a small header using each flavor's own color: a curved text on the button-grid tiles, shown for all flavors; a flat label on the BG graph tile, limited to AAPSClient/2/3 since AAPS is mostly a single install and that tile's space is too valuable to spend on a decorative label.

Tested ok on all flavors, video below:

https://github.com/user-attachments/assets/4237dee0-c6d2-4911-86ec-fec1ce6a07e7

