### PR TITLE
Show autosens ratio used in algorithm on AAPSClient

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/compose/overview/chips/ChipsViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/overview/chips/ChipsViewModel.kt
@@ -157,7 +157,10 @@ class ChipsViewModel @AssistedInject constructor(
             if (config.APS) request?.variableSens ?: 0.0
             else if (config.AAPSCLIENT) processedDeviceStatusData.getAPSResult()?.variableSens ?: 0.0
             else 0.0
-        val ratioUsed = request?.autosensResult?.ratio ?: 1.0
+        val ratioUsed =
+            if (config.APS) request?.autosensResult?.ratio ?: 1.0
+            else if (config.AAPSCLIENT) processedDeviceStatusData.openAPSData.suggested?.sensitivityRatio ?: 1.0
+            else 1.0
         val units = profileFunction.getUnits()
 
         var asText = ""


### PR DESCRIPTION
My proposal to fix https://github.com/nightscout/AndroidAPS/issues/3815

Tested ok on AAPSClient

| Before | After |
|--------|--------|
| <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/bb90ae89-cc9f-4a64-8b8e-5247648f4044" /> | <img width="503" height="1229" alt="image" src="https://github.com/user-attachments/assets/d958ac5a-af11-417f-8a7f-6691830cebbb" /> | 