### PR TITLE
Fix deliverTreatment in PumpWithConcentrationImpl (very small boluses with U200 Insulins or more)

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/pump/PumpWithConcentrationImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/pump/PumpWithConcentrationImpl.kt
@@ -30,12 +30,14 @@ import app.aaps.core.objects.constraints.ConstraintObject
 import kotlinx.coroutines.flow.StateFlow
 import org.json.JSONObject
 import javax.inject.Inject
+import javax.inject.Provider
 
 class PumpWithConcentrationImpl @Inject constructor(
     private val aapsLogger: AAPSLogger,
     private val activePlugin: ActivePlugin,
     private val profileFunction: ProfileFunction,
     private val constraintsChecker: ConstraintsChecker,
+    private val pumpEnactResultProvider: Provider<PumpEnactResult>,
     private val insulin: Insulin
 ) : PumpWithConcentration {
 
@@ -108,22 +110,29 @@ class PumpWithConcentrationImpl @Inject constructor(
 
     override val baseBasalRate: PumpRate get() = activePumpInternal.baseBasalRate
 
-    override suspend fun deliverTreatment(detailedBolusInfo: DetailedBolusInfo): PumpEnactResult = activePumpInternal.deliverTreatment(
-        detailedBolusInfo.also {
-            if (it.bolusType != BS.Type.PRIMING) {
-                // IU -> cU. The max limit is applied in IU by ConstraintsChecker (it folds the pump's own cU cap
-                // into the scan); here we (1) last-resort guard against the overall cU max [defense-in-depth, the
-                // queue already applied it] and (2) floor to the pump's native pulse step so a concentration-unaware
-                // driver never gets an off-grid amount (e.g. U200 0.25 IU -> 0.125 cU -> 0.10 cU). Reasons are logged.
-                val converted = it.insulin / concentration
-                val guarded = converted.coerceAtMost(constraintsChecker.getMaxBolusAllowed().value() / concentration)
-                val result = Round.floorTo(guarded, activePumpInternal.pumpDescription.pumpType.determineCorrectBolusStepSize(guarded))
-                if (result != converted)
-                    aapsLogger.warn(LTag.PUMP, "Concentration boundary adjusted bolus: requested ${it.insulin} IU -> $converted cU -> $result cU (concentration $concentration)")
-                it.insulin = result
+    override suspend fun deliverTreatment(detailedBolusInfo: DetailedBolusInfo): PumpEnactResult {
+        if (detailedBolusInfo.bolusType != BS.Type.PRIMING) {
+            // IU -> cU. The max limit is applied in IU by ConstraintsChecker (it folds the pump's own cU cap
+            // into the scan); here we (1) last-resort guard against the overall cU max [defense-in-depth, the
+            // queue already applied it] and (2) floor to the pump's native pulse step so a concentration-unaware
+            // driver never gets an off-grid amount (e.g. U200 0.25 IU -> 0.125 cU -> 0.10 cU). Reasons are logged.
+            val requestedIu = detailedBolusInfo.insulin
+            val converted = requestedIu / concentration
+            val guarded = converted.coerceAtMost(constraintsChecker.getMaxBolusAllowed().value() / concentration)
+            val result = Round.floorTo(guarded, activePumpInternal.pumpDescription.pumpType.determineCorrectBolusStepSize(guarded))
+            if (result != converted)
+                aapsLogger.warn(LTag.PUMP, "Concentration boundary adjusted bolus: requested $requestedIu IU -> $converted cU -> $result cU (concentration $concentration)")
+            detailedBolusInfo.insulin = result
+            // A bolus below the pump's native pulse step floors to 0.0 cU (e.g. U200 sub-0.10 IU SMB -> < 0.05 cU).
+            // Sending 0.0 to a driver that requires insulin > 0 (Medtrum) crashes with IllegalArgumentException.
+            // Short-circuit to a clean "processed, nothing delivered" result instead of calling the pump.
+            if (result <= 0.0) {
+                aapsLogger.warn(LTag.PUMP, "Bolus rounds to 0 under concentration $concentration (requested $requestedIu IU, below pump step) → not delivered")
+                return pumpEnactResultProvider.get().success(true).enacted(false).bolusDelivered(0.0)
             }
         }
-    )
+        return activePumpInternal.deliverTreatment(detailedBolusInfo)
+    }
 
     override suspend fun setTempBasalAbsolute(absoluteRate: Double, durationInMinutes: Int, enforceNew: Boolean, tbrType: PumpSync.TemporaryBasalType): PumpEnactResult =
         profileFunction.getProfile()?.let { profile ->

--- a/implementation/src/test/kotlin/app/aaps/implementation/pump/PumpWithConcentrationImplTest.kt
+++ b/implementation/src/test/kotlin/app/aaps/implementation/pump/PumpWithConcentrationImplTest.kt
@@ -27,8 +27,10 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import javax.inject.Provider
 
 class PumpWithConcentrationImplTest : TestBase() {
 
@@ -52,7 +54,7 @@ class PumpWithConcentrationImplTest : TestBase() {
         // Feature-2 last-resort guard queries the overall max; default to no effective cap.
         whenever(constraintsChecker.getMaxBolusAllowed()).thenReturn(ConstraintObject(Double.MAX_VALUE, aapsLogger))
         whenever(constraintsChecker.getMaxExtendedBolusAllowed()).thenReturn(ConstraintObject(Double.MAX_VALUE, aapsLogger))
-        sut = PumpWithConcentrationImpl(aapsLogger, activePlugin, profileFunction, constraintsChecker, insulin)
+        sut = PumpWithConcentrationImpl(aapsLogger, activePlugin, profileFunction, constraintsChecker, Provider { pumpEnactResult }, insulin)
     }
 
     private suspend fun setupConcentration(concentration: Double) {
@@ -67,7 +69,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     // --- deliverTreatment tests ---
 
     @Test
-    fun `deliverTreatment with U100 passes insulin unchanged`() = runBlocking {
+    fun `deliverTreatment with U100 passes insulin unchanged`() = runBlocking<Unit> {
         setupU100()
         val dbi = DetailedBolusInfo().apply { insulin = 5.0 }
         whenever(pump.deliverTreatment(any())).thenReturn(pumpEnactResult)
@@ -78,7 +80,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `deliverTreatment with U200 halves insulin for normal bolus`() = runBlocking {
+    fun `deliverTreatment with U200 halves insulin for normal bolus`() = runBlocking<Unit> {
         setupConcentration(2.0)
         val dbi = DetailedBolusInfo().apply { insulin = 6.0; bolusType = BS.Type.NORMAL }
         whenever(pump.deliverTreatment(any())).thenReturn(pumpEnactResult)
@@ -89,7 +91,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `deliverTreatment with U200 does not modify priming bolus`() = runBlocking {
+    fun `deliverTreatment with U200 does not modify priming bolus`() = runBlocking<Unit> {
         setupConcentration(2.0)
         val dbi = DetailedBolusInfo().apply { insulin = 4.0; bolusType = BS.Type.PRIMING }
         whenever(pump.deliverTreatment(any())).thenReturn(pumpEnactResult)
@@ -100,7 +102,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `deliverTreatment with U50 doubles insulin for normal bolus`() = runBlocking {
+    fun `deliverTreatment with U50 doubles insulin for normal bolus`() = runBlocking<Unit> {
         setupConcentration(0.5)
         val dbi = DetailedBolusInfo().apply { insulin = 2.0; bolusType = BS.Type.NORMAL }
         whenever(pump.deliverTreatment(any())).thenReturn(pumpEnactResult)
@@ -110,10 +112,39 @@ class PumpWithConcentrationImplTest : TestBase() {
         verify(pump).deliverTreatment(argThat { insulin == 4.0 })
     }
 
+    @Test
+    fun `deliverTreatment with U200 skips pump when bolus floors to zero`() = runBlocking<Unit> {
+        setupConcentration(2.0)
+        // 0.05 IU / 2.0 = 0.025 cU -> below DANA_RS bolus step -> floors to 0.0 cU
+        val dbi = DetailedBolusInfo().apply { insulin = 0.05; bolusType = BS.Type.SMB }
+        whenever(pumpEnactResult.success(any())).thenReturn(pumpEnactResult)
+        whenever(pumpEnactResult.enacted(any())).thenReturn(pumpEnactResult)
+        whenever(pumpEnactResult.bolusDelivered(any())).thenReturn(pumpEnactResult)
+
+        val result = sut.deliverTreatment(dbi)
+
+        verify(pump, never()).deliverTreatment(any())
+        assertThat(result).isSameInstanceAs(pumpEnactResult)
+        verify(pumpEnactResult).success(true)
+        verify(pumpEnactResult).enacted(false)
+        verify(pumpEnactResult).bolusDelivered(0.0)
+    }
+
+    @Test
+    fun `deliverTreatment with zero priming bolus still calls pump`() = runBlocking<Unit> {
+        setupConcentration(2.0)
+        val dbi = DetailedBolusInfo().apply { insulin = 0.0; bolusType = BS.Type.PRIMING }
+        whenever(pump.deliverTreatment(any())).thenReturn(pumpEnactResult)
+
+        sut.deliverTreatment(dbi)
+
+        verify(pump).deliverTreatment(any())
+    }
+
     // --- setTempBasalAbsolute tests ---
 
     @Test
-    fun `setTempBasalAbsolute with U200 halves rate sent to pump`() = runBlocking {
+    fun `setTempBasalAbsolute with U200 halves rate sent to pump`() = runBlocking<Unit> {
         setupConcentration(2.0)
         val constraintResult: Constraint<Double> = mock()
         whenever(constraintResult.value()).thenReturn(4.0)
@@ -127,7 +158,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `setTempBasalAbsolute with U100 passes rate unchanged`() = runBlocking {
+    fun `setTempBasalAbsolute with U100 passes rate unchanged`() = runBlocking<Unit> {
         setupU100()
         whenever(profileFunction.getProfile()).thenReturn(effectiveProfile)
         val constraintResult: Constraint<Double> = mock()
@@ -143,7 +174,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     // --- setExtendedBolus tests ---
 
     @Test
-    fun `setExtendedBolus with U200 halves insulin`() = runBlocking {
+    fun `setExtendedBolus with U200 halves insulin`() = runBlocking<Unit> {
         setupConcentration(2.0)
         whenever(pump.setExtendedBolus(any(), any())).thenReturn(pumpEnactResult)
 
@@ -153,7 +184,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `setExtendedBolus with U100 passes insulin unchanged`() = runBlocking {
+    fun `setExtendedBolus with U100 passes insulin unchanged`() = runBlocking<Unit> {
         setupU100()
         whenever(pump.setExtendedBolus(any(), any())).thenReturn(pumpEnactResult)
 
@@ -163,7 +194,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `setExtendedBolus with U50 doubles insulin`() = runBlocking {
+    fun `setExtendedBolus with U50 doubles insulin`() = runBlocking<Unit> {
         setupConcentration(0.5)
         whenever(pump.setExtendedBolus(any(), any())).thenReturn(pumpEnactResult)
 
@@ -176,7 +207,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     // --- pumpDescription tests ---
 
     @Test
-    fun `pumpDescription scales values for U200`() = runBlocking {
+    fun `pumpDescription scales values for U200`() = runBlocking<Unit> {
         setupConcentration(2.0)
         val desc = PumpDescription().apply {
             bolusStep = 0.1
@@ -220,7 +251,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     }
 
     @Test
-    fun `pumpDescription scales for U50`() = runBlocking {
+    fun `pumpDescription scales for U50`() = runBlocking<Unit> {
         setupConcentration(0.5)
         val desc = PumpDescription().apply {
             bolusStep = 0.1
@@ -243,7 +274,7 @@ class PumpWithConcentrationImplTest : TestBase() {
     // --- setNewBasalProfile tests ---
 
     @Test
-    fun `setNewBasalProfile converts EffectiveProfile to PumpProfile`() = runBlocking {
+    fun `setNewBasalProfile converts EffectiveProfile to PumpProfile`() = runBlocking<Unit> {
         whenever(effectiveProfile.toPump()).thenReturn(pumpProfile)
         whenever(pump.setNewBasalProfile(pumpProfile)).thenReturn(pumpEnactResult)
 


### PR DESCRIPTION
Fix proposed by @MTR93600 to handle very small boluses or SMBs with insulin U200
If amount is close to pump minimal bolus, convertion to CU divided by 2 with U200 so floor can lead to 0.0U sent to the pump
- According to pump driver it can raise an IllegalArgumentException