### PR TITLE
Wear: fix install error on Wear OS 3 watches (missing wear-sdk library)

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -37,6 +37,14 @@
         android:label="@string/app_name"
         android:theme="@android:style/Theme.DeviceDefault">
 
+        <!-- androidx.wear.watchfacepush declares the wear-sdk platform library as required, which
+             blocks install on watches older than Wear OS 4 (INSTALL_FAILED_MISSING_SHARED_LIBRARY).
+             Make it optional: all Watch Face Push usage is guarded by SDK checks (Wear OS 6+). -->
+        <uses-library
+            android:name="wear-sdk"
+            android:required="false"
+            tools:node="replace" />
+
         <meta-data
             android:name="com.google.android.wearable.standalone"
             android:value="false" />


### PR DESCRIPTION
The Watch Face Push library (added in #5022) marks the `wear-sdk` platform library as required. That library only exists on Wear OS 4+, so installing the wear APK on Wear OS 3 watches (e.g. TicWatch E3) failed with `INSTALL_FAILED_MISSING_SHARED_LIBRARY`.
<img width="2273" height="130" alt="image" src="https://github.com/user-attachments/assets/e85daee1-f549-459d-b344-bf37b3f932f5" />

This overrides the entry to `required="false"` in our manifest. Safe because all Watch Face Push code is already behind a Wear OS 6+ runtime check — on older watches the watchface install menu simply does not appear.

Tested OK on Wear OS 6 (watchface push still works). 
Tested OK on Wear OS 3 Virtual device:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/14dd17a4-8d80-42b4-ae1d-f065543ec94c" />

Tested OK on TicWatch E3 from @gerison77 who reported the issue. 

https://discord.com/channels/629952586895851530/1488837966188253206/1536831262533099632