### PR TITLE
Wear: push predictions to AAPSClient watch when NS devicestatus arrives

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
@@ -23,6 +23,7 @@ import app.aaps.core.interfaces.rx.collectResilient
 import app.aaps.core.interfaces.rx.events.EventAutosensCalculationFinished
 import app.aaps.core.interfaces.rx.events.EventLoopUpdateGui
 import app.aaps.core.interfaces.rx.events.EventMobileToWear
+import app.aaps.core.interfaces.rx.events.EventNsClientStatusUpdated
 import app.aaps.core.interfaces.rx.events.EventWearUpdateGui
 import app.aaps.core.interfaces.rx.events.EventWearUpdateTiles
 import app.aaps.core.interfaces.rx.weardata.CwfData
@@ -158,6 +159,19 @@ class WearPlugin @Inject constructor(
             .observeOn(aapsSchedulers.io)
             .concatMapCompletable {
                 rxCompletable { dataHandlerMobile.resendData("EventLoopUpdateGui") }
+                    .doOnError(fabricPrivacy::logException)
+                    .onErrorComplete()
+            }
+            .subscribe()
+        // AAPSCLIENT: fresh predictions arrive via NS devicestatus, not a local loop run — without this the
+        // watch graph trails the phone by one loop cycle (the BG-triggered autosens resend fires BEFORE the
+        // master's new devicestatus lands). Event is only sent on AAPSCLIENT; processedDeviceStatusData is
+        // updated synchronously before it fires, so the resend reads the new predictions.
+        disposable += rxBus
+            .toObservable(EventNsClientStatusUpdated::class.java)
+            .observeOn(aapsSchedulers.io)
+            .concatMapCompletable {
+                rxCompletable { dataHandlerMobile.resendData("EventNsClientStatusUpdated") }
                     .doOnError(fabricPrivacy::logException)
                     .onErrorComplete()
             }


### PR DESCRIPTION
Noticed issues with predictions not updating on AAPSClient wear when working on #5037 - this is my proposal to fix this.

On AAPSCLIENT fresh predictions come from the master's devicestatus, not a local loop run, so no wear resend was triggered — the BG-driven autosens resend fires before the new devicestatus lands, leaving the watch BG graph one loop cycle (~5 min) behind the phone. Subscribe WearPlugin to EventNsClientStatusUpdated (client-only event) and resend, matching the
master's EventLoopUpdateGui behavior. No change in behavior for AAPS master.

Tested on AAPSClient + wear.