### PR TITLE
Allow silencing failed basal profile update alarm

### DIFF
--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -67,6 +67,7 @@ enum class BooleanKey(
     AlertUrgentAsAndroidNotification("raise_urgent_alarms_as_android_notification", true, R.string.pref_title_alert_urgent_as_android_notification),
     AlertIncreaseVolume("gradually_increase_notification_volume", true, R.string.pref_title_alert_increase_volume),
     AlertOverrideDoNotDisturb("alert_override_dnd", true, R.string.pref_title_alert_override_dnd, R.string.pref_summary_alert_override_dnd, defaultedBySM = true),
+    AlertFailedUpdateBasalProfileSound("enable_failed_update_basal_profile_sound", true, R.string.pref_title_alert_failed_update_basal_profile_sound, R.string.pref_summary_alert_failed_update_basal_profile_sound),
 
     BgSourceUploadToNs("dexcomg5_nsupload", true, R.string.pref_title_bg_source_upload_to_ns, defaultedBySM = true, hideParentScreenIfHidden = true),
     BgSourceCreateSensorChange("dexcom_lognssensorchange", true, R.string.pref_title_bg_source_create_sensor_change, R.string.pref_summary_bg_source_create_sensor_change, defaultedBySM = true),

--- a/core/keys/src/main/res/values/strings.xml
+++ b/core/keys/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="pref_title_alert_increase_volume">Gradually increase notification volume</string>
     <string name="pref_title_alert_override_dnd">Override Do Not Disturb mode</string>
     <string name="pref_summary_alert_override_dnd">When enabled, AAPS alarms play through silent and Do Not Disturb modes (alarm stream). When disabled, alarms respect silent/DND (notification stream).</string>
+    <string name="pref_title_alert_failed_update_basal_profile_sound">Play sound on failed basal profile update</string>
+    <string name="pref_summary_alert_failed_update_basal_profile_sound">When disabled, AAPS still shows the failed basal profile update alert, but without the alarm sound.</string>
 
     <!-- BG Source preferences -->
     <string name="pref_title_bg_source_upload_to_ns">Upload BG data to NS</string>

--- a/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
+++ b/implementation/src/main/kotlin/app/aaps/implementation/queue/CommandQueueImplementation.kt
@@ -39,6 +39,7 @@ import app.aaps.core.interfaces.smsCommunicator.SmsCommunicator
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.core.objects.constraints.ConstraintObject
 import app.aaps.core.objects.extensions.getCustomizedName
@@ -189,10 +190,11 @@ class CommandQueueImplementation @Inject constructor(
      * [PumpEnactResult]; none post profile-set notifications themselves). `internal` so it can be unit-tested.
      *
      *  - failure (timeout `result == null`, or `!success`): post the persistent [NotificationId.FAILED_UPDATE_PROFILE]
-     *    "wrong basal until fixed" card, rung via [app.aaps.core.ui.R.raw.boluserror]; the driver's `comment` supplies
+     *    "wrong basal until fixed" card. By default it rings via [app.aaps.core.ui.R.raw.boluserror], but the user can
+     *    silence only this sound with [BooleanKey.AlertFailedUpdateBasalProfileSound]. The driver's `comment` supplies
      *    the reason (a timeout has none). Deliberately NOT a full-screen `runAlarm` — a wrong base profile is serious
-     *    but persistent, so a dismissible alarm-notification is the right weight (a failed TBR is even quieter,
-     *    surfaced only in the loop status).
+     *    but persistent, so a dismissible alarm-notification is the right weight (a failed TBR is even quieter, surfaced
+     *    only in the loop status).
      *  - success: clear any stale FAILED_UPDATE_PROFILE; and on a real write ([PumpEnactResult.enacted]) that is not
      *    internal/automatic (`!silent` — e.g. a Scene reverting its own ProfileSwitch, issue #4959) raise the
      *    "Basal profile in pump updated" ([NotificationId.PROFILE_SET_OK]) confirmation. Deferred / already-set writes
@@ -205,10 +207,11 @@ class CommandQueueImplementation @Inject constructor(
      */
     internal fun postProfileWriteResult(result: PumpEnactResult?, silent: Boolean): Boolean {
         if (result == null || !result.success) {
+            val soundRes = if (preferences.get(BooleanKey.AlertFailedUpdateBasalProfileSound)) app.aaps.core.ui.R.raw.boluserror else null
             notificationManager.post(
                 NotificationId.FAILED_UPDATE_PROFILE,
                 result?.comment?.takeIf { it.isNotBlank() } ?: rh.gs(app.aaps.core.ui.R.string.failed_update_basal_profile),
-                soundRes = app.aaps.core.ui.R.raw.boluserror
+                soundRes = soundRes
             )
             return false
         }

--- a/implementation/src/test/kotlin/app/aaps/implementation/queue/CommandQueueImplementationTest.kt
+++ b/implementation/src/test/kotlin/app/aaps/implementation/queue/CommandQueueImplementationTest.kt
@@ -27,6 +27,7 @@ import app.aaps.core.interfaces.smsCommunicator.SmsCommunicator
 import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.core.objects.constraints.ConstraintObject
 import app.aaps.implementation.profile.ProfileSwitchSilentGate
@@ -161,6 +162,7 @@ class CommandQueueImplementationTest : TestBaseWithProfile() {
             whenever(rh.gs(app.aaps.core.ui.R.string.command_replaced)).thenReturn("Replaced by newer command")
             whenever(rh.gs(eq(app.aaps.core.ui.R.string.format_insulin_units), anyOrNull())).thenReturn("%1\$.2f U")
             whenever(rh.gs(app.aaps.core.ui.R.string.goingtodeliver)).thenReturn("Going to deliver %1\$.2f U")
+            whenever(preferences.get(BooleanKey.AlertFailedUpdateBasalProfileSound)).thenReturn(true)
         }
     }
 
@@ -268,10 +270,10 @@ class CommandQueueImplementationTest : TestBaseWithProfile() {
             anyOrNull(), any<List<NotificationAction>>(), anyOrNull()
         )
 
-    private fun verifyFailurePosted(text: String) =
+    private fun verifyFailurePosted(text: String, soundRes: Int? = app.aaps.core.ui.R.raw.boluserror) =
         verify(notificationManager).post(
             eq(NotificationId.FAILED_UPDATE_PROFILE), eq(text), any<NotificationLevel>(), any<Int>(),
-            eq(app.aaps.core.ui.R.raw.boluserror), any<List<NotificationAction>>(), anyOrNull()
+            eq(soundRes), any<List<NotificationAction>>(), anyOrNull()
         )
 
     private fun verifyNothingPosted() =
@@ -316,6 +318,17 @@ class CommandQueueImplementationTest : TestBaseWithProfile() {
 
         assertThat(persisted).isFalse()
         verifyFailurePosted("pump rejected")
+        verify(notificationManager, never()).dismiss(any<NotificationId>())
+    }
+
+    @Test
+    fun postProfileWriteResult_error_canPostFailureWithoutSound() {
+        whenever(preferences.get(BooleanKey.AlertFailedUpdateBasalProfileSound)).thenReturn(false)
+
+        val persisted = commandQueue.postProfileWriteResult(enactResult(isSuccess = false, isEnacted = false, commentText = "pump rejected"), silent = false)
+
+        assertThat(persisted).isFalse()
+        verifyFailurePosted("pump rejected", soundRes = null)
         verify(notificationManager, never()).dismiss(any<NotificationId>())
     }
 

--- a/ui/src/main/kotlin/app/aaps/ui/search/BuiltInSearchables.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/search/BuiltInSearchables.kt
@@ -183,7 +183,8 @@ class BuiltInSearchables @Inject constructor(
             BooleanKey.AlertCarbsRequired,
             BooleanKey.AlertUrgentAsAndroidNotification,
             BooleanKey.AlertIncreaseVolume,
-            BooleanKey.AlertOverrideDoNotDisturb
+            BooleanKey.AlertOverrideDoNotDisturb,
+            BooleanKey.AlertFailedUpdateBasalProfileSound
         ),
         icon = Icons.Default.Notifications
     )
@@ -360,4 +361,3 @@ class BuiltInSearchables @Inject constructor(
         add(SearchableItem.Category(siteRotation))
     }
 }
-


### PR DESCRIPTION
## Summary

- add a final Settings > Alerts preference for the failed basal profile update sound
- keep the preference enabled by default to preserve existing behavior
- continue posting the failure notification while suppressing its alarm sound when disabled
- cover the silent failure-notification path with a unit test

## Testing

- `git diff --check`
- `./gradlew :implementation:testFullDebugUnitTest --tests app.aaps.implementation.queue.CommandQueueImplementationTest` *(unable to run because the Android SDK is not installed or configured in this environment)*

Related to #275.
