### PR TITLE
Wear: don't overwrite final bolus progress text with empty clear frame

### DIFF
--- a/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
+++ b/plugins/sync/src/main/kotlin/app/aaps/plugins/sync/wear/WearPlugin.kt
@@ -111,6 +111,11 @@ class WearPlugin @Inject constructor(
         val newScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         scope = newScope
         deferredStart.start { dataLayerListenerServiceMobileHelper.startService(context) }
+        // Last percent actually sent to the watch. Starts at 100 = "nothing to clear": the empty-status
+        // clear frame on state-null is only needed when the watch was left mid-progress (< 100). If the
+        // driver already reported 100% ("Bolus delivered successfully"), sending the clear frame would
+        // overwrite that text with "100% - " for the notification's 5 s dismiss window.
+        var lastSentPercent = 100
         bolusProgressData.state
             .drop(1) // Skip initial null emission on collection start
             .collectResilient(newScope, aapsLogger, LTag.WEAR) { state ->
@@ -118,10 +123,12 @@ class WearPlugin @Inject constructor(
                     if (state != null) {
                         if (!state.isSMB || preferences.get(BooleanKey.WearNotifyOnSmb)) {
                             rxBus.send(EventMobileToWear(EventData.BolusProgress(percent = state.percent, status = state.wearStatus)))
+                            lastSentPercent = state.percent
                         }
-                    } else {
-                        // Bolus ended — send 100% to clear wear display
+                    } else if (lastSentPercent < 100) {
+                        // Bolus ended without a 100% frame (cancelled/failed) — send 100% to clear wear display
                         rxBus.send(EventMobileToWear(EventData.BolusProgress(percent = 100, status = "")))
+                        lastSentPercent = 100
                     }
                 }
             }


### PR DESCRIPTION
On bolus end, WearPlugin unconditionally sent a percent=100 empty-status frame, overwriting the driver's last status — the wear notification showed "100% -" for its 5 s dismiss window.
 
Now the clear frame is only sent when the watch was left mid-progress (cancel/failure). A completed bolus keeps the driver's final text, e.g. "Bolus delivered successfully". 

Side fix: no more stray "100% -" notification for SMBs when "Notify on SMB" is disabled.

:plugins:sync:test tests passed - tested ok on AAPS / AAPSCLient wear with Dash and virtual pump

Before:

https://github.com/user-attachments/assets/f78ef900-a474-49d0-a166-cfb4e27a1e9b


After:

https://github.com/user-attachments/assets/e4501643-c83e-47ac-938a-40b583fb1fb3

