### PR TITLE
Improve settings search and client settings visibility

### DIFF
--- a/app/src/main/kotlin/app/aaps/ComposeMainActivity.kt
+++ b/app/src/main/kotlin/app/aaps/ComposeMainActivity.kt
@@ -802,6 +802,7 @@ class ComposeMainActivity : AppCompatActivity() {
                 preferences = preferences,
                 rh = rh,
                 builtInSearchables = builtInSearchables,
+                configBuilder = configBuilder,
                 prefFileList = prefFileList,
                 persistenceLayer = persistenceLayer,
                 visibilityContext = visibilityContext,

--- a/app/src/main/kotlin/app/aaps/compose/navigation/AppNavGraph.kt
+++ b/app/src/main/kotlin/app/aaps/compose/navigation/AppNavGraph.kt
@@ -33,6 +33,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import app.aaps.core.data.model.TE
 import app.aaps.core.data.time.T
+import app.aaps.core.interfaces.configuration.ConfigBuilder
 import app.aaps.core.interfaces.constraints.Objectives
 import app.aaps.core.interfaces.db.PersistenceLayer
 import app.aaps.core.interfaces.maintenance.FileListProvider
@@ -151,6 +152,7 @@ fun NavGraphBuilder.appNavGraph(
     preferences: Preferences,
     rh: ResourceHelper,
     builtInSearchables: BuiltInSearchables,
+    configBuilder: ConfigBuilder,
     prefFileList: FileListProvider,
     persistenceLayer: PersistenceLayer,
     visibilityContext: VisibilityContext,
@@ -495,6 +497,7 @@ fun NavGraphBuilder.appNavGraph(
             activePlugin = activePlugin,
             rh = rh,
             builtInSearchables = builtInSearchables,
+            configBuilder = configBuilder,
             onBackClick = { navController.safePopBackStack() }
         )
     }

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveDoublePreference.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveDoublePreference.kt
@@ -5,15 +5,12 @@
 package app.aaps.core.ui.compose.preference
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import app.aaps.core.keys.decimalPlaces
 import app.aaps.core.keys.interfaces.DoublePreferenceKey
 import app.aaps.core.keys.interfaces.VisibilityContext
@@ -83,16 +80,14 @@ fun AdaptiveDoublePreferenceItem(
                 .fillMaxWidth()
                 .padding(theme.padding)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = stringResource(effectiveTitleResId),
-                    style = theme.titleTextStyle,
-                    // Mirror Preference's disabled styling (the switch row greys the same way) since this
-                    // slider branch builds its own row instead of going through Preference.
-                    color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
-                )
-                SyncBadge(doubleKey, Modifier.padding(start = 6.dp))
-            }
+            TextWithSyncBadge(
+                text = stringResource(effectiveTitleResId),
+                key = doubleKey,
+                style = theme.titleTextStyle,
+                // Mirror Preference's disabled styling (the switch row greys the same way) since this
+                // slider branch builds its own row instead of going through Preference.
+                color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
+            )
             if (summary != null) {
                 Text(
                     text = summary,

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveIntPreference.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveIntPreference.kt
@@ -5,15 +5,12 @@
 package app.aaps.core.ui.compose.preference
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import app.aaps.core.keys.interfaces.IntPreferenceKey
 import app.aaps.core.keys.interfaces.VisibilityContext
 import app.aaps.core.keys.rangeResId
@@ -75,16 +72,14 @@ fun AdaptiveIntPreferenceItem(
                 .fillMaxWidth()
                 .padding(theme.padding)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = stringResource(effectiveTitleResId),
-                    style = theme.titleTextStyle,
-                    // Mirror Preference's disabled styling (the switch row greys the same way) since this
-                    // slider branch builds its own row instead of going through Preference.
-                    color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
-                )
-                SyncBadge(intKey, Modifier.padding(start = 6.dp))
-            }
+            TextWithSyncBadge(
+                text = stringResource(effectiveTitleResId),
+                key = intKey,
+                style = theme.titleTextStyle,
+                // Mirror Preference's disabled styling (the switch row greys the same way) since this
+                // slider branch builds its own row instead of going through Preference.
+                color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
+            )
             if (summary != null) {
                 Text(
                     text = summary,

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveUnitDoublePreference.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/AdaptiveUnitDoublePreference.kt
@@ -5,15 +5,12 @@
 package app.aaps.core.ui.compose.preference
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import app.aaps.core.keys.interfaces.VisibilityContext
 import app.aaps.core.keys.interfaces.UnitDoublePreferenceKey
 import app.aaps.core.ui.compose.LocalPreferences
@@ -81,16 +78,14 @@ fun AdaptiveUnitDoublePreferenceItem(
             .fillMaxWidth()
             .padding(theme.padding)
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(effectiveTitleResId),
-                style = theme.titleTextStyle,
-                // Mirror Preference's disabled styling (the switch row greys the same way) since this
-                // slider branch builds its own row instead of going through Preference.
-                color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
-            )
-            SyncBadge(unitKey, Modifier.padding(start = 6.dp))
-        }
+        TextWithSyncBadge(
+            text = stringResource(effectiveTitleResId),
+            key = unitKey,
+            style = theme.titleTextStyle,
+            // Mirror Preference's disabled styling (the switch row greys the same way) since this
+            // slider branch builds its own row instead of going through Preference.
+            color = theme.titleColor.let { if (visibility.enabled) it else it.copy(alpha = theme.disabledOpacity) }
+        )
         if (summary != null) {
             Text(
                 text = summary,

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/PreferenceContentExtensions.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/PreferenceContentExtensions.kt
@@ -2,7 +2,9 @@ package app.aaps.core.ui.compose.preference
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +25,7 @@ import app.aaps.core.keys.interfaces.IntentPreferenceKey
 import app.aaps.core.keys.interfaces.LongPreferenceKey
 import app.aaps.core.keys.interfaces.PreferenceKey
 import app.aaps.core.keys.interfaces.VisibilityContext
+import app.aaps.core.ui.compose.rememberBringIntoViewOnExpand
 import kotlinx.coroutines.delay
 
 /**
@@ -181,10 +184,14 @@ private fun shouldShowSubScreenInline(
     return true
 }
 
+/** How long a search-highlighted preference stays tinted before fading out. */
+private const val HIGHLIGHT_DURATION_MS = 5000L
+
 /**
  * Wrapper that highlights a preference if it matches the LocalHighlightKey.
- * Shows a brief color flash animation to draw attention to the preference.
+ * Scrolls the preference into view, then shows a color flash animation to draw attention to it.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HighlightablePreference(
     preferenceKey: String,
@@ -195,11 +202,15 @@ private fun HighlightablePreference(
 
     var isHighlighted by remember { mutableStateOf(shouldHighlight) }
 
+    // The whole screen renders as one LazyColumn item, so index-based scrolling can't reach the
+    // row — bring it into view through the nearest scrollable ancestor instead.
+    val bringIntoViewRequester = rememberBringIntoViewOnExpand(shouldHighlight)
+
     // Animate highlight fade out
     LaunchedEffect(shouldHighlight) {
         if (shouldHighlight) {
             isHighlighted = true
-            delay(2000) // Keep highlight for 2 seconds
+            delay(HIGHLIGHT_DURATION_MS)
             isHighlighted = false
         }
     }
@@ -217,6 +228,7 @@ private fun HighlightablePreference(
     Box(
         modifier = Modifier
             .fillMaxWidth()
+            .bringIntoViewRequester(bringIntoViewRequester)
             .background(highlightColor)
     ) {
         content()

--- a/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/SyncBadge.kt
+++ b/core/ui/src/main/kotlin/app/aaps/core/ui/compose/preference/SyncBadge.kt
@@ -1,18 +1,25 @@
 package app.aaps.core.ui.compose.preference
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PhonelinkRing
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import app.aaps.core.keys.interfaces.NonPreferenceKey
 import app.aaps.core.keys.interfaces.SyncDirection
 import app.aaps.core.ui.R
@@ -21,9 +28,10 @@ import app.aaps.core.ui.compose.LocalConfig
 /**
  * Small badge marking something that two-way syncs with the master ("main phone").
  *
- * The raw marker — renders nothing when [visible] is false, so it's safe to drop anywhere. Use the
- * [SyncBadge] key overload for preference titles (it computes visibility from the key); pass an explicit
- * flag here for callers that already know (e.g. a synced Configuration category).
+ * The raw marker — renders nothing when [visible] is false, so it's safe to drop anywhere. Use
+ * [TextWithSyncBadge]/[PreferenceTitleWithSyncBadge] for preference titles (they compute visibility
+ * from the key and keep the badge inline with wrapped text); pass an explicit flag here for callers
+ * that already know (e.g. a synced Configuration category).
  */
 @Composable
 fun SyncBadge(visible: Boolean, modifier: Modifier = Modifier) {
@@ -38,25 +46,56 @@ fun SyncBadge(visible: Boolean, modifier: Modifier = Modifier) {
     )
 }
 
-/**
- * Preference-title overload: shown ONLY on a client (AAPSCLIENT) and ONLY for keys declared
- * [SyncDirection.Bidirectional] (read from the key's [NonPreferenceKey.sync] — the single source of truth).
- */
+/** Badge visibility for [key]: shown ONLY on a client (AAPSCLIENT) and ONLY for keys declared
+ *  [SyncDirection.Bidirectional] (read from the key's [NonPreferenceKey.sync] — the single source of truth). */
 @Composable
-fun SyncBadge(key: NonPreferenceKey?, modifier: Modifier = Modifier) =
-    SyncBadge(
-        visible = LocalConfig.current.AAPSCLIENT && key?.sync?.direction == SyncDirection.Bidirectional,
-        modifier = modifier
-    )
+private fun syncBadgeVisible(key: NonPreferenceKey?): Boolean =
+    LocalConfig.current.AAPSCLIENT && key?.sync?.direction == SyncDirection.Bidirectional
 
 /**
- * Preference title text with a trailing [SyncBadge]. Drop-in replacement for `Text(stringResource(id))`
- * in an `Adaptive*PreferenceItem` title slot; the badge only appears on a client for Bidirectional keys.
+ * Text with a trailing [SyncBadge] rendered as inline text content: on a wrapped title the badge
+ * flows right after the last word (on the last line) instead of being pushed to the far end of the
+ * row. Renders a plain [Text] when the badge is not visible.
  */
 @Composable
-fun PreferenceTitleWithSyncBadge(titleResId: Int, key: NonPreferenceKey?) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(stringResource(titleResId))
-        SyncBadge(key, Modifier.padding(start = 6.dp))
+fun TextWithSyncBadge(
+    text: String,
+    key: NonPreferenceKey?,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified
+) {
+    if (!syncBadgeVisible(key)) {
+        Text(text = text, modifier = modifier, style = style, color = color)
+        return
     }
+    val badgeId = "syncBadge"
+    val annotated = buildAnnotatedString {
+        append(text)
+        append(' ')
+        appendInlineContent(badgeId, alternateText = " ")
+    }
+    val inlineContent = mapOf(
+        badgeId to InlineTextContent(
+            // Sized relative to the font so the badge scales with the title (~14dp at default title size)
+            Placeholder(width = 0.9.em, height = 0.9.em, placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter)
+        ) {
+            Icon(
+                imageVector = Icons.Default.PhonelinkRing,
+                contentDescription = stringResource(R.string.pref_syncs_with_main_phone),
+                modifier = Modifier.fillMaxSize(),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+    )
+    Text(text = annotated, inlineContent = inlineContent, modifier = modifier, style = style, color = color)
 }
+
+/**
+ * Preference title text with a trailing inline [SyncBadge]. Drop-in replacement for
+ * `Text(stringResource(id))` in an `Adaptive*PreferenceItem` title slot; the badge only appears
+ * on a client for Bidirectional keys.
+ */
+@Composable
+fun PreferenceTitleWithSyncBadge(titleResId: Int, key: NonPreferenceKey?) =
+    TextWithSyncBadge(stringResource(titleResId), key)

--- a/ui/src/main/kotlin/app/aaps/ui/compose/preferences/AllPreferencesScreen.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/preferences/AllPreferencesScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import app.aaps.core.data.plugin.PluginType
 import app.aaps.core.interfaces.autotune.Autotune
+import app.aaps.core.interfaces.configuration.ConfigBuilder
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.plugin.PluginBase
 import app.aaps.core.interfaces.resources.ResourceHelper
@@ -60,6 +61,7 @@ fun AllPreferencesScreen(
     activePlugin: ActivePlugin,
     rh: ResourceHelper,
     builtInSearchables: BuiltInSearchables,
+    configBuilder: ConfigBuilder,
     onBackClick: () -> Unit
 ) {
     val preferences = LocalPreferences.current
@@ -97,16 +99,21 @@ fun AllPreferencesScreen(
         // 2. Safety plugin (always enabled)
         getPreferenceContentIfEnabled(activePlugin.activeSafety as PluginBase)?.let { add(it) }
 
-        // 3. BG Source plugin
-        getPreferenceContentIfEnabled(activePlugin.activeBgSource as PluginBase)?.let { add(it) }
+        // 3. BG Source plugin — master only: on a client the collector runs on the master and can't
+        // be changed or configured locally (mirrors the Configuration screen's category gate)
+        if (!config.AAPSCLIENT) {
+            getPreferenceContentIfEnabled(activePlugin.activeBgSource as PluginBase)?.let { add(it) }
+        }
 
         // 4. LOOP type plugins (enabled only if APS is configured)
         activePlugin.getSpecificPluginsList(PluginType.LOOP).forEach { plugin ->
             getPreferenceContentIfEnabled(plugin, config.APS)?.let { add(it) }
         }
 
-        // 5. APS plugin (enabled only if APS is configured)
-        (activePlugin.activeAPS as? PluginBase)?.let { getPreferenceContentIfEnabled(it, config.APS)?.let { pref -> add(pref) } }
+        // 5. APS plugin — on a master when APS is configured; also on a client when the APS selection
+        // syncs (its settings are Bidirectional-synced, so they are editable from the client)
+        val apsAvailable = config.APS || (config.AAPSCLIENT && PluginType.APS in configBuilder.syncedSelectionTypes)
+        (activePlugin.activeAPS as? PluginBase)?.let { getPreferenceContentIfEnabled(it, apsAvailable)?.let { pref -> add(pref) } }
 
         // 6. Sensitivity plugin
         getPreferenceContentIfEnabled(activePlugin.activeSensitivity as PluginBase)?.let { add(it) }

--- a/ui/src/main/kotlin/app/aaps/ui/search/SearchIndexBuilder.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/search/SearchIndexBuilder.kt
@@ -1,5 +1,6 @@
 package app.aaps.ui.search
 
+import app.aaps.core.data.plugin.PluginType
 import app.aaps.core.interfaces.plugin.ActivePlugin
 import app.aaps.core.interfaces.plugin.PluginBase
 import app.aaps.core.interfaces.resources.ResourceHelper
@@ -152,12 +153,30 @@ class SearchIndexBuilder @Inject constructor(
     }
 
     /**
-     * A plugin (and therefore its settings screen/category and individual preference keys) is searchable only
-     * when it's visible in its list. E.g. VirtualPump's showInList is `{ !config.AAPSCLIENT }`, so on a client it
-     * and all its settings drop out of search — the values come from the master and aren't editable locally.
+     * On a client the whole BG source category is hidden from Configuration — the collector runs on
+     * the master and can't be changed or configured locally — so BG source plugins, their settings
+     * screens and their keys stay out of search there too (mirrors ConfigurationViewModel's gate).
+     */
+    private fun PluginBase.categoryAvailable(): Boolean =
+        !(preferences.nsclientMode && pluginDescription.mainType == PluginType.BGSOURCE)
+
+    /**
+     * A plugin appears as a plugin row in search only when it's visible in its list, mirroring the
+     * Config Builder. E.g. VirtualPump's showInList is `{ !config.AAPSCLIENT }`, so on a client its
+     * row drops out of search.
      */
     private fun PluginBase.isListVisible(): Boolean =
-        showInList(pluginDescription.mainType) && pluginDescription.pluginName != -1
+        categoryAvailable() && showInList(pluginDescription.mainType) && pluginDescription.pluginName != -1
+
+    /**
+     * A plugin's settings (screen/category and individual preference keys) are searchable when the
+     * plugin is list-visible or permanently enabled. alwaysEnabled plugins (e.g. Safety) are hidden
+     * from the Config Builder list only because they cannot be toggled — their settings are still
+     * user-facing and shown in Preferences. VirtualPump on a client is hidden and not alwaysEnabled,
+     * so its settings stay out of search — the values come from the master and aren't editable locally.
+     */
+    private fun PluginBase.hasSearchableSettings(): Boolean =
+        categoryAvailable() && (showInList(pluginDescription.mainType) || pluginDescription.alwaysEnabled) && pluginDescription.pluginName != -1
 
     private fun collectPlugins(entries: MutableList<SearchIndexEntry>, seenKeys: MutableSet<String>) {
         activePlugin.getPluginsList()
@@ -174,8 +193,7 @@ class SearchIndexBuilder @Inject constructor(
 
     private fun collectPluginScreens(entries: MutableList<SearchIndexEntry>, seenKeys: MutableSet<String>) {
         activePlugin.getPluginsList()
-            // A plugin hidden from its list must not surface its settings screen/category in search either.
-            .filter { it.isListVisible() }
+            .filter { it.hasSearchableSettings() }
             .forEach { plugin ->
                 val content = plugin.getPreferenceScreenContent()
                 if (content is PreferenceSubScreenDef) {
@@ -226,10 +244,10 @@ class SearchIndexBuilder @Inject constructor(
             if (preferences.pumpControlMode && !prefKey.showInPumpControlMode) return@forEach
 
             val parentInfo = parentScreenMap[prefKey.key]
-            // Skip keys whose owning plugin is hidden from its list (e.g. VirtualPump on a client — its values
-            // come from the master, so its settings must not be searchable). Keys with no owning plugin pass.
+            // Skip keys whose owning plugin has no searchable settings (e.g. VirtualPump on a client — its
+            // values come from the master, so they must not be searchable). Keys with no owning plugin pass.
             val ownerPlugin = parentInfo?.plugin
-            if (ownerPlugin != null && !ownerPlugin.isListVisible()) return@forEach
+            if (ownerPlugin != null && !ownerPlugin.hasSearchableSettings()) return@forEach
             val item = SearchableItem.Preference(prefKey, parentInfo?.key, parentInfo?.plugin)
             val entry = createIndexEntry(item)
             val uniqueKey = "${entry.category.name}_${entry.item.key}"
@@ -270,7 +288,14 @@ class SearchIndexBuilder @Inject constructor(
     ) {
         screen.items.forEach { item ->
             when (item) {
-                is PreferenceKey          -> map[item.key] = ParentScreenInfo(screenKey, plugin)
+                is PreferenceKey          -> {
+                    // Shared keys sit on several plugins' screens (e.g. ApsUseAutosens on SMB/AMA/AutoISF).
+                    // Prefer an enabled plugin as owner so search doesn't dim the setting as belonging to a
+                    // disabled one and navigates to the screen that is actually in use.
+                    val existing = map[item.key]
+                    if (existing == null || (plugin?.isEnabled() == true && existing.plugin?.isEnabled() != true))
+                        map[item.key] = ParentScreenInfo(screenKey, plugin)
+                }
 
                 is PreferenceSubScreenDef -> collectPreferenceKeysFromScreen(item, item.key, plugin, map)
 


### PR DESCRIPTION
Collection of settings search and settings menu fixes/improvements:

**Search**
- Preference keys shared by several plugin screens (e.g. `ApsUseAutosens` on SMB/AMA/AutoISF) were always attributed to the last registered plugin, so results showed dimmed as "Plugin Auto ISF disabled" and navigated to the wrong screen. Search now prefers the enabled plugin as owner.
- Tapping a search result now scrolls the preference into view (the whole screen is a single lazy item, so the highlight could sit below the fold and fade unseen). Highlight duration raised from 2 s to 5 s.
- Safety plugin settings (Patient age, Max bolus, Max carbs allowed) were excluded from search because the plugin is hidden from the Config Builder list. Settings of `alwaysEnabled` plugins are now searchable; VirtualPump on a client stays excluded as intended.

**Client (AAPSCLIENT)**
- BG source settings are no longer shown in the settings menu or search — the collector runs on the master and can't be changed or configured locally (mirrors the Configuration screen's category gate).
- Selected APS settings now appear in the settings menu — they are Bidirectional-synced and editable from the client (same SSOT gate as the Configuration screen, `configBuilder.syncedSelectionTypes`).
- Sync badge disappeared when a preference title wrapped to multiple lines. It's now rendered as inline text content: always visible, placed right after the last word, and scales with the title font.

Tests pass (`:ui:test`, `:core:ui:test`).

**Some screenshots to illustrate before / after.**
| Before | After |
|--------|--------|
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/201d28e8-1c8c-4865-a7cd-49590f52f91b" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/14178874-8437-41dc-bda9-a7ea1a00732a" /> |
| Before (using SMB alg) | After (Using SMB alg) |
| <img width="583" height="1229" alt="image" src="https://github.com/user-attachments/assets/22164252-656e-4f7a-9714-027abd9b8697" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/2e515a20-7d35-4132-986e-2e01ef35452c" /> |
| Before (Client) | After (Client) |
|<img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/1d50e733-ef16-4344-bf56-b78777b65d1a" />|<img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/32cb59a1-2125-45fa-bbde-3ff88f79026f" /> | 