### PR TITLE
fix CI Cleanup permissions

### DIFF
--- a/.github/workflows/aaps-ci.yml
+++ b/.github/workflows/aaps-ci.yml
@@ -362,6 +362,8 @@ jobs:
     name: Cleanup Old Workflow Runs
     needs: build
     if: always()
+    permissions:
+      actions: write
     uses: ./.github/workflows/cleanup-workflow-runs.yml
     with:
       workflow_name: 'AAPS CI'

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -302,6 +302,8 @@ jobs:
     name: Cleanup Old Workflow Runs
     needs: build
     if: always()
+    permissions:
+      actions: write
     uses: ./.github/workflows/cleanup-workflow-runs.yml
     with:
       workflow_name: 'Branch CI'


### PR DESCRIPTION
Since `cleanup-workflow-runs.yml` was added, the workflow now requires **write** permission.

This PR prevents build failures when users have not configured the required **write** permission for GitHub Actions.

For more details, see:
https://www.facebook.com/share/p/1FJ8sELu6A/