### PR TITLE
fix: derive EPS remaining-time display from timestamp + duration (dev3)

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/profile/ProfileFunctionImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/profile/ProfileFunctionImpl.kt
@@ -79,7 +79,10 @@ class ProfileFunctionImpl @Inject constructor(
         if (profileSwitch != null) {
             profileName = if (customized) profileSwitch.originalCustomizedName else profileSwitch.originalProfileName
             if (showRemainingTime && profileSwitch.originalDuration != 0L) {
-                profileName += dateUtil.untilString(profileSwitch.originalEnd, rh)
+                // originalEnd is not reliable (see its declaration in EPS.kt: "not used (calculated from duration)").
+                // A stale/mismatched originalEnd on a record synced in verbatim from Nightscout (AAPSCLIENT, or
+                // NsClientAcceptProfileSwitch / full resync on master) otherwise renders a nonsensical duration here.
+                profileName += dateUtil.untilString(profileSwitch.timestamp + profileSwitch.originalDuration, rh)
             }
         }
         return profileName


### PR DESCRIPTION
## Summary

Same fix as #4987, ported to `dev3`. Fixes #4985 — `ProfileFunctionImpl.getProfileName()` reads
`EPS.originalEnd` directly to render the remaining-time suffix on the active-profile display
(Overview ribbon + home-screen widget). That field is documented on the entity itself as
`// not used (calculated from duration)`.

When a given EPS record's stored `originalEnd` doesn't actually match
`timestamp + originalDuration`, `getProfileName()` renders a nonsensical duration (e.g.
`32399999998h` instead of a plausible remaining time).

This is most reliably triggered on **AAPSCLIENT**, since a follower never creates EPS locally
(`CommandQueueImplementation`'s creation path is gated by `if (config.AAPSCLIENT) return`) — every
EPS it has comes from Nightscout verbatim, `originalEnd` included, with nothing re-deriving or
sanity-checking it. But it's not actually AAPSCLIENT-specific: a **master** install also inserts new,
unvalidated EPS records sourced from Nightscout whenever `NsClientAcceptProfileSwitch` is enabled or
a full resync happens, so a stale/mismatched `originalEnd` on one of those records produces the same
garbage on a regular pump-owning install.

## Fix

Derive the end time from `timestamp + originalDuration` instead of trusting the stored
`originalEnd`.

## Test plan

- [x] `:implementation:compileFullDebugKotlin` builds clean on `dev3`
- [ ] Maintainers/reviewers to confirm no existing test asserts on the old (buggy) `originalEnd`-based behavior
