### PR TITLE
Add Loop plugin to QuickLaunch plugin list

### DIFF
--- a/ui/src/main/kotlin/app/aaps/ui/compose/quickLaunch/QuickLaunchConfigViewModel.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/compose/quickLaunch/QuickLaunchConfigViewModel.kt
@@ -178,7 +178,7 @@ class QuickLaunchConfigViewModel @Inject constructor(
 
     private fun buildPluginGroups(selectedSet: Set<String>): List<PluginGroup> {
         val typeOrder = listOf(
-            PluginType.PUMP, PluginType.BGSOURCE, PluginType.APS,
+            PluginType.PUMP, PluginType.BGSOURCE, PluginType.APS, PluginType.LOOP,
             PluginType.SENSITIVITY, PluginType.SMOOTHING, PluginType.CALIBRATION,
             PluginType.CONSTRAINTS,
             PluginType.SYNC, PluginType.GENERAL


### PR DESCRIPTION
Loop plugin is a feature I use from time to time to manually execute loop so it would be nice to have it in QuickLaunch - if it is left out intentionally you can close this PR.