### PR TITLE
Wear: BG graph complication time range setting

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/complications/BgGraphComplication.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/BgGraphComplication.kt
@@ -83,7 +83,7 @@ class BgGraphComplication : ModernBaseComplicationProviderService() {
         val widthPx = resources.displayMetrics.widthPixels
         val heightPx = widthPx / 2
         val bitmap = createBitmap(widthPx, heightPx)
-        val historyHours = sp.getString("complication_bg_graph_hours", "3").toIntOrNull() ?: 3
+        val historyHours = sp.getString(R.string.key_complication_bg_graph_hours, "3").toIntOrNull() ?: 3
         CanvasDrawScope().draw(
             density = Density(resources.displayMetrics.density),
             layoutDirection = LayoutDirection.Ltr,

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
@@ -1,6 +1,7 @@
 package app.aaps.wear.interaction
 
 import android.Manifest
+import android.content.ComponentName
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -11,9 +12,11 @@ import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceGroup
 import androidx.preference.PreferenceManager
+import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.wear.R
+import app.aaps.wear.complications.BgGraphComplication
 import app.aaps.wear.preference.WearPreferenceActivity
 import javax.inject.Inject
 
@@ -59,6 +62,12 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
     }
 
     override fun onSharedPreferenceChanged(sp: SharedPreferences, key: String?) {
+        if (key == getString(R.string.key_complication_bg_graph_hours)) {
+            // Re-render the graph complication immediately instead of waiting for the next BG/poll
+            ComplicationDataSourceUpdateRequester
+                .create(this, ComponentName(this, BgGraphComplication::class.java))
+                .requestUpdateAll()
+        }
         if (key == getString(R.string.key_heart_rate_sampling) && sp.getBoolean(key, false))
             requestBodySensorPermission()
         if (key == getString(R.string.key_steps_sampling)) {

--- a/wear/src/main/kotlin/app/aaps/wear/tile/BgGraphTileSettingsActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/tile/BgGraphTileSettingsActivity.kt
@@ -38,16 +38,15 @@ class BgGraphTileSettingsActivity : AppCompatActivity() {
 private fun BgGraphTileSettingsScreen(sp: SP) {
     val tapAction = remember { mutableStateOf(sp.getString("tile_bg_graph_tap_action", "bg_graph")) }
     val hours = remember { mutableStateOf(sp.getString("tile_bg_graph_hours", "3")) }
-    val hourUnit = stringResource(R.string.hour_short)
     val tapOptions = listOf(
         TileSettingOption("bg_graph", stringResource(R.string.tile_tap_bg_graph)),
         TileSettingOption("menu", stringResource(R.string.tile_tap_main_menu)),
         TileSettingOption("loop_status", stringResource(R.string.tile_tap_loop_status))
     )
     val hourOptions = listOf(
-        TileSettingOption("1", "1$hourUnit"),
-        TileSettingOption("3", "3$hourUnit"),
-        TileSettingOption("6", "6$hourUnit"),
+        TileSettingOption("1", stringResource(R.string.duration_1_hour)),
+        TileSettingOption("3", stringResource(R.string.duration_3_hours)),
+        TileSettingOption("6", stringResource(R.string.duration_6_hours)),
     )
     val rows = listOf(
         TileSettingRow(

--- a/wear/src/main/res/values/arrays.xml
+++ b/wear/src/main/res/values/arrays.xml
@@ -27,6 +27,18 @@
         <item>@string/menu_none</item>
     </string-array>
 
+    <string-array name="complication_bg_graph_hours">
+        <item>@string/duration_1_hour</item>
+        <item>@string/duration_3_hours</item>
+        <item>@string/duration_6_hours</item>
+    </string-array>
+
+    <string-array name="complication_bg_graph_hours_values">
+        <item>1</item>
+        <item>3</item>
+        <item>6</item>
+    </string-array>
+
     <string-array name="complication_tap_action_values">
         <item>default</item>
         <item>menu</item>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="pref_single_target">Single Target</string>
     <string name="pref_wizard_percentage">Calculator Percentage</string>
     <string name="pref_complication_tap_action">Complication Tap Action</string>
+    <string name="pref_complication_bg_graph_hours">BG graph time range</string>
+    <string name="duration_1_hour">1 hour</string>
+    <string name="duration_3_hours">3 hours</string>
+    <string name="duration_6_hours">6 hours</string>
     <string name="pref_unicode_in_complications">Unicode in Complications</string>
     <string name="pref_version">Version:</string>
     <string name="pref_moreWatchfaceSettings">More Watchface settings</string>
@@ -227,6 +231,7 @@
     <string name="key_simplify_ui" translatable="false">simplify_ui</string>
     <string name="key_dark" translatable="false">dark</string>
     <string name="key_complication_tap_action" translatable="false">complication_tap_action</string>
+    <string name="key_complication_bg_graph_hours" translatable="false">complication_bg_graph_hours</string>
     <string name="key_show_seconds" translatable="false">show_second</string>
     <string name="key_include_external" translatable="false">include_external</string>
     <string name="key_switch_external" translatable="false">switch_external</string>

--- a/wear/src/main/res/xml/complication_preferences.xml
+++ b/wear/src/main/res/xml/complication_preferences.xml
@@ -10,6 +10,14 @@
         android:title="@string/pref_complication_tap_action"
         android:summary="%s" />
 
+    <ListPreference
+        android:defaultValue="3"
+        android:entries="@array/complication_bg_graph_hours"
+        android:entryValues="@array/complication_bg_graph_hours_values"
+        android:key="@string/key_complication_bg_graph_hours"
+        android:title="@string/pref_complication_bg_graph_hours"
+        android:summary="%s" />
+
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="complication_unicode"

--- a/wear/src/test/kotlin/app/aaps/wear/complications/BgGraphComplicationTest.kt
+++ b/wear/src/test/kotlin/app/aaps/wear/complications/BgGraphComplicationTest.kt
@@ -4,6 +4,7 @@ import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.PhotoImageComplicationData
 import androidx.wear.watchface.complications.data.SmallImageComplicationData
 import app.aaps.wear.AAPSLoggerTest
+import app.aaps.wear.R
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,7 +28,7 @@ internal class BgGraphComplicationTest {
         Robolectric.buildService(BgGraphComplication::class.java).get().also {
             it.aapsLogger = AAPSLoggerTest()
             it.sp = mock()
-            whenever(it.sp.getString("complication_bg_graph_hours", "3")).thenReturn("3")
+            whenever(it.sp.getString(R.string.key_complication_bg_graph_hours, "3")).thenReturn("3")
         }
 
     @Test


### PR DESCRIPTION
Adds a "BG graph time range" setting (1/3/6 hours, default 3) to Settings → Complications, so users can choose the history window of the BG graph complication from #4996. The complication re-renders immediately when the setting changes.

Also unifies the time range labels between tile settings and the new setting ("1 hour" / "3 hours" / "6 hours" string resources, replacing in-code label concatenation).

Tested on watch; `:wear:test` passes.

<img width="525" height="531" alt="image" src="https://github.com/user-attachments/assets/861e884d-0515-4fc8-be58-d4c44d58b692" />
