### PR TITLE
Fix: BG graph axis stays in stale unit after switching mg/dl ↔ mmol/l without restart

### DIFF
--- a/implementation/src/main/kotlin/app/aaps/implementation/sharedPreferences/PreferencesImpl.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/sharedPreferences/PreferencesImpl.kt
@@ -177,12 +177,14 @@ class PreferencesImpl @Inject constructor(
         sp.putString(key.key, value)
         stringFlows[key.key]?.value = value
         onLocalSyncedWrite(key)
+        if (key.key == StringKey.GeneralUnits.key) refreshUnitDoubleFlows()
     }
 
     override fun putRemote(key: StringNonPreferenceKey, value: String, version: Long) {
         sp.putString(key.key, value)
         stringFlows[key.key]?.value = value
         onRemoteSyncedWrite(key, version)
+        if (key.key == StringKey.GeneralUnits.key) refreshUnitDoubleFlows()
     }
 
     override fun observe(key: StringNonPreferenceKey): StateFlow<String> =
@@ -257,6 +259,12 @@ class PreferencesImpl @Inject constructor(
 
     override fun observe(key: UnitDoublePreferenceKey): StateFlow<Double> =
         unitDoubleFlows.computeIfAbsent(key.key) { MutableStateFlow(get(key)) }
+
+    private fun refreshUnitDoubleFlows() {
+        unitDoubleFlows.forEach { (keyString, flow) ->
+            (get(keyString) as? UnitDoublePreferenceKey)?.let { flow.value = get(it) }
+        }
+    }
 
     override fun get(key: IntNonPreferenceKey): Int =
         sp.getInt(key.key, key.defaultValue)


### PR DESCRIPTION
It is documented that `Preferences.observe(UnitDoublePreferenceKey)` emits a value upon changes to both the unit and the value; however, the system only responded to direct writes to the key. Changing the unit without restarting left `chartConfig.highMark` and `chartConfig.lowMark` outdated (retaining the old unit), even though the BG graph data was correctly converted.

Fix: refresh the observed `UnitDoubleKey` streams when writing `StringKey.GeneralUnits`.