### PR TITLE
CareLevo: prioritize Android 13 BLE handling and scan selection

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/ble/BleTransport.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/pump/ble/BleTransport.kt
@@ -41,7 +41,8 @@ interface BleAdapter {
 data class ScannedDevice(
     val name: String,
     val address: String,
-    val scanRecordBytes: ByteArray? = null
+    val scanRecordBytes: ByteArray? = null,
+    val rssi: Int = Int.MIN_VALUE
 )
 
 interface BleScanner {

--- a/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/ble/CarelevoBleTransportImpl.kt
+++ b/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/ble/CarelevoBleTransportImpl.kt
@@ -10,12 +10,14 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.ParcelUuid
 import android.os.SystemClock
 import androidx.core.app.ActivityCompat
@@ -209,7 +211,8 @@ class CarelevoBleTransportImpl @Inject constructor(
                             ScannedDevice(
                                 name = name,
                                 address = result.device.address,
-                                scanRecordBytes = result.scanRecord?.bytes
+                                scanRecordBytes = result.scanRecord?.bytes,
+                                rssi = result.rssi
                             )
                         )
                     }
@@ -289,11 +292,19 @@ class CarelevoBleTransportImpl @Inject constructor(
         @Suppress("deprecation")
         override fun enableNotifications() {
             val chara = notifyChara ?: return
-            val result = bluetoothGatt?.setCharacteristicNotification(chara, true)
-            if (result == true) {
-                val descriptor = chara.getDescriptor(CCCD_UUID)
-                descriptor?.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
-                bluetoothGatt?.writeDescriptor(descriptor)
+            val gatt = bluetoothGatt ?: return
+            val result = gatt.setCharacteristicNotification(chara, true)
+            if (result) {
+                val descriptor = chara.getDescriptor(CCCD_UUID) ?: return
+                val writeStarted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    gatt.writeDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) == BluetoothStatusCodes.SUCCESS
+                } else {
+                    descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    gatt.writeDescriptor(descriptor)
+                }
+                if (!writeStarted) {
+                    aapsLogger.debug(LTag.PUMPBTCOMM, "enableNotifications: writeDescriptor could not start")
+                }
             }
         }
 
@@ -309,8 +320,15 @@ class CarelevoBleTransportImpl @Inject constructor(
             // setValue-then-write is NOT atomic on the shared characteristic object; it is safe only
             // because BleTransportGattConnection.gattMutex serializes all suspend GATT ops. Do not
             // decouple this transport from that serialization without adding one here.
-            chara.setValue(data)
-            gatt.writeCharacteristic(chara)
+            val writeStarted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                gatt.writeCharacteristic(chara, data, chara.writeType) == BluetoothStatusCodes.SUCCESS
+            } else {
+                chara.value = data
+                gatt.writeCharacteristic(chara)
+            }
+            if (!writeStarted) {
+                aapsLogger.debug(LTag.PUMPBTCOMM, "writeCharacteristic: writeCharacteristic could not start")
+            }
         }
 
         override fun requestConnectionPriority(priority: Int) {

--- a/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/presentation/viewmodel/CarelevoPatchConnectViewModel.kt
+++ b/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/presentation/viewmodel/CarelevoPatchConnectViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -100,8 +99,8 @@ class CarelevoPatchConnectViewModel @Inject constructor(
 
     /**
      * Discovery scan over the transport. `scanAddress = null` puts `CarelevoBleTransportImpl`'s scanner
-     * in service-UUID discovery mode; the first advertising patch wins. Stops early on a hit instead of
-     * always burning the full window.
+     * in service-UUID discovery mode; results are collected for a short window and the strongest RSSI
+     * patch is selected.
      */
     fun startScan() {
         if (!carelevoPatch.isBluetoothEnabled()) {
@@ -118,12 +117,19 @@ class CarelevoPatchConnectViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             val found = try {
                 transport.scanAddress = null
-                withTimeoutOrNull(SCAN_TIMEOUT_MS.milliseconds) {
+                val devicesByAddress = linkedMapOf<String, ScannedDevice>()
+                withTimeoutOrNull(DISCOVERY_COLLECTION_MS.milliseconds) {
                     transport.scanner.scannedDevices
                         // Subscribe BEFORE starting the scan so an immediate advertisement cannot be missed.
                         .onSubscription { transport.scanner.startScan() }
-                        .first()
+                        .collect { scanned ->
+                            val current = devicesByAddress[scanned.address]
+                            if (scanned.rssi >= MIN_SCAN_RSSI && (current == null || scanned.rssi > current.rssi)) {
+                                devicesByAddress[scanned.address] = scanned
+                            }
+                        }
                 }
+                devicesByAddress.values.maxByOrNull { it.rssi }
             } finally {
                 transport.scanner.stopScan()
                 _isScanWorking = false
@@ -286,7 +292,7 @@ class CarelevoPatchConnectViewModel @Inject constructor(
 
     private companion object {
 
-        // 10 s scan window; completes early on the first hit.
-        private const val SCAN_TIMEOUT_MS = 10_000L
+        private const val DISCOVERY_COLLECTION_MS = 5_000L
+        private const val MIN_SCAN_RSSI = -45
     }
 }


### PR DESCRIPTION
The earlier `isBonded` change alone was not enough to resolve the connection issue on Android OS 13 in our testing.

I also adjusted the scan selection logic, because when multiple patches were nearby the first detected device was not always the intended one. The scan now collects results briefly and selects the strongest candidate.

Please review whether this approach looks reasonable for:
1. Android 13 connection handling
2. More stable patch selection during scanning