### PR TITLE
Carelevo Retry additional priming via dedicated BLE session timeout path

### DIFF
--- a/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/ble/CarelevoBleSession.kt
+++ b/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/ble/CarelevoBleSession.kt
@@ -3,6 +3,7 @@ package app.aaps.pump.carelevo.ble
 import app.aaps.core.interfaces.logging.AAPSLogger
 import app.aaps.core.interfaces.logging.LTag
 import app.aaps.pump.carelevo.ble.commands.AlertAlarmSetCommand
+import app.aaps.pump.carelevo.ble.commands.AdditionalPrimingCommand
 import app.aaps.pump.carelevo.ble.commands.AppAuthCommand
 import app.aaps.pump.carelevo.ble.commands.BasalProgramCommand
 import app.aaps.pump.carelevo.ble.commands.InfusionInfoCommand
@@ -12,6 +13,7 @@ import app.aaps.pump.carelevo.ble.commands.PatchInfoResponse
 import app.aaps.pump.carelevo.ble.commands.SafetyCheckCommand
 import app.aaps.pump.carelevo.ble.commands.SafetyCheckResponse
 import app.aaps.pump.carelevo.ble.commands.SetTimeForPatchInfoCommand
+import app.aaps.pump.carelevo.ble.commands.SimpleResultResponse
 import app.aaps.pump.carelevo.ble.commands.ThresholdSetupCommand
 import app.aaps.pump.carelevo.ble.gatt.BleTransportGattConnection
 import app.aaps.pump.carelevo.ble.gatt.GattConnState
@@ -146,6 +148,10 @@ class CarelevoBleSession @Inject constructor(
     /** Run any single-response [command] (write or read) on a fresh session. */
     suspend fun <R : BleResponse> runSingle(address: String, command: BleCommand<R>, timeoutMs: Long = READ_TIMEOUT_MS): R =
         withSession(address, command::class.simpleName ?: "command", timeoutMs) { it.request(command) }
+
+    /** Additional priming (0x1D -> 0x7D) may take longer than a normal single write. */
+    suspend fun runAdditionalPriming(address: String): SimpleResultResponse =
+        withSession(address, "additional priming", ADDITIONAL_PRIMING_TIMEOUT_MS) { it.request(AdditionalPrimingCommand()) }
 
     /**
      * Run the streaming Safety Check (0x12 → 0x72). [onFrame] is invoked for every decoded frame (each
@@ -485,6 +491,7 @@ class CarelevoBleSession @Inject constructor(
 
         const val CONNECT_TIMEOUT_MS = 20_000L
         const val READ_TIMEOUT_MS = 15_000L
+        const val ADDITIONAL_PRIMING_TIMEOUT_MS = 60_000L
 
         // Safety check streams progress for ~100-210 s before the terminal frame; give it headroom.
         const val SAFETY_CHECK_TIMEOUT_MS = 250_000L

--- a/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/command/CarelevoActivationExecutor.kt
+++ b/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/command/CarelevoActivationExecutor.kt
@@ -86,7 +86,7 @@ class CarelevoActivationExecutor @Inject constructor(
         is CmdSafetyCheck            -> runSafetyCheck()
         is CmdNeedleCheck            -> runNeedleCheck()
         is CmdSetBasal               -> runSetBasal()
-        is CmdAdditionalPriming      -> runSingleWrite("additionalPriming") { AdditionalPrimingCommand() }
+        is CmdAdditionalPriming      -> runAdditionalPriming()
         is CmdDiscard                -> runDiscard()
         is CmdPumpStop               -> runPumpStop(command.durationMin)
         is CmdPumpResume             -> runPumpResume()
@@ -292,6 +292,23 @@ class CarelevoActivationExecutor @Inject constructor(
             result.success(success).enacted(success)
         } catch (e: Exception) {
             aapsLogger.error(LTag.PUMPCOMM, "ble.$label FAILED", e)
+            result.success(false).enacted(false).comment(e.message ?: "error")
+        }
+    }
+
+    private fun runAdditionalPriming(): PumpEnactResult {
+        val result = pumpEnactResultProvider.get()
+        val address = carelevoPatch.getPatchInfoAddress()
+            ?: return result.success(false).enacted(false).comment("no patch address")
+        return try {
+            val response = runBlocking {
+                bleSession.runAdditionalPriming(address)
+            }
+            val success = response.resultCode == RESULT_SUCCESS
+            aapsLogger.info(LTag.PUMPCOMM, "ble.additionalPriming OK result=${response.resultCode}")
+            result.success(success).enacted(success)
+        } catch (e: Exception) {
+            aapsLogger.error(LTag.PUMPCOMM, "ble.additionalPriming FAILED", e)
             result.success(false).enacted(false).comment(e.message ?: "error")
         }
     }

--- a/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/presentation/viewmodel/CarelevoPatchSafetyCheckViewModel.kt
+++ b/pump/carelevo/src/main/kotlin/app/aaps/pump/carelevo/presentation/viewmodel/CarelevoPatchSafetyCheckViewModel.kt
@@ -228,7 +228,7 @@ class CarelevoPatchSafetyCheckViewModel @Inject constructor(
             setUiState(UiState.Idle)
             if (!result.success) {
                 aapsLogger.error(LTag.PUMPCOMM, "additional priming failed")
-                triggerEvent(CarelevoConnectSafetyCheckEvent.DiscardFailed)
+                triggerEvent(CarelevoConnectSafetyCheckEvent.SafetyCheckFailed)
             }
         }
     }

--- a/pump/carelevo/src/test/kotlin/app/aaps/pump/carelevo/command/CarelevoActivationExecutorTest.kt
+++ b/pump/carelevo/src/test/kotlin/app/aaps/pump/carelevo/command/CarelevoActivationExecutorTest.kt
@@ -41,6 +41,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.Optional
@@ -112,9 +113,17 @@ internal class CarelevoActivationExecutorTest {
         whenever { bleSession.runSingle<BleResponse>(any(), any(), any()) }.thenReturn(response)
     }
 
+    private fun stubAdditionalPriming(response: SimpleResultResponse) {
+        whenever { bleSession.runAdditionalPriming(any()) }.thenReturn(response)
+    }
+
     /** Make the (suspend) generic [CarelevoBleSession.runSingle] throw. */
     private fun stubRunSingleThrows(message: String = BOOM) {
         whenever { bleSession.runSingle<BleResponse>(any(), any(), any()) }.thenAnswer { throw RuntimeException(message) }
+    }
+
+    private fun stubAdditionalPrimingThrows(message: String = BOOM) {
+        whenever { bleSession.runAdditionalPriming(any()) }.thenAnswer { throw RuntimeException(message) }
     }
 
     /** Drive the streaming safety check: feed [frames] to the executor's onFrame callback. */
@@ -523,20 +532,28 @@ internal class CarelevoActivationExecutorTest {
     }
 
     @Test fun `additionalPriming success when accepted`() {
-        stubRunSingle(SimpleResultResponse(resultCode = 0))
+        stubAdditionalPriming(SimpleResultResponse(resultCode = 0))
         val result = sut.execute(CmdAdditionalPriming())
         assertThat(result?.success).isTrue()
         assertThat(result?.enacted).isTrue()
     }
 
+    @Test fun `additionalPriming uses dedicated ble session path`() {
+        stubAdditionalPriming(SimpleResultResponse(resultCode = 0))
+
+        sut.execute(CmdAdditionalPriming())
+
+        verifyBlocking(bleSession) { runAdditionalPriming(any()) }
+    }
+
     @Test fun `additionalPriming fails when rejected`() {
-        stubRunSingle(SimpleResultResponse(resultCode = 7))
+        stubAdditionalPriming(SimpleResultResponse(resultCode = 7))
         val result = sut.execute(CmdAdditionalPriming())
         assertThat(result?.success).isFalse()
     }
 
     @Test fun `additionalPriming returns failed result on exception`() {
-        stubRunSingleThrows()
+        stubAdditionalPrimingThrows()
         val result = sut.execute(CmdAdditionalPriming())
         assertThat(result?.success).isFalse()
         assertThat(result?.comment).isEqualTo(BOOM)


### PR DESCRIPTION
## Summary

This PR addresses the safety check retry issue discussed in the related issue.

When retry is triggered from the safety check flow, additional priming could time out on the generic single-command path. This PR moves additional priming to a dedicated BLE session timeout path so the retry flow can complete more reliably.

It also fixes the retry failure message so a safety check retry failure is no longer reported as a discard / patch termination failure.

## Changes

- use a dedicated BLE session timeout path for additional priming
- route safety check retry additional priming through that dedicated path
- show the correct safety check retry failure message instead of the discard failure message

## Related issue

- fixes the safety check retry / additional priming timeout issue
- fixes the incorrect failure message shown after retry failure