### PR TITLE
Watchface Activation for Samsung recent watch (waiting for tests to confirm it works before merge)

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -10,6 +10,13 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="com.google.android.wearable.permission.RECEIVE_COMPLICATION_DATA" />
+    <!-- Samsung-only, protectionLevel="normal" so it is granted automatically at install and is a
+         no-op on non-Samsung watches (the permission simply doesn't exist there). Lets us send
+         ACTION_EDIT_WATCH_FACE to Samsung SysUI's exported WatchFaceEditorBroadcastReceiver, which
+         is the only known way for an app to get the system to start a watch face editing session -
+         see ComplicationPickerSupport for why that session is required. -->
+    <uses-permission android:name="com.samsung.android.wearable.sysui.permission.EDIT_WATCH_FACE" />
     <!-- Watch Face Push (Wear OS 6+): PUSH_WATCH_FACES gates binding to the system push service;
          SET_PUSHED_WATCH_FACE_AS_ACTIVE allows re-activating the pushed AAPS watchface after the
          one-shot activation on first install was used -->

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
     <!-- Samsung-only, protectionLevel="normal" so it is granted automatically at install and is a
          no-op on non-Samsung watches (the permission simply doesn't exist there). Lets us send
          ACTION_EDIT_WATCH_FACE to Samsung SysUI's exported WatchFaceEditorBroadcastReceiver, which
-         is the only known way for an app to get the system to start a watch face editing session -
-         see ComplicationPickerSupport for why that session is required. -->
+         is the only known way for an app to get the system to activate a watchface. -->
     <uses-permission android:name="com.samsung.android.wearable.sysui.permission.EDIT_WATCH_FACE" />
     <!-- Watch Face Push (Wear OS 6+): PUSH_WATCH_FACES gates binding to the system push service;
          SET_PUSHED_WATCH_FACE_AS_ACTIVE allows re-activating the pushed AAPS watchface after the

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/SamsungWatchFaceEditor.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/SamsungWatchFaceEditor.kt
@@ -1,0 +1,53 @@
+package app.aaps.wear.interaction
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+
+/** Samsung SysUI's exported (protectionLevel="normal") watch face editor entry point. */
+internal object SamsungWatchFaceEditor {
+
+    private const val SYSUI_PACKAGE = "com.samsung.android.wearable.sysui"
+    private const val ACTION_EDIT_WATCH_FACE = "com.samsung.android.wearable.sysui.action.EDIT_WATCH_FACE"
+
+    /**
+     * The only extra SysUI's receiver reads: the watch face service's flattened [ComponentName].
+     * It bails out immediately (logging "no watchface") if this is absent, and again (logging
+     * "not installed watchface") if the component doesn't resolve to a known watch face.
+     */
+    private const val EXTRA_WATCH_FACE = "watchface"
+
+    private fun editIntent() = Intent(ACTION_EDIT_WATCH_FACE).setPackage(SYSUI_PACKAGE)
+
+    /** True when this watch exposes Samsung's SysUI watch face editor receiver (any non-Samsung watch: false). */
+    fun isAvailable(context: Context): Boolean =
+        context.packageManager.queryBroadcastReceivers(editIntent(), 0).isNotEmpty()
+
+    /**
+     * Asks Samsung's SysUI to make [watchFace] the active watch face and open its editor.
+     *
+     * This is the only known way for the app to get the system to start a watch face *editing
+     * session*, which Wear Services requires before it will serve the complication chooser (see
+     * `ComplicationPickerSupport.handlePreferenceClick` for why nothing we can put in an intent
+     * substitutes for it). SysUI then launches [ConfigurationActivity] itself, exactly as the
+     * long-press "Customize" flow does, so from there everything - including the complication
+     * chooser, for CustomWatchface - works normally. Applies to every watch face, not just
+     * CustomWatchface: any of them benefits from actually being active while its settings are
+     * open, complications or not.
+     *
+     * SysUI's handler is internally named "setActiveWatchfaceAndStartEditor" and does just
+     * that: it adds the watch face to the user's favourites, **makes it active**, and only then
+     * opens the editor. Activating the watch face is intended here, not a side effect to work
+     * around - on Wear OS 5+ watches whose watch face picker no longer offers code-based faces,
+     * this may be the only way to activate one of ours at all (unconfirmed - see the project
+     * notes).
+     *
+     * Returns false when the receiver isn't present (any non-Samsung watch), so the caller can
+     * degrade rather than assume the editor is on its way.
+     */
+    fun requestEditor(context: Context, watchFace: ComponentName): Boolean {
+        if (!isAvailable(context)) return false
+        context.sendBroadcast(editIntent().putExtra(EXTRA_WATCH_FACE, watchFace.flattenToString()))
+        return true
+    }
+}

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/WatchFaceCatalog.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/WatchFaceCatalog.kt
@@ -1,0 +1,31 @@
+package app.aaps.wear.interaction
+
+import android.content.ComponentName
+import android.content.Context
+import app.aaps.wear.R
+import app.aaps.wear.watchfaces.CircleWatchface
+import app.aaps.wear.watchfaces.CustomWatchface
+import app.aaps.wear.watchfaces.DigitalStyleWatchface
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
+
+/**
+ * The single source of truth for what identifies each of the 3 built-in, code-based watch faces:
+ * its [ComponentName] and its own preference screen. [SelectedWatchFace.NONE] maps to nothing -
+ * there is no watch face to activate or configure for it.
+ */
+internal object WatchFaceCatalog {
+
+    fun componentNameFor(context: Context, watchFace: SelectedWatchFace): ComponentName? = when (watchFace) {
+        SelectedWatchFace.CUSTOM  -> ComponentName(context, CustomWatchface::class.java)
+        SelectedWatchFace.DIGITAL -> ComponentName(context, DigitalStyleWatchface::class.java)
+        SelectedWatchFace.CIRCLE  -> ComponentName(context, CircleWatchface::class.java)
+        SelectedWatchFace.NONE    -> null
+    }
+
+    fun preferenceXmlFor(watchFace: SelectedWatchFace): Int? = when (watchFace) {
+        SelectedWatchFace.CUSTOM  -> R.xml.watch_face_configuration_custom
+        SelectedWatchFace.DIGITAL -> R.xml.watch_face_configuration_digitalstyle
+        SelectedWatchFace.CIRCLE  -> R.xml.watch_face_configuration_circle
+        SelectedWatchFace.NONE    -> null
+    }
+}

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
@@ -2,8 +2,6 @@ package app.aaps.wear.interaction
 
 import android.Manifest
 import android.content.ComponentName
-import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -20,9 +18,7 @@ import app.aaps.core.interfaces.logging.LTag
 import app.aaps.wear.R
 import app.aaps.wear.complications.BgGraphComplication
 import app.aaps.wear.preference.WearPreferenceActivity
-import app.aaps.wear.watchfaces.CircleWatchface
-import app.aaps.wear.watchfaces.CustomWatchface
-import app.aaps.wear.watchfaces.DigitalStyleWatchface
+import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 import javax.inject.Inject
 
 class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
@@ -39,28 +35,23 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
         dagger.android.AndroidInjection.inject(this)
 
         // MUST set preferenceFile BEFORE calling super.onCreate() because super creates the fragment
-        preferenceFile = intent.getIntExtra(getString(R.string.key_preference_id), R.xml.display_preferences)
+        val requestedWatchFace = intent.getIntExtra(getString(R.string.key_selected_watchface), -1)
+            .takeIf { it >= 0 }
+            ?.let { SelectedWatchFace.fromId(it) }
+
+        preferenceFile = requestedWatchFace
+            ?.let { WatchFaceCatalog.preferenceXmlFor(it) }
+            ?: intent.getIntExtra(getString(R.string.key_preference_id), R.xml.display_preferences)
 
         super.onCreate(savedInstanceState)
 
-        // Opening one of the 3 watch faces' own settings (as opposed to the app-wide
-        // display/graph/interface/tile/others screens, which aren't tied to any single watch face)
-        // hands straight over to the system watch face editor. That both activates the watch face
-        // being configured and shows this same preference screen backed by a live editing session
-        // - the only state in which entries like CustomWatchface's "Complication N" actually work.
-        // See [requestSystemWatchFaceEditor] for why activation is the point, not a side effect to
-        // work around, and for what "hands over" concretely does.
-        //
-        // Finished immediately so this screen is never drawn: the editor takes ~1s to appear, and
-        // without this the user watches one preference menu get replaced by a near-identical one.
-        // Finishing before the first frame makes this a trampoline - Android skips drawing it - and
-        // leaves back from the editor returning to the settings list rather than to a dead copy.
-        //
-        // Only when the broadcast was actually accepted. If there's no receiver (any non-Samsung
-        // watch) we must keep this screen, since it's then the only one the user gets.
-        if (savedInstanceState == null) {
-            val watchFaceComponent = watchFaceComponentFor(preferenceFile)
-            if (watchFaceComponent != null && requestSystemWatchFaceEditor(watchFaceComponent)) {
+        // Only the 3 dedicated watch-face menu entries pass key_selected_watchface. The app-wide
+        // display/graph/interface/complication/others screens (and the phone-triggered
+        // OpenSettings default) must never activate a watch face as a side effect of being
+        // opened, so the SysUI hand-off below only ever runs when one was explicitly requested.
+        if (savedInstanceState == null && requestedWatchFace != null) {
+            val watchFaceComponent = WatchFaceCatalog.componentNameFor(this, requestedWatchFace)
+            if (watchFaceComponent != null && SamsungWatchFaceEditor.requestEditor(this, watchFaceComponent)) {
                 finish()
                 return
             }
@@ -87,15 +78,6 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
             for (i in 0 until parent.childCount)
                 removeBackgroundRecursively(parent.getChildAt(i))
         parent.background = null
-    }
-
-    /** The watch face [preferenceFile] configures, or null for the app-wide screens that aren't
-     *  tied to any single watch face (display/graph/interface/tile/complication/others). */
-    private fun watchFaceComponentFor(preferenceFile: Int): ComponentName? = when (preferenceFile) {
-        R.xml.watch_face_configuration_custom       -> ComponentName(this, CustomWatchface::class.java)
-        R.xml.watch_face_configuration_circle       -> ComponentName(this, CircleWatchface::class.java)
-        R.xml.watch_face_configuration_digitalstyle -> ComponentName(this, DigitalStyleWatchface::class.java)
-        else                                        -> ComponentName(this, CustomWatchface::class.java)
     }
 
     override fun onSharedPreferenceChanged(sp: SharedPreferences, key: String?) {
@@ -188,45 +170,5 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
 
     companion object {
         private const val BODY_SENSOR_PERMISSION_REQUEST_CODE = 1
-
-        /** Samsung SysUI's exported (protectionLevel="normal") watch face editor entry point. */
-        private const val SYSUI_PACKAGE = "com.samsung.android.wearable.sysui"
-        private const val ACTION_EDIT_WATCH_FACE = "com.samsung.android.wearable.sysui.action.EDIT_WATCH_FACE"
-
-        /**
-         * The only extra SysUI's receiver reads: the watch face service's flattened [ComponentName].
-         * It bails out immediately (logging "no watchface") if this is absent, and again (logging
-         * "not installed watchface") if the component doesn't resolve to a known watch face.
-         */
-        private const val EXTRA_WATCH_FACE = "watchface"
-
-        /**
-         * Asks Samsung's SysUI to make [watchFace] the active watch face and open its editor.
-         *
-         * This is the only known way for the app to get the system to start a watch face *editing
-         * session*, which Wear Services requires before it will serve the complication chooser (see
-         * `ComplicationPickerSupport.handlePreferenceClick` for why nothing we can put in an intent
-         * substitutes for it). SysUI then launches [ConfigurationActivity] itself, exactly as the
-         * long-press "Customize" flow does, so from there everything - including the complication
-         * chooser, for CustomWatchface - works normally. Applies to every watch face, not just
-         * CustomWatchface: any of them benefits from actually being active while its settings are
-         * open, complications or not.
-         *
-         * SysUI's handler is internally named "setActiveWatchfaceAndStartEditor" and does just
-         * that: it adds the watch face to the user's favourites, **makes it active**, and only then
-         * opens the editor. Activating the watch face is intended here, not a side effect to work
-         * around - on Wear OS 5+ watches whose watch face picker no longer offers code-based faces,
-         * this may be the only way to activate one of ours at all (unconfirmed - see the project
-         * notes).
-         *
-         * Returns false when the receiver isn't present (any non-Samsung watch), so the caller can
-         * degrade rather than assume the editor is on its way.
-         */
-        private fun Context.requestSystemWatchFaceEditor(watchFace: ComponentName): Boolean {
-            val intent = Intent(ACTION_EDIT_WATCH_FACE).setPackage(SYSUI_PACKAGE)
-            if (packageManager.queryBroadcastReceivers(intent, 0).isEmpty()) return false
-            sendBroadcast(intent.putExtra(EXTRA_WATCH_FACE, watchFace.flattenToString()))
-            return true
-        }
     }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/WatchfaceConfigurationActivity.kt
@@ -2,6 +2,8 @@ package app.aaps.wear.interaction
 
 import android.Manifest
 import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -18,6 +20,9 @@ import app.aaps.core.interfaces.logging.LTag
 import app.aaps.wear.R
 import app.aaps.wear.complications.BgGraphComplication
 import app.aaps.wear.preference.WearPreferenceActivity
+import app.aaps.wear.watchfaces.CircleWatchface
+import app.aaps.wear.watchfaces.CustomWatchface
+import app.aaps.wear.watchfaces.DigitalStyleWatchface
 import javax.inject.Inject
 
 class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
@@ -37,6 +42,29 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
         preferenceFile = intent.getIntExtra(getString(R.string.key_preference_id), R.xml.display_preferences)
 
         super.onCreate(savedInstanceState)
+
+        // Opening one of the 3 watch faces' own settings (as opposed to the app-wide
+        // display/graph/interface/tile/others screens, which aren't tied to any single watch face)
+        // hands straight over to the system watch face editor. That both activates the watch face
+        // being configured and shows this same preference screen backed by a live editing session
+        // - the only state in which entries like CustomWatchface's "Complication N" actually work.
+        // See [requestSystemWatchFaceEditor] for why activation is the point, not a side effect to
+        // work around, and for what "hands over" concretely does.
+        //
+        // Finished immediately so this screen is never drawn: the editor takes ~1s to appear, and
+        // without this the user watches one preference menu get replaced by a near-identical one.
+        // Finishing before the first frame makes this a trampoline - Android skips drawing it - and
+        // leaves back from the editor returning to the settings list rather than to a dead copy.
+        //
+        // Only when the broadcast was actually accepted. If there's no receiver (any non-Samsung
+        // watch) we must keep this screen, since it's then the only one the user gets.
+        if (savedInstanceState == null) {
+            val watchFaceComponent = watchFaceComponentFor(preferenceFile)
+            if (watchFaceComponent != null && requestSystemWatchFaceEditor(watchFaceComponent)) {
+                finish()
+                return
+            }
+        }
 
         PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(this)
 
@@ -59,6 +87,15 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
             for (i in 0 until parent.childCount)
                 removeBackgroundRecursively(parent.getChildAt(i))
         parent.background = null
+    }
+
+    /** The watch face [preferenceFile] configures, or null for the app-wide screens that aren't
+     *  tied to any single watch face (display/graph/interface/tile/complication/others). */
+    private fun watchFaceComponentFor(preferenceFile: Int): ComponentName? = when (preferenceFile) {
+        R.xml.watch_face_configuration_custom       -> ComponentName(this, CustomWatchface::class.java)
+        R.xml.watch_face_configuration_circle       -> ComponentName(this, CircleWatchface::class.java)
+        R.xml.watch_face_configuration_digitalstyle -> ComponentName(this, DigitalStyleWatchface::class.java)
+        else                                        -> ComponentName(this, CustomWatchface::class.java)
     }
 
     override fun onSharedPreferenceChanged(sp: SharedPreferences, key: String?) {
@@ -151,5 +188,45 @@ class WatchfaceConfigurationActivity : WearPreferenceActivity(), SharedPreferenc
 
     companion object {
         private const val BODY_SENSOR_PERMISSION_REQUEST_CODE = 1
+
+        /** Samsung SysUI's exported (protectionLevel="normal") watch face editor entry point. */
+        private const val SYSUI_PACKAGE = "com.samsung.android.wearable.sysui"
+        private const val ACTION_EDIT_WATCH_FACE = "com.samsung.android.wearable.sysui.action.EDIT_WATCH_FACE"
+
+        /**
+         * The only extra SysUI's receiver reads: the watch face service's flattened [ComponentName].
+         * It bails out immediately (logging "no watchface") if this is absent, and again (logging
+         * "not installed watchface") if the component doesn't resolve to a known watch face.
+         */
+        private const val EXTRA_WATCH_FACE = "watchface"
+
+        /**
+         * Asks Samsung's SysUI to make [watchFace] the active watch face and open its editor.
+         *
+         * This is the only known way for the app to get the system to start a watch face *editing
+         * session*, which Wear Services requires before it will serve the complication chooser (see
+         * `ComplicationPickerSupport.handlePreferenceClick` for why nothing we can put in an intent
+         * substitutes for it). SysUI then launches [ConfigurationActivity] itself, exactly as the
+         * long-press "Customize" flow does, so from there everything - including the complication
+         * chooser, for CustomWatchface - works normally. Applies to every watch face, not just
+         * CustomWatchface: any of them benefits from actually being active while its settings are
+         * open, complications or not.
+         *
+         * SysUI's handler is internally named "setActiveWatchfaceAndStartEditor" and does just
+         * that: it adds the watch face to the user's favourites, **makes it active**, and only then
+         * opens the editor. Activating the watch face is intended here, not a side effect to work
+         * around - on Wear OS 5+ watches whose watch face picker no longer offers code-based faces,
+         * this may be the only way to activate one of ours at all (unconfirmed - see the project
+         * notes).
+         *
+         * Returns false when the receiver isn't present (any non-Samsung watch), so the caller can
+         * degrade rather than assume the editor is on its way.
+         */
+        private fun Context.requestSystemWatchFaceEditor(watchFace: ComponentName): Boolean {
+            val intent = Intent(ACTION_EDIT_WATCH_FACE).setPackage(SYSUI_PACKAGE)
+            if (packageManager.queryBroadcastReceivers(intent, 0).isEmpty()) return false
+            sendBroadcast(intent.putExtra(EXTRA_WATCH_FACE, watchFace.flattenToString()))
+            return true
+        }
     }
 }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
@@ -3,12 +3,12 @@ package app.aaps.wear.interaction.menus
 import android.content.Intent
 import android.os.Bundle
 import app.aaps.wear.R
+import app.aaps.wear.interaction.SamsungWatchFaceEditor
 import app.aaps.wear.interaction.WatchfaceConfigurationActivity
 import app.aaps.wear.interaction.utils.MenuListActivity
 import app.aaps.wear.watchfaces.utils.WatchfaceViewAdapter.Companion.SelectedWatchFace
 
 class PreferenceMenuActivity : MenuListActivity() {
-    private var lastWatchface = SelectedWatchFace.NONE
     override fun onCreate(savedInstanceState: Bundle?) {
         setTitle(R.string.menu_settings)
         super.onCreate(savedInstanceState)
@@ -22,9 +22,12 @@ class PreferenceMenuActivity : MenuListActivity() {
             add(MenuItem(R.drawable.ic_tile_settings, getString(R.string.pref_tile_settings)))
             add(MenuItem(R.drawable.ic_complication, getString(R.string.pref_complication_settings)))
             add(MenuItem(R.drawable.ic_others, getString(R.string.pref_others_settings)))
-            add(MenuItem(R.drawable.watchface_custom, getString(R.string.label_watchface_custom)))
-            add(MenuItem(R.drawable.watchface_digitalstyle, getString(R.string.label_watchface_digital_style)))
-            add(MenuItem(R.drawable.watchface_circle, getString(R.string.label_watchface_circle)))
+            // These 3 items only make sense where SysUI can hand off to a live editing session
+            if (SamsungWatchFaceEditor.isAvailable(this@PreferenceMenuActivity)) {
+                add(MenuItem(R.drawable.watchface_custom, getString(R.string.label_watchface_custom)))
+                add(MenuItem(R.drawable.watchface_digitalstyle, getString(R.string.label_watchface_digital_style)))
+                add(MenuItem(R.drawable.watchface_circle, getString(R.string.label_watchface_circle)))
+            }
         }
 
     override fun doAction(position: String) {
@@ -52,13 +55,13 @@ class PreferenceMenuActivity : MenuListActivity() {
             })
 
             getString(R.string.label_watchface_custom)     -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
-                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_custom)
+                putExtra(getString(R.string.key_selected_watchface), SelectedWatchFace.CUSTOM.ordinal)
             })
             getString(R.string.label_watchface_digital_style) -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
-                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_digitalstyle)
+                putExtra(getString(R.string.key_selected_watchface), SelectedWatchFace.DIGITAL.ordinal)
             })
             getString(R.string.label_watchface_circle)     -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
-                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_circle)
+                putExtra(getString(R.string.key_selected_watchface), SelectedWatchFace.CIRCLE.ordinal)
             })
         }
     }

--- a/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/interaction/menus/PreferenceMenuActivity.kt
@@ -22,13 +22,9 @@ class PreferenceMenuActivity : MenuListActivity() {
             add(MenuItem(R.drawable.ic_tile_settings, getString(R.string.pref_tile_settings)))
             add(MenuItem(R.drawable.ic_complication, getString(R.string.pref_complication_settings)))
             add(MenuItem(R.drawable.ic_others, getString(R.string.pref_others_settings)))
-            lastWatchface = SelectedWatchFace.fromId(sp.getInt(R.string.key_last_selected_watchface, SelectedWatchFace.NONE.ordinal))
-            when(lastWatchface) {
-                SelectedWatchFace.NONE -> Unit
-                SelectedWatchFace.CUSTOM -> add(MenuItem(R.drawable.watchface_custom, getString(R.string.label_watchface_custom)))
-                SelectedWatchFace.DIGITAL -> add(MenuItem(R.drawable.watchface_digitalstyle, getString(R.string.label_watchface_digital_style)))
-                SelectedWatchFace.CIRCLE -> add(MenuItem(R.drawable.watchface_circle, getString(R.string.label_watchface_circle)))
-            }
+            add(MenuItem(R.drawable.watchface_custom, getString(R.string.label_watchface_custom)))
+            add(MenuItem(R.drawable.watchface_digitalstyle, getString(R.string.label_watchface_digital_style)))
+            add(MenuItem(R.drawable.watchface_circle, getString(R.string.label_watchface_circle)))
         }
 
     override fun doAction(position: String) {
@@ -55,15 +51,14 @@ class PreferenceMenuActivity : MenuListActivity() {
                 putExtra(getString(R.string.key_preference_id), R.xml.others_preferences)
             })
 
-            getString(R.string.label_watchface_custom),
-            getString(R.string.label_watchface_digital_style),
+            getString(R.string.label_watchface_custom)     -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
+                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_custom)
+            })
+            getString(R.string.label_watchface_digital_style) -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
+                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_digitalstyle)
+            })
             getString(R.string.label_watchface_circle)     -> startActivity(Intent(this, WatchfaceConfigurationActivity::class.java).apply {
-                when (lastWatchface) {
-                    SelectedWatchFace.NONE    -> Unit
-                    SelectedWatchFace.CUSTOM  -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_custom)
-                    SelectedWatchFace.DIGITAL -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_digitalstyle)
-                    SelectedWatchFace.CIRCLE  -> putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_circle)
-                }
+                putExtra(getString(R.string.key_preference_id), R.xml.watch_face_configuration_circle)
             })
         }
     }

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="wear_control_not_enabled">Wear controls disabled</string>
     <string name="wear_control_no_data">No data available</string>
     <string name="key_preference_id" translatable="false">preference_id</string>
+    <string name="key_selected_watchface" translatable="false">selected_watchface</string>
     <string name="key_units_mgdl" translatable="false">units_mgdl</string>
     <string name="key_bolus_wizard_percentage" translatable="false">boluswizard_percentage</string>
     <string name="key_treatments_safety_max_carbs" translatable="false">treatmentssafety_maxcarbs</string>


### PR DESCRIPTION
On newer "Factory Built" Wear OS 5+ Samsung watches, the on-watch picker no longer offers code-based watch faces, so CustomWatchface may be impossible to activate at all. This adds a fallback: opening CWF's settings from the AAPS menu now sends a broadcast asking Samsung SysUI to activate and open the editor for CustomWatchface, Digital or Circle

This uses a standard, Samsung-authorized entry point (exported=true, auto-granted normal permission) — the mechanism itself is legitimate and documented as callable by third-party apps, only the specific intent extra key was found by inspection rather than official docs.

Fully safe on non-Samsung watches or older Samsung builds: the receiver is checked before sending, and the fallback is the exact existing behavior (nothing sent, screen shown normally).

I'm looking for tester... (an owner of recent Galaxy Watch no more compatible)
- To activate the watchface, open AAPS app, go to Preferences > At the end you have AAPS (Custom), AAPS (Digital) and AAPS (Circle).
- Click and wait a bit, it should normally open the dedicated preferences attached to each of these Watchfaces (but before it normally should activate the corresponding watchface)
![Screenshot_20260801_222321_androidaps.png](https://github.com/user-attachments/assets/b7080181-e6a7-4bfb-a727-fce1ab950254)



It works with my GW4, and I want to check if it also work with latest GW7, GW8 ...