### PR TITLE
Wear: show remaining duration of temporary running mode in Loop Status

### DIFF
--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/EventData.kt
@@ -20,8 +20,14 @@ sealed class EventData : Event() {
 
     companion object {
 
+        /**
+         * Tolerates unknown keys so an app on an older build can still decode payloads from a
+         * newer peer that added fields (phone and wear are not always updated together).
+         */
+        private val lenientJson = Json { ignoreUnknownKeys = true }
+
         fun deserialize(json: String) = try {
-            Json.decodeFromString(serializer(), json)
+            lenientJson.decodeFromString(serializer(), json)
         } catch (_: Exception) {
             Error(System.currentTimeMillis())
         }

--- a/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusData.kt
+++ b/core/interfaces/src/main/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusData.kt
@@ -12,7 +12,9 @@ data class LoopStatusData(
     val tempTarget: TempTargetInfo?,
     val autosensTarget: String? = null,
     val defaultRange: TargetRange,
-    val oapsResult: OapsResultInfo?
+    val oapsResult: OapsResultInfo?,
+    /** End time (epoch ms) of a temporary running mode (suspend/disconnect/superbolus), null when the mode is permanent */
+    val modeEndTime: Long? = null
 ) {
     @Serializable
     enum class LoopMode {

--- a/core/interfaces/src/test/kotlin/app/aaps/core/interfaces/rx/weardata/EventDataTest.kt
+++ b/core/interfaces/src/test/kotlin/app/aaps/core/interfaces/rx/weardata/EventDataTest.kt
@@ -233,4 +233,20 @@ class EventDataTest {
             assertThat(EventData.deserialize(it.serialize())).isEqualTo(it)
         }
     }
+
+    @Test
+    fun deserializeToleratesUnknownKeysFromNewerPeer() {
+        // A newer peer may add fields this build doesn't know (phone and wear are not always
+        // updated together) — decoding must not fall back to Error, or screens waiting for the
+        // event spin forever
+        val event = EventData.LoopStatusResponse(
+            timeStamp = 1L,
+            data = LoopStatusData(0L, LoopStatusData.LoopMode.DISCONNECTED, null, null, null, null, null, TargetRange("a", "b", "c", "u"), null)
+        )
+        val topLevelUnknown = event.serialize().replaceFirst("\"timeStamp\"", "\"futureField\":42,\"timeStamp\"")
+        assertThat(EventData.deserialize(topLevelUnknown)).isEqualTo(event)
+
+        val nestedUnknown = event.serialize().replaceFirst("\"loopMode\"", "\"futureField\":42,\"loopMode\"")
+        assertThat(EventData.deserialize(nestedUnknown)).isEqualTo(event)
+    }
 }

--- a/core/interfaces/src/test/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusDataTest.kt
+++ b/core/interfaces/src/test/kotlin/app/aaps/core/interfaces/rx/weardata/LoopStatusDataTest.kt
@@ -23,7 +23,8 @@ class LoopStatusDataTest {
             oapsResult = OapsResultInfo(
                 changeRequested = true, isLetTempRun = false, rate = 1.2, ratePercent = 120,
                 duration = 30, reason = "test", smbAmount = 0.5
-            )
+            ),
+            modeEndTime = 9000L
         )
         val encoded = json.encodeToString(LoopStatusData.serializer(), data)
         val restored = json.decodeFromString(LoopStatusData.serializer(), encoded)
@@ -31,6 +32,15 @@ class LoopStatusDataTest {
         assertThat(restored.tempTarget?.durationMinutes).isEqualTo(30)
         assertThat(restored.defaultRange.highDisplay).isEqualTo("120")
         assertThat(restored.oapsResult?.rate).isEqualTo(1.2)
+        assertThat(restored.modeEndTime).isEqualTo(9000L)
+    }
+
+    @Test
+    fun missingModeEndTimeDecodesAsNull() {
+        // payload shape from a phone older than the modeEndTime field
+        val legacy = """{"timestamp":0,"loopMode":"SUSPENDED","apsName":null,"lastRun":null,"lastEnact":null,"tempTarget":null,""" +
+            """"defaultRange":{"lowDisplay":"a","highDisplay":"b","targetDisplay":"c","units":"u"},"oapsResult":null}"""
+        assertThat(json.decodeFromString(LoopStatusData.serializer(), legacy).modeEndTime).isNull()
     }
 
     @Test

--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/wearintegration/DataHandlerMobile.kt
@@ -402,7 +402,8 @@ class DataHandlerMobile @Inject constructor(
         }
 
         // Map loop mode
-        val loopMode = when (loop.runningMode()) {
+        val runningModeRecord = loop.runningModeRecord()
+        val loopMode = when (runningModeRecord.mode) {
             RM.Mode.CLOSED_LOOP       -> LoopStatusData.LoopMode.CLOSED
             RM.Mode.OPEN_LOOP         -> LoopStatusData.LoopMode.OPEN
             RM.Mode.CLOSED_LOOP_LGS   -> LoopStatusData.LoopMode.LGS
@@ -414,6 +415,8 @@ class DataHandlerMobile @Inject constructor(
             RM.Mode.SUPER_BOLUS       -> LoopStatusData.LoopMode.SUPERBOLUS
             else                      -> LoopStatusData.LoopMode.UNKNOWN
         }
+        // End time of a temporary mode (suspend/disconnect/superbolus) so the watch can show remaining duration
+        val modeEndTime = if (runningModeRecord.isTemporary()) runningModeRecord.timestamp + runningModeRecord.duration else null
 
         // Build temp target info
         val tempTargetInfo = tempTarget?.let {
@@ -530,14 +533,15 @@ class DataHandlerMobile @Inject constructor(
         return LoopStatusData(
             timestamp = System.currentTimeMillis(),
             loopMode = loopMode,
-            apsName = if (loop.runningMode().isLoopRunning())
+            apsName = if (runningModeRecord.mode.isLoopRunning())
                 (usedAPS as? PluginBase)?.name else null,
             lastRun = lastRunTimestamp,
             lastEnact = lastEnactTimestamp,
             tempTarget = tempTargetInfo,
             autosensTarget = autosensTarget,
             defaultRange = defaultRange,
-            oapsResult = oapsResultInfo
+            oapsResult = oapsResultInfo,
+            modeEndTime = modeEndTime
         )
     }
 

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/activities/LoopStatusActivity.kt
@@ -69,6 +69,7 @@ import app.aaps.wear.interaction.actions.TempTargetYellow
 import app.aaps.wear.interaction.actions.WearDivider
 import app.aaps.wear.interaction.actions.WearSecondaryText
 import app.aaps.wear.interaction.actions.WearSummaryCardBg
+import app.aaps.wear.interaction.actions.formatDurationMinutes
 import dagger.android.AndroidInjection
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.plusAssign
@@ -212,7 +213,7 @@ private fun LoopStatusContent(
         verticalArrangement = Arrangement.spacedBy(6.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        HeaderCard(mode = data.loopMode, apsName = data.apsName)
+        HeaderCard(mode = data.loopMode, apsName = data.apsName, modeEndTime = data.modeEndTime)
         ResultCard(
             lastRun = data.lastRun,
             lastEnact = data.lastEnact,
@@ -318,7 +319,9 @@ private fun RowDivider() {
 // ─── Header Card ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun HeaderCard(mode: LoopStatusData.LoopMode, apsName: String?) {
+private fun HeaderCard(mode: LoopStatusData.LoopMode, apsName: String?, modeEndTime: Long?) {
+    val context = LocalContext.current
+
     StatusCard {
         Text(
             text = when (mode) {
@@ -339,6 +342,22 @@ private fun HeaderCard(mode: LoopStatusData.LoopMode, apsName: String?) {
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()
         )
+        // Remaining duration of a temporary mode (suspend/disconnect/superbolus); hidden once expired
+        val remainingMinutes = modeEndTime?.let { ((it - System.currentTimeMillis()) / 60_000).toInt() } ?: 0
+        if (modeEndTime != null && remainingMinutes > 0) {
+            val endTimeStr = remember(modeEndTime) {
+                DateFormat.getTimeFormat(context).format(Date(modeEndTime))
+            }
+            Text(
+                text = stringResource(R.string.loop_status_duration_until, formatDurationMinutes(remainingMinutes), endTimeStr),
+                color = WearSecondaryText,
+                fontSize = 11.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 2.dp)
+            )
+        }
         if (apsName != null) {
             Text(
                 text = apsName,
@@ -467,7 +486,7 @@ private fun OapsResultSection(
                     Spacer(Modifier.height(4.dp))
                     InfoRow(
                         label = stringResource(R.string.loop_status_duration),
-                        value = stringResource(R.string.loop_status_tbr_duration_remaining, duration)
+                        value = stringResource(R.string.loop_status_duration_remaining, formatDurationMinutes(duration))
                     )
                 }
             }
@@ -499,7 +518,7 @@ private fun OapsResultSection(
                 Spacer(Modifier.height(4.dp))
                 InfoRow(
                     label = stringResource(R.string.loop_status_duration),
-                    value = stringResource(R.string.loop_status_tbr_duration, duration)
+                    value = formatDurationMinutes(duration)
                 )
             }
         }
@@ -588,7 +607,7 @@ private fun TargetsCard(
                         )
                     }
                     Text(
-                        text = stringResource(R.string.loop_status_tempt_duration, tempTarget.durationMinutes, endTimeStr),
+                        text = stringResource(R.string.loop_status_duration_until, formatDurationMinutes(tempTarget.durationMinutes), endTimeStr),
                         color = WearSecondaryText,
                         fontSize = 11.sp,
                         modifier = Modifier.padding(top = 3.dp)

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -321,10 +321,9 @@
     <string name="contacting_master_unknown">State unknown — check phone</string>
     <string name="tile_settings">Tile settings</string>
     <string name="loop_status_error">Failed to load status</string>
-    <string name="loop_status_tempt_duration">%1$d min (%2$s)</string>
-    <string name="loop_status_tbr_duration">%1$d min</string>
+    <string name="loop_status_duration_until" comment="%1$s=formatted duration e.g. 2 h 5 min, %2$s=end time. Example: 2 h 5 min (14:35)">%1$s (%2$s)</string>
     <string name="loop_status_tbr_rate">%1$.2f U/h (%2$d%%)</string>
-    <string name="loop_status_tbr_duration_remaining">%1$d min remaining</string>
+    <string name="loop_status_duration_remaining" comment="%1$s=formatted duration e.g. 2 h 5 min. Example: 2 h 5 min remaining">%1$s remaining</string>
     <string name="loop_status_tbr_continues">Temp basal continues</string>
     <string name="loop_status_tbr_cancel">Setting regular basal</string>
     <string name="loop_status_smb">%1$.2f U</string>


### PR DESCRIPTION
The Loop Status screen showed the running mode but not how long it remains active — Suspend loop and Disconnect pump are duration based.

- Phone sends the temporary mode's end time (LoopStatusData.modeEndTime, null for permanent modes; the watch hides it once expired)
- Header now shows e.g. "SUSPENDED / 2 h 5 min (14:35)"
- All durations on the screen use the input screens' format ("2 h", "2 h 5 min") — temp target, TBR duration/remaining, new mode line
- EventData JSON decoding now ignores unknown keys, so adding fields like modeEndTime no longer breaks an older peer (found testing version skew: old watch + new phone showed an endless spinner in disconnected mode)

**Screenshots**
| Before | After |
|--------|--------|
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/819a2b95-0b91-462f-b421-9300f099c054" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/d9b35e95-83c9-4dd6-85f8-bd49f4d85d64" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/688a5ad5-4664-4e50-a498-dbc9e7d32251" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/71c5a55a-a097-4177-9cd4-a3ec60e60bf9" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/6b198091-ec6c-4719-9d38-b1b987ea2592" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/5ecbc89a-f634-44d9-a184-a3ec377999ea" /> |
| <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/c9636320-8467-4549-8ccb-a571bd6169e4" /> | <img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/cee0ea41-a097-4f4a-ad31-9e84cbf2591f" /> | 
