### PR TITLE
Wear: back always returns to where you came from (watchface or tile)

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -701,10 +701,13 @@
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
+        <!-- singleTask: entry-point activity (launcher, tile tap, complication MENU action) — reuse
+             the alive instance Android 12+ keeps on back instead of stacking a duplicate on top -->
         <activity
             android:name=".interaction.menus.MainMenuActivity"
             android:exported="true"
             android:label="@string/label_actions_activity"
+            android:launchMode="singleTask"
             android:theme="@style/WearAppCompatDark">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -714,19 +717,29 @@
         <activity
             android:name=".interaction.WatchfaceConfigurationActivity"
             android:exported="true"
-            android:label="@string/menu_settings" />
+            android:label="@string/menu_settings"
+            android:taskAffinity="" />
+        <!-- taskAffinity="": activities launched from tiles/complications (NEW_TASK) get their own
+             task, so back returns to the tile/watchface instead of a lingering main menu. Launches
+             from within the app (no NEW_TASK) still stack in the caller's task as before. -->
         <activity
             android:name=".interaction.actions.WizardActivity"
             android:exported="true"
             android:label="@string/menu_wizard"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
+        <!-- taskAffinity="" on the two service-launched overlays: without it their NEW_TASK launch
+             routes into the default app task, dragging a backgrounded main menu to the front —
+             which is then what remains on screen once the overlay finishes -->
         <activity
             android:name=".interaction.actions.ContactingMasterActivity"
             android:exported="false"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name="androidx.wear.activity.ConfirmationActivity"
             android:exported="false"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.DeviceDefault" />
         <activity
             android:name=".interaction.menus.FillMenuActivity"
@@ -741,10 +754,12 @@
         <activity
             android:name=".interaction.activities.LoopStatusActivity"
             android:exported="true"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.activities.BgGraphActivity"
             android:exported="true"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.menus.PreferenceMenuActivity"
@@ -759,16 +774,19 @@
             android:name=".interaction.actions.TreatmentActivity"
             android:exported="true"
             android:label="@string/menu_treatment"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.actions.BolusActivity"
             android:exported="true"
             android:label="@string/action_insulin"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.actions.ProfileSwitchActivity"
             android:exported="true"
             android:label="@string/status_profile_switch"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.actions.AcceptActivity"
@@ -786,16 +804,19 @@
             android:name=".interaction.actions.ECarbActivity"
             android:exported="true"
             android:label="@string/action_ecarbs"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.actions.CarbActivity"
             android:exported="true"
             android:label="@string/action_carbs"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
         <activity
             android:name=".interaction.actions.TempTargetActivity"
             android:exported="true"
             android:label="@string/menu_tempt"
+            android:taskAffinity=""
             android:theme="@style/WearAppCompatDark" />
 
         <activity

--- a/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationTapActivity.kt
+++ b/wear/src/main/kotlin/app/aaps/wear/complications/ComplicationTapActivity.kt
@@ -166,7 +166,10 @@ class ComplicationTapActivity : DaggerAppCompatActivity() {
         }
 
         if (intentOpen != null) {
-            intentOpen.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            // CLEAR_TASK: a complication tap is a fresh entry point from the watchface — replace
+            // whatever lingers in the app task (Android 12+ keeps the root launcher activity alive
+            // on back, which would otherwise resurface under the opened screen on back press)
+            intentOpen.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             startActivity(intentOpen)
         }
     }


### PR DESCRIPTION
Opening a screen from a complication or tile and pressing back could land on a stale main menu instead of the watchface or tile, because android keeps the launcher activity (main menu) alive in a background task and new launches were stacked on top of it. 

Examples: 
watchface → complication → back showed the menu; 
tile → Calculator → send treatment → success animation dropped you on the menu; a "menu" tile tap could even open a
second menu on top of the first, needing two back presses.

Now every entry point cleans this up:

- Complication taps make the opened screen the task root (CLEAR_TASK) — back returns straight to the watchface
- Tile-launched screens get their own task (taskAffinity="") — back returns to the tile; in-app navigation is unchanged
- Main menu is singleTask, so entry-point taps reuse it instead of stacking duplicates
- Service-launched overlays (confirmation success animation, relay spinner, phone-initiated profile switch/settings) get their own task, so finishing a flow reveals the tile/watchface, not the menu

:wear:test passed

Before:

https://github.com/user-attachments/assets/440c8772-2244-4733-b6f4-0f1955aff0fe


After:

https://github.com/user-attachments/assets/f11dd54f-f198-4044-bd64-4f284c200819

