### PR TITLE
Wear: bound negative carb entry to COB and show carb removals on BG graph

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -372,7 +372,9 @@ sealed class EventData : Event() {
         val tempTargetDuration: Long = -1L,
         val reservoirString: String,
         val reservoir: Double,
-        val reservoirLevel: Int
+        val reservoirLevel: Int,
+        // Numeric COB in grams for input bounds on the watch; -1.0 = unknown (older sender or no data)
+        val cobValue: Double = -1.0
     ) : EventData(), EventDataSet
 
     @Serializable

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -1299,6 +1299,7 @@ class DataHandlerMobile @Inject constructor(
         var iobSum = ""
         var iobDetail = ""
         var cobString = ""
+        var cobValue = -1.0
         var currentBasal = ""
         var bgiString = ""
         if (config.appInitialized && profile != null) {
@@ -1306,7 +1307,9 @@ class DataHandlerMobile @Inject constructor(
             val basalIob = iobCobCalculator.calculateIobFromTempBasalsIncludingConvertedExtended().round()
             iobSum = decimalFormatter.to2Decimal(bolusIob.iob + basalIob.basaliob)
             iobDetail = "(${decimalFormatter.to2Decimal(bolusIob.iob)}|${decimalFormatter.to2Decimal(basalIob.basaliob)})"
-            cobString = iobCobCalculator.getCobInfo("WatcherUpdaterService").generateCOBString(decimalFormatter)
+            val cobInfo = iobCobCalculator.getCobInfo("WatcherUpdaterService")
+            cobString = cobInfo.generateCOBString(decimalFormatter)
+            cobValue = cobInfo.displayCob ?: -1.0
             currentBasal =
                 processedTbrEbData.getTempBasalIncludingConvertedExtended(System.currentTimeMillis())?.toStringShort(rh) ?: rh.gs(app.aaps.core.ui.R.string.pump_base_basal_rate, profile.getBasal())
 
@@ -1374,6 +1377,7 @@ class DataHandlerMobile @Inject constructor(
                 iobSum = iobSum,
                 iobDetail = iobDetail,
                 cob = cobString,
+                cobValue = cobValue,
                 currentBasal = currentBasal,
                 battery = phoneBattery.toString(),
                 rigBattery = rigBattery,

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/CarbActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +44,8 @@ import app.aaps.core.interfaces.sharedPreferences.SP
 import app.aaps.core.keys.IntKey
 import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.wear.R
+import app.aaps.wear.data.ComplicationData
+import app.aaps.wear.data.ComplicationDataRepository
 import dagger.android.support.DaggerAppCompatActivity
 import java.text.DecimalFormat
 import javax.inject.Inject
@@ -52,6 +55,7 @@ class CarbActivity : DaggerAppCompatActivity() {
     @Inject lateinit var rxBus: RxBus
     @Inject lateinit var preferences: Preferences
     @Inject lateinit var sp: SP
+    @Inject lateinit var complicationDataRepository: ComplicationDataRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -65,6 +69,11 @@ class CarbActivity : DaggerAppCompatActivity() {
             MaterialTheme {
                 var carbs by remember { mutableStateOf(0.0) }
                 val pagerState = rememberPagerState(pageCount = { 2 })
+                // Mirror the phone Carbs dialog (issue #4637): a negative entry may remove at most the carbs
+                // currently on board, taken from the last Status pushed by the phone (unknown → 0, no removal).
+                // The master re-clamps on prepare, so a stale value here is only cosmetic.
+                val data by complicationDataRepository.complicationData.collectAsState(initial = ComplicationData())
+                val cobLimit = data.statusData.cobValue.toInt().coerceAtLeast(0)
 
                 Box(modifier = Modifier.fillMaxSize()) {
                     HorizontalPager(
@@ -74,11 +83,12 @@ class CarbActivity : DaggerAppCompatActivity() {
                             0 -> PlusMinusInputScreen(
                                 value = carbs,
                                 onValueChange = { carbs = it },
-                                min = -maxCarbs,
+                                min = -cobLimit.toDouble(),
                                 max = maxCarbs,
                                 stepValues = stepValues,
                                 format = DecimalFormat("0"),
                                 label = stringResource(R.string.action_carbs_gram),
+                                hint = if (carbs < 0) stringResource(R.string.carbs_removal_cob_limit, cobLimit) else null,
                                 allowZero = false,
                                 isActive = pagerState.currentPage == 0,
                                 enabled = !pagerState.isScrollInProgress,

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/PlusMinusInputScreen.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/PlusMinusInputScreen.kt
@@ -97,6 +97,7 @@ internal fun PlusMinusInputScreen(
     format: DecimalFormat,
     label: String,
     displayText: String? = null,
+    hint: String? = null,
     allowZero: Boolean = false,
     isActive: Boolean = true,
     symmetricLargeSteps: Boolean = false,
@@ -200,6 +201,14 @@ internal fun PlusMinusInputScreen(
                         fontSize = labelFontSize,
                         textAlign = TextAlign.Center,
                     )
+                    if (hint != null) {
+                        Text(
+                            text = hint,
+                            color = WearWarningAmber,
+                            fontSize = 10.sp,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                 }
                 StepButton(step = stepValues[0], isIncrement = true, onStep = ::step, enabled = enabled)
             }
@@ -219,6 +228,14 @@ internal fun PlusMinusInputScreen(
                     fontSize = labelFontSize,
                     textAlign = TextAlign.Center,
                 )
+                if (hint != null) {
+                    Text(
+                        text = hint,
+                        color = WearWarningAmber,
+                        fontSize = 10.sp,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
 
             // Bottom-left: decrement (fine step)

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/actions/TreatmentActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,8 @@ import app.aaps.core.keys.DoubleKey
 import app.aaps.core.keys.IntKey
 import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.wear.R
+import app.aaps.wear.data.ComplicationData
+import app.aaps.wear.data.ComplicationDataRepository
 import dagger.android.support.DaggerAppCompatActivity
 import java.text.DecimalFormat
 import javax.inject.Inject
@@ -54,6 +57,7 @@ class TreatmentActivity : DaggerAppCompatActivity() {
     @Inject lateinit var rxBus: RxBus
     @Inject lateinit var preferences: Preferences
     @Inject lateinit var sp: SP
+    @Inject lateinit var complicationDataRepository: ComplicationDataRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,6 +78,11 @@ class TreatmentActivity : DaggerAppCompatActivity() {
                 var insulin by remember { mutableStateOf(0.0) }
                 var carbs by remember { mutableStateOf(0.0) }
                 val pagerState = rememberPagerState(pageCount = { 3 })
+                // Mirror the phone Carbs dialog (issue #4637): a negative entry may remove at most the carbs
+                // currently on board, taken from the last Status pushed by the phone (unknown → 0, no removal).
+                // The master re-clamps on prepare, so a stale value here is only cosmetic.
+                val data by complicationDataRepository.complicationData.collectAsState(initial = ComplicationData())
+                val cobLimit = data.statusData.cobValue.toInt().coerceAtLeast(0)
 
                 Box(modifier = Modifier.fillMaxSize()) {
                     HorizontalPager(
@@ -97,11 +106,12 @@ class TreatmentActivity : DaggerAppCompatActivity() {
                             1 -> PlusMinusInputScreen(
                                 value = carbs,
                                 onValueChange = { carbs = it },
-                                min = -maxCarbs,
+                                min = -cobLimit.toDouble(),
                                 max = maxCarbs,
                                 stepValues = stepValuesCarbs,
                                 format = DecimalFormat("0"),
                                 label = stringResource(R.string.action_carbs_gram),
+                                hint = if (carbs < 0) stringResource(R.string.carbs_removal_cob_limit, cobLimit) else null,
                                 allowZero = false,
                                 isActive = pagerState.currentPage == 1,
                                 enabled = !pagerState.isScrollInProgress,

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphRenderer.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/BgGraphRenderer.kt
@@ -21,6 +21,8 @@ import kotlin.math.min
 internal val BgInRangeColor = Color(0xFF00FF00)
 internal val BgHighColor    = Color(0xFFFFFF00)
 internal val BgLowColor     = Color(0xFFFF0000)
+// Magenta: the only hue on the graph not taken by BG (green/yellow/red), carbs (orange) or insulin (cyan)
+internal val CarbsRemovalMagenta = Color(0xFFE040FB)
 internal val SecondaryText  = Color(0xFFAAAAAA)
 internal val TempTargetColor     = Color(0xFFFDD835)
 internal val AutosensTargetColor = Color(0xFF77DD77)
@@ -201,7 +203,8 @@ internal fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int, 
 
     for (treatment in boluses) {
         if (!treatment.isValid || treatment.isSMB) continue
-        if (treatment.carbs <= 0 || treatment.date !in startTime..endTime) continue
+        // carbs != 0: negative entries (COB removal) are drawn too, like on the phone graph — in magenta to tell them apart
+        if (treatment.carbs == 0.0 || treatment.date !in startTime..endTime) continue
         val x = timeToX(treatment.date)
         drawPath(
             Path().apply {
@@ -210,7 +213,7 @@ internal fun DrawScope.renderBgGraph(data: ComplicationData, historyHours: Int, 
                 lineTo(x + triSize, bottom)
                 close()
             },
-            CarbsOrange
+            if (treatment.carbs < 0) CarbsRemovalMagenta else CarbsOrange
         )
     }
 

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="action_high_unit" comment="In temp target menu, higher value from range">High [%s]</string>
     <string name="action_carbs">Carbs</string>
     <string name="action_carbs_gram">Carbs [g]</string>
+    <string name="carbs_removal_cob_limit" comment="Shown under the carbs input when removing carbs (a negative value). %1$d = grams of carbs currently on board, the maximum removable. Example: Max removal: 30 g (COB)">Max removal: %1$d g (COB)</string>
     <string name="action_ecarbs">eCarbs</string>
     <string name="action_percentage">Percentage\n[%]</string>
     <string name="action_start_minutes">Start\n[minutes]</string>


### PR DESCRIPTION
Wear-side follow-up to completely fix #4637 (already fixed on phone). 

- Carbs input on the watch (Carbs + Treatment dialogs) is now bounded to -COB instead of -maxCarbs, matching the phone dialog. While the value is negative, a hint shows the max removable amount.
- COB is read from the watch's stored Status data — a new numeric `cobValue` field on `EventData.Status` (sent with every status push), so opening the dialog needs no phone round-trip. Unknown COB → no removal allowed, same as the phone. The master still re-clamps on prepare, so a stale value is only cosmetic.
- Negative carb entries now appear on the Compose BG graph (activity/tile/complication) with the same triangle marker in magenta, so a registered removal is visible on the watch. 

Tested on AAPS and AAPSClient.

<img width="956" height="338" alt="image" src="https://github.com/user-attachments/assets/40b5a18b-7fa8-4cff-8ccc-7adda02f71a1" />
