### PR TITLE
Wear: balance BG graph history/prediction split on 1h range.

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphRenderer.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphRenderer.kt
@@ -16,6 +16,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.min
 
 internal val BgInRangeColor = Color(0xFF00FF00)
 internal val BgHighColor    = Color(0xFFFFFF00)
@@ -55,7 +56,8 @@ internal fun ageColor(ageMs: Long): Color {
 internal fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int, showNowLabel: Boolean = true) {
     val now = System.currentTimeMillis()
     val historyMs = historyHours * 60 * 60 * 1000L
-    val predictionMs = 90 * 60 * 1000L
+    // Cap predictions at the history span so short ranges (1h) aren't dominated by the prediction area
+    val predictionMs = min(90 * 60 * 1000L, historyMs)
     val startTime = now - historyMs
     val endTime = now + predictionMs
     val timeSpan = (endTime - startTime).toFloat()


### PR DESCRIPTION
The BG graph (complication, tile, activity) always shows a fixed 90 min prediction window, so the 1h range was dominated by predictions: 60 min history vs 90 min predictions (40/60).

Cap the prediction window at the history span — the 1h range now splits 50/50 at the now-line; 3h and 6h are unchanged.

| Before | After |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/aa6fd8d1-5ab4-414b-8f1a-e4c3c8695cd7" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/106fe993-fd52-462a-8aa1-9ff44e3d0f08" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/aaf85184-901b-42fb-b526-cce39a58d451" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/41d88ad8-d70c-4853-821c-0da2ded9ac17" /> | 