### PR TITLE
Fix invisible "Use Autosens" setting on AMA/AutoISF when dynamic sensitivity was enabled on SMB

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/aps/APS.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/aps/APS.kt
@@ -26,6 +26,14 @@ interface APS {
     fun supportsDynamicIsf(): Boolean = false
 
     /**
+     * Does this algorithm offer the "Use dynamic sensitivity" option at all
+     * (static capability, independent of the preference value)?
+     * Unlike [supportsDynamicIsf] this does not depend on whether the user enabled it.
+     * @return true if yes
+     */
+    fun offersDynamicSensitivity(): Boolean = false
+
+    /**
      * Is APS providing variable IC calculation?
      * @return true if yes
      */

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -73,7 +73,14 @@ enum class BooleanKey(
     BgSourceRandomBgRandomize("randombg_randomize", true, R.string.pref_title_random_bg_randomize, R.string.pref_summary_random_bg_randomize, defaultedBySM = true),
 
     ApsUseDynamicSensitivity("use_dynamic_sensitivity", false, R.string.pref_title_aps_use_dynamic_sensitivity, R.string.pref_summary_aps_use_dynamic_sensitivity, sync = SyncSpec(SyncChannel.Cold, SyncDirection.Bidirectional)),
-    ApsUseAutosens("openapsama_useautosens", true, R.string.pref_title_aps_use_autosens, defaultedBySM = true, negativeDependency = ApsUseDynamicSensitivity, sync = SyncSpec(SyncChannel.Cold, SyncDirection.Bidirectional)),
+    ApsUseAutosens(
+        "openapsama_useautosens", true, R.string.pref_title_aps_use_autosens, defaultedBySM = true,
+        // Hidden only while the active APS both offers dynamic sensitivity and has it enabled.
+        // A plain negativeDependency on ApsUseDynamicSensitivity would also hide it on algorithms
+        // whose screens never show that toggle (AMA, AutoISF), with no way to reveal it (issue #4482).
+        visibility = ElementVisibility { !(it.apsOffersDynamicSensitivity && it.preferences.get(ApsUseDynamicSensitivity)) },
+        sync = SyncSpec(SyncChannel.Cold, SyncDirection.Bidirectional)
+    ),
     ApsUseSmb("use_smb", true, R.string.pref_title_aps_use_smb, R.string.pref_summary_aps_use_smb, defaultedBySM = true, sync = SyncSpec(SyncChannel.Cold, SyncDirection.Bidirectional)),
     ApsUseSmbWithHighTt(
         "enableSMB_with_high_temptarget",

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/interfaces/VisibilityContext.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/interfaces/VisibilityContext.kt
@@ -72,6 +72,14 @@ interface VisibilityContext {
      */
     val isConcentrationEnabled: Boolean
         get() = false
+
+    /**
+     * Whether the active APS algorithm offers the "Use dynamic sensitivity" option
+     * (static capability, independent of the preference value). False when no APS
+     * is active (client mode, early startup) or on platforms without APS (wear).
+     */
+    val apsOffersDynamicSensitivity: Boolean
+        get() = false
 }
 
 /**

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/PreferenceState.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/PreferenceState.kt
@@ -62,6 +62,7 @@ private class ReactiveVisibilityContext(
     override val isPumpInitialized: Boolean get() = delegate.isPumpInitialized
     override val isConcentrationEnabled: Boolean get() = delegate.isConcentrationEnabled
     override val isClient: Boolean get() = delegate.isClient
+    override val apsOffersDynamicSensitivity: Boolean get() = delegate.apsOffersDynamicSensitivity
 
     // Return a reactive preferences wrapper
     override val preferences: Preferences get() = ReactivePreferencesWrapper(delegatePreferences, sharedStates)

--- a/implementation/src/main/kotlin/app/aaps/implementation/preference/VisibilityContextImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/preference/VisibilityContextImpl.kt
@@ -86,4 +86,7 @@ class VisibilityContextImpl @Inject constructor(
 
     override val isConcentrationEnabled: Boolean
         get() = constraintsChecker.isConcentrationEnabled().value()
+
+    override val apsOffersDynamicSensitivity: Boolean
+        get() = activePlugin.activeAPS?.offersDynamicSensitivity() == true
 }

--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSSMB/OpenAPSSMBPlugin.kt
@@ -140,6 +140,7 @@ open class OpenAPSSMBPlugin @Inject constructor(
     override val algorithm = APSResult.Algorithm.SMB
     override var lastAPSResult: APSResult? = null
     override fun supportsDynamicIsf(): Boolean = preferences.get(BooleanKey.ApsUseDynamicSensitivity)
+    override fun offersDynamicSensitivity(): Boolean = true
 
     override fun getIsfMgdl(profile: Profile, caller: String): Double? {
         val start = dateUtil.now()

--- a/wear/src/test/kotlin/app/aaps/wear/sharedPreferences/PreferencesImplTest.kt
+++ b/wear/src/test/kotlin/app/aaps/wear/sharedPreferences/PreferencesImplTest.kt
@@ -108,7 +108,7 @@ internal class PreferencesImplTest {
     }
 
     @Test
-    fun getDependingOnReturnsDependencyAndNegativeDependencyChildren() {
+    fun getDependingOnReturnsDependencyChildren() {
         val wearControlDependents = sut.getDependingOn("wearcontrol")
         assertThat(wearControlDependents).containsAtLeast(
             BooleanKey.WearWizardBg,
@@ -117,10 +117,6 @@ internal class PreferencesImplTest {
             BooleanKey.WearWizardCob,
             BooleanKey.WearWizardIob
         )
-
-        // ApsUseAutosens declares a negativeDependency on ApsUseDynamicSensitivity (key "use_dynamic_sensitivity")
-        val dynSensDependents = sut.getDependingOn("use_dynamic_sensitivity")
-        assertThat(dynSensDependents).contains(BooleanKey.ApsUseAutosens)
     }
 
     @Test


### PR DESCRIPTION
Fixes #4482

"Use Autosens" (`openapsama_useautosens`) declared a `negativeDependency` on `ApsUseDynamicSensitivity`, hiding it globally whenever dynamic sensitivity was enabled. Only SMB's preference screen offers that toggle, so after enabling it on SMB and switching to AMA or AutoISF the setting became invisible (reachable only via search) while still controlling autosens behavior.

Now the key uses an `ElementVisibility` check: hidden only when the active APS offers dynamic sensitivity (`APS.offersDynamicSensitivity()`, true for SMB only) AND it is enabled. SMB screen behavior is unchanged, including live show/hide on toggle; AMA/AutoISF always show the setting.

This was the last `negativeDependency` usage — removing that infrastructure will follow in a separate cleanup PR or leave as is in case the use for it reappear?