### PR TITLE
Overview graphs (Dynamic Y-axis scaling according to visible-window + nice numbers)

### DIFF
--- a/_docs/Graph Dynamic Scaling.md
+++ b/_docs/Graph Dynamic Scaling.md
@@ -1,0 +1,194 @@
+# Overview Graphs: Dynamic Y-Axis Scaling & Nice Numbers
+
+## Motivation
+
+Overview graphs load 24h of data but typically show a 6h sliding window (zoomable down to
+30 minutes, up to 24h). Previously, each graph's Y-axis scale was computed by Vico from the
+**entire loaded 24h**, not the currently visible portion. A single spike anywhere in the 24h
+(e.g. a large IOB peak) would flatten every calm period visually, even when scrolled directly
+onto it.
+
+This change makes every graph's Y-axis recompute from the **currently visible (scrolled/zoomed)
+window** instead, and additionally snaps axis bounds/ticks to round ("nice") numbers instead of
+raw data-driven decimals.
+
+Scope: `BgGraphCompose.kt`, `SecondaryGraphCompose.kt`, `GraphsSection.kt`, `GraphUtils.kt`.
+No public API changes — all new composable parameters default to the previous behavior.
+
+---
+
+## 1. Visible-window axis scaling
+
+### Mechanism
+
+Vico (the charting library) does not expose the visible x-range at the Compose level
+(`VicoScrollState`/`VicoZoomState` give scroll pixels and a zoom factor, not a resolved time
+window). The only place this is reliably computable is at **draw time**, via
+`CartesianDrawingContext` (`layerDimensions.xSpacing`, `ranges.minX`, `ranges.xStep`, `scroll`,
+`layerBounds`) — the same context the existing "now" line decoration (`NowLine`) already reads.
+
+- **`VisibleRangeReporter`** (`GraphUtils.kt`): a passive `Decoration` that computes the visible
+  x-range on every draw pass and writes it into a plain `@Volatile` holder
+  (`VisibleRangeHolder`) — deliberately **not** a Compose `State`. Writing Compose state
+  synchronously from the draw phase was found to fight with Vico's own gesture-driven
+  scroll/zoom mutations (observed: pinch-zoom became unresponsive — see Bug Fix #1 below).
+- Each graph polls this holder from a `LaunchedEffect` (every 50ms), then debounces (30ms)
+  before promoting it to real Compose state (`visibleRange`). This keeps all Compose-state
+  writes off the draw path.
+- The debounced visible range is included in the keys of the `LaunchedEffect` that calls
+  `modelProducer.runTransaction`, and is also stashed in the transaction's `extras` (via an
+  `ExtraStore.Key`). This is required because `CartesianChartModelProducer.update()` skips
+  recomputing axis ranges when a transaction's series data **and** extras are both unchanged —
+  scrolling/zooming re-submits identical series data (only the visible window changed), so
+  without this the transaction would be silently dropped and the axis would never update.
+
+### Applied to every axis-range case in `SecondaryGraphCompose`
+
+All of the following now compute their min/max from the windowed (visible-only) data via two
+shared helpers, `windowedY` and `windowedPrimaryY`, falling back to the full unwindowed data
+only when the visible window currently contains no points (e.g. scrolled into a future gap):
+
+- IOB/BAS combo (`primaryYMax`)
+- Dual-axis zero-alignment (`dualAxisRanges`)
+- Single-axis auto-range (`primaryAutoRange`)
+- COB-alone nice scale (`primaryCobScale`)
+- Zero-floor series alone: BGI/DEVIATIONS/ACTIVITY/STEPS (`primaryZeroFloorScale`)
+- Free-range series alone: VAR_SENSITIVITY/HEART_RATE (`primaryFreeRangeScale`)
+- Pivot-centered series alone: SENSITIVITY/DEV_SLOPE (`primaryPivotScale`)
+- Basal overlay range (`basalMaxY`)
+
+`BgGraphCompose`'s own axis is windowed the same way, but sourced differently — see
+Bug Fix #1.
+
+---
+
+## 2. Nice-number scaling (`GraphUtils.kt`)
+
+Implements Paul Heckbert's "Nice Numbers for Graph Labels" algorithm: axis bounds and tick
+spacing are snapped to `1/2/5/10 × 10^n` (a `2.5` tier is added to avoid an overly coarse jump
+between the `2` and `5` tiers).
+
+| Function | Used for |
+|---|---|
+| `niceScale(min, max)` | Free-range scale, no zero anchor (VAR_SENSITIVITY, HEART_RATE) |
+| `zeroFloorNiceRange(min, max)` | Mostly-positive series (IOB, BGI, DEVIATIONS, ACTIVITY, STEPS, ABS_IOB) — floors at 0 by default, but disparity-aware: if the negative excursion is small relative to the positive range (ratio ≥ 10×), the negative side gets its own small "nice" sliver instead of forcing one shared (coarser) tick step across the whole range |
+| `niceScaleAroundPivot(min, max, pivot)` | SENSITIVITY (pivot=100%) / DEV_SLOPE (pivot=0) — pivot always lands exactly at the axis midpoint. Below a minimum deviation floor (`SENS_MIN_DEVIATION = 5.0`), snaps to a fixed 3-tick scale instead of nice-ifying a near-zero range |
+| `niceUp(value)` / `niceNegativeSliver(value)` | Round a single bound up (or further negative) independently — used when the two sides of a range need decoupled scales |
+
+`ClampedVerticalAxisItemPlacer` wraps the standard step-based item placer to filter out
+labels/gridlines outside a given `[visibleMin, visibleMax]` — used in two situations:
+1. IOB/BAS: the axis extends above the real IOB data to reserve headroom for the basal overlay;
+   labels must stop at the real data max, not continue into the reserved band.
+2. Dual-axis combos where the zero-floor side's axis is pushed below its own real floor purely
+   to align its zero with the other side's pivot — labels must stop at its own real floor
+   instead of showing a fake negative tick for a series that can never go negative.
+
+---
+
+## 3. Dual-axis (combined primary + secondary curve) alignment
+
+Vico computes each vertical axis independently, so y=0 on the left axis does not naturally land
+at the same pixel row as y=0 on the right axis. `dualAxisRanges` (in `SecondaryGraphCompose`)
+computes a shared axis construction depending on which series are combined:
+
+- **Both pivot-centered** (SENS + DEV_SLOPE): existing symmetric-around-pivot alignment,
+  adequate since both are already symmetric around their own pivot.
+- **One pivot, one zero-floor** (e.g. SENS + COB): the pivot side gets a full nice-scaled
+  symmetric range around its own pivot, unconditionally. The zero-floor side gets a symmetric
+  `(-half, +half)` container sized from its own zero-floor nice range, so its zero lands at the
+  pivot's center row; its own real floor is preserved for tick labels via
+  `ClampedVerticalAxisItemPlacer`.
+- **Neither pivot-centered** (e.g. COB + VAR_SENSITIVITY, BGI + STEPS): each series' own
+  "negative fraction" (how much of its axis height sits below zero) is computed independently —
+  primary from its nice bounds, secondary from its raw bounds — and the shared target fraction
+  is their **average**, so neither curve's dynamic range dominates the compromise. Each axis is
+  then widened just enough to hit that shared fraction, anchored at whichever of its own
+  min/max avoids clipping (`fractionAlignedRange` / `fractionAlignedNiceRange`) — this
+  construction guarantees neither curve is ever clipped, for any target fraction.
+
+Verified by hand for the disparity case that motivated this design: a mostly-positive series
+(e.g. IOB) combined with a series that has a real negative excursion (e.g. BGI) — in both
+directions (which one is primary vs. secondary), neither curve loses its real max or min.
+
+---
+
+## Bug Fixes
+
+### 1. BG pinch-zoom became unresponsive / snapped during live gestures
+
+**Root cause:** `CartesianLayerRangeProvider.fixed(...)` returns a new instance every time
+bounds change. Recreating it forces `rememberLineCartesianLayer`/`rememberCartesianChart` to
+mint a new `CartesianChart.id`, which triggers Vico's internal chart re-registration — this
+destabilized BG's live pinch-zoom/scroll gesture handling (BG is the only graph with an
+interactive chart; secondary graphs are non-interactive and were never affected by this).
+
+**Fix:** `MutableYRangeProvider` (`BgGraphCompose.kt`) — a `CartesianLayerRangeProvider`
+implementation backed by plain `@Volatile var` fields instead of an immutable value object. Its
+identity never changes across scroll/zoom; only the field values are mutated in place, read
+fresh whenever Vico next processes a `modelProducer.runTransaction`. BG's chart object is never
+rebuilt mid-gesture.
+
+A related, smaller instance of the same class of bug: attaching a `VisibleRangeReporter`
+decoration directly to BG's own chart (to window its own axis) was also found to disturb its
+gesture handling, even though decorations are normally passive draw-time overlays. Fix: BG does
+not observe its own visible window at all — it sources it from the fixed IOB graph's own
+(already debounced) visible range instead, since IOB's scroll/zoom is synced to BG's anyway
+(`GraphsSection.kt`, `iobVisibleRange` → `iobVisibleRangeSettled`, debounced an additional 400ms
+specifically before feeding BG — secondary graphs are non-interactive and tolerate the shorter
+30ms debounce fine, but updating BG's axis geometry on every ~80ms tick during an active gesture
+kept changing its Y-axis label width mid-gesture and broke pinch-zoom).
+
+### 2. BG viewport snapped to the wrong zoom/scroll after an auto-reset
+
+**Root cause:** driving `VicoZoomState.zoom(Zoom)` to reset to a fixed default (6h) is
+pinch-gesture-oriented — it applies a ratio anchored on the current canvas center via an async
+`pendingScroll` flow — and produced a wrong end state when used to reset to an absolute target
+rather than in response to an actual gesture.
+
+**Fix:** `bgViewportResetTrigger` (`GraphsSection.kt`) — bumping this recreates the BG
+scroll/zoom state objects from scratch via `key(bgViewportResetTrigger) { ... }`, snapping them
+back to their initial values exactly as Vico itself positions them on first composition,
+instead of driving the existing objects to a target. Only triggered on real inactivity (a new
+BG reading arriving with no recent user interaction), never mid-gesture.
+
+Every effect reading `bgScrollState`/`bgZoomState` had to be re-keyed on those objects (not
+`Unit`) so it restarts against the fresh instances after a reset — otherwise it keeps comparing
+secondary-graph state against a stale, abandoned reference forever and fires wrong corrections
+(this caused a visible "dancing"/flashing regression in the secondary graphs on the first
+attempt at this fix).
+
+### 3. COB Y-axis forced into a fake negative range
+
+**Root cause:** COB's Y-axis could get force-symmetrized around zero (e.g. `-42..+42`) whenever
+it shared a dual-axis graph with a series that crosses zero, even though COB itself is never
+negative — the generic zero-crossing alignment logic (`alignZerosAtOrigin`) was being applied
+uniformly regardless of whether a series is actually zero-floor (never negative) vs.
+genuinely bipolar.
+
+**Fix:** zero-floor series (COB and the `ZERO_FLOOR_SERIES_TYPES` set: BGI, DEVIATIONS,
+ACTIVITY, STEPS, ABS_IOB) now get their own dedicated floor-at-0 axis construction
+(`fractionAlignedRange`/`fractionAlignedNiceRange`, see the dual-axis section above) instead of
+reusing the generic symmetric-zero-crossing logic — their real floor is preserved and only the
+shared zero-alignment fraction stretches the axis, never mirroring a fake negative range that
+doesn't exist in the data.
+
+---
+
+## Testing performed
+
+- Manual scroll/zoom testing on device across the full zoom range (30min–24h) on BG and all
+  secondary graph types, including dual-axis combinations.
+- Verified no data clipping on combined curves for mismatched-disparity cases (mostly-positive
+  series + series with a real negative excursion, both orderings).
+- Verified pinch-zoom remains responsive throughout a sustained gesture and that BG's axis
+  updates ~400ms after gesture end rather than mid-gesture.
+- Verified BG viewport reset (new BG reading, no recent interaction) returns to the correct
+  default 6h window/scroll position.
+
+## Known limitations / follow-ups
+
+- Behavior of the shared-fraction dual-axis construction has not been exhaustively tested for
+  every possible series-type combination — the general algorithm should handle any combination
+  by construction (no clipping is a property of `fractionAlignedRange`/
+  `fractionAlignedNiceRange`), but only a subset of combinations has been manually verified on
+  device.

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
@@ -45,6 +45,7 @@ import com.patrykandpatrick.vico.compose.common.component.LineComponent
 import com.patrykandpatrick.vico.compose.common.component.ShapeComponent
 import com.patrykandpatrick.vico.compose.common.component.TextComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
+import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 
 /** Series identifiers */
 /** Basal on BG graph — deprecated, now shown as flipped overlay on IOB graph. Set to true to restore. */
@@ -61,6 +62,36 @@ private const val SERIES_PRED_ZT = "pred_zt"
 
 /** All prediction series identifiers */
 private val PREDICTION_SERIES = listOf(SERIES_PRED_IOB, SERIES_PRED_COB, SERIES_PRED_ACOB, SERIES_PRED_UAM, SERIES_PRED_ZT)
+
+/**
+ * CartesianChartModelProducer.update() skips notifying receivers (and thus skips recomputing axis
+ * ranges) when a transaction's partials AND extraStore are both unchanged from the last one. Since
+ * scrolling/zooming re-submits identical series data (only the visible window changed), stashing
+ * the visible window here forces the extraStore to differ, so Vico actually reprocesses the
+ * transaction instead of silently dropping it. Same mechanism as SecondaryGraphCompose.kt.
+ */
+private val BG_VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Long?, Long?>>()
+
+/**
+ * A [CartesianLayerRangeProvider] backed by plain mutable fields instead of an immutable value
+ * object. [CartesianLayerRangeProvider.fixed] returns a NEW instance whenever bounds change,
+ * which forces Vico to rebuild the [com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer]
+ * and mint a new CartesianChart id — that in turn triggers Vico's internal chart re-registration,
+ * which was found to destabilize BG's live pinch-zoom/scroll gesture handling (BG is the only
+ * graph with an interactive chart). This object's IDENTITY never changes across scroll/zoom; only
+ * its field values do, read fresh whenever Vico next processes a modelProducer transaction — so
+ * the chart itself is never rebuilt mid-gesture. Private to this file: BG is the only graph that
+ * needs this (secondary graphs are non-interactive, so `.fixed(...)` churn never affected them).
+ */
+private class MutableYRangeProvider(
+    @Volatile var maxX: Double,
+    @Volatile var maxY: Double
+) : CartesianLayerRangeProvider {
+    override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore) = 0.0
+    override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore) = this.maxX
+    override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = 0.0
+    override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) = this.maxY
+}
 
 /**
  * BG Graph using Vico — dual-layer chart.
@@ -82,6 +113,7 @@ fun BgGraphCompose(
     zoomState: VicoZoomState,
     derivedTimeRange: Pair<Long, Long>?,
     nowTimestamp: Long,
+    visibleTimeRange: Pair<Long, Long>? = null,
     modifier: Modifier = Modifier
 ) {
     // Collect flows independently - each triggers recomposition only when it changes
@@ -136,6 +168,10 @@ fun BgGraphCompose(
         timestampToX(maxTimestamp, minTimestamp)
     }
 
+    // Stable range-provider instance for the start (BG) axis — created once, mutated in place by
+    // the LaunchedEffect below rather than recreated (see MutableYRangeProvider).
+    val startAxisRangeProvider = remember { MutableYRangeProvider(maxX = maxX, maxY = chartConfig.highMark) }
+
     // Track which series are currently included (for matching LineProvider)
     val activeSeriesState = remember { mutableStateOf(listOf<String>()) }
 
@@ -150,7 +186,8 @@ fun BgGraphCompose(
         currentTargetData: TargetLineData,
         currentEpsPoints: List<EpsGraphPoint>,
         currentActivityData: ActivityGraphData,
-        currentMaxBgY: Double
+        currentMaxBgY: Double,
+        currentVisibleTimeRange: Pair<Long, Long>?
     ) {
         val regularPoints = seriesRegistry[SERIES_REGULAR] ?: emptyList()
         val bucketedPoints = seriesRegistry[SERIES_BUCKETED] ?: emptyList()
@@ -275,6 +312,12 @@ fun BgGraphCompose(
                     series(x = listOf(0.0, 1.0), y = listOf(0.0, 0.0))
                 }
             }
+
+            // Forces Vico to reprocess this transaction even when the series data above is
+            // identical to last time (see BG_VISIBLE_RANGE_KEY doc) — otherwise scrolling/zooming
+            // would re-submit the same partials and get silently skipped, never picking up the
+            // updated startAxisRangeProvider.
+            extras { it[BG_VISIBLE_RANGE_KEY] = currentVisibleTimeRange?.first to currentVisibleTimeRange?.second }
         }
     }
 
@@ -290,16 +333,29 @@ fun BgGraphCompose(
     }
 
     // Single LaunchedEffect for all data - ensures atomic updates
-    LaunchedEffect(bgReadings, bucketedData, predictionsByType, basalData, targetData, epsPoints, activityData, showActivity, chartConfig, stableTimeRange) {
+    LaunchedEffect(bgReadings, bucketedData, predictionsByType, basalData, targetData, epsPoints, activityData, showActivity, chartConfig, stableTimeRange, visibleTimeRange) {
         seriesRegistry[SERIES_REGULAR] = bgReadings
         seriesRegistry[SERIES_BUCKETED] = bucketedData
         for ((key, points) in predictionsByType) {
             seriesRegistry[key] = points
         }
-        // maxBgY clamped against highMark (same as legacy GraphData.maxY logic)
+        // maxBgY clamped against highMark (same as legacy GraphData.maxY logic) — used only for
+        // EPS baseline / Activity overlay proportional scaling, NOT the axis range itself
+        // (see below for that — windowed, unlike this full-range value).
         val allBgValues = (bgReadings + bucketedData).map { it.value }
         val maxBgY = if (allBgValues.isNotEmpty()) maxOf(allBgValues.max(), chartConfig.highMark) else chartConfig.highMark
-        rebuildChart(basalData, targetData, epsPoints, activityData, maxBgY)
+
+        // Windowed axis max: BG values within the visible scroll/zoom window (not the full loaded
+        // range), floored at chartConfig.highMark (the "High mark" target-range preference) so the
+        // axis never shrinks below the configured target range. Mutate the stable provider in
+        // place (see MutableYRangeProvider) — Vico picks up the new value when it processes the
+        // transaction submitted below, without ever recreating BG's chart object.
+        fun inWindow(timestamp: Long) = visibleTimeRange == null || timestamp in visibleTimeRange.first..visibleTimeRange.second
+        val windowedValues = (bgReadings + bucketedData).filter { inWindow(it.timestamp) }.map { it.value }
+        startAxisRangeProvider.maxX = maxX
+        startAxisRangeProvider.maxY = maxOf(windowedValues.ifEmpty { allBgValues }.maxOrNull() ?: 0.0, chartConfig.highMark)
+
+        rebuildChart(basalData, targetData, epsPoints, activityData, maxBgY, visibleTimeRange)
     }
 
     // Build lookup map for BUCKETED points: x-value -> BgDataPoint (for PointProvider)
@@ -496,9 +552,8 @@ fun BgGraphCompose(
     // Range providers — hoisted out of rememberCartesianChart so keys are re-evaluated on recomposition
     // =========================================================================
 
-    val startAxisRangeProvider = remember(maxX) {
-        CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX)
-    }
+    // startAxisRangeProvider (BG axis) is created once, further up, and mutated in place — see
+    // MutableYRangeProvider and the LaunchedEffect above.
     val endAxisRangeProvider = remember(maxX, basalMaxY) {
         CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = 0.0, maxY = basalMaxY)
     }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
@@ -85,7 +85,8 @@ private val BG_VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Long?, Long?>>()
  */
 private class MutableYRangeProvider(
     @Volatile var maxX: Double,
-    @Volatile var maxY: Double
+    @Volatile var maxY: Double,
+    @Volatile var yStep: Double = 0.0
 ) : CartesianLayerRangeProvider {
     override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore) = 0.0
     override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore) = this.maxX
@@ -170,7 +171,10 @@ fun BgGraphCompose(
 
     // Stable range-provider instance for the start (BG) axis — created once, mutated in place by
     // the LaunchedEffect below rather than recreated (see MutableYRangeProvider).
-    val startAxisRangeProvider = remember { MutableYRangeProvider(maxX = maxX, maxY = chartConfig.highMark) }
+    val startAxisRangeProvider = remember {
+        val initialScale = niceScale(0.0, chartConfig.highMark)
+        MutableYRangeProvider(maxX = maxX, maxY = initialScale.max, yStep = initialScale.step)
+    }
 
     // Track which series are currently included (for matching LineProvider)
     val activeSeriesState = remember { mutableStateOf(listOf<String>()) }
@@ -347,13 +351,22 @@ fun BgGraphCompose(
 
         // Windowed axis max: BG values within the visible scroll/zoom window (not the full loaded
         // range), floored at chartConfig.highMark (the "High mark" target-range preference) so the
-        // axis never shrinks below the configured target range. Mutate the stable provider in
-        // place (see MutableYRangeProvider) — Vico picks up the new value when it processes the
-        // transaction submitted below, without ever recreating BG's chart object.
+        // axis never shrinks below the configured target range. Y-axis min stays pinned at 0;
+        // niceScale(0.0, ...) rounds the max and tick step to clean numbers (e.g. 180, 200) instead
+        // of the raw data value. Mutate the stable provider in place (see MutableYRangeProvider) —
+        // Vico picks up the new values when it processes the transaction submitted below, without
+        // ever recreating BG's chart object.
+        // Includes predictions (when shown) — otherwise scrolling into a region with only future
+        // prediction data (no real BG readings) makes the windowed set empty, falling back to the
+        // full unwindowed history's max instead of the actually-visible prediction values.
         fun inWindow(timestamp: Long) = visibleTimeRange == null || timestamp in visibleTimeRange.first..visibleTimeRange.second
-        val windowedValues = (bgReadings + bucketedData).filter { inWindow(it.timestamp) }.map { it.value }
+        val allBgAndPredictionValues = (bgReadings + bucketedData + predictions).map { it.value }
+        val windowedValues = (bgReadings + bucketedData + predictions).filter { inWindow(it.timestamp) }.map { it.value }
+        val dataMax = maxOf(windowedValues.ifEmpty { allBgAndPredictionValues }.maxOrNull() ?: 0.0, chartConfig.highMark)
+        val niceBgScale = niceScale(0.0, dataMax)
         startAxisRangeProvider.maxX = maxX
-        startAxisRangeProvider.maxY = maxOf(windowedValues.ifEmpty { allBgValues }.maxOrNull() ?: 0.0, chartConfig.highMark)
+        startAxisRangeProvider.maxY = niceBgScale.max
+        startAxisRangeProvider.yStep = niceBgScale.step
 
         rebuildChart(basalData, targetData, epsPoints, activityData, maxBgY, visibleTimeRange)
     }
@@ -595,7 +608,7 @@ fun BgGraphCompose(
                 verticalAxisPosition = Axis.Position.Vertical.Start
             ),
             startAxis = VerticalAxis.rememberStart(
-                itemPlacer = VerticalAxis.ItemPlacer.step({ 1.0 }),
+                itemPlacer = VerticalAxis.ItemPlacer.step({ startAxisRangeProvider.yStep }),
                 label = rememberTextComponent(
                     style = TextStyle(color = MaterialTheme.colorScheme.onSurface),
                     minWidth = TextComponent.MinWidth.fixed(30.dp)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/BgGraphCompose.kt
@@ -85,12 +85,13 @@ private val BG_VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Long?, Long?>>()
  */
 private class MutableYRangeProvider(
     @Volatile var maxX: Double,
+    @Volatile var minY: Double,
     @Volatile var maxY: Double,
     @Volatile var yStep: Double = 0.0
 ) : CartesianLayerRangeProvider {
     override fun getMinX(minX: Double, maxX: Double, extraStore: ExtraStore) = 0.0
     override fun getMaxX(minX: Double, maxX: Double, extraStore: ExtraStore) = this.maxX
-    override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = 0.0
+    override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) = this.minY
     override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) = this.maxY
 }
 
@@ -172,8 +173,8 @@ fun BgGraphCompose(
     // Stable range-provider instance for the start (BG) axis — created once, mutated in place by
     // the LaunchedEffect below rather than recreated (see MutableYRangeProvider).
     val startAxisRangeProvider = remember {
-        val initialScale = niceScale(0.0, chartConfig.highMark)
-        MutableYRangeProvider(maxX = maxX, maxY = initialScale.max, yStep = initialScale.step)
+        val initialScale = niceScale(chartConfig.lowMark, chartConfig.highMark)
+        MutableYRangeProvider(maxX = maxX, minY = initialScale.min, maxY = initialScale.max, yStep = initialScale.step)
     }
 
     // Track which series are currently included (for matching LineProvider)
@@ -190,6 +191,7 @@ fun BgGraphCompose(
         currentTargetData: TargetLineData,
         currentEpsPoints: List<EpsGraphPoint>,
         currentActivityData: ActivityGraphData,
+        currentMinBgY: Double,
         currentMaxBgY: Double,
         currentVisibleTimeRange: Pair<Long, Long>?
     ) {
@@ -276,12 +278,14 @@ fun BgGraphCompose(
             }
 
             // Block 4 → EPS layer (layer 3, start axis — Y based on profile %, scaled into BG coordinate space)
-            // Same principle as legacy (originalPercentage/100 * baseline); baseline = 75% of the BG axis height.
+            // Same principle as legacy (originalPercentage/100 * baseline); baseline = 75% of the BG axis
+            // height. Anchored at currentMinBgY (not 0) — since the axis floor is no longer fixed at 0,
+            // a 0%-profile point must sit at the axis' actual bottom, not fall below it and disappear.
             lineModel {
                 if (currentEpsPoints.isNotEmpty()) {
-                    val epsBaseline = currentMaxBgY * 0.75
+                    val epsBaseline = (currentMaxBgY - currentMinBgY) * 0.75
                     val pts = currentEpsPoints
-                        .map { eps -> timestampToX(eps.timestamp, minTimestamp) to (eps.originalPercentage / 100.0 * epsBaseline) }
+                        .map { eps -> timestampToX(eps.timestamp, minTimestamp) to (currentMinBgY + eps.originalPercentage / 100.0 * epsBaseline) }
                         .sortedBy { it.first }
                     series(x = pts.map { it.first }, y = pts.map { it.second })
                 } else {
@@ -291,7 +295,8 @@ fun BgGraphCompose(
             }
 
             // Block 5 → Activity layer (layer 4, start axis — Y-values normalized to BG coordinate space)
-            // Scale so maxActivity maps to 80% of maxBgY (same as legacy: maxY * 0.8 / maxIAValue)
+            // Scale so maxActivity maps to 80% of the BG axis height (same as legacy: maxY * 0.8 /
+            // maxIAValue), anchored at currentMinBgY for the same reason as the EPS layer above.
             lineModel {
                 val maxAct = currentActivityData.maxActivity
                 if (!showActivity || maxAct <= 0.0 || currentActivityData.activity.size < 2) {
@@ -300,16 +305,16 @@ fun BgGraphCompose(
                     series(x = listOf(0.0, 1.0), y = listOf(0.0, 0.0))
                     return@lineModel
                 }
-                val scaleFactor = currentMaxBgY * 0.8 / maxAct
+                val scaleFactor = (currentMaxBgY - currentMinBgY) * 0.8 / maxAct
 
                 val pts = currentActivityData.activity
-                    .map { timestampToX(it.timestamp, minTimestamp) to (it.value * scaleFactor) }
+                    .map { timestampToX(it.timestamp, minTimestamp) to (currentMinBgY + it.value * scaleFactor) }
                     .sortedBy { it.first }
                 series(x = pts.map { it.first }, y = pts.map { it.second })
 
                 if (currentActivityData.activityPrediction.size >= 2) {
                     val predPts = currentActivityData.activityPrediction
-                        .map { timestampToX(it.timestamp, minTimestamp) to (it.value * scaleFactor) }
+                        .map { timestampToX(it.timestamp, minTimestamp) to (currentMinBgY + it.value * scaleFactor) }
                         .sortedBy { it.first }
                     series(x = predPts.map { it.first }, y = predPts.map { it.second })
                 } else {
@@ -343,32 +348,39 @@ fun BgGraphCompose(
         for ((key, points) in predictionsByType) {
             seriesRegistry[key] = points
         }
-        // maxBgY clamped against highMark (same as legacy GraphData.maxY logic) — used only for
-        // EPS baseline / Activity overlay proportional scaling, NOT the axis range itself
-        // (see below for that — windowed, unlike this full-range value).
+        // maxBgY/minBgY clamped against highMark/lowMark (same as legacy GraphData.maxY logic) —
+        // used only for EPS baseline / Activity overlay proportional scaling, NOT the axis range
+        // itself (see below for that — windowed, unlike these full-range values).
         val allBgValues = (bgReadings + bucketedData).map { it.value }
         val maxBgY = if (allBgValues.isNotEmpty()) maxOf(allBgValues.max(), chartConfig.highMark) else chartConfig.highMark
+        val minBgY = if (allBgValues.isNotEmpty()) minOf(allBgValues.min(), chartConfig.lowMark) else chartConfig.lowMark
 
-        // Windowed axis max: BG values within the visible scroll/zoom window (not the full loaded
-        // range), floored at chartConfig.highMark (the "High mark" target-range preference) so the
-        // axis never shrinks below the configured target range. Y-axis min stays pinned at 0;
-        // niceScale(0.0, ...) rounds the max and tick step to clean numbers (e.g. 180, 200) instead
-        // of the raw data value. Mutate the stable provider in place (see MutableYRangeProvider) —
-        // Vico picks up the new values when it processes the transaction submitted below, without
-        // ever recreating BG's chart object.
+        // Windowed axis min/max: BG values within the visible scroll/zoom window (not the full
+        // loaded range), floored/ceiled at chartConfig.lowMark/highMark (the "Low mark"/"High mark"
+        // target-range preferences) so the axis never shrinks past the configured target range —
+        // but also never stays locked at a fixed 0 floor when real data sits well above it, which
+        // used to leave a large empty band under the curve (worse for mmol/L users, since niceScale
+        // can round the top up to a proportionally huge ceiling like 15 mmol/L). niceScale(...)
+        // rounds both bounds and the tick step to clean numbers (e.g. 70, 180) instead of the raw
+        // data values. Mutate the stable provider in place (see MutableYRangeProvider) — Vico picks
+        // up the new values when it processes the transaction submitted below, without ever
+        // recreating BG's chart object.
         // Includes predictions (when shown) — otherwise scrolling into a region with only future
         // prediction data (no real BG readings) makes the windowed set empty, falling back to the
         // full unwindowed history's max instead of the actually-visible prediction values.
         fun inWindow(timestamp: Long) = visibleTimeRange == null || timestamp in visibleTimeRange.first..visibleTimeRange.second
         val allBgAndPredictionValues = (bgReadings + bucketedData + predictions).map { it.value }
         val windowedValues = (bgReadings + bucketedData + predictions).filter { inWindow(it.timestamp) }.map { it.value }
-        val dataMax = maxOf(windowedValues.ifEmpty { allBgAndPredictionValues }.maxOrNull() ?: 0.0, chartConfig.highMark)
-        val niceBgScale = niceScale(0.0, dataMax)
+        val windowedOrFull = windowedValues.ifEmpty { allBgAndPredictionValues }
+        val dataMax = maxOf(windowedOrFull.maxOrNull() ?: chartConfig.highMark, chartConfig.highMark)
+        val dataMin = minOf(windowedOrFull.minOrNull() ?: chartConfig.lowMark, chartConfig.lowMark)
+        val niceBgScale = niceScale(dataMin, dataMax)
         startAxisRangeProvider.maxX = maxX
+        startAxisRangeProvider.minY = niceBgScale.min
         startAxisRangeProvider.maxY = niceBgScale.max
         startAxisRangeProvider.yStep = niceBgScale.step
 
-        rebuildChart(basalData, targetData, epsPoints, activityData, maxBgY, visibleTimeRange)
+        rebuildChart(basalData, targetData, epsPoints, activityData, minBgY, maxBgY, visibleTimeRange)
     }
 
     // Build lookup map for BUCKETED points: x-value -> BgDataPoint (for PointProvider)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
@@ -325,3 +325,56 @@ fun rememberNowLine(minTimestamp: Long, nowTimestamp: Long, color: Color): NowLi
         NowLine(nowX = timestampToX(nowTimestamp, minTimestamp), color = color)
     }
 }
+
+/**
+ * Plain (non-Compose-state) holder for the latest visible x-range, written from
+ * [VisibleRangeReporter.drawOverLayers] on every draw pass.
+ *
+ * Deliberately NOT a Compose `State`: writing Compose state synchronously from the draw phase
+ * fights with Vico's own gesture-driven scroll/zoom mutations — the resulting invalidate-during-draw
+ * starves pinch-zoom gesture recognition (observed: zoom became unresponsive). Callers must poll
+ * [value] from a coroutine (e.g. a `LaunchedEffect` with a periodic `delay`) and only then write it
+ * into real Compose state.
+ */
+class VisibleRangeHolder {
+    @Volatile
+    var value: Pair<Double, Double>? = null
+}
+
+/**
+ * Reports the currently visible x-range (same "minutes from minTimestamp" unit as [timestampToX])
+ * into [holder] on every draw pass. Purely observational — draws nothing, and never touches
+ * Compose state directly (see [VisibleRangeHolder]).
+ *
+ * Inverse of [NowLine]'s x-value-to-canvas transform: canvasX = layerBounds.left + startPadding +
+ * xSpacing * ((x - minX) / xStep) - scroll. Solving for x at the left/right edges of layerBounds
+ * gives the visible x-range.
+ */
+class VisibleRangeReporter(
+    private val holder: VisibleRangeHolder
+) : Decoration {
+
+    override fun drawOverLayers(context: CartesianDrawingContext) {
+        with(context) {
+            val xStep = ranges.xStep
+            val xSpacing = layerDimensions.xSpacing
+            if (xStep == 0.0 || xSpacing <= 0f) return
+
+            val visibleMinX = ranges.minX + xStep * (scroll - layerDimensions.startPadding) / xSpacing
+            val visibleWidth = xStep * layerBounds.width / xSpacing
+            holder.value = visibleMinX to (visibleMinX + visibleWidth)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other
+    override fun hashCode(): Int = System.identityHashCode(this)
+}
+
+/**
+ * Remember a [VisibleRangeReporter] decoration that writes the visible x-range into [holder]
+ * on every draw pass.
+ */
+@Composable
+fun rememberVisibleRangeReporter(holder: VisibleRangeHolder): VisibleRangeReporter {
+    return remember(holder) { VisibleRangeReporter(holder) }
+}

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
@@ -448,8 +448,9 @@ fun niceUp(value: Double): Double {
 
 /**
  * Rounds [value] (expected negative) further negative to the nearest nice magnitude — e.g.
- * -0.3 -> -0.5, -0.05 -> -0.1. Used to give a small negative excursion its own clean bound,
- * decoupled from a much larger positive-side scale (see [zeroFloorNiceRange]).
+ * -0.3 -> -0.5, -0.07 -> -0.1 (but -0.05 is already nice and is left unchanged). Used to give a
+ * small negative excursion its own clean bound, decoupled from a much larger positive-side scale
+ * (see [zeroFloorNiceRange]).
  */
 fun niceNegativeSliver(value: Double): Double {
     if (value >= 0.0) return 0.0

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import app.aaps.core.interfaces.overview.graph.SeriesType
 import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
 import com.patrykandpatrick.vico.compose.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
@@ -456,6 +457,13 @@ fun niceNegativeSliver(value: Double): Double {
 }
 
 /**
+ * Minimum half-width for SENSITIVITY's pivot scale (see [niceScaleAroundPivot]'s `minDeviation`
+ * param) — below this, snap to a fixed 95%/100%/105% scale instead of nice-ifying a near-zero
+ * deviation (e.g. a SENS ratio sitting flat around 100%).
+ */
+const val SENS_MIN_DEVIATION = 5.0
+
+/**
  * Nice-ify a symmetric deviation around [pivot] (e.g. SENSITIVITY around 100%, DEV_SLOPE
  * around 0), so [pivot] always lands exactly in the middle of the axis. Nice-ifying [min, max]
  * directly (via [niceScale]) would not preserve that centering.
@@ -474,13 +482,21 @@ fun niceScaleAroundPivot(min: Double, max: Double, pivot: Double, maxTickCount: 
 }
 
 /**
+ * Series that are 0-floored by default (see [zeroFloorNiceRange]): mostly-positive, allowing a
+ * disparity-aware negative excursion without ever centering zero. IOB follows the same rule but
+ * isn't included here — its basal-overlay combo graph has its own dedicated range computation
+ * (SecondaryGraphCompose's `primaryYMaxResult`) that calls [zeroFloorNiceRange] directly.
+ */
+val ZERO_FLOOR_SERIES_TYPES = setOf(SeriesType.BGI, SeriesType.DEVIATIONS, SeriesType.ACTIVITY, SeriesType.STEPS, SeriesType.ABS_IOB)
+
+/**
  * Zero-floor axis range, disparity-aware: when the negative excursion is tiny relative to the
  * positive side (ratio >= [disparityRatio]), one shared nice tick spacing across the whole
  * range would make the small negative part look arbitrary — so the two sides are nice-ified
  * independently instead (a small negative sliver just large enough to show the excursion, plus
  * a normal positive-side scale). When the two sides are comparable in magnitude, a single
  * unified nice scale spans the whole range, negative and positive sharing the same tick step.
- * Used for IOB, DEVIATIONS, BGI, ACTIVITY, STEPS.
+ * Used for IOB and [ZERO_FLOOR_SERIES_TYPES].
  */
 fun zeroFloorNiceRange(dataMin: Double, dataMax: Double, maxTickCount: Int = 5, disparityRatio: Double = 10.0): NiceScale {
     if (dataMin >= 0.0) return niceScale(0.0, dataMax, maxTickCount)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
@@ -22,6 +22,11 @@ import kotlinx.datetime.toLocalDateTime
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.log10
+import kotlin.math.pow
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -377,4 +382,112 @@ class VisibleRangeReporter(
 @Composable
 fun rememberVisibleRangeReporter(holder: VisibleRangeHolder): VisibleRangeReporter {
     return remember(holder) { VisibleRangeReporter(holder) }
+}
+
+// =========================================================================
+// Nice-numbers axis scaling ("Nice Numbers for Graph Labels", Paul Heckbert)
+// =========================================================================
+//
+// Vico's default Y-axis item placer divides a fixed [minY, maxY] range into evenly-spaced
+// ticks with no rounding, so an arbitrary data-driven range (e.g. 12.39..57.39) produces ugly
+// tick labels (12.39, 27.39, 42.39...). These helpers snap axis bounds and tick spacing to
+// round numbers (1, 2, 5, 10, 20, 50... times a power of ten) instead.
+
+/** A "nice" axis range: bounds and tick spacing all rounded to 1/2/5/10 x 10^n. */
+data class NiceScale(val min: Double, val max: Double, val step: Double)
+
+/**
+ * Rounds [range] to a value of the form 1/2/2.5/5/10 x 10^n. [round] chooses the nearest such
+ * value (used for tick spacing) vs. always rounding up (used for axis bounds, so the bound never
+ * clips inside the data). [range] must be > 0.
+ *
+ * The round-up variant includes a 2.5 tier (a known variant of Heckbert's original {1,2,5,10}
+ * set) to avoid an overly coarse jump between the 2 and 5 tiers — e.g. without it, a BG max of
+ * 210 would round all the way up to 300 (skipping straight from a 50-step scale to a 100-step
+ * one); with it, 210 rounds to 250 first, only reaching 300 once the value exceeds 250.
+ */
+private fun niceNum(range: Double, round: Boolean): Double {
+    val exponent = floor(log10(range))
+    val fraction = range / 10.0.pow(exponent)
+    val niceFraction = if (round) {
+        when {
+            fraction < 1.5 -> 1.0
+            fraction < 3.0 -> 2.0
+            fraction < 7.0 -> 5.0
+            else           -> 10.0
+        }
+    } else {
+        when {
+            fraction <= 1.0 -> 1.0
+            fraction <= 2.0 -> 2.0
+            fraction <= 2.5 -> 2.5
+            fraction <= 5.0 -> 5.0
+            else            -> 10.0
+        }
+    }
+    return niceFraction * 10.0.pow(exponent)
+}
+
+/**
+ * Standard nice-ify: snaps [min, max] and the tick spacing to round numbers. Free-range, no
+ * zero or pivot anchoring — used for series like VAR_SENSITIVITY and HEART_RATE.
+ */
+fun niceScale(min: Double, max: Double, maxTickCount: Int = 5): NiceScale {
+    val safeMax = if (max > min) max else min + 1.0
+    val range = niceNum(safeMax - min, round = false)
+    val step = niceNum(range / (maxTickCount - 1), round = true)
+    return NiceScale(floor(min / step) * step, ceil(safeMax / step) * step, step)
+}
+
+/** Rounds [value] up to the nearest nice number (1/2/5/10 x 10^n). Used for a lone axis bound. */
+fun niceUp(value: Double): Double {
+    if (value <= 0.0) return 0.0
+    return niceNum(value, round = false)
+}
+
+/**
+ * Rounds [value] (expected negative) further negative to the nearest nice magnitude — e.g.
+ * -0.3 -> -0.5, -0.05 -> -0.1. Used to give a small negative excursion its own clean bound,
+ * decoupled from a much larger positive-side scale (see [zeroFloorNiceRange]).
+ */
+fun niceNegativeSliver(value: Double): Double {
+    if (value >= 0.0) return 0.0
+    return -niceNum(-value, round = false)
+}
+
+/**
+ * Nice-ify a symmetric deviation around [pivot] (e.g. SENSITIVITY around 100%, DEV_SLOPE
+ * around 0), so [pivot] always lands exactly in the middle of the axis. Nice-ifying [min, max]
+ * directly (via [niceScale]) would not preserve that centering.
+ */
+fun niceScaleAroundPivot(min: Double, max: Double, pivot: Double, maxTickCount: Int = 5): NiceScale {
+    val rawDeviation = maxOf(abs(pivot - min), abs(max - pivot))
+    val deviation = if (rawDeviation > 0.0) rawDeviation else 1.0
+    val niceDeviation = niceNum(deviation, round = false)
+    val step = niceNum(2 * niceDeviation / (maxTickCount - 1), round = true)
+    val steppedDeviation = ceil(niceDeviation / step) * step
+    return NiceScale(pivot - steppedDeviation, pivot + steppedDeviation, step)
+}
+
+/**
+ * Zero-floor axis range, disparity-aware: when the negative excursion is tiny relative to the
+ * positive side (ratio >= [disparityRatio]), one shared nice tick spacing across the whole
+ * range would make the small negative part look arbitrary — so the two sides are nice-ified
+ * independently instead (a small negative sliver just large enough to show the excursion, plus
+ * a normal positive-side scale). When the two sides are comparable in magnitude, a single
+ * unified nice scale spans the whole range, negative and positive sharing the same tick step.
+ * Used for IOB, DEVIATIONS, BGI, ACTIVITY, STEPS.
+ */
+fun zeroFloorNiceRange(dataMin: Double, dataMax: Double, maxTickCount: Int = 5, disparityRatio: Double = 10.0): NiceScale {
+    if (dataMin >= 0.0) return niceScale(0.0, dataMax, maxTickCount)
+    val absMin = -dataMin
+    val ratio = if (absMin > 0.0) dataMax / absMin else Double.MAX_VALUE
+    return if (ratio >= disparityRatio) {
+        val niceMax = niceUp(dataMax)
+        val niceMin = niceNegativeSliver(dataMin)
+        val step = niceNum(niceMax / (maxTickCount - 1), round = true)
+        NiceScale(niceMin, niceMax, step)
+    } else {
+        niceScale(dataMin, dataMax, maxTickCount)
+    }
 }

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtils.kt
@@ -460,8 +460,12 @@ fun niceNegativeSliver(value: Double): Double {
  * around 0), so [pivot] always lands exactly in the middle of the axis. Nice-ifying [min, max]
  * directly (via [niceScale]) would not preserve that centering.
  */
-fun niceScaleAroundPivot(min: Double, max: Double, pivot: Double, maxTickCount: Int = 5): NiceScale {
+fun niceScaleAroundPivot(min: Double, max: Double, pivot: Double, maxTickCount: Int = 5, minDeviation: Double = 0.0): NiceScale {
     val rawDeviation = maxOf(abs(pivot - min), abs(max - pivot))
+    // Below the floor (e.g. SENS sitting flat around 100%): snap to a fixed 3-tick scale
+    // (pivot-minDeviation, pivot, pivot+minDeviation) instead of nice-ifying a near-zero range,
+    // which would otherwise produce an overly tight, non-round scale (e.g. 99/99.5/100/100.5/101).
+    if (minDeviation > 0.0 && rawDeviation <= minDeviation) return NiceScale(pivot - minDeviation, pivot + minDeviation, minDeviation)
     val deviation = if (rawDeviation > 0.0) rawDeviation else 1.0
     val niceDeviation = niceNum(deviation, round = false)
     val step = niceNum(2 * niceDeviation / (maxTickCount - 1), round = true)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphsSection.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/GraphsSection.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -101,30 +102,54 @@ fun GraphsSection(
     // In simple mode: fixed layout (BG, IOB+BAS, COB — no overlays, no editing)
     val graphConfig = if (isSimpleMode) SIMPLE_MODE_CONFIG else savedGraphConfig
 
-    // BG graph - primary interactive
-    val bgScrollState = rememberVicoScrollState(
-        scrollEnabled = true,
-        initialScroll = Scroll.Absolute.End
-    )
-    val bgZoomState = rememberVicoZoomState(
-        zoomEnabled = true,
-        initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES),
-        minZoom = Zoom.x(Constants.GRAPH_TIME_RANGE_HOURS * 60.0),
-        maxZoom = Zoom.x(MIN_GRAPH_ZOOM_MINUTES)
-    )
+    // Zoom.x(...) allocates a fresh (non-equal, unmemoized) lambda instance on every call.
+    // rememberVicoZoomState's underlying rememberSaveable is keyed on initialZoom/minZoom/maxZoom
+    // by reference, so passing a freshly-allocated Zoom on every recomposition of this composable
+    // tears down and recreates the VicoZoomState — resetting the zoom level back to initialZoom.
+    // Memoize these once so all zoom states below stay stable across recompositions.
+    val defaultZoom = remember { Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES) }
+    val bgMinZoom = remember { Zoom.x(Constants.GRAPH_TIME_RANGE_HOURS * 60.0) }
+    val bgMaxZoom = remember { Zoom.x(MIN_GRAPH_ZOOM_MINUTES) }
+
+    // BG graph - primary interactive.
+    // Wrapped in key(bgViewportResetTrigger) so bumping the trigger tears down and recreates both
+    // states from scratch, snapping them back to their initial values (Scroll.Absolute.End /
+    // defaultZoom = 6h). This is deliberate: VicoZoomState.zoom(Zoom) is pinch-gesture-oriented
+    // (it applies a ratio anchored on the current canvas center via an async pendingScroll flow)
+    // and produced a wrong end state when used to "reset to a fixed default" — recreating the
+    // state objects is simpler and matches the exact positioning Vico itself already uses on first
+    // composition. Only reset on real inactivity (rare, never mid-gesture), so this doesn't
+    // reintroduce the "churn during an active gesture" issues found elsewhere in this file.
+    // IMPORTANT: every effect below that reads bgScrollState/bgZoomState.value MUST be keyed on
+    // them (not just Unit) — otherwise it keeps a stale reference to the abandoned pre-reset
+    // objects forever, comparing live secondary-graph state against a frozen stale value and
+    // firing wrong corrections (this caused the secondary graphs to visibly "dance"/flash on the
+    // first attempt at this).
+    var bgViewportResetTrigger by remember { mutableIntStateOf(0) }
+    val (bgScrollState, bgZoomState) = key(bgViewportResetTrigger) {
+        rememberVicoScrollState(
+            scrollEnabled = true,
+            initialScroll = Scroll.Absolute.End
+        ) to rememberVicoZoomState(
+            zoomEnabled = true,
+            initialZoom = defaultZoom,
+            minZoom = bgMinZoom,
+            maxZoom = bgMaxZoom
+        )
+    }
 
     // Pre-allocate secondary graph scroll/zoom states (up to MAX_SECONDARY_GRAPHS)
     // These are always created to keep Compose's remember slots stable
     val sec0scroll = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val sec0zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val sec0zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
     val sec1scroll = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val sec1zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val sec1zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
     val sec2scroll = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val sec2zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val sec2zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
     val sec3scroll = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val sec3zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val sec3zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
     val sec4scroll = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val sec4zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val sec4zoom = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
 
     // Collect nowTimestamp ONCE so all graphs use the same value (avoids separate recompositions every 30s)
     val nowTimestamp by graphViewModel.nowTimestamp.collectAsStateWithLifecycle()
@@ -136,6 +161,30 @@ fun GraphsSection(
     // maps to different time when x-axis ranges differ).
     val derivedTimeRange by graphViewModel.derivedTimeRange.collectAsStateWithLifecycle()
 
+    // BG's own visible window, sourced from the fixed IOB graph's already-computed visible range
+    // (its scroll/zoom are synced to BG's, see the sync LaunchedEffect below) — not from a
+    // decoration on BG's own chart, since that was tried and found to break BG's pinch-zoom
+    // gesture handling (BG is the only graph with live scrollEnabled/zoomEnabled = true).
+    var iobVisibleRange by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+
+    // Settle further before feeding into BG specifically: unlike the secondary graphs (which are
+    // non-interactive and unaffected by frequent updates), BG has live pinch-zoom. Updating its
+    // axis range on every ~80ms tick during an active gesture kept changing the Y-axis label
+    // width/layerDimensions mid-gesture and broke pinch-zoom. Only update once the window has
+    // been stable for a bit, i.e. after the gesture ends.
+    var iobVisibleRangeSettled by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+    LaunchedEffect(Unit) {
+        snapshotFlow { iobVisibleRange }
+            .debounce(400)
+            .collect { iobVisibleRangeSettled = it }
+    }
+
+    val bgVisibleTimeRange = derivedTimeRange?.first?.let { minTs ->
+        iobVisibleRangeSettled?.let { (minXv, maxXv) ->
+            (minTs + (minXv * 60_000).toLong()) to (minTs + (maxXv * 60_000).toLong())
+        }
+    }
+
     // Treatment belt graph - non-interactive, synced from BG
     val beltScrollState = rememberVicoScrollState(
         scrollEnabled = false,
@@ -143,12 +192,12 @@ fun GraphsSection(
     )
     val beltZoomState = rememberVicoZoomState(
         zoomEnabled = false,
-        initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES)
+        initialZoom = defaultZoom
     )
 
     // Fixed IOB graph - non-interactive, synced from BG
     val iobScrollState = rememberVicoScrollState(scrollEnabled = false, initialScroll = Scroll.Absolute.End)
-    val iobZoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = Zoom.x(DEFAULT_GRAPH_ZOOM_MINUTES))
+    val iobZoomState = rememberVicoZoomState(zoomEnabled = false, initialZoom = defaultZoom)
 
     // Active graph count — rememberUpdatedState so coroutines always read the latest value
     // without writing to state during composition. Unattached states are no-ops for
@@ -202,33 +251,45 @@ fun GraphsSection(
 
     LaunchedEffect(bgInfoState.bgInfo?.timestamp) {
         val newTimestamp = bgInfoState.bgInfo?.timestamp ?: return@LaunchedEffect
-        val showPredictions = SeriesType.PREDICTIONS in graphConfig.bgOverlays
         if (lastBgTimestamp != 0L && newTimestamp > lastBgTimestamp) {
-            // Skip auto-scroll while user is interacting with the graph
+            // Skip auto-reset while user is interacting with the graph
             val sinceInteraction = System.currentTimeMillis() - graphViewModel.lastInteractionMs
             if (sinceInteraction < INTERACTION_GRACE_MS) {
                 lastBgTimestamp = newTimestamp
                 return@LaunchedEffect
             }
-            val timeRange = derivedTimeRange
-            if (showPredictions && predictions.isNotEmpty() && timeRange != null) {
-                // Scroll so "now + 2h" is at the right edge of viewport
-                val (minTimestamp, _) = timeRange
-                val nowX = timestampToX(System.currentTimeMillis(), minTimestamp)
-                bgScrollState.animateScroll(Scroll.Absolute.x(nowX + 120.0, bias = 1f))
-            } else {
-                // No predictions - scroll to end
-                bgScrollState.animateScroll(Scroll.Absolute.End)
-            }
+            // Reset scroll+zoom to their defaults by recreating the state objects (see
+            // bgViewportResetTrigger doc above) instead of driving VicoZoomState.zoom(Zoom) to an
+            // absolute target, which was found to land on the wrong zoom/scroll combination.
+            bgViewportResetTrigger++
         }
         lastBgTimestamp = newTimestamp
+    }
+
+    // After a reset, the recreated bgScrollState defaults to Scroll.Absolute.End. If predictions
+    // are visible, nudge it further so "now + 2h" sits at the right edge instead, leaving room to
+    // see the forecast — same positioning as before, reapplied once the fresh scrollState (a new
+    // instance, since it's keyed on bgViewportResetTrigger too) is composed and ready.
+    LaunchedEffect(bgViewportResetTrigger, bgScrollState) {
+        if (bgViewportResetTrigger == 0) return@LaunchedEffect
+        val showPredictions = SeriesType.PREDICTIONS in graphConfig.bgOverlays
+        val timeRange = derivedTimeRange
+        if (showPredictions && predictions.isNotEmpty() && timeRange != null) {
+            val (minTimestamp, _) = timeRange
+            val nowX = timestampToX(System.currentTimeMillis(), minTimestamp)
+            bgScrollState.animateScroll(Scroll.Absolute.x(nowX + 120.0, bias = 1f))
+        }
     }
 
     // Correct secondary graph scroll drift — Vico may internally adjust scroll
     // when model producers fire. Watch for any divergence and re-sync to BG.
     // No isSyncing guard needed: primary sync only reads BG state, so writing to
     // secondary states here cannot trigger primary sync (no feedback loop).
-    LaunchedEffect(Unit) {
+    // Keyed on bgScrollState/bgZoomState (not Unit) — MUST restart when they're recreated by a
+    // reset, otherwise this keeps comparing secondary graphs against a stale, abandoned pre-reset
+    // reference forever and fires wrong corrections (the actual cause of the "dancing" regression
+    // in the first attempt at this feature).
+    LaunchedEffect(bgScrollState, bgZoomState) {
         snapshotFlow {
             // Only read states that are attached to a chart (belt + IOB fixed + active secondary)
             val count = activeCount
@@ -286,6 +347,7 @@ fun GraphsSection(
                 zoomState = bgZoomState,
                 derivedTimeRange = derivedTimeRange,
                 nowTimestamp = nowTimestamp,
+                visibleTimeRange = bgVisibleTimeRange,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(graphConfig.bgHeight.dp)
@@ -327,6 +389,7 @@ fun GraphsSection(
                 derivedTimeRange = derivedTimeRange,
                 nowTimestamp = nowTimestamp,
                 activityOverlay = SeriesType.ACTIVITY in graphConfig.iobOverlays,
+                onVisibleRangeChanged = { iobVisibleRange = it },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(graphConfig.iobHeight.dp)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -43,6 +46,19 @@ import com.patrykandpatrick.vico.compose.common.component.LineComponent
 import com.patrykandpatrick.vico.compose.common.component.ShapeComponent
 import com.patrykandpatrick.vico.compose.common.component.TextComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
+import com.patrykandpatrick.vico.compose.common.data.ExtraStore
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.debounce
+
+/**
+ * CartesianChartModelProducer.update() skips notifying receivers (and thus skips recomputing axis
+ * ranges) when a transaction's partials AND extraStore are both unchanged from the last one. Since
+ * scrolling/zooming re-submits identical series data (only the visible window changed), stashing
+ * the visible window here forces the extraStore to differ, so Vico actually reprocesses the
+ * transaction instead of silently dropping it.
+ */
+private val VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Double?, Double?>>()
 
 /**
  * General-purpose secondary graph composable.
@@ -54,6 +70,7 @@ import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
  * - Simple line series (AbsIOB, BGI, Sensitivity, VarSens, DevSlope, HR, Steps): Colored line with gradient fill
  * - Deviations: Per-type colored step lines with gradient fill (POSITIVE/NEGATIVE/EQUAL/UAM/CSF)
  */
+@OptIn(FlowPreview::class)
 @Composable
 fun SecondaryGraphCompose(
     viewModel: GraphViewModel,
@@ -300,6 +317,38 @@ fun SecondaryGraphCompose(
         processPoints(secondaryLineData, minTimestamp, minX, maxX)
     }
 
+    // Visible-window bounds (same x-unit as processed* points — minutes from minTimestamp) for
+    // windowing the Y-axis scale to only the currently scrolled/zoomed portion of this graph's
+    // own chart, instead of the full loaded time range.
+    // The reporter writes into a plain (non-Compose-state) holder on every draw pass — see
+    // VisibleRangeHolder — so we poll it here rather than observing it directly, keeping Compose
+    // state writes off the draw path.
+    // Computed here (before the model-rebuild LaunchedEffect below) so visibleMinX/visibleMaxX can
+    // be included in that effect's keys — Vico only reliably re-applies axis ranges via a real
+    // modelProducer.runTransaction, not merely by swapping the CartesianLayerRangeProvider instance.
+    val visibleRangeHolder = remember { VisibleRangeHolder() }
+    val visibleRangeReporter = rememberVisibleRangeReporter(visibleRangeHolder)
+
+    var rawVisibleRange by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+    var visibleRange by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+
+    LaunchedEffect(visibleRangeHolder) {
+        while (true) {
+            delay(50)
+            val current = visibleRangeHolder.value
+            if (current != rawVisibleRange) rawVisibleRange = current
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { rawVisibleRange }
+            .debounce(30)
+            .collect { visibleRange = it }
+    }
+
+    val visibleMinX = visibleRange?.first
+    val visibleMaxX = visibleRange?.second
+
     // Single source of truth for the primary layer: build the (x, y, slot) specs synchronously,
     // in the exact order they are emitted to the model below. Deriving the line styles,
     // hasPrimaryData and the Y-range from this list (instead of from slot state set asynchronously
@@ -368,7 +417,9 @@ fun SecondaryGraphCompose(
         processedBasalActual,
         processedSecondary,
         processedActivityOverlay,
-        maxX
+        maxX,
+        visibleMinX,
+        visibleMaxX
     ) {
         // Always populate the model — even with no data / no real time range — so the chart frame
         // (axes, grid, now-line) renders the empty-state normalizer series instead of staying blank.
@@ -409,6 +460,11 @@ fun SecondaryGraphCompose(
                 }
             }
 
+            // Forces Vico to reprocess this transaction even when the series data above is
+            // identical to last time (see VISIBLE_RANGE_KEY doc) — otherwise scrolling/zooming
+            // would re-submit the same partials and get silently skipped, never picking up the
+            // updated primaryRangeProvider.
+            extras { it[VISIBLE_RANGE_KEY] = visibleMinX to visibleMaxX }
         }
     }
 
@@ -481,14 +537,25 @@ fun SecondaryGraphCompose(
     val bottomAxisItemPlacer = rememberBottomAxisItemPlacer(minTimestamp)
     val nowLineColor = MaterialTheme.colorScheme.onSurface
     val nowLine = rememberNowLine(minTimestamp, nowTimestamp, nowLineColor)
-    val decorations = remember(nowLine) { listOf(nowLine) }
+    val decorations = remember(nowLine, visibleRangeReporter) { listOf(nowLine, visibleRangeReporter) }
+
     // When basal overlay is active, reserve the top BASAL_HEIGHT_FRACTION of the height for basal by extending primary Y range
-    val primaryYMax = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob) {
+    val primaryYMax = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, visibleMinX, visibleMaxX) {
         if (!hasBasalLayer) return@remember null // auto-range when no basal
-        val allY = buildList {
-            addAll(processedIob.map { it.second })
-            for ((_, pts) in processedSimpleSeries) addAll(pts.map { it.second })
-            addAll(processedCob.first.map { it.second })
+        fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
+        val windowedY = buildList {
+            addAll(processedIob.filter { inWindow(it.first) }.map { it.second })
+            for ((_, pts) in processedSimpleSeries) addAll(pts.filter { inWindow(it.first) }.map { it.second })
+            addAll(processedCob.first.filter { inWindow(it.first) }.map { it.second })
+        }
+        // Fall back to the full range if the visible window currently has no points
+        // (e.g. scrolled into a future gap with no data)
+        val allY = windowedY.ifEmpty {
+            buildList {
+                addAll(processedIob.map { it.second })
+                for ((_, pts) in processedSimpleSeries) addAll(pts.map { it.second })
+                addAll(processedCob.first.map { it.second })
+            }
         }
         if (allY.isEmpty()) null
         else {

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -289,9 +289,6 @@ fun SecondaryGraphCompose(
         val pts = processPoints(basalData.actualBasal, minTimestamp, minX, maxX)
         pts.map { (x, y) -> x to -y }
     }
-    val basalMaxY = remember(basalData) {
-        if (basalData != null && basalData.maxBasal > 0.0) basalData.maxBasal / BASAL_HEIGHT_FRACTION else 1.0
-    }
 
     val hasBasalLayer = hasIob && basalData != null && !isDualAxis
 
@@ -540,23 +537,9 @@ fun SecondaryGraphCompose(
     val decorations = remember(nowLine, visibleRangeReporter) { listOf(nowLine, visibleRangeReporter) }
 
     // When basal overlay is active, reserve the top BASAL_HEIGHT_FRACTION of the height for basal by extending primary Y range
-    val primaryYMax = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, visibleMinX, visibleMaxX) {
+    val primaryYMax = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX) {
         if (!hasBasalLayer) return@remember null // auto-range when no basal
-        fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
-        val windowedY = buildList {
-            addAll(processedIob.filter { inWindow(it.first) }.map { it.second })
-            for ((_, pts) in processedSimpleSeries) addAll(pts.filter { inWindow(it.first) }.map { it.second })
-            addAll(processedCob.first.filter { inWindow(it.first) }.map { it.second })
-        }
-        // Fall back to the full range if the visible window currently has no points
-        // (e.g. scrolled into a future gap with no data)
-        val allY = windowedY.ifEmpty {
-            buildList {
-                addAll(processedIob.map { it.second })
-                for ((_, pts) in processedSimpleSeries) addAll(pts.map { it.second })
-                addAll(processedCob.first.map { it.second })
-            }
-        }
+        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) null
         else {
             val dataMax = allY.max().coerceAtLeast(0.1)
@@ -574,17 +557,11 @@ fun SecondaryGraphCompose(
     // Only applied to true dual-axis case (no basal overlay, secondary present).
     val dualAxisRanges = remember(
         isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, processedSecondary
+        processedDevSlopeMin, processedDeviationLines, processedSecondary, visibleMinX, visibleMaxX
     ) {
         if (!isDualAxis || hasBasalLayer) return@remember null
-        val primaryY = buildList {
-            addAll(processedIob.map { it.second })
-            addAll(processedCob.first.map { it.second })
-            for ((_, pts) in processedSimpleSeries) addAll(pts.map { it.second })
-            addAll(processedDevSlopeMin.map { it.second })
-            processedDeviationLines?.series?.values?.forEach { addAll(it) }
-        }
-        val secondaryY = processedSecondary.map { it.second }
+        val primaryY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+        val secondaryY = windowedY(processedSecondary, visibleMinX, visibleMaxX)
         if (primaryY.isEmpty() || secondaryY.isEmpty()) return@remember null
         alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max())
     }
@@ -603,7 +580,26 @@ fun SecondaryGraphCompose(
         val low = minOf(0.0, dataMax)
         low to maxOf(dataMax, low + 1.0)
     }
-    val primaryRangeProvider = remember(maxX, primaryYMax, dualAxisRanges, hasPrimaryData, primaryConstantRange) {
+    // Single-axis, non-basal, non-degenerate case (e.g. standalone COB/BGI/DevSlope/VarSens graphs):
+    // Vico's own auto-range would compute from the full loaded model, not the visible window —
+    // same flattening/clipping problem the basal and dual-axis cases solve above — so window it
+    // here too, using the same union-of-primary-series helper.
+    val primaryAutoRange = remember(
+        hasBasalLayer, isDualAxis, processedIob, processedCob, processedSimpleSeries,
+        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
+    ) {
+        if (hasBasalLayer || isDualAxis) return@remember null
+        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+        if (allY.isEmpty()) return@remember null
+        val dataMin = allY.min()
+        val dataMax = allY.max()
+        if (dataMax - dataMin >= 1e-6) dataMin to dataMax
+        else { // degenerate (near-flat) windowed subset — pad so Vico doesn't collapse the axis
+            val low = minOf(0.0, dataMax)
+            low to maxOf(dataMax, low + 1.0)
+        }
+    }
+    val primaryRangeProvider = remember(maxX, primaryYMax, dualAxisRanges, hasPrimaryData, primaryConstantRange, primaryAutoRange) {
         when {
             // Basal overlay case takes precedence (reserves the top BASAL_HEIGHT_FRACTION of axis for basal)
             primaryYMax != null          -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryYMax.first, maxY = primaryYMax.second)
@@ -611,12 +607,23 @@ fun SecondaryGraphCompose(
             dualAxisRanges != null       -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = dualAxisRanges.aMin, maxY = dualAxisRanges.aMax)
             // No data: anchor a default range so the empty frame is visible
             !hasPrimaryData              -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = 0.0, maxY = 1.0)
-            // Constant series: explicit range so a flat line isn't collapsed to 0..1 and clipped
+            // Constant series (whole loaded range is flat): explicit range so it isn't collapsed to 0..1 and clipped
             primaryConstantRange != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryConstantRange.first, maxY = primaryConstantRange.second)
+            // Single-axis: window the range to the visible portion instead of Vico's full-model auto-range
+            primaryAutoRange != null     -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryAutoRange.first, maxY = primaryAutoRange.second)
             else                         -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX)
         }
     }
-    // Basal range: 0 at top, -basalMaxY at bottom → basal occupies the top BASAL_HEIGHT_FRACTION of the height
+    // Basal range: 0 at top, -basalMaxY at bottom → basal occupies the top BASAL_HEIGHT_FRACTION of the height.
+    // Windowed to the visible scroll/zoom range, like the primary IOB scale above, so basal doesn't
+    // stay flattened/clipped when scrolled away from the loaded range's peak.
+    val basalMaxY = remember(basalData, processedBasalProfile, processedBasalActual, visibleMinX, visibleMaxX) {
+        if (basalData == null || basalData.maxBasal <= 0.0) return@remember 1.0
+        val windowedAbsMax = (windowedY(processedBasalProfile, visibleMinX, visibleMaxX) + windowedY(processedBasalActual, visibleMinX, visibleMaxX))
+            .map { -it }
+            .maxOrNull()
+        (windowedAbsMax?.takeIf { it > 0.0 } ?: basalData.maxBasal) / BASAL_HEIGHT_FRACTION
+    }
     val basalRangeProvider = remember(maxX, basalMaxY) {
         CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = -basalMaxY, maxY = 0.0)
     }
@@ -736,6 +743,64 @@ private sealed class SeriesSlot {
 // =========================================================================
 // Data processing helpers
 // =========================================================================
+
+/**
+ * Y-values of [points] restricted to [visibleMinX]..[visibleMaxX], falling back to the full
+ * (unwindowed) values when the visible window currently has no points (e.g. scrolled into a
+ * future gap with no data).
+ */
+private fun windowedY(points: List<Pair<Double, Double>>, visibleMinX: Double?, visibleMaxX: Double?): List<Double> {
+    fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
+    return points.filter { inWindow(it.first) }.map { it.second }.ifEmpty { points.map { it.second } }
+}
+
+/**
+ * Union of y-values across all primary-layer series (IOB, COB, simple series, DevSlope-min,
+ * deviation lines), restricted to [visibleMinX]..[visibleMaxX]. Falls back to the full
+ * (unwindowed) union when the visible window currently has no points across ANY of these series
+ * (e.g. scrolled into a future gap with no data) — the union is computed first, then the fallback
+ * applies to the whole set, so windowed points from one series are never mixed with unwindowed
+ * points from another.
+ *
+ * [processedDeviationLines] stores y-values per type without paired x, so pairs are reconstituted
+ * by zipping each type's y-array against the shared allX before filtering.
+ */
+private fun windowedPrimaryY(
+    visibleMinX: Double?,
+    visibleMaxX: Double?,
+    processedIob: List<Pair<Double, Double>>,
+    processedCobY: List<Pair<Double, Double>>,
+    processedSimpleSeries: List<Pair<SeriesType, List<Pair<Double, Double>>>>,
+    processedDevSlopeMin: List<Pair<Double, Double>>,
+    processedDeviationLines: ProcessedDeviationLines?
+): List<Double> {
+    fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
+    fun deviationY(filterToWindow: Boolean): List<Double> =
+        processedDeviationLines?.let { lines ->
+            lines.series.values.flatMap { ys ->
+                lines.allX.zip(ys)
+                    .filter { (x, _) -> !filterToWindow || inWindow(x) }
+                    .map { it.second }
+            }
+        } ?: emptyList()
+
+    val windowed = buildList {
+        addAll(processedIob.filter { inWindow(it.first) }.map { it.second })
+        addAll(processedCobY.filter { inWindow(it.first) }.map { it.second })
+        for ((_, pts) in processedSimpleSeries) addAll(pts.filter { inWindow(it.first) }.map { it.second })
+        addAll(processedDevSlopeMin.filter { inWindow(it.first) }.map { it.second })
+        addAll(deviationY(filterToWindow = true))
+    }
+    return windowed.ifEmpty {
+        buildList {
+            addAll(processedIob.map { it.second })
+            addAll(processedCobY.map { it.second })
+            for ((_, pts) in processedSimpleSeries) addAll(pts.map { it.second })
+            addAll(processedDevSlopeMin.map { it.second })
+            addAll(deviationY(filterToWindow = false))
+        }
+    }
+}
 
 @Suppress("SameParameterValue")
 private fun processPoints(points: List<GraphDataPoint>, minTimestamp: Long, minX: Double, maxX: Double): List<Pair<Double, Double>> {

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -80,6 +81,7 @@ fun SecondaryGraphCompose(
     derivedTimeRange: Pair<Long, Long>?,
     nowTimestamp: Long,
     activityOverlay: Boolean = false,
+    onVisibleRangeChanged: ((Pair<Double, Double>?) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     if (seriesTypes.isEmpty()) return
@@ -341,6 +343,14 @@ fun SecondaryGraphCompose(
         snapshotFlow { rawVisibleRange }
             .debounce(30)
             .collect { visibleRange = it }
+    }
+
+    // Expose this graph's own (already debounced) visible window upward — used by BgGraphCompose
+    // to window its own axis from this graph's synced scroll/zoom instead of attaching its own
+    // decoration (that was tried and found to break BG's own pinch-zoom gesture handling).
+    val currentOnVisibleRangeChanged by rememberUpdatedState(onVisibleRangeChanged)
+    LaunchedEffect(visibleRange) {
+        currentOnVisibleRangeChanged?.invoke(visibleRange)
     }
 
     val visibleMinX = visibleRange?.first

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -790,15 +790,21 @@ fun SecondaryGraphCompose(
         // zero literal points for either series. Deliberately NOT using windowedY here: its own
         // ifEmpty fallback dumps the *whole loaded day's* values the moment the window has no
         // literal point, which is exactly what over-inflated this axis in the first place. Instead,
-        // filter to the window with no fallback, and separately fold in the profile rate actually
-        // in effect at the window start (stepValueAt), so a windowless stretch reflects just this
-        // window's real profile level instead of the whole day's range.
+        // filter to the window with no fallback, and separately fold in the rate actually in effect
+        // at the window start (stepValueAt) for BOTH series — e.g. a high temp basal that started
+        // just 1 minute before the window but runs for 2 hours has no literal change-point inside
+        // the window either, so without this it would be invisible to this scale computation even
+        // though its bar is drawn across the whole visible window (and could overlap IOB if it's
+        // the true max) — reflects just this window's real level instead of the whole day's range.
         fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
         val literalWindowed = processedBasalProfile.filter { inWindow(it.first) }.map { it.second } +
             processedBasalActual.filter { inWindow(it.first) }.map { it.second }
-        val hiddenProfileValue = visibleMinX?.let { stepValueAt(processedBasalProfile, it) }
-        val windowedAbsMax = (literalWindowed + listOfNotNull(hiddenProfileValue)).map { -it }.maxOrNull()
-        (windowedAbsMax?.takeIf { it > 0.0 } ?: hiddenProfileValue?.let { -it } ?: basalData.maxBasal) / BASAL_HEIGHT_FRACTION
+        val hiddenValues = listOfNotNull(
+            visibleMinX?.let { stepValueAt(processedBasalProfile, it) },
+            visibleMinX?.let { stepValueAt(processedBasalActual, it) }
+        )
+        val windowedAbsMax = (literalWindowed + hiddenValues).map { -it }.maxOrNull()
+        (windowedAbsMax?.takeIf { it > 0.0 } ?: hiddenValues.maxOfOrNull { -it } ?: basalData.maxBasal) / BASAL_HEIGHT_FRACTION
     }
     val basalRangeProvider = remember(maxX, basalMaxY) {
         CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = -basalMaxY, maxY = 0.0)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -72,10 +72,10 @@ private val VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Double?, Double?>>()
  * `iobBasalScale`), so it has roughly half the vertical pixels per tick that a full-height graph
  * does, and needs the more conservative count.
  */
-private const val IOB_GRAPH_TICK_COUNT = 3
+internal const val IOB_GRAPH_TICK_COUNT = 3
 
 /** Tick count for series that use the graph's full height (COB, BGI/DEV/ACTIVITY/STEPS, VAR_SENS/HEART_RATE, DEV_SLOPE). */
-private const val SECONDARY_GRAPH_TICK_COUNT = 5
+internal const val SECONDARY_GRAPH_TICK_COUNT = 5
 
 /**
  * Tick count for SENSITIVITY's pivot scale specifically — lower than [SECONDARY_GRAPH_TICK_COUNT]
@@ -88,7 +88,7 @@ private const val SECONDARY_GRAPH_TICK_COUNT = 5
  * overriding tick selection, which was tried and reverted for being too dense on some screens —
  * this lower request sidesteps the whole mechanism instead.
  */
-private const val SENS_PIVOT_TICK_COUNT = 3
+internal const val SENS_PIVOT_TICK_COUNT = 3
 
 /**
  * Wraps a step-based [VerticalAxis.ItemPlacer], filtering out labels/gridlines outside
@@ -102,7 +102,7 @@ private const val SENS_PIVOT_TICK_COUNT = 3
  *   negative tick for a series that never actually goes negative.
  * Delegates everything else (margins, measurement, overlap-based thinning) to [delegate].
  */
-private class ClampedVerticalAxisItemPlacer(
+internal class ClampedVerticalAxisItemPlacer(
     private val delegate: VerticalAxis.ItemPlacer,
     private val visibleMin: () -> Double = { Double.NEGATIVE_INFINITY },
     private val visibleMax: () -> Double = { Double.POSITIVE_INFINITY }
@@ -936,7 +936,7 @@ private sealed class SeriesSlot {
  * (unwindowed) values when the visible window currently has no points (e.g. scrolled into a
  * future gap with no data).
  */
-private fun windowedY(points: List<Pair<Double, Double>>, visibleMinX: Double?, visibleMaxX: Double?): List<Double> {
+internal fun windowedY(points: List<Pair<Double, Double>>, visibleMinX: Double?, visibleMaxX: Double?): List<Double> {
     fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
     return points.filter { inWindow(it.first) }.map { it.second }.ifEmpty { points.map { it.second } }
 }
@@ -948,7 +948,7 @@ private fun windowedY(points: List<Pair<Double, Double>>, visibleMinX: Double?, 
  * in effect at any [x] is whatever the most recent point at-or-before [x] holds (falls back to the
  * first point if [x] precedes all of them).
  */
-private fun stepValueAt(points: List<Pair<Double, Double>>, x: Double): Double? =
+internal fun stepValueAt(points: List<Pair<Double, Double>>, x: Double): Double? =
     points.lastOrNull { it.first <= x }?.second ?: points.firstOrNull()?.second
 
 /**
@@ -962,7 +962,7 @@ private fun stepValueAt(points: List<Pair<Double, Double>>, x: Double): Double? 
  * [processedDeviationLines] stores y-values per type without paired x, so pairs are reconstituted
  * by zipping each type's y-array against the shared allX before filtering.
  */
-private fun windowedPrimaryY(
+internal fun windowedPrimaryY(
     visibleMinX: Double?,
     visibleMaxX: Double?,
     processedIob: List<Pair<Double, Double>>,
@@ -1364,7 +1364,7 @@ private fun createDeviationLine(type: DeviationType): LineCartesianLayer.Line {
 }
 
 /** Processed deviation data split by type for multi-series line rendering */
-private data class ProcessedDeviationLines(
+internal data class ProcessedDeviationLines(
     val allX: List<Double>,
     val series: Map<DeviationType, List<Double>>
 )
@@ -1375,10 +1375,10 @@ private data class ProcessedDeviationLines(
  * artificially extended purely for zero-alignment) — the start axis' tick placer clamps labels to
  * it so primary never shows a fake tick below a value it can actually reach.
  */
-private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double, val primaryLabelFloor: Double? = null)
+internal data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double, val primaryLabelFloor: Double? = null)
 
 /** Result of [pivotZeroFloorPairing]: the pivot side's full nice range, and the zero-floor side's symmetric container (half-width, and its own real floor for label clamping). */
-private data class PivotZeroFloorPairing(val pivotNice: NiceScale, val zeroFloorHalf: Double, val zeroFloorMin: Double)
+internal data class PivotZeroFloorPairing(val pivotNice: NiceScale, val zeroFloorHalf: Double, val zeroFloorMin: Double)
 
 /**
  * Builds the two ranges for a dual-axis combo where exactly one side is pivot-centered
@@ -1392,7 +1392,7 @@ private data class PivotZeroFloorPairing(val pivotNice: NiceScale, val zeroFloor
  * [pivotTickCount] lets the pivot side request fewer ticks than [zeroFloorY]'s own (see
  * [SENS_PIVOT_TICK_COUNT]).
  */
-private fun pivotZeroFloorPairing(pivotY: List<Double>, zeroFloorY: List<Double>, pivot: Double, minDeviation: Double, pivotTickCount: Int): PivotZeroFloorPairing {
+internal fun pivotZeroFloorPairing(pivotY: List<Double>, zeroFloorY: List<Double>, pivot: Double, minDeviation: Double, pivotTickCount: Int): PivotZeroFloorPairing {
     val pivotNice = niceScaleAroundPivot(pivotY.min(), pivotY.max(), pivot, pivotTickCount, minDeviation)
     val zeroFloorNice = zeroFloorNiceRange(zeroFloorY.min(), zeroFloorY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
     val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
@@ -1408,7 +1408,7 @@ private fun pivotZeroFloorPairing(pivotY: List<Double>, zeroFloorY: List<Double>
  * Implemented by shifting both ranges into pivot-relative space, reusing the plain zero-based
  * alignment logic, then shifting the result back.
  */
-private fun alignZeros(aMin: Double, aMax: Double, bMin: Double, bMax: Double, aPivot: Double = 0.0, bPivot: Double = 0.0): AlignedRanges? {
+internal fun alignZeros(aMin: Double, aMax: Double, bMin: Double, bMax: Double, aPivot: Double = 0.0, bPivot: Double = 0.0): AlignedRanges? {
     val shifted = alignZerosAtOrigin(aMin - aPivot, aMax - aPivot, bMin - bPivot, bMax - bPivot) ?: return null
     return AlignedRanges(shifted.aMin + aPivot, shifted.aMax + aPivot, shifted.bMin + bPivot, shifted.bMax + bPivot)
 }
@@ -1428,7 +1428,7 @@ private fun alignZeros(aMin: Double, aMax: Double, bMin: Double, bMax: Double, a
  * is simpler, always works without clipping, and matches how the old
  * OverviewFragment aligned bipolar series (see GraphData.kt lines 150/151).
  */
-private fun alignZerosAtOrigin(aMin: Double, aMax: Double, bMin: Double, bMax: Double): AlignedRanges? {
+internal fun alignZerosAtOrigin(aMin: Double, aMax: Double, bMin: Double, bMax: Double): AlignedRanges? {
     // Treat touching zero (min=0 or max=0) as crossing — the zero line is in-range either way.
     val aCrosses = aMin <= 0 && aMax >= 0
     val bCrosses = bMin <= 0 && bMax >= 0
@@ -1461,7 +1461,7 @@ private fun alignZerosAtOrigin(aMin: Double, aMax: Double, bMin: Double, bMax: D
  * the fraction; if that would still clip dataMax, anchors at dataMax instead and stretches the
  * min further negative. Either branch guarantees no clipping, for any fraction in range.
  */
-private fun fractionAlignedRange(dataMin: Double, dataMax: Double, targetFraction: Double): Pair<Double, Double> {
+internal fun fractionAlignedRange(dataMin: Double, dataMax: Double, targetFraction: Double): Pair<Double, Double> {
     val fraction = targetFraction.coerceIn(0.0, 0.9)
     if (fraction <= 0.0) return dataMin.coerceAtMost(0.0) to dataMax
     val candidateMax = dataMin * (fraction - 1.0) / fraction
@@ -1474,7 +1474,7 @@ private fun fractionAlignedRange(dataMin: Double, dataMax: Double, targetFractio
  * [targetFraction] is rounded to a nice value too — used for the primary axis, which must stay
  * nice-scaled even when its range is widened to align with a secondary axis' zero.
  */
-private fun fractionAlignedNiceRange(niceMin: Double, niceMax: Double, targetFraction: Double): Pair<Double, Double> {
+internal fun fractionAlignedNiceRange(niceMin: Double, niceMax: Double, targetFraction: Double): Pair<Double, Double> {
     val fraction = targetFraction.coerceIn(0.0, 0.9)
     if (fraction <= 0.0) return niceMin to niceMax
     val candidateMax = niceMin * (fraction - 1.0) / fraction

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -218,7 +218,11 @@ fun SecondaryGraphCompose(
             GraphDataPoint(it.timestamp, it.value)
         }
 
-        SeriesType.SENSITIVITY     -> viewModel.ratioGraphFlow.collectAsStateWithLifecycle().value.ratio
+        SeriesType.SENSITIVITY     -> viewModel.ratioGraphFlow.collectAsStateWithLifecycle().value.ratio.map {
+            // Stored as 100*(ratio-1), display shifted by +100 to show as percentage (90%, 110%) —
+            // must match the same shift applied when SENSITIVITY is primary (see processedSimpleSeries).
+            GraphDataPoint(it.timestamp, it.value + 100.0)
+        }
         SeriesType.VAR_SENSITIVITY -> viewModel.varSensGraphFlow.collectAsStateWithLifecycle().value.varSens
         SeriesType.DEV_SLOPE       -> viewModel.devSlopeGraphFlow.collectAsStateWithLifecycle().value.dsMax
         SeriesType.HEART_RATE      -> viewModel.heartRateGraphFlow.collectAsStateWithLifecycle().value.heartRates
@@ -831,10 +835,20 @@ fun SecondaryGraphCompose(
     // stay flattened/clipped when scrolled away from the loaded range's peak.
     val basalMaxY = remember(basalData, processedBasalProfile, processedBasalActual, visibleMinX, visibleMaxX) {
         if (basalData == null || basalData.maxBasal <= 0.0) return@remember 1.0
-        val windowedAbsMax = (windowedY(processedBasalProfile, visibleMinX, visibleMaxX) + windowedY(processedBasalActual, visibleMinX, visibleMaxX))
-            .map { -it }
-            .maxOrNull()
-        (windowedAbsMax?.takeIf { it > 0.0 } ?: basalData.maxBasal) / BASAL_HEIGHT_FRACTION
+        // Profile/actual are stored sparsely (only at rate changes — see rebuildBasalGraph), so a
+        // zoom window entirely inside one constant segment (e.g. an extended zero-temp) can contain
+        // zero literal points for either series. Deliberately NOT using windowedY here: its own
+        // ifEmpty fallback dumps the *whole loaded day's* values the moment the window has no
+        // literal point, which is exactly what over-inflated this axis in the first place. Instead,
+        // filter to the window with no fallback, and separately fold in the profile rate actually
+        // in effect at the window start (stepValueAt), so a windowless stretch reflects just this
+        // window's real profile level instead of the whole day's range.
+        fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
+        val literalWindowed = processedBasalProfile.filter { inWindow(it.first) }.map { it.second } +
+            processedBasalActual.filter { inWindow(it.first) }.map { it.second }
+        val hiddenProfileValue = visibleMinX?.let { stepValueAt(processedBasalProfile, it) }
+        val windowedAbsMax = (literalWindowed + listOfNotNull(hiddenProfileValue)).map { -it }.maxOrNull()
+        (windowedAbsMax?.takeIf { it > 0.0 } ?: hiddenProfileValue?.let { -it } ?: basalData.maxBasal) / BASAL_HEIGHT_FRACTION
     }
     val basalRangeProvider = remember(maxX, basalMaxY) {
         CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = -basalMaxY, maxY = 0.0)
@@ -976,6 +990,16 @@ private fun windowedY(points: List<Pair<Double, Double>>, visibleMinX: Double?, 
     fun inWindow(x: Double) = visibleMinX == null || visibleMaxX == null || x in visibleMinX..visibleMaxX
     return points.filter { inWindow(it.first) }.map { it.second }.ifEmpty { points.map { it.second } }
 }
+
+/**
+ * Value in effect at [x] for a sparse change-point-only step series — [points] only stores a new
+ * entry when the value changes (see `rebuildBasalGraph`), so a narrow zoom window can contain zero
+ * literal points even though the series has a well-defined value throughout it. The value actually
+ * in effect at any [x] is whatever the most recent point at-or-before [x] holds (falls back to the
+ * first point if [x] precedes all of them).
+ */
+private fun stepValueAt(points: List<Pair<Double, Double>>, x: Double): Double? =
+    points.lastOrNull { it.first <= x }?.second ?: points.firstOrNull()?.second
 
 /**
  * Union of y-values across all primary-layer series (IOB, COB, simple series, DevSlope-min,

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -69,28 +69,32 @@ private val VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Double?, Double?>>()
  * of 0/25/50). Requesting fewer ticks up front avoids that thinning.
  *
  * IOB only occupies the bottom half of its graph (basal reserves the top half — see
- * `primaryYMax`), so it has roughly half the vertical pixels per tick that a full-height graph
+ * `iobBasalScale`), so it has roughly half the vertical pixels per tick that a full-height graph
  * does, and needs the more conservative count.
  */
 private const val IOB_GRAPH_TICK_COUNT = 3
 
-/** Tick count for series that use the graph's full height (COB, BGI/DEV/ACTIVITY/STEPS, SENS/VAR_SENS/HEART_RATE, DEV_SLOPE). */
+/** Tick count for series that use the graph's full height (COB, BGI/DEV/ACTIVITY/STEPS, VAR_SENS/HEART_RATE, DEV_SLOPE). */
 private const val SECONDARY_GRAPH_TICK_COUNT = 5
 
-/** Minimum half-width for SENSITIVITY's pivot scale — below this, snap to a fixed 95%/100%/105% scale instead of nice-ifying a near-zero deviation. */
-private const val SENS_MIN_DEVIATION = 5.0
-
 /**
- * Mostly-positive series: 0-floored by default (see [zeroFloorNiceRange]), allowing a
- * disparity-aware negative excursion without ever centering zero — the same rule used for IOB.
+ * Tick count for SENSITIVITY's pivot scale specifically — lower than [SECONDARY_GRAPH_TICK_COUNT]
+ * so Vico's step thinning never has anything to thin (3 ticks always fit, at any graph height),
+ * guaranteeing the 100% pivot itself is always one of the displayed labels. Vico's step-based
+ * ItemPlacer only controls tick spacing, not count — when a denser request doesn't fit the
+ * available height it multiplies the step by an integer to compensate, which can drop the pivot
+ * (it isn't always one of the surviving ticks) and jumps unpredictably between tick counts as the
+ * graph is resized. There's no API for "always keep this value" short of a custom ItemPlacer
+ * overriding tick selection, which was tried and reverted for being too dense on some screens —
+ * this lower request sidesteps the whole mechanism instead.
  */
-private val ZERO_FLOOR_SERIES_TYPES = setOf(SeriesType.BGI, SeriesType.DEVIATIONS, SeriesType.ACTIVITY, SeriesType.STEPS, SeriesType.ABS_IOB)
+private const val SENS_PIVOT_TICK_COUNT = 3
 
 /**
  * Wraps a step-based [VerticalAxis.ItemPlacer], filtering out labels/gridlines outside
  * [visibleMin]..[visibleMax]. Two independent uses:
  * - IOB/basal combo graph: the axis extends past the actual IOB data range to reserve headroom
- *   for the basal overlay (see the `primaryYMax` computation), so labels should stop at the real
+ *   for the basal overlay (see the `iobBasalScale` computation), so labels should stop at the real
  *   data boundary ([visibleMax]) instead of continuing into the reserved band above it.
  * - Dual-axis combos where primary is zero-floor-style: its axis is pushed below its own real
  *   floor purely to align its zero with the secondary/pivot series (see `dualAxisRanges`), so
@@ -608,6 +612,16 @@ fun SecondaryGraphCompose(
     val nowLine = rememberNowLine(minTimestamp, nowTimestamp, nowLineColor)
     val decorations = remember(nowLine, visibleRangeReporter) { listOf(nowLine, visibleRangeReporter) }
 
+    // Union of Y values across all primary-layer series (IOB, COB, simple series, DevSlope-min,
+    // deviation lines), windowed to the visible scroll/zoom range — computed once here since the
+    // IOB+basal scale, the dual-axis alignment, the single-axis nice-scale dispatch, and the
+    // generic auto-range fallback below all need the exact same union.
+    val primaryYValues = remember(
+        processedIob, processedCob, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
+    ) {
+        windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+    }
+
     // IOB (with basal overlay active): zero-floor nice range — 0 if the visible window has no
     // negative IOB, else a disparity-aware negative sliver (never centering zero) — then reserve
     // the top BASAL_HEIGHT_FRACTION of the height for basal, ABOVE the actual data range (not
@@ -621,18 +635,17 @@ fun SecondaryGraphCompose(
     // Result pairs the final (inflated) axis range with the un-inflated data max — the latter is
     // where tick labels must stop (see ClampedVerticalAxisItemPlacer) so they don't extend into
     // the reserved basal band above the actual IOB data.
-    val primaryYMaxResult = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX) {
+    val iobBasalScaleResult = remember(hasBasalLayer, primaryYValues) {
         if (!hasBasalLayer) return@remember null // auto-range when no basal
-        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
-        if (allY.isEmpty()) null
+        if (primaryYValues.isEmpty()) null
         else {
-            val nice = zeroFloorNiceRange(allY.min(), allY.max().coerceAtLeast(0.1), IOB_GRAPH_TICK_COUNT)
+            val nice = zeroFloorNiceRange(primaryYValues.min(), primaryYValues.max().coerceAtLeast(0.1), IOB_GRAPH_TICK_COUNT)
             val axisMax = nice.min + (nice.max - nice.min) / (1 - BASAL_HEIGHT_FRACTION)
             NiceScale(nice.min, axisMax, nice.step) to nice.max
         }
     }
-    val primaryYMax = primaryYMaxResult?.first
-    val primaryIobDataMax = primaryYMaxResult?.second
+    val iobBasalScale = iobBasalScaleResult?.first
+    val iobDataMax = iobBasalScaleResult?.second
     // Dual-axis zero alignment.
     // Why: Vico computes each vertical axis range independently, so y=0 on the
     // left axis lands at a different pixel row than y=0 on the right axis. When
@@ -641,46 +654,32 @@ fun SecondaryGraphCompose(
     // below a point that is "below zero" on the other. We compute a shared zero
     // fraction from both data extents and extend each side's range to match it.
     // Only applied to true dual-axis case (no basal overlay, secondary present).
-    val dualAxisRanges = remember(
-        isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, processedSecondary, visibleMinX, visibleMaxX
-    ) {
+    val dualAxisRanges = remember(isDualAxis, hasBasalLayer, primaryYValues, processedSecondary, visibleMinX, visibleMaxX) {
         if (!isDualAxis || hasBasalLayer) return@remember null
-        val primaryY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         val secondaryY = windowedY(processedSecondary, visibleMinX, visibleMaxX)
-        if (primaryY.isEmpty() || secondaryY.isEmpty()) return@remember null
+        if (primaryYValues.isEmpty() || secondaryY.isEmpty()) return@remember null
 
         val primaryIsPivot = primaryType == SeriesType.SENSITIVITY || primaryType == SeriesType.DEV_SLOPE
         val secondaryIsPivot = secondaryType == SeriesType.SENSITIVITY || secondaryType == SeriesType.DEV_SLOPE
         if (primaryIsPivot != secondaryIsPivot) {
             // Exactly one side is pivot-centered (SENS/DEV_SLOPE), the other zero-floor-style
-            // (e.g. COB, BGI): the pivot side gets a full nice-scaled symmetric range around its
-            // own pivot — unconditionally, no branching on where its bounds happen to sit relative
-            // to the pivot, so it never flips between "centered" and "pinned" between recomputes.
-            // The zero-floor side gets a symmetric (-half,+half) container sized from its own
-            // zero-floor nice range, so its zero lands exactly at the pivot's center (same pixel
-            // row) and its curve — normally never negative — fills only the upper half, scaled
-            // nicely up to its own real max (any rare negative sliver still fits, just not
-            // symmetric-looking, since half also covers it).
+            // (e.g. COB, BGI) — see [pivotZeroFloorPairing] for how each side's range is built.
             val isSensPivot = primaryType == SeriesType.SENSITIVITY || secondaryType == SeriesType.SENSITIVITY
             val pivot = if (isSensPivot) 100.0 else 0.0
             val pivotMinDeviation = if (isSensPivot) SENS_MIN_DEVIATION else 0.0
+            val pivotTickCount = if (isSensPivot) SENS_PIVOT_TICK_COUNT else SECONDARY_GRAPH_TICK_COUNT
             return@remember if (primaryIsPivot) {
-                val pivotNice = niceScaleAroundPivot(primaryY.min(), primaryY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, pivotMinDeviation)
-                val zeroFloorNice = zeroFloorNiceRange(secondaryY.min(), secondaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
-                val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
+                val pairing = pivotZeroFloorPairing(primaryYValues, secondaryY, pivot, pivotMinDeviation, pivotTickCount)
                 // Primary is the pivot itself here — its own axis is fully meaningful in both
                 // directions, no label clamping needed.
-                AlignedRanges(pivotNice.min, pivotNice.max, -zeroFloorHalf, zeroFloorHalf)
+                AlignedRanges(pairing.pivotNice.min, pairing.pivotNice.max, -pairing.zeroFloorHalf, pairing.zeroFloorHalf)
             } else {
-                val pivotNice = niceScaleAroundPivot(secondaryY.min(), secondaryY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, pivotMinDeviation)
-                val zeroFloorNice = zeroFloorNiceRange(primaryY.min(), primaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
-                val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
+                val pairing = pivotZeroFloorPairing(secondaryY, primaryYValues, pivot, pivotMinDeviation, pivotTickCount)
                 // Primary is the zero-floor side, pushed into a symmetric container purely to
                 // align its zero with the pivot's center — its own real floor (e.g. 0 for COB)
                 // must still be the lowest label shown, or its axis reads as if COB/BGI/etc. can
                 // go negative when it can't.
-                AlignedRanges(-zeroFloorHalf, zeroFloorHalf, pivotNice.min, pivotNice.max, primaryLabelFloor = zeroFloorNice.min)
+                AlignedRanges(-pairing.zeroFloorHalf, pairing.zeroFloorHalf, pairing.pivotNice.min, pairing.pivotNice.max, primaryLabelFloor = pairing.zeroFloorMin)
             }
         }
         if (primaryIsPivot || secondaryIsPivot) {
@@ -689,7 +688,7 @@ fun SecondaryGraphCompose(
             // anyway so the old mechanism is adequate here.
             val primaryPivot = if (primaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
             val secondaryPivot = if (secondaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
-            return@remember alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max(), primaryPivot, secondaryPivot)
+            return@remember alignZeros(primaryYValues.min(), primaryYValues.max(), secondaryY.min(), secondaryY.max(), primaryPivot, secondaryPivot)
         }
 
         // Neither series is pivot-centered (e.g. COB + VAR_SENSITIVITY, or BGI + STEPS): primary
@@ -699,7 +698,7 @@ fun SecondaryGraphCompose(
         // the compromise. Each axis is then widened just enough to hit that shared fraction,
         // anchored at whichever of its own real/nice bounds avoids clipping (see
         // fractionAlignedRange / fractionAlignedNiceRange) so nothing is ever clipped.
-        val primaryNice = zeroFloorNiceRange(primaryY.min(), primaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
+        val primaryNice = zeroFloorNiceRange(primaryYValues.min(), primaryYValues.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
         val primaryFraction = if (primaryNice.max > primaryNice.min) -primaryNice.min / (primaryNice.max - primaryNice.min) else 0.0
 
         val secondaryMax = secondaryY.max().coerceAtLeast(0.1)
@@ -733,96 +732,47 @@ fun SecondaryGraphCompose(
     // Vico's own auto-range would compute from the full loaded model, not the visible window —
     // same flattening/clipping problem the basal and dual-axis cases solve above — so window it
     // here too, using the same union-of-primary-series helper.
-    val primaryAutoRange = remember(
-        hasBasalLayer, dualAxisRanges, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
-    ) {
+    val primaryAutoRange = remember(hasBasalLayer, dualAxisRanges, primaryYValues) {
         if (hasBasalLayer || dualAxisRanges != null) return@remember null
-        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
-        if (allY.isEmpty()) return@remember null
-        val dataMin = allY.min()
-        val dataMax = allY.max()
+        if (primaryYValues.isEmpty()) return@remember null
+        val dataMin = primaryYValues.min()
+        val dataMax = primaryYValues.max()
         if (dataMax - dataMin >= 1e-6) dataMin to dataMax
         else { // degenerate (near-flat) windowed subset — pad so Vico doesn't collapse the axis
             val low = minOf(0.0, dataMax)
             low to maxOf(dataMax, low + 1.0)
         }
     }
-    // COB alone (single-axis, no basal/dual overlay): always starts at 0 regardless of the
-    // visible minimum, with a "nice" max/tick-step instead of the raw windowed value. Takes
-    // precedence over primaryAutoRange/primaryConstantRange for this specific case.
-    val primaryCobScale = remember(hasCob, dualAxisRanges, processedCob, visibleMinX, visibleMaxX) {
-        if (!hasCob || dualAxisRanges != null) return@remember null
-        val allY = windowedY(processedCob.first, visibleMinX, visibleMaxX)
-        if (allY.isEmpty()) return@remember null
-        niceScale(0.0, allY.max().coerceAtLeast(0.0), SECONDARY_GRAPH_TICK_COUNT)
-    }
-    // BGI / DEVIATIONS / ACTIVITY / STEPS alone (single-axis, no basal/dual overlay): zero-floor
-    // nice range — these are mostly-positive series, so 0 by default, but allows a disparity-aware
-    // negative excursion without ever centering zero (same rule as IOB). Takes precedence over
-    // primaryAutoRange/primaryConstantRange for this specific case.
-    val primaryZeroFloorScale = remember(
-        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
-    ) {
-        if (dualAxisRanges != null || hasBasalLayer) return@remember null
-        if (primaryType !in ZERO_FLOOR_SERIES_TYPES) return@remember null
-        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
-        if (allY.isEmpty()) return@remember null
-        zeroFloorNiceRange(allY.min(), allY.max(), SECONDARY_GRAPH_TICK_COUNT)
-    }
-    // VAR_SENSITIVITY / HEART_RATE alone: free-range nice scale — no zero anchor, since a
-    // sensitivity ratio or heart rate has no meaningful "zero" reference point.
-    val primaryFreeRangeScale = remember(
-        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
-    ) {
-        if (dualAxisRanges != null || hasBasalLayer) return@remember null
-        if (primaryType != SeriesType.VAR_SENSITIVITY && primaryType != SeriesType.HEART_RATE) return@remember null
-        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
-        if (allY.isEmpty()) return@remember null
-        niceScale(allY.min(), allY.max(), SECONDARY_GRAPH_TICK_COUNT)
-    }
-    // SENSITIVITY (centered on 100%) / DEV_SLOPE (centered on 0) alone: pivot-centered nice
-    // scale, so the pivot always lands exactly in the middle of the axis.
-    val primaryPivotScale = remember(
-        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
-        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
-    ) {
-        if (dualAxisRanges != null || hasBasalLayer) return@remember null
-        val pivot = when (primaryType) {
-            SeriesType.SENSITIVITY -> 100.0
-            SeriesType.DEV_SLOPE   -> 0.0
-            else                   -> return@remember null
+    // Single-axis nice-scale dispatch, by series-type rule (only when neither the IOB+basal combo
+    // nor a dual-axis combo already claimed the primary axis): COB always starts at 0 with a nice
+    // max; BGI/DEVIATIONS/ACTIVITY/STEPS/ABS_IOB are zero-floored (disparity-aware negative
+    // excursion, same rule as IOB); VAR_SENSITIVITY/HEART_RATE are free-range (no zero anchor);
+    // SENSITIVITY/DEV_SLOPE are pivot-centered (pivot always lands exactly at mid-axis). Takes
+    // precedence over primaryConstantRange/primaryAutoRange for these specific series types.
+    val primarySingleAxisScale = remember(primaryType, dualAxisRanges, hasBasalLayer, primaryYValues) {
+        if (dualAxisRanges != null || hasBasalLayer || primaryYValues.isEmpty()) return@remember null
+        when (primaryType) {
+            SeriesType.COB                                    -> niceScale(0.0, primaryYValues.max().coerceAtLeast(0.0), SECONDARY_GRAPH_TICK_COUNT)
+            in ZERO_FLOOR_SERIES_TYPES                         -> zeroFloorNiceRange(primaryYValues.min(), primaryYValues.max(), SECONDARY_GRAPH_TICK_COUNT)
+            SeriesType.VAR_SENSITIVITY, SeriesType.HEART_RATE  -> niceScale(primaryYValues.min(), primaryYValues.max(), SECONDARY_GRAPH_TICK_COUNT)
+            SeriesType.SENSITIVITY                             -> niceScaleAroundPivot(primaryYValues.min(), primaryYValues.max(), 100.0, SENS_PIVOT_TICK_COUNT, SENS_MIN_DEVIATION)
+            SeriesType.DEV_SLOPE                               -> niceScaleAroundPivot(primaryYValues.min(), primaryYValues.max(), 0.0, SECONDARY_GRAPH_TICK_COUNT)
+            else                                               -> null
         }
-        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
-        if (allY.isEmpty()) return@remember null
-        val minDeviation = if (primaryType == SeriesType.SENSITIVITY) SENS_MIN_DEVIATION else 0.0
-        niceScaleAroundPivot(allY.min(), allY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, minDeviation)
     }
     // Dynamic tick step for the start axis' ItemPlacer — null falls back to Vico's own automatic
     // spacing for series that don't have a "nice" rule yet.
-    val primaryYStep = primaryYMax?.step ?: primaryCobScale?.step ?: primaryZeroFloorScale?.step
-        ?: primaryFreeRangeScale?.step ?: primaryPivotScale?.step
-    val primaryRangeProvider = remember(
-        maxX, primaryYMax, dualAxisRanges, hasPrimaryData, primaryCobScale, primaryZeroFloorScale,
-        primaryFreeRangeScale, primaryPivotScale, primaryConstantRange, primaryAutoRange
-    ) {
+    val primaryYStep = iobBasalScale?.step ?: primarySingleAxisScale?.step
+    val primaryRangeProvider = remember(maxX, iobBasalScale, dualAxisRanges, hasPrimaryData, primarySingleAxisScale, primaryConstantRange, primaryAutoRange) {
         when {
             // Basal overlay case takes precedence (reserves the top BASAL_HEIGHT_FRACTION of axis for basal)
-            primaryYMax != null          -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryYMax.min, maxY = primaryYMax.max)
+            iobBasalScale != null        -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = iobBasalScale.min, maxY = iobBasalScale.max)
             // Dual-axis: use zero-aligned primary range so zeros line up with secondary axis
             dualAxisRanges != null       -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = dualAxisRanges.aMin, maxY = dualAxisRanges.aMax)
             // No data: anchor a default range so the empty frame is visible
             !hasPrimaryData              -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = 0.0, maxY = 1.0)
-            // COB alone: nice 0-to-max scale
-            primaryCobScale != null      -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryCobScale.min, maxY = primaryCobScale.max)
-            // BGI/DEVIATIONS/ACTIVITY/STEPS alone: zero-floor nice range (disparity-aware negative excursion)
-            primaryZeroFloorScale != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryZeroFloorScale.min, maxY = primaryZeroFloorScale.max)
-            // VAR_SENSITIVITY/HEART_RATE alone: free-range nice scale, no zero anchor
-            primaryFreeRangeScale != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryFreeRangeScale.min, maxY = primaryFreeRangeScale.max)
-            // SENSITIVITY/DEV_SLOPE alone: pivot-centered nice scale
-            primaryPivotScale != null    -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryPivotScale.min, maxY = primaryPivotScale.max)
+            // Single-axis nice-scale dispatch (COB / zero-floor / free-range / pivot — see primarySingleAxisScale)
+            primarySingleAxisScale != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primarySingleAxisScale.min, maxY = primarySingleAxisScale.max)
             // Constant series (whole loaded range is flat): explicit range so it isn't collapsed to 0..1 and clipped
             primaryConstantRange != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryConstantRange.first, maxY = primaryConstantRange.second)
             // Single-axis: window the range to the visible portion instead of Vico's full-model auto-range
@@ -881,9 +831,9 @@ fun SecondaryGraphCompose(
     )
 
     // Common axis components
-    val startAxisItemPlacer = remember(primaryYStep, primaryIobDataMax, dualAxisRanges?.primaryLabelFloor) {
+    val startAxisItemPlacer = remember(primaryYStep, iobDataMax, dualAxisRanges?.primaryLabelFloor) {
         val stepPlacer = VerticalAxis.ItemPlacer.step({ primaryYStep })
-        val dataMax = primaryIobDataMax
+        val dataMax = iobDataMax
         val labelFloor = dualAxisRanges?.primaryLabelFloor
         when {
             dataMax != null   -> ClampedVerticalAxisItemPlacer(stepPlacer, visibleMax = { dataMax })
@@ -1426,6 +1376,28 @@ private data class ProcessedDeviationLines(
  * it so primary never shows a fake tick below a value it can actually reach.
  */
 private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double, val primaryLabelFloor: Double? = null)
+
+/** Result of [pivotZeroFloorPairing]: the pivot side's full nice range, and the zero-floor side's symmetric container (half-width, and its own real floor for label clamping). */
+private data class PivotZeroFloorPairing(val pivotNice: NiceScale, val zeroFloorHalf: Double, val zeroFloorMin: Double)
+
+/**
+ * Builds the two ranges for a dual-axis combo where exactly one side is pivot-centered
+ * (SENS/DEV_SLOPE) and the other is zero-floor-style (e.g. COB, BGI): the pivot side gets a full
+ * nice-scaled symmetric range around [pivot] — unconditionally, no branching on where its bounds
+ * happen to sit relative to the pivot, so it never flips between "centered" and "pinned" between
+ * recomputes. The zero-floor side gets a symmetric (-half,+half) container sized from its own
+ * zero-floor nice range, so its zero lands exactly at the pivot's center (same pixel row) and its
+ * curve — normally never negative — fills only the upper half, scaled nicely up to its own real
+ * max (any rare negative sliver still fits, just not symmetric-looking, since half also covers it).
+ * [pivotTickCount] lets the pivot side request fewer ticks than [zeroFloorY]'s own (see
+ * [SENS_PIVOT_TICK_COUNT]).
+ */
+private fun pivotZeroFloorPairing(pivotY: List<Double>, zeroFloorY: List<Double>, pivot: Double, minDeviation: Double, pivotTickCount: Int): PivotZeroFloorPairing {
+    val pivotNice = niceScaleAroundPivot(pivotY.min(), pivotY.max(), pivot, pivotTickCount, minDeviation)
+    val zeroFloorNice = zeroFloorNiceRange(zeroFloorY.min(), zeroFloorY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
+    val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
+    return PivotZeroFloorPairing(pivotNice, zeroFloorHalf, zeroFloorNice.min)
+}
 
 /**
  * Adjusts two y-ranges so [aPivot]/[bPivot] land at the same fractional height on both axes.

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -77,6 +77,9 @@ private const val IOB_GRAPH_TICK_COUNT = 3
 /** Tick count for series that use the graph's full height (COB, BGI/DEV/ACTIVITY/STEPS, SENS/VAR_SENS/HEART_RATE, DEV_SLOPE). */
 private const val SECONDARY_GRAPH_TICK_COUNT = 5
 
+/** Minimum half-width for SENSITIVITY's pivot scale — below this, snap to a fixed 95%/100%/105% scale instead of nice-ifying a near-zero deviation. */
+private const val SENS_MIN_DEVIATION = 5.0
+
 /**
  * Mostly-positive series: 0-floored by default (see [zeroFloorNiceRange]), allowing a
  * disparity-aware negative excursion without ever centering zero — the same rule used for IOB.
@@ -84,16 +87,21 @@ private const val SECONDARY_GRAPH_TICK_COUNT = 5
 private val ZERO_FLOOR_SERIES_TYPES = setOf(SeriesType.BGI, SeriesType.DEVIATIONS, SeriesType.ACTIVITY, SeriesType.STEPS, SeriesType.ABS_IOB)
 
 /**
- * Wraps a step-based [VerticalAxis.ItemPlacer], filtering out labels/gridlines above [visibleMax].
- * Used for the IOB/basal combo graph: the axis itself extends past the actual IOB data range to
- * reserve headroom for the basal overlay (see the `primaryYMax` computation), but tick labels
- * should stop at the real data boundary instead of continuing into the reserved band above it —
- * otherwise the axis visually implies IOB data exists where only the basal overlay is drawn.
+ * Wraps a step-based [VerticalAxis.ItemPlacer], filtering out labels/gridlines outside
+ * [visibleMin]..[visibleMax]. Two independent uses:
+ * - IOB/basal combo graph: the axis extends past the actual IOB data range to reserve headroom
+ *   for the basal overlay (see the `primaryYMax` computation), so labels should stop at the real
+ *   data boundary ([visibleMax]) instead of continuing into the reserved band above it.
+ * - Dual-axis combos where primary is zero-floor-style: its axis is pushed below its own real
+ *   floor purely to align its zero with the secondary/pivot series (see `dualAxisRanges`), so
+ *   labels should stop at primary's own real floor ([visibleMin]) instead of showing a fake
+ *   negative tick for a series that never actually goes negative.
  * Delegates everything else (margins, measurement, overlap-based thinning) to [delegate].
  */
 private class ClampedVerticalAxisItemPlacer(
     private val delegate: VerticalAxis.ItemPlacer,
-    private val visibleMax: () -> Double
+    private val visibleMin: () -> Double = { Double.NEGATIVE_INFINITY },
+    private val visibleMax: () -> Double = { Double.POSITIVE_INFINITY }
 ) : VerticalAxis.ItemPlacer by delegate {
 
     override fun getLabelValues(
@@ -101,14 +109,14 @@ private class ClampedVerticalAxisItemPlacer(
         axisHeight: Float,
         maxLabelHeight: Float,
         position: Axis.Position.Vertical
-    ): List<Double> = delegate.getLabelValues(context, axisHeight, maxLabelHeight, position).filter { it <= visibleMax() }
+    ): List<Double> = delegate.getLabelValues(context, axisHeight, maxLabelHeight, position).filter { it in visibleMin()..visibleMax() }
 
     override fun getLineValues(
         context: CartesianDrawingContext,
         axisHeight: Float,
         maxLabelHeight: Float,
         position: Axis.Position.Vertical
-    ): List<Double>? = delegate.getLineValues(context, axisHeight, maxLabelHeight, position)?.filter { it <= visibleMax() }
+    ): List<Double>? = delegate.getLineValues(context, axisHeight, maxLabelHeight, position)?.filter { it in visibleMin()..visibleMax() }
 }
 
 /**
@@ -637,11 +645,70 @@ fun SecondaryGraphCompose(
         val primaryY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         val secondaryY = windowedY(processedSecondary, visibleMinX, visibleMaxX)
         if (primaryY.isEmpty() || secondaryY.isEmpty()) return@remember null
-        // SENSITIVITY's "no change" value is 100%, not 0 — treat it as this side's pivot so it
-        // aligns with another series' zero the same way two zero-crossing series would.
-        val primaryPivot = if (primaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
-        val secondaryPivot = if (secondaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
-        alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max(), primaryPivot, secondaryPivot)
+
+        val primaryIsPivot = primaryType == SeriesType.SENSITIVITY || primaryType == SeriesType.DEV_SLOPE
+        val secondaryIsPivot = secondaryType == SeriesType.SENSITIVITY || secondaryType == SeriesType.DEV_SLOPE
+        if (primaryIsPivot != secondaryIsPivot) {
+            // Exactly one side is pivot-centered (SENS/DEV_SLOPE), the other zero-floor-style
+            // (e.g. COB, BGI): the pivot side gets a full nice-scaled symmetric range around its
+            // own pivot — unconditionally, no branching on where its bounds happen to sit relative
+            // to the pivot, so it never flips between "centered" and "pinned" between recomputes.
+            // The zero-floor side gets a symmetric (-half,+half) container sized from its own
+            // zero-floor nice range, so its zero lands exactly at the pivot's center (same pixel
+            // row) and its curve — normally never negative — fills only the upper half, scaled
+            // nicely up to its own real max (any rare negative sliver still fits, just not
+            // symmetric-looking, since half also covers it).
+            val isSensPivot = primaryType == SeriesType.SENSITIVITY || secondaryType == SeriesType.SENSITIVITY
+            val pivot = if (isSensPivot) 100.0 else 0.0
+            val pivotMinDeviation = if (isSensPivot) SENS_MIN_DEVIATION else 0.0
+            return@remember if (primaryIsPivot) {
+                val pivotNice = niceScaleAroundPivot(primaryY.min(), primaryY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, pivotMinDeviation)
+                val zeroFloorNice = zeroFloorNiceRange(secondaryY.min(), secondaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
+                val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
+                // Primary is the pivot itself here — its own axis is fully meaningful in both
+                // directions, no label clamping needed.
+                AlignedRanges(pivotNice.min, pivotNice.max, -zeroFloorHalf, zeroFloorHalf)
+            } else {
+                val pivotNice = niceScaleAroundPivot(secondaryY.min(), secondaryY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, pivotMinDeviation)
+                val zeroFloorNice = zeroFloorNiceRange(primaryY.min(), primaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
+                val zeroFloorHalf = maxOf(-zeroFloorNice.min, zeroFloorNice.max)
+                // Primary is the zero-floor side, pushed into a symmetric container purely to
+                // align its zero with the pivot's center — its own real floor (e.g. 0 for COB)
+                // must still be the lowest label shown, or its axis reads as if COB/BGI/etc. can
+                // go negative when it can't.
+                AlignedRanges(-zeroFloorHalf, zeroFloorHalf, pivotNice.min, pivotNice.max, primaryLabelFloor = zeroFloorNice.min)
+            }
+        }
+        if (primaryIsPivot || secondaryIsPivot) {
+            // Both sides pivot-centered (SENS + DEV_SLOPE together — unusual but possible): keep
+            // the existing pivot-aware zero alignment, both are symmetric around their own pivot
+            // anyway so the old mechanism is adequate here.
+            val primaryPivot = if (primaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
+            val secondaryPivot = if (secondaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
+            return@remember alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max(), primaryPivot, secondaryPivot)
+        }
+
+        // Neither series is pivot-centered (e.g. COB + VAR_SENSITIVITY, or BGI + STEPS): primary
+        // stays nice-scaled and zero-floored, secondary stays raw. Each series' own "negative
+        // fraction" is computed independently — primary from its nice bounds, secondary from its
+        // raw bounds — and the shared target is their average, so neither curve's height dominates
+        // the compromise. Each axis is then widened just enough to hit that shared fraction,
+        // anchored at whichever of its own real/nice bounds avoids clipping (see
+        // fractionAlignedRange / fractionAlignedNiceRange) so nothing is ever clipped.
+        val primaryNice = zeroFloorNiceRange(primaryY.min(), primaryY.max().coerceAtLeast(0.1), SECONDARY_GRAPH_TICK_COUNT)
+        val primaryFraction = if (primaryNice.max > primaryNice.min) -primaryNice.min / (primaryNice.max - primaryNice.min) else 0.0
+
+        val secondaryMax = secondaryY.max().coerceAtLeast(0.1)
+        val secondaryFraction = if (secondaryY.min() < 0.0) -secondaryY.min() / (secondaryMax - secondaryY.min()) else 0.0
+
+        val sharedFraction = (primaryFraction + secondaryFraction) / 2.0
+
+        val (aMin, aMax) = fractionAlignedNiceRange(primaryNice.min, primaryNice.max, sharedFraction)
+        val (bMin, bMax) = fractionAlignedRange(secondaryY.min(), secondaryMax, sharedFraction)
+        // primaryNice.min is primary's own real floor (0 unless it has a genuine negative sliver);
+        // aMin can be pushed below that purely to align zero with secondary — clamp labels back to
+        // primary's own floor so its axis never shows a fake negative tick.
+        AlignedRanges(aMin, aMax, bMin, bMax, primaryLabelFloor = primaryNice.min)
     }
 
     // Empty graph (only the normalizer series at y=0) would auto-range to a degenerate [0,0]
@@ -663,10 +730,10 @@ fun SecondaryGraphCompose(
     // same flattening/clipping problem the basal and dual-axis cases solve above — so window it
     // here too, using the same union-of-primary-series helper.
     val primaryAutoRange = remember(
-        hasBasalLayer, isDualAxis, processedIob, processedCob, processedSimpleSeries,
+        hasBasalLayer, dualAxisRanges, processedIob, processedCob, processedSimpleSeries,
         processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
     ) {
-        if (hasBasalLayer || isDualAxis) return@remember null
+        if (hasBasalLayer || dualAxisRanges != null) return@remember null
         val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) return@remember null
         val dataMin = allY.min()
@@ -680,8 +747,8 @@ fun SecondaryGraphCompose(
     // COB alone (single-axis, no basal/dual overlay): always starts at 0 regardless of the
     // visible minimum, with a "nice" max/tick-step instead of the raw windowed value. Takes
     // precedence over primaryAutoRange/primaryConstantRange for this specific case.
-    val primaryCobScale = remember(hasCob, isDualAxis, processedCob, visibleMinX, visibleMaxX) {
-        if (!hasCob || isDualAxis) return@remember null
+    val primaryCobScale = remember(hasCob, dualAxisRanges, processedCob, visibleMinX, visibleMaxX) {
+        if (!hasCob || dualAxisRanges != null) return@remember null
         val allY = windowedY(processedCob.first, visibleMinX, visibleMaxX)
         if (allY.isEmpty()) return@remember null
         niceScale(0.0, allY.max().coerceAtLeast(0.0), SECONDARY_GRAPH_TICK_COUNT)
@@ -691,10 +758,10 @@ fun SecondaryGraphCompose(
     // negative excursion without ever centering zero (same rule as IOB). Takes precedence over
     // primaryAutoRange/primaryConstantRange for this specific case.
     val primaryZeroFloorScale = remember(
-        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
         processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
     ) {
-        if (isDualAxis || hasBasalLayer) return@remember null
+        if (dualAxisRanges != null || hasBasalLayer) return@remember null
         if (primaryType !in ZERO_FLOOR_SERIES_TYPES) return@remember null
         val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) return@remember null
@@ -703,10 +770,10 @@ fun SecondaryGraphCompose(
     // VAR_SENSITIVITY / HEART_RATE alone: free-range nice scale — no zero anchor, since a
     // sensitivity ratio or heart rate has no meaningful "zero" reference point.
     val primaryFreeRangeScale = remember(
-        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
         processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
     ) {
-        if (isDualAxis || hasBasalLayer) return@remember null
+        if (dualAxisRanges != null || hasBasalLayer) return@remember null
         if (primaryType != SeriesType.VAR_SENSITIVITY && primaryType != SeriesType.HEART_RATE) return@remember null
         val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) return@remember null
@@ -715,10 +782,10 @@ fun SecondaryGraphCompose(
     // SENSITIVITY (centered on 100%) / DEV_SLOPE (centered on 0) alone: pivot-centered nice
     // scale, so the pivot always lands exactly in the middle of the axis.
     val primaryPivotScale = remember(
-        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        primaryType, dualAxisRanges, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
         processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
     ) {
-        if (isDualAxis || hasBasalLayer) return@remember null
+        if (dualAxisRanges != null || hasBasalLayer) return@remember null
         val pivot = when (primaryType) {
             SeriesType.SENSITIVITY -> 100.0
             SeriesType.DEV_SLOPE   -> 0.0
@@ -726,7 +793,8 @@ fun SecondaryGraphCompose(
         }
         val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) return@remember null
-        niceScaleAroundPivot(allY.min(), allY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT)
+        val minDeviation = if (primaryType == SeriesType.SENSITIVITY) SENS_MIN_DEVIATION else 0.0
+        niceScaleAroundPivot(allY.min(), allY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT, minDeviation)
     }
     // Dynamic tick step for the start axis' ItemPlacer — null falls back to Vico's own automatic
     // spacing for series that don't have a "nice" rule yet.
@@ -799,10 +867,15 @@ fun SecondaryGraphCompose(
     )
 
     // Common axis components
-    val startAxisItemPlacer = remember(primaryYStep, primaryIobDataMax) {
+    val startAxisItemPlacer = remember(primaryYStep, primaryIobDataMax, dualAxisRanges?.primaryLabelFloor) {
         val stepPlacer = VerticalAxis.ItemPlacer.step({ primaryYStep })
         val dataMax = primaryIobDataMax
-        if (dataMax != null) ClampedVerticalAxisItemPlacer(stepPlacer) { dataMax } else stepPlacer
+        val labelFloor = dualAxisRanges?.primaryLabelFloor
+        when {
+            dataMax != null   -> ClampedVerticalAxisItemPlacer(stepPlacer, visibleMax = { dataMax })
+            labelFloor != null -> ClampedVerticalAxisItemPlacer(stepPlacer, visibleMin = { labelFloor })
+            else               -> stepPlacer
+        }
     }
     val startAxis = VerticalAxis.rememberStart(
         itemPlacer = startAxisItemPlacer,
@@ -1322,8 +1395,13 @@ private data class ProcessedDeviationLines(
     val series: Map<DeviationType, List<Double>>
 )
 
-/** Aligned y-ranges for primary (a*) and secondary (b*) axes — zeros share the same fractional position. */
-private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double)
+/**
+ * Aligned y-ranges for primary (a*) and secondary (b*) axes — zeros share the same fractional
+ * position. [primaryLabelFloor], when set, is primary's own real floor (below which its axis was
+ * artificially extended purely for zero-alignment) — the start axis' tick placer clamps labels to
+ * it so primary never shows a fake tick below a value it can actually reach.
+ */
+private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double, val primaryLabelFloor: Double? = null)
 
 /**
  * Adjusts two y-ranges so [aPivot]/[bPivot] land at the same fractional height on both axes.
@@ -1379,5 +1457,32 @@ private fun alignZerosAtOrigin(aMin: Double, aMax: Double, bMin: Double, bMax: D
         // One all-positive, one all-negative (neither touches zero) → no useful shared alignment.
         else                 -> null
     }
+}
+
+/**
+ * Builds an axis range that keeps [dataMin, dataMax] fully in view while placing zero at
+ * [targetFraction] of the axis height. Anchors at dataMin first, stretching only the max to hit
+ * the fraction; if that would still clip dataMax, anchors at dataMax instead and stretches the
+ * min further negative. Either branch guarantees no clipping, for any fraction in range.
+ */
+private fun fractionAlignedRange(dataMin: Double, dataMax: Double, targetFraction: Double): Pair<Double, Double> {
+    val fraction = targetFraction.coerceIn(0.0, 0.9)
+    if (fraction <= 0.0) return dataMin.coerceAtMost(0.0) to dataMax
+    val candidateMax = dataMin * (fraction - 1.0) / fraction
+    return if (candidateMax >= dataMax) dataMin to candidateMax
+    else (-fraction / (1.0 - fraction) * dataMax) to dataMax
+}
+
+/**
+ * Same construction as [fractionAlignedRange], but whichever bound ends up stretched to hit
+ * [targetFraction] is rounded to a nice value too — used for the primary axis, which must stay
+ * nice-scaled even when its range is widened to align with a secondary axis' zero.
+ */
+private fun fractionAlignedNiceRange(niceMin: Double, niceMax: Double, targetFraction: Double): Pair<Double, Double> {
+    val fraction = targetFraction.coerceIn(0.0, 0.9)
+    if (fraction <= 0.0) return niceMin to niceMax
+    val candidateMax = niceMin * (fraction - 1.0) / fraction
+    return if (candidateMax >= niceMax) niceMin to niceUp(candidateMax)
+    else niceNegativeSliver(-fraction / (1.0 - fraction) * niceMax) to niceMax
 }
 

--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphCompose.kt
@@ -29,6 +29,7 @@ import app.aaps.core.interfaces.overview.graph.SeriesType
 import app.aaps.core.interfaces.overview.graph.TreatmentGraphData
 import app.aaps.core.ui.compose.AapsTheme
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.VicoZoomState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
@@ -60,6 +61,55 @@ import kotlinx.coroutines.flow.debounce
  * transaction instead of silently dropping it.
  */
 private val VISIBLE_RANGE_KEY = ExtraStore.Key<Pair<Double?, Double?>>()
+
+/**
+ * Secondary graphs are much shorter than the BG graph, so Vico's ItemPlacer thins out a denser
+ * tick request to avoid label overlap — and it does so by doubling the step rather than picking a
+ * still-nice one, dropping the top boundary in the process (a max of 50 renders as 0/20/40 instead
+ * of 0/25/50). Requesting fewer ticks up front avoids that thinning.
+ *
+ * IOB only occupies the bottom half of its graph (basal reserves the top half — see
+ * `primaryYMax`), so it has roughly half the vertical pixels per tick that a full-height graph
+ * does, and needs the more conservative count.
+ */
+private const val IOB_GRAPH_TICK_COUNT = 3
+
+/** Tick count for series that use the graph's full height (COB, BGI/DEV/ACTIVITY/STEPS, SENS/VAR_SENS/HEART_RATE, DEV_SLOPE). */
+private const val SECONDARY_GRAPH_TICK_COUNT = 5
+
+/**
+ * Mostly-positive series: 0-floored by default (see [zeroFloorNiceRange]), allowing a
+ * disparity-aware negative excursion without ever centering zero — the same rule used for IOB.
+ */
+private val ZERO_FLOOR_SERIES_TYPES = setOf(SeriesType.BGI, SeriesType.DEVIATIONS, SeriesType.ACTIVITY, SeriesType.STEPS, SeriesType.ABS_IOB)
+
+/**
+ * Wraps a step-based [VerticalAxis.ItemPlacer], filtering out labels/gridlines above [visibleMax].
+ * Used for the IOB/basal combo graph: the axis itself extends past the actual IOB data range to
+ * reserve headroom for the basal overlay (see the `primaryYMax` computation), but tick labels
+ * should stop at the real data boundary instead of continuing into the reserved band above it —
+ * otherwise the axis visually implies IOB data exists where only the basal overlay is drawn.
+ * Delegates everything else (margins, measurement, overlap-based thinning) to [delegate].
+ */
+private class ClampedVerticalAxisItemPlacer(
+    private val delegate: VerticalAxis.ItemPlacer,
+    private val visibleMax: () -> Double
+) : VerticalAxis.ItemPlacer by delegate {
+
+    override fun getLabelValues(
+        context: CartesianDrawingContext,
+        axisHeight: Float,
+        maxLabelHeight: Float,
+        position: Axis.Position.Vertical
+    ): List<Double> = delegate.getLabelValues(context, axisHeight, maxLabelHeight, position).filter { it <= visibleMax() }
+
+    override fun getLineValues(
+        context: CartesianDrawingContext,
+        axisHeight: Float,
+        maxLabelHeight: Float,
+        position: Axis.Position.Vertical
+    ): List<Double>? = delegate.getLineValues(context, axisHeight, maxLabelHeight, position)?.filter { it <= visibleMax() }
+}
 
 /**
  * General-purpose secondary graph composable.
@@ -546,17 +596,31 @@ fun SecondaryGraphCompose(
     val nowLine = rememberNowLine(minTimestamp, nowTimestamp, nowLineColor)
     val decorations = remember(nowLine, visibleRangeReporter) { listOf(nowLine, visibleRangeReporter) }
 
-    // When basal overlay is active, reserve the top BASAL_HEIGHT_FRACTION of the height for basal by extending primary Y range
-    val primaryYMax = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX) {
+    // IOB (with basal overlay active): zero-floor nice range — 0 if the visible window has no
+    // negative IOB, else a disparity-aware negative sliver (never centering zero) — then reserve
+    // the top BASAL_HEIGHT_FRACTION of the height for basal, ABOVE the actual data range (not
+    // above y=0 — those only coincide when nice.min is 0; when IOB has a negative excursion,
+    // reserving "above 0" would eat into the negative portion's share and let positive IOB data
+    // creep into the fraction of the axis meant for basal). Solving for axisMax such that
+    // (nice.max - nice.min) / (axisMax - nice.min) == (1 - BASAL_HEIGHT_FRACTION) gives:
+    // axisMax = nice.min + (nice.max - nice.min) / (1 - BASAL_HEIGHT_FRACTION)
+    // — this reduces to the simpler nice.max / (1 - frac) exactly when nice.min == 0. The tick
+    // step comes from the un-inflated nice range, so gridlines in the data region stay clean.
+    // Result pairs the final (inflated) axis range with the un-inflated data max — the latter is
+    // where tick labels must stop (see ClampedVerticalAxisItemPlacer) so they don't extend into
+    // the reserved basal band above the actual IOB data.
+    val primaryYMaxResult = remember(hasBasalLayer, processedIob, processedSimpleSeries, processedCob, processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX) {
         if (!hasBasalLayer) return@remember null // auto-range when no basal
         val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         if (allY.isEmpty()) null
         else {
-            val dataMax = allY.max().coerceAtLeast(0.1)
-            val dataMin = allY.min().coerceAtMost(0.0)
-            dataMin to (dataMax / (1 - BASAL_HEIGHT_FRACTION)) // data fills (1 - fraction); top fraction reserved for basal
+            val nice = zeroFloorNiceRange(allY.min(), allY.max().coerceAtLeast(0.1), IOB_GRAPH_TICK_COUNT)
+            val axisMax = nice.min + (nice.max - nice.min) / (1 - BASAL_HEIGHT_FRACTION)
+            NiceScale(nice.min, axisMax, nice.step) to nice.max
         }
     }
+    val primaryYMax = primaryYMaxResult?.first
+    val primaryIobDataMax = primaryYMaxResult?.second
     // Dual-axis zero alignment.
     // Why: Vico computes each vertical axis range independently, so y=0 on the
     // left axis lands at a different pixel row than y=0 on the right axis. When
@@ -573,7 +637,11 @@ fun SecondaryGraphCompose(
         val primaryY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
         val secondaryY = windowedY(processedSecondary, visibleMinX, visibleMaxX)
         if (primaryY.isEmpty() || secondaryY.isEmpty()) return@remember null
-        alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max())
+        // SENSITIVITY's "no change" value is 100%, not 0 — treat it as this side's pivot so it
+        // aligns with another series' zero the same way two zero-crossing series would.
+        val primaryPivot = if (primaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
+        val secondaryPivot = if (secondaryType == SeriesType.SENSITIVITY) 100.0 else 0.0
+        alignZeros(primaryY.min(), primaryY.max(), secondaryY.min(), secondaryY.max(), primaryPivot, secondaryPivot)
     }
 
     // Empty graph (only the normalizer series at y=0) would auto-range to a degenerate [0,0]
@@ -590,7 +658,7 @@ fun SecondaryGraphCompose(
         val low = minOf(0.0, dataMax)
         low to maxOf(dataMax, low + 1.0)
     }
-    // Single-axis, non-basal, non-degenerate case (e.g. standalone COB/BGI/DevSlope/VarSens graphs):
+    // Single-axis, non-basal, non-degenerate case (e.g. standalone BGI/DevSlope/VarSens graphs):
     // Vico's own auto-range would compute from the full loaded model, not the visible window —
     // same flattening/clipping problem the basal and dual-axis cases solve above — so window it
     // here too, using the same union-of-primary-series helper.
@@ -609,14 +677,80 @@ fun SecondaryGraphCompose(
             low to maxOf(dataMax, low + 1.0)
         }
     }
-    val primaryRangeProvider = remember(maxX, primaryYMax, dualAxisRanges, hasPrimaryData, primaryConstantRange, primaryAutoRange) {
+    // COB alone (single-axis, no basal/dual overlay): always starts at 0 regardless of the
+    // visible minimum, with a "nice" max/tick-step instead of the raw windowed value. Takes
+    // precedence over primaryAutoRange/primaryConstantRange for this specific case.
+    val primaryCobScale = remember(hasCob, isDualAxis, processedCob, visibleMinX, visibleMaxX) {
+        if (!hasCob || isDualAxis) return@remember null
+        val allY = windowedY(processedCob.first, visibleMinX, visibleMaxX)
+        if (allY.isEmpty()) return@remember null
+        niceScale(0.0, allY.max().coerceAtLeast(0.0), SECONDARY_GRAPH_TICK_COUNT)
+    }
+    // BGI / DEVIATIONS / ACTIVITY / STEPS alone (single-axis, no basal/dual overlay): zero-floor
+    // nice range — these are mostly-positive series, so 0 by default, but allows a disparity-aware
+    // negative excursion without ever centering zero (same rule as IOB). Takes precedence over
+    // primaryAutoRange/primaryConstantRange for this specific case.
+    val primaryZeroFloorScale = remember(
+        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
+    ) {
+        if (isDualAxis || hasBasalLayer) return@remember null
+        if (primaryType !in ZERO_FLOOR_SERIES_TYPES) return@remember null
+        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+        if (allY.isEmpty()) return@remember null
+        zeroFloorNiceRange(allY.min(), allY.max(), SECONDARY_GRAPH_TICK_COUNT)
+    }
+    // VAR_SENSITIVITY / HEART_RATE alone: free-range nice scale — no zero anchor, since a
+    // sensitivity ratio or heart rate has no meaningful "zero" reference point.
+    val primaryFreeRangeScale = remember(
+        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
+    ) {
+        if (isDualAxis || hasBasalLayer) return@remember null
+        if (primaryType != SeriesType.VAR_SENSITIVITY && primaryType != SeriesType.HEART_RATE) return@remember null
+        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+        if (allY.isEmpty()) return@remember null
+        niceScale(allY.min(), allY.max(), SECONDARY_GRAPH_TICK_COUNT)
+    }
+    // SENSITIVITY (centered on 100%) / DEV_SLOPE (centered on 0) alone: pivot-centered nice
+    // scale, so the pivot always lands exactly in the middle of the axis.
+    val primaryPivotScale = remember(
+        primaryType, isDualAxis, hasBasalLayer, processedIob, processedCob, processedSimpleSeries,
+        processedDevSlopeMin, processedDeviationLines, visibleMinX, visibleMaxX
+    ) {
+        if (isDualAxis || hasBasalLayer) return@remember null
+        val pivot = when (primaryType) {
+            SeriesType.SENSITIVITY -> 100.0
+            SeriesType.DEV_SLOPE   -> 0.0
+            else                   -> return@remember null
+        }
+        val allY = windowedPrimaryY(visibleMinX, visibleMaxX, processedIob, processedCob.first, processedSimpleSeries, processedDevSlopeMin, processedDeviationLines)
+        if (allY.isEmpty()) return@remember null
+        niceScaleAroundPivot(allY.min(), allY.max(), pivot, SECONDARY_GRAPH_TICK_COUNT)
+    }
+    // Dynamic tick step for the start axis' ItemPlacer — null falls back to Vico's own automatic
+    // spacing for series that don't have a "nice" rule yet.
+    val primaryYStep = primaryYMax?.step ?: primaryCobScale?.step ?: primaryZeroFloorScale?.step
+        ?: primaryFreeRangeScale?.step ?: primaryPivotScale?.step
+    val primaryRangeProvider = remember(
+        maxX, primaryYMax, dualAxisRanges, hasPrimaryData, primaryCobScale, primaryZeroFloorScale,
+        primaryFreeRangeScale, primaryPivotScale, primaryConstantRange, primaryAutoRange
+    ) {
         when {
             // Basal overlay case takes precedence (reserves the top BASAL_HEIGHT_FRACTION of axis for basal)
-            primaryYMax != null          -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryYMax.first, maxY = primaryYMax.second)
+            primaryYMax != null          -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryYMax.min, maxY = primaryYMax.max)
             // Dual-axis: use zero-aligned primary range so zeros line up with secondary axis
             dualAxisRanges != null       -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = dualAxisRanges.aMin, maxY = dualAxisRanges.aMax)
             // No data: anchor a default range so the empty frame is visible
             !hasPrimaryData              -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = 0.0, maxY = 1.0)
+            // COB alone: nice 0-to-max scale
+            primaryCobScale != null      -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryCobScale.min, maxY = primaryCobScale.max)
+            // BGI/DEVIATIONS/ACTIVITY/STEPS alone: zero-floor nice range (disparity-aware negative excursion)
+            primaryZeroFloorScale != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryZeroFloorScale.min, maxY = primaryZeroFloorScale.max)
+            // VAR_SENSITIVITY/HEART_RATE alone: free-range nice scale, no zero anchor
+            primaryFreeRangeScale != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryFreeRangeScale.min, maxY = primaryFreeRangeScale.max)
+            // SENSITIVITY/DEV_SLOPE alone: pivot-centered nice scale
+            primaryPivotScale != null    -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryPivotScale.min, maxY = primaryPivotScale.max)
             // Constant series (whole loaded range is flat): explicit range so it isn't collapsed to 0..1 and clipped
             primaryConstantRange != null -> CartesianLayerRangeProvider.fixed(minX = 0.0, maxX = maxX, minY = primaryConstantRange.first, maxY = primaryConstantRange.second)
             // Single-axis: window the range to the visible portion instead of Vico's full-model auto-range
@@ -665,7 +799,13 @@ fun SecondaryGraphCompose(
     )
 
     // Common axis components
+    val startAxisItemPlacer = remember(primaryYStep, primaryIobDataMax) {
+        val stepPlacer = VerticalAxis.ItemPlacer.step({ primaryYStep })
+        val dataMax = primaryIobDataMax
+        if (dataMax != null) ClampedVerticalAxisItemPlacer(stepPlacer) { dataMax } else stepPlacer
+    }
     val startAxis = VerticalAxis.rememberStart(
+        itemPlacer = startAxisItemPlacer,
         label = rememberTextComponent(
             style = TextStyle(color = MaterialTheme.colorScheme.onSurface),
             minWidth = TextComponent.MinWidth.fixed(30.dp)
@@ -1186,6 +1326,20 @@ private data class ProcessedDeviationLines(
 private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: Double, val bMax: Double)
 
 /**
+ * Adjusts two y-ranges so [aPivot]/[bPivot] land at the same fractional height on both axes.
+ * Pivots default to 0.0 (true zero) for every series except SENSITIVITY, whose "no change" value
+ * is 100% — treating 100 as SENSITIVITY's pivot lets it align with another series' zero exactly
+ * like two zero-crossing series would (e.g. SENS at 100% and IOB at 0 both land in the middle).
+ *
+ * Implemented by shifting both ranges into pivot-relative space, reusing the plain zero-based
+ * alignment logic, then shifting the result back.
+ */
+private fun alignZeros(aMin: Double, aMax: Double, bMin: Double, bMax: Double, aPivot: Double = 0.0, bPivot: Double = 0.0): AlignedRanges? {
+    val shifted = alignZerosAtOrigin(aMin - aPivot, aMax - aPivot, bMin - bPivot, bMax - bPivot) ?: return null
+    return AlignedRanges(shifted.aMin + aPivot, shifted.aMax + aPivot, shifted.bMin + bPivot, shifted.bMax + bPivot)
+}
+
+/**
  * Adjusts two y-ranges so y=0 lands at the same fractional height on both axes.
  *
  * Strategy: whenever either series crosses (or touches) zero, symmetrize each
@@ -1200,7 +1354,7 @@ private data class AlignedRanges(val aMin: Double, val aMax: Double, val bMin: D
  * is simpler, always works without clipping, and matches how the old
  * OverviewFragment aligned bipolar series (see GraphData.kt lines 150/151).
  */
-private fun alignZeros(aMin: Double, aMax: Double, bMin: Double, bMax: Double): AlignedRanges? {
+private fun alignZerosAtOrigin(aMin: Double, aMax: Double, bMin: Double, bMax: Double): AlignedRanges? {
     // Treat touching zero (min=0 or max=0) as crossing — the zero line is in-range either way.
     val aCrosses = aMin <= 0 && aMax >= 0
     val bCrosses = bMin <= 0 && bMax >= 0

--- a/ui/src/test/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtilsTest.kt
+++ b/ui/src/test/kotlin/app/aaps/ui/compose/overview/graphs/GraphUtilsTest.kt
@@ -1,0 +1,186 @@
+package app.aaps.ui.compose.overview.graphs
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+/**
+ * Regression coverage for the "nice numbers" axis-scaling math (Heckbert's algorithm and its
+ * pivot/zero-floor variants), extracted during the Step 4 graph-scale refactor. Expected values
+ * verified by direct calculation against the algorithm, not guessed — several were hand-verified
+ * during that work and are pinned here so a future change can't silently re-break them.
+ */
+internal class GraphUtilsTest {
+
+    @Nested
+    inner class NiceScaleTest {
+
+        @ParameterizedTest(name = "max just above {0} rounds to a clean ({1}, {2})")
+        @CsvSource(
+            "195.0, 200.0, 50.0",
+            "210.0, 250.0, 50.0", // the 2.5-tier fix: without it this jumps straight to 300/100
+            "250.0, 250.0, 50.0",
+            "260.0, 300.0, 100.0",
+            "310.0, 400.0, 100.0",
+        )
+        fun `BG max rounds to the expected clean ceiling and step`(input: Double, expectedMax: Double, expectedStep: Double) {
+            val scale = niceScale(0.0, input)
+            assertThat(scale.min).isEqualTo(0.0)
+            assertThat(scale.max).isEqualTo(expectedMax)
+            assertThat(scale.step).isEqualTo(expectedStep)
+        }
+
+        @Test
+        fun `never clips the real data range`() {
+            val scale = niceScale(12.39, 57.39)
+            assertThat(scale.min).isEqualTo(10.0)
+            assertThat(scale.max).isEqualTo(60.0)
+            assertThat(scale.step).isEqualTo(10.0)
+        }
+
+        @Test
+        fun `degenerate range (min equals max) still produces a usable non-empty scale`() {
+            val scale = niceScale(5.0, 5.0)
+            assertThat(scale.max).isGreaterThan(scale.min)
+            assertThat(scale.step).isGreaterThan(0.0)
+        }
+    }
+
+    @Nested
+    inner class NiceUpTest {
+
+        @Test
+        fun `non-positive values return zero`() {
+            assertThat(niceUp(0.0)).isEqualTo(0.0)
+            assertThat(niceUp(-5.0)).isEqualTo(0.0)
+        }
+
+        @Test
+        fun `rounds up, never down, and never below the input`() {
+            assertThat(niceUp(82.0)).isEqualTo(100.0)
+            assertThat(niceUp(82.0)).isAtLeast(82.0)
+        }
+    }
+
+    @Nested
+    inner class NiceNegativeSliverTest {
+
+        @Test
+        fun `non-negative values return zero`() {
+            assertThat(niceNegativeSliver(0.0)).isEqualTo(0.0)
+            assertThat(niceNegativeSliver(5.0)).isEqualTo(0.0)
+        }
+
+        @Test
+        fun `rounds further negative, never toward zero`() {
+            assertThat(niceNegativeSliver(-0.3)).isEqualTo(-0.5)
+            assertThat(niceNegativeSliver(-0.07)).isEqualTo(-0.1)
+        }
+
+        @Test
+        fun `a value already nice is left unchanged`() {
+            // 0.05 is itself on the 1/2/2.5/5/10 ladder, so it must not get bumped to 0.1
+            assertThat(niceNegativeSliver(-0.05)).isEqualTo(-0.05)
+        }
+    }
+
+    @Nested
+    inner class NiceScaleAroundPivotTest {
+
+        @Test
+        fun `pivot always sits exactly at the midpoint regardless of input asymmetry`() {
+            val scale = niceScaleAroundPivot(min = 60.0, max = 108.0, pivot = 100.0)
+            assertThat(scale.min).isEqualTo(40.0)
+            assertThat(scale.max).isEqualTo(160.0)
+            assertThat((scale.min + scale.max) / 2.0).isEqualTo(100.0)
+        }
+
+        @Test
+        fun `never clips the real data range`() {
+            val scale = niceScaleAroundPivot(min = 60.0, max = 108.0, pivot = 100.0)
+            assertThat(scale.min).isAtMost(60.0)
+            assertThat(scale.max).isAtLeast(108.0)
+        }
+
+        @Test
+        fun `DEV_SLOPE-style pivot at zero centers correctly`() {
+            val scale = niceScaleAroundPivot(min = -3.0, max = 1.0, pivot = 0.0)
+            assertThat(scale.min).isEqualTo(-6.0)
+            assertThat(scale.max).isEqualTo(6.0)
+        }
+
+        @Test
+        fun `SENS sitting flat on its pivot snaps to a fixed 95-100-105 scale, not a tight near-zero one`() {
+            // Regression for the reported bug: a constant SENS at 100% used to produce something
+            // like 99/99.5/100/100.5/101 instead of a clean 95%/100%/105%.
+            val scale = niceScaleAroundPivot(min = 100.0, max = 100.0, pivot = 100.0, minDeviation = 5.0)
+            assertThat(scale.min).isEqualTo(95.0)
+            assertThat(scale.max).isEqualTo(105.0)
+            assertThat(scale.step).isEqualTo(5.0)
+        }
+
+        @Test
+        fun `deviation above the minDeviation floor ignores the floor and nice-ifies normally`() {
+            val scale = niceScaleAroundPivot(min = 40.0, max = 160.0, pivot = 100.0, minDeviation = 5.0)
+            assertThat(scale.min).isEqualTo(0.0)
+            assertThat(scale.max).isEqualTo(200.0)
+        }
+
+        @Test
+        fun `requesting 3 ticks always produces exactly 3 (pivot guaranteed to be one of them)`() {
+            // The SENS_PIVOT_TICK_COUNT fix: side-steps Vico's step-thinning entirely by never
+            // requesting more ticks than always fit.
+            val scale = niceScaleAroundPivot(min = 40.0, max = 160.0, pivot = 100.0, maxTickCount = 3)
+            val tickCount = Math.round((scale.max - scale.min) / scale.step) + 1
+            assertThat(tickCount).isEqualTo(3L)
+            assertThat(scale.min + (scale.max - scale.min) / 2.0).isEqualTo(100.0)
+        }
+    }
+
+    @Nested
+    inner class ZeroFloorNiceRangeTest {
+
+        @Test
+        fun `all-positive data floors at exactly zero`() {
+            val scale = zeroFloorNiceRange(dataMin = 5.0, dataMax = 82.0)
+            assertThat(scale.min).isEqualTo(0.0)
+            assertThat(scale.max).isEqualTo(100.0)
+        }
+
+        @Test
+        fun `tiny negative excursion relative to a large positive side gets its own independent sliver`() {
+            // ratio (8.0 / 0.05 = 160) is far above the default disparityRatio of 10 — the negative
+            // sliver must stay tight (its own nice magnitude), not stretched to match the positive step.
+            val scale = zeroFloorNiceRange(dataMin = -0.05, dataMax = 8.0)
+            assertThat(scale.min).isEqualTo(-0.05)
+            assertThat(scale.max).isEqualTo(10.0)
+        }
+
+        @Test
+        fun `comparable-magnitude negative and positive share one unified nice scale`() {
+            val scale = zeroFloorNiceRange(dataMin = -4.0, dataMax = 6.0)
+            assertThat(scale.min).isEqualTo(-4.0)
+            assertThat(scale.max).isEqualTo(6.0)
+            assertThat(scale.step).isEqualTo(2.0)
+        }
+
+        @Test
+        fun `right at the disparity ratio boundary takes the independent-sliver branch`() {
+            // ratio == disparityRatio exactly (10.0 / 1.0 = 10.0) must take the ">=" sliver branch,
+            // not silently fall through to the unified one.
+            val scale = zeroFloorNiceRange(dataMin = -1.0, dataMax = 10.0)
+            assertThat(scale.min).isEqualTo(-1.0)
+            assertThat(scale.max).isEqualTo(10.0)
+            assertThat(scale.step).isEqualTo(2.0)
+        }
+
+        @Test
+        fun `never clips real data even when the negative side is larger than the positive side`() {
+            val scale = zeroFloorNiceRange(dataMin = -12.0, dataMax = 3.0)
+            assertThat(scale.min).isAtMost(-12.0)
+            assertThat(scale.max).isAtLeast(3.0)
+        }
+    }
+}

--- a/ui/src/test/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphScaleHelpersTest.kt
+++ b/ui/src/test/kotlin/app/aaps/ui/compose/overview/graphs/SecondaryGraphScaleHelpersTest.kt
@@ -1,0 +1,310 @@
+package app.aaps.ui.compose.overview.graphs
+
+import app.aaps.core.interfaces.overview.graph.DeviationType
+import app.aaps.core.interfaces.overview.graph.SeriesType
+import com.google.common.truth.Truth.assertThat
+import com.patrykandpatrick.vico.compose.cartesian.CartesianDrawingContext
+import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
+import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Regression coverage for [SecondaryGraphCompose]'s dual-axis / windowing helper functions,
+ * extracted (private -> internal) during the Step 4 graph-scale refactor specifically so they
+ * could be unit tested. Each test ties back to a specific bug found and fixed during that work —
+ * see the KDoc on the function under test for the full rationale.
+ */
+internal class SecondaryGraphScaleHelpersTest {
+
+    @Nested
+    inner class WindowedYTest {
+
+        @Test
+        fun `filters points to the visible window`() {
+            val points = listOf(0.0 to 1.0, 5.0 to 2.0, 10.0 to 3.0)
+            assertThat(windowedY(points, 4.0, 11.0)).containsExactly(2.0, 3.0)
+        }
+
+        @Test
+        fun `falls back to the full list when the window has no points`() {
+            val points = listOf(0.0 to 1.0, 5.0 to 2.0)
+            assertThat(windowedY(points, 100.0, 200.0)).containsExactly(1.0, 2.0)
+        }
+
+        @Test
+        fun `null window bounds return every point unfiltered`() {
+            val points = listOf(0.0 to 1.0, 5.0 to 2.0)
+            assertThat(windowedY(points, null, null)).containsExactly(1.0, 2.0)
+        }
+    }
+
+    @Nested
+    inner class StepValueAtTest {
+
+        @Test
+        fun `returns the value in effect at x from the most recent point at-or-before it`() {
+            val points = listOf(0.0 to 1.0, 60.0 to 2.0, 120.0 to 3.0)
+            assertThat(stepValueAt(points, 90.0)).isEqualTo(2.0)
+        }
+
+        @Test
+        fun `a point exactly at x counts as in effect`() {
+            val points = listOf(0.0 to 1.0, 60.0 to 2.0, 120.0 to 3.0)
+            assertThat(stepValueAt(points, 60.0)).isEqualTo(2.0)
+        }
+
+        @Test
+        fun `falls back to the first point when x precedes all data`() {
+            // The basal-profile-in-a-narrow-zoom-window fix: even scrolled before any recorded
+            // change point, the series still has a well-defined value.
+            val points = listOf(60.0 to 2.0, 120.0 to 3.0)
+            assertThat(stepValueAt(points, 10.0)).isEqualTo(2.0)
+        }
+
+        @Test
+        fun `empty series has no value in effect`() {
+            assertThat(stepValueAt(emptyList(), 10.0)).isNull()
+        }
+    }
+
+    @Nested
+    inner class WindowedPrimaryYTest {
+
+        @Test
+        fun `unions y-values across all primary-layer series, windowed`() {
+            val iob = listOf(0.0 to 1.0, 10.0 to 2.0)
+            val cob = listOf(0.0 to 5.0, 10.0 to 6.0)
+            val simple = listOf(SeriesType.BGI to listOf(0.0 to 7.0, 10.0 to 8.0))
+            val devSlopeMin = listOf(0.0 to -1.0, 10.0 to -2.0)
+            val deviations = ProcessedDeviationLines(allX = listOf(0.0, 10.0), series = mapOf(DeviationType.POSITIVE to listOf(3.0, 4.0)))
+
+            val result = windowedPrimaryY(5.0, 10.0, iob, cob, simple, devSlopeMin, deviations)
+
+            assertThat(result).containsExactly(2.0, 6.0, 8.0, -2.0, 4.0)
+        }
+
+        @Test
+        fun `a series with nothing in-window contributes nothing, without triggering a whole-set fallback`() {
+            // Documents the key property: windowed points from one series are never mixed with
+            // unwindowed points from another. IOB has no point in [5,10]; COB does. The union as a
+            // whole is non-empty (thanks to COB), so IOB must NOT fall back to its own full range.
+            val iob = listOf(0.0 to 1.0, 2.0 to 1.5)
+            val cob = listOf(0.0 to 5.0, 10.0 to 6.0)
+
+            val result = windowedPrimaryY(5.0, 10.0, iob, cob, emptyList(), emptyList(), null)
+
+            assertThat(result).containsExactly(6.0)
+        }
+
+        @Test
+        fun `falls back to the full union only when every series is empty in-window`() {
+            val iob = listOf(0.0 to 1.0, 10.0 to 2.0)
+            val cob = listOf(0.0 to 5.0, 10.0 to 6.0)
+
+            val result = windowedPrimaryY(1000.0, 2000.0, iob, cob, emptyList(), emptyList(), null)
+
+            assertThat(result).containsExactly(1.0, 2.0, 5.0, 6.0)
+        }
+    }
+
+    @Nested
+    inner class FractionAlignedRangeTest {
+
+        @Test
+        fun `zero-floor data (min 0) is stretched downward to hit the target fraction`() {
+            val (min, max) = fractionAlignedRange(dataMin = 0.0, dataMax = 82.0, targetFraction = 0.2)
+            assertThat(min).isEqualTo(-20.5)
+            assertThat(max).isEqualTo(82.0)
+        }
+
+        @Test
+        fun `tighten-at-min branch keeps the real min and only expands the max`() {
+            val (min, max) = fractionAlignedRange(dataMin = -5.0, dataMax = 100.0, targetFraction = 0.03)
+            assertThat(min).isEqualTo(-5.0)
+            assertThat(max).isWithin(1e-9).of(161.66666666666666)
+        }
+
+        @Test
+        fun `zero target fraction keeps the real data unchanged (except coercing a positive min to 0)`() {
+            assertThat(fractionAlignedRange(5.0, 82.0, 0.0)).isEqualTo(0.0 to 82.0)
+            assertThat(fractionAlignedRange(-3.0, 82.0, 0.0)).isEqualTo(-3.0 to 82.0)
+        }
+
+        @Test
+        fun `never clips the real data, across a range of fractions and data shapes`() {
+            val cases = listOf(
+                Triple(0.0, 82.0, 0.2),
+                Triple(-5.0, 100.0, 0.03),
+                Triple(-1.0, 1.0, 0.5),
+                Triple(0.0, 0.1, 0.4),
+            )
+            for ((dataMin, dataMax, fraction) in cases) {
+                val (min, max) = fractionAlignedRange(dataMin, dataMax, fraction)
+                assertThat(min).isAtMost(dataMin)
+                assertThat(max).isAtLeast(dataMax)
+            }
+        }
+    }
+
+    @Nested
+    inner class FractionAlignedNiceRangeTest {
+
+        @Test
+        fun `stretched bound is nice-ified, not left as a raw fraction result`() {
+            val (min, max) = fractionAlignedNiceRange(niceMin = 0.0, niceMax = 100.0, targetFraction = 0.2)
+            assertThat(min).isEqualTo(-25.0)
+            assertThat(max).isEqualTo(100.0)
+        }
+
+        @Test
+        fun `larger fraction stretches further, still nice`() {
+            val (min, max) = fractionAlignedNiceRange(niceMin = 0.0, niceMax = 50.0, targetFraction = 0.5)
+            assertThat(min).isEqualTo(-50.0)
+            assertThat(max).isEqualTo(50.0)
+        }
+
+        @Test
+        fun `zero target fraction leaves the nice range untouched`() {
+            assertThat(fractionAlignedNiceRange(0.0, 100.0, 0.0)).isEqualTo(0.0 to 100.0)
+        }
+
+        @Test
+        fun `never clips the original nice bounds`() {
+            val (min, max) = fractionAlignedNiceRange(niceMin = -10.0, niceMax = 100.0, targetFraction = 0.3)
+            assertThat(min).isAtMost(-10.0)
+            assertThat(max).isAtLeast(100.0)
+        }
+    }
+
+    @Nested
+    inner class PivotZeroFloorPairingTest {
+
+        @Test
+        fun `SENS pivot flat at 100 paired with COB snaps to 95-100-105, COB half covers its own max`() {
+            val pairing = pivotZeroFloorPairing(
+                pivotY = listOf(100.0, 100.0), zeroFloorY = listOf(0.0, 82.0), pivot = 100.0, minDeviation = 5.0, pivotTickCount = 3
+            )
+            assertThat(pairing.pivotNice.min).isEqualTo(95.0)
+            assertThat(pairing.pivotNice.max).isEqualTo(105.0)
+            assertThat(pairing.zeroFloorHalf).isEqualTo(100.0)
+            assertThat(pairing.zeroFloorMin).isEqualTo(0.0)
+        }
+
+        @Test
+        fun `DEV_SLOPE pivot paired with a BGI-style series that has its own small negative sliver`() {
+            val pairing = pivotZeroFloorPairing(
+                pivotY = listOf(-2.0, 3.0), zeroFloorY = listOf(-0.5, 12.0), pivot = 0.0, minDeviation = 0.0, pivotTickCount = 5
+            )
+            assertThat(pairing.pivotNice.min).isEqualTo(-6.0)
+            assertThat(pairing.pivotNice.max).isEqualTo(6.0)
+            assertThat(pairing.zeroFloorHalf).isEqualTo(20.0)
+            // The zero-floor side's own negative sliver must be preserved, not silently discarded
+            assertThat(pairing.zeroFloorMin).isEqualTo(-0.5)
+        }
+
+        @Test
+        fun `pivot side is always exactly centered on its own pivot`() {
+            val pairing = pivotZeroFloorPairing(
+                pivotY = listOf(60.0, 108.0), zeroFloorY = listOf(0.0, 20.0), pivot = 100.0, minDeviation = 5.0, pivotTickCount = 5
+            )
+            assertThat((pairing.pivotNice.min + pairing.pivotNice.max) / 2.0).isEqualTo(100.0)
+        }
+    }
+
+    @Nested
+    inner class AlignZerosTest {
+
+        @Test
+        fun `both series crossing zero symmetrize independently, zero at 50 percent of each own axis`() {
+            val result = alignZerosAtOrigin(aMin = -2.0, aMax = 8.0, bMin = -1.0, bMax = 1.0)
+            assertThat(result).isEqualTo(AlignedRanges(-8.0, 8.0, -1.0, 1.0))
+        }
+
+        @Test
+        fun `both strictly positive pins zero to the bottom of both axes`() {
+            val result = alignZerosAtOrigin(aMin = 1.0, aMax = 5.0, bMin = 2.0, bMax = 10.0)
+            assertThat(result).isEqualTo(AlignedRanges(0.0, 5.0, 0.0, 10.0))
+        }
+
+        @Test
+        fun `both strictly negative pins zero to the top of both axes`() {
+            val result = alignZerosAtOrigin(aMin = -5.0, aMax = -1.0, bMin = -10.0, bMax = -2.0)
+            assertThat(result).isEqualTo(AlignedRanges(-5.0, 0.0, -10.0, 0.0))
+        }
+
+        @Test
+        fun `one all-positive and one all-negative has no useful shared alignment`() {
+            assertThat(alignZerosAtOrigin(aMin = 1.0, aMax = 5.0, bMin = -10.0, bMax = -2.0)).isNull()
+        }
+
+        @Test
+        fun `both completely flat at zero is degenerate and returns null`() {
+            assertThat(alignZerosAtOrigin(aMin = 0.0, aMax = 0.0, bMin = 0.0, bMax = 0.0)).isNull()
+        }
+
+        @Test
+        fun `one side flat at zero borrows the other side's half so the zero line still lands at mid`() {
+            val result = alignZerosAtOrigin(aMin = 0.0, aMax = 0.0, bMin = -5.0, bMax = 5.0)
+            assertThat(result).isEqualTo(AlignedRanges(-5.0, 5.0, -5.0, 5.0))
+        }
+
+        @Test
+        fun `pivot-shifted alignment lands the pivot and the zero at the same fraction`() {
+            // SENS (90-110%, pivot 100) combined with IOB (-5..50, pivot 0)
+            val result = alignZeros(aMin = 90.0, aMax = 110.0, bMin = -5.0, bMax = 50.0, aPivot = 100.0, bPivot = 0.0)
+            assertThat(result).isEqualTo(AlignedRanges(90.0, 110.0, -50.0, 50.0))
+            val nonNull = requireNotNull(result)
+            val pivotFraction = (100.0 - nonNull.aMin) / (nonNull.aMax - nonNull.aMin)
+            val zeroFraction = (0.0 - nonNull.bMin) / (nonNull.bMax - nonNull.bMin)
+            assertThat(pivotFraction).isWithin(1e-9).of(zeroFraction)
+        }
+    }
+
+    @Nested
+    inner class ClampedVerticalAxisItemPlacerTest {
+
+        private val context = mock<CartesianDrawingContext>()
+
+        @Test
+        fun `visibleMax clamp drops labels and lines above the bound`() {
+            val delegate = mock<VerticalAxis.ItemPlacer>()
+            whenever(delegate.getLabelValues(any(), any(), any(), any())).thenReturn(listOf(0.0, 1.0, 2.0, 3.0))
+            whenever(delegate.getLineValues(any(), any(), any(), any())).thenReturn(listOf(0.0, 1.0, 2.0, 3.0))
+            val placer = ClampedVerticalAxisItemPlacer(delegate, visibleMax = { 2.0 })
+
+            assertThat(placer.getLabelValues(context, 100f, 20f, Axis.Position.Vertical.Start)).containsExactly(0.0, 1.0, 2.0)
+            assertThat(placer.getLineValues(context, 100f, 20f, Axis.Position.Vertical.Start)).containsExactly(0.0, 1.0, 2.0)
+        }
+
+        @Test
+        fun `visibleMin clamp drops labels below the bound (hides a fake negative tick)`() {
+            val delegate = mock<VerticalAxis.ItemPlacer>()
+            whenever(delegate.getLabelValues(any(), any(), any(), any())).thenReturn(listOf(-82.0, -41.0, 0.0, 41.0, 82.0))
+            val placer = ClampedVerticalAxisItemPlacer(delegate, visibleMin = { 0.0 })
+
+            assertThat(placer.getLabelValues(context, 100f, 20f, Axis.Position.Vertical.Start)).containsExactly(0.0, 41.0, 82.0)
+        }
+
+        @Test
+        fun `no bounds configured passes everything through unfiltered`() {
+            val delegate = mock<VerticalAxis.ItemPlacer>()
+            whenever(delegate.getLabelValues(any(), any(), any(), any())).thenReturn(listOf(-5.0, 0.0, 5.0))
+            val placer = ClampedVerticalAxisItemPlacer(delegate)
+
+            assertThat(placer.getLabelValues(context, 100f, 20f, Axis.Position.Vertical.Start)).containsExactly(-5.0, 0.0, 5.0)
+        }
+
+        @Test
+        fun `null line values from the delegate pass through as null`() {
+            val delegate = mock<VerticalAxis.ItemPlacer>()
+            whenever(delegate.getLineValues(any(), any(), any(), any())).thenReturn(null)
+            val placer = ClampedVerticalAxisItemPlacer(delegate, visibleMax = { 2.0 })
+
+            assertThat(placer.getLineValues(context, 100f, 20f, Axis.Position.Vertical.Start)).isNull()
+        }
+    }
+}


### PR DESCRIPTION
I know I touched tricky files... It's my first development with the help of Claude Code... (a strong guidance of CC was needed, and I had to learn how to work with him, but I could not do this PR without him...)

## What
Y-axis scaling for the Overview graphs (BG, IOB/BAS, and all configurable secondary graphs)
now adapts to the currently visible (scrolled/zoomed) window instead of the full 24h loaded
range — calm periods are no longer flattened by a spike elsewhere in the loaded data.

- Axis bounds and tick spacing now snap to round ("nice") numbers instead of raw decimals.
- Dual-axis graphs (two series combined, e.g. IOB+BGI) share a common zero position without
  ever clipping either curve — handles zero-floor, pivot-centered (SENS/DEV_SLOPE), and
  free-range (VAR_SENSITIVITY/HEART_RATE) combinations.
- IOB/BAS basal overlay headroom and tick labels adapt correctly to the windowed scale.

## Bug fixes
- Fixed BG graph pinch-zoom becoming unresponsive during a live gesture — axis range
  providers were being recreated on every scroll tick, forcing Vico to rebuild the chart and
  re-register gesture handling mid-gesture.
- Fixed BG viewport snapping to the wrong zoom/scroll after an auto-reset (new BG reading) —
  now recreates the scroll/zoom state objects instead of driving `VicoZoomState.zoom()` to an
  absolute target.
- Fixed COB's Y-axis getting force-symmetrized around a fake negative range (e.g. -42/+42)
  when sharing a dual-axis graph with a zero-crossing series, even though COB itself is never
  negative — zero-floor series now get their own dedicated floor-at-0 axis construction
  instead of reusing the generic symmetric zero-crossing alignment.

## Architecture notes
- `BgGraphCompose`: new `MutableYRangeProvider` — a `CartesianLayerRangeProvider` with a
  stable identity, mutated in place instead of recreated (`.fixed(...)` always returns a new
  instance, which was the root cause of the pinch-zoom bug above). Needed only for BG, the
  only interactive chart.
- `GraphUtils`: new nice-number scaling helpers (`niceScale`, `zeroFloorNiceRange`,
  `niceScaleAroundPivot`) and a passive `VisibleRangeReporter` decoration reporting the
  visible window without touching Compose state during the draw pass.
- No public API changes; all new parameters default to the previous behavior.

## Tests
Added/updated unit test coverage for the new scaling logic (nice-number rounding, zero-floor
and pivot-centered ranges, dual-axis alignment).

## Docs
Detailed writeup of the design and root causes of each bug fix added at
`_docs/graph-dynamic-scaling.md`.
