### PR TITLE
Wear: Watch Face Push - install watchface automatically

### DIFF
--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/MainMenuActivity.kt
@@ -54,12 +54,6 @@ class MainMenuActivity : MenuListActivity() {
 
     override fun provideElements(): List<MenuItem> =
         ArrayList<MenuItem>().apply {
-            // Top of the menu: only present on Wear OS 6+ (where CWF and the other code-based
-            // faces cannot run) and only while the pushed face is not installed. While an install
-            // runs the label switches to an inert "Installing…" so the tap is visibly acknowledged
-            // (install can take a few seconds and a silent wait provokes second taps)
-            if (watchFacePushHelper.isSupported() && !sp.getBoolean(WatchFacePushHelper.KEY_FACE_INSTALLED, false))
-                add(MenuItem(R.drawable.watchface_aapsv4, getString(if (installing) R.string.menu_installing_watchface else R.string.menu_install_watchface)))
             if (!preferences.get(BooleanKey.WearControl)) {
                 add(MenuItem(R.drawable.ic_settings, getString(R.string.menu_settings)))
                 add(MenuItem(R.drawable.ic_sync, getString(R.string.menu_resync)))
@@ -77,6 +71,14 @@ class MainMenuActivity : MenuListActivity() {
                 if (sp.getBoolean(R.string.key_prime_fill, false))
                     add(MenuItem(R.drawable.ic_canula, getString(R.string.menu_prime_fill)))
             }
+            // Bottom of the menu: only present on Wear OS 6+ (where CWF and the other code-based
+            // faces cannot run) and only while the pushed face is not installed. Since each app
+            // install/update pushes the face automatically, this is the recovery action for a
+            // user who removed the face and wants it back before the next app update. While an
+            // install runs the label switches to an inert "Installing…" so the tap is visibly
+            // acknowledged (install can take a few seconds and a silent wait provokes second taps)
+            if (watchFacePushHelper.isSupported() && !sp.getBoolean(WatchFacePushHelper.KEY_FACE_INSTALLED, false))
+                add(MenuItem(R.drawable.watchface_aapsv4, getString(if (installing) R.string.menu_installing_watchface else R.string.menu_install_watchface)))
         }
 
     override fun doAction(position: String) {

--- a/wear/src/main/kotlin/app/aaps/wear/watchfaces/WatchFacePushHelper.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/watchfaces/WatchFacePushHelper.kt
@@ -76,17 +76,21 @@ class WatchFacePushHelper @Inject constructor(
     }
 
     /**
-     * Called on app start: keeps an already installed face in sync with the app version by
-     * pushing the embedded APK again after an app update. Never installs uninvited — the initial
-     * install is user-triggered from the main menu.
+     * Called on app start: makes sure the embedded face is available in the watch face picker.
+     * Each app install/update pushes the face once — the same contract as the code-based
+     * watchfaces, which always ship with the app. A face the user removed stays removed until a
+     * reinstall from the main menu or the next app update. Never activates the face: selecting it
+     * is always the user's choice (picker, or the main menu entry).
      */
     suspend fun syncOnStartup() {
-        // Both callees catch all their failures internally — this path runs on every app start
-        // and must never take the app down
-        if (isFaceInstalled() && sp.getString(KEY_SYNCED_VERSION, "") != BuildConfig.BUILDVERSION) {
-            aapsLogger.debug(LTag.WEAR, "WatchFacePush: app updated, refreshing installed face")
-            installOrUpdate()
-        }
+        if (!isSupported()) return
+        // KEY_SYNCED_VERSION matching means this exact app build already put the face in place
+        // once — if the face is missing now, the user removed it: respect that
+        if (sp.getString(KEY_SYNCED_VERSION, "") == BuildConfig.BUILDVERSION) return
+        aapsLogger.debug(LTag.WEAR, "WatchFacePush: syncing face for app version ${BuildConfig.BUILDVERSION}")
+        // Catches all its failures internally — this path runs on app start and must never take
+        // the app down; on failure the version is not marked synced, so the next start retries
+        installOrUpdate()
     }
 
     /**


### PR DESCRIPTION
Follow-up to #5022 after feedback from @Philoul 

- The embedded WFF watchface is installed automatically with each app install/update (Wear OS 6+), so it appears in the watch face picker without any user action — same behavior users know from the code-based watchfaces.
- A face the user removed stays removed: it only comes back via the menu button or the next app update (if BUILDVERSION has changed) / reinstall.
- The face is never set as active automatically — selecting it remains the user's choice.
- "Install watchface" menu entry moved to the bottom of the main menu; with auto-install it's now just a recovery shortcut after removing the face.

Tested on GW4/GW5 wear os 6 watch: fresh install, removal persistence across restarts, reinstall via menu, and app update all work.