### PR TITLE
Add preference to show/render BG in the notification icon

### DIFF
--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -67,10 +67,7 @@ enum class BooleanKey(
     AlertUrgentAsAndroidNotification("raise_urgent_alarms_as_android_notification", true, R.string.pref_title_alert_urgent_as_android_notification),
     AlertIncreaseVolume("gradually_increase_notification_volume", true, R.string.pref_title_alert_increase_volume),
     AlertOverrideDoNotDisturb("alert_override_dnd", true, R.string.pref_title_alert_override_dnd, R.string.pref_summary_alert_override_dnd, defaultedBySM = true),
-    NotificationShowBgOnIcon(
-        "notification_show_bg_on_icon", false, R.string.pref_title_notification_show_bg_on_icon, R.string.pref_summary_notification_show_bg_on_icon
-    ),
-
+    NotificationShowBgOnIcon("notification_show_bg_on_icon", false, R.string.pref_title_notification_show_bg_on_icon),
     BgSourceUploadToNs("dexcomg5_nsupload", true, R.string.pref_title_bg_source_upload_to_ns, defaultedBySM = true, hideParentScreenIfHidden = true),
     BgSourceCreateSensorChange("dexcom_lognssensorchange", true, R.string.pref_title_bg_source_create_sensor_change, R.string.pref_summary_bg_source_create_sensor_change, defaultedBySM = true),
     BgSourceRandomBgRandomize("randombg_randomize", true, R.string.pref_title_random_bg_randomize, R.string.pref_summary_random_bg_randomize, defaultedBySM = true),

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/BooleanKey.kt
@@ -67,6 +67,9 @@ enum class BooleanKey(
     AlertUrgentAsAndroidNotification("raise_urgent_alarms_as_android_notification", true, R.string.pref_title_alert_urgent_as_android_notification),
     AlertIncreaseVolume("gradually_increase_notification_volume", true, R.string.pref_title_alert_increase_volume),
     AlertOverrideDoNotDisturb("alert_override_dnd", true, R.string.pref_title_alert_override_dnd, R.string.pref_summary_alert_override_dnd, defaultedBySM = true),
+    NotificationShowBgOnIcon(
+        "notification_show_bg_on_icon", false, R.string.pref_title_notification_show_bg_on_icon, R.string.pref_summary_notification_show_bg_on_icon
+    ),
 
     BgSourceUploadToNs("dexcomg5_nsupload", true, R.string.pref_title_bg_source_upload_to_ns, defaultedBySM = true, hideParentScreenIfHidden = true),
     BgSourceCreateSensorChange("dexcom_lognssensorchange", true, R.string.pref_title_bg_source_create_sensor_change, R.string.pref_summary_bg_source_create_sensor_change, defaultedBySM = true),

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
@@ -433,7 +433,7 @@ enum class IntKey(
         }
     ),
 
-    BgSourceRandomInterval(key = "randombg_interval_min", defaultValue = 5, min = 1, max = 15, titleResId = R.string.pref_title_random_bg_interval, defaultedBySM = true, unitType = UnitType.MIN),
+    BgSourceRandomInterval(key = "randombg_interval_min", defaultValue = 1, min = 1, max = 15, titleResId = R.string.pref_title_random_bg_interval, defaultedBySM = true, unitType = UnitType.MIN),
     NsClientAlarmStaleData(key = "ns_alarm_stale_data_value", defaultValue = 16, min = 15, max = 120, titleResId = R.string.pref_title_alarm_stale_data, unitType = UnitType.MIN),
     NsClientUrgentAlarmStaleData(key = "ns_alarm_urgent_stale_data_value", defaultValue = 31, min = 30, max = 180, titleResId = R.string.pref_title_urgent_alarm_stale_data, unitType = UnitType.MIN),
 

--- a/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
+++ b/core/keys/src/main/kotlin/app/aaps/core/keys/IntKey.kt
@@ -433,7 +433,7 @@ enum class IntKey(
         }
     ),
 
-    BgSourceRandomInterval(key = "randombg_interval_min", defaultValue = 1, min = 1, max = 15, titleResId = R.string.pref_title_random_bg_interval, defaultedBySM = true, unitType = UnitType.MIN),
+    BgSourceRandomInterval(key = "randombg_interval_min", defaultValue = 5, min = 1, max = 15, titleResId = R.string.pref_title_random_bg_interval, defaultedBySM = true, unitType = UnitType.MIN),
     NsClientAlarmStaleData(key = "ns_alarm_stale_data_value", defaultValue = 16, min = 15, max = 120, titleResId = R.string.pref_title_alarm_stale_data, unitType = UnitType.MIN),
     NsClientUrgentAlarmStaleData(key = "ns_alarm_urgent_stale_data_value", defaultValue = 31, min = 30, max = 180, titleResId = R.string.pref_title_urgent_alarm_stale_data, unitType = UnitType.MIN),
 

--- a/core/keys/src/main/res/values/strings.xml
+++ b/core/keys/src/main/res/values/strings.xml
@@ -37,7 +37,6 @@
     <string name="pref_title_alert_override_dnd">Override Do Not Disturb mode</string>
     <string name="pref_summary_alert_override_dnd">When enabled, AAPS alarms play through silent and Do Not Disturb modes (alarm stream). When disabled, alarms respect silent/DND (notification stream).</string>
     <string name="pref_title_notification_show_bg_on_icon">Show glucose value on notification icon</string>
-    <string name="pref_summary_notification_show_bg_on_icon">Draw the current glucose value into the ongoing notification status bar icon instead of the app icon.</string>
 
     <!-- BG Source preferences -->
     <string name="pref_title_bg_source_upload_to_ns">Upload BG data to NS</string>

--- a/core/keys/src/main/res/values/strings.xml
+++ b/core/keys/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="pref_title_alert_increase_volume">Gradually increase notification volume</string>
     <string name="pref_title_alert_override_dnd">Override Do Not Disturb mode</string>
     <string name="pref_summary_alert_override_dnd">When enabled, AAPS alarms play through silent and Do Not Disturb modes (alarm stream). When disabled, alarms respect silent/DND (notification stream).</string>
+    <string name="pref_title_notification_show_bg_on_icon">Show glucose value on notification icon</string>
+    <string name="pref_summary_notification_show_bg_on_icon">Draw the current glucose value into the ongoing notification status bar icon instead of the app icon.</string>
 
     <!-- BG Source preferences -->
     <string name="pref_title_bg_source_upload_to_ns">Upload BG data to NS</string>

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/BgIconRenderer.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/BgIconRenderer.kt
@@ -20,7 +20,12 @@ class BgIconRenderer @Inject constructor() {
         const val MIN_TEXT_SIZE_PX = 8f
     }
 
+    private var cachedText: String? = null
+    private var cachedIcon: IconCompat? = null
+
+    @Synchronized
     fun render(text: String): IconCompat {
+        cachedIcon?.let { if (text == cachedText) return it }
         val bitmap = Bitmap.createBitmap(SIZE_PX, SIZE_PX, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -33,7 +38,10 @@ class BgIconRenderer @Inject constructor() {
         val x = SIZE_PX / 2f
         val y = SIZE_PX / 2f - bounds.exactCenterY()
         canvas.drawText(text, x, y, paint)
-        return IconCompat.createWithBitmap(bitmap)
+        val icon = IconCompat.createWithBitmap(bitmap)
+        cachedText = text
+        cachedIcon = icon
+        return icon
     }
 
     private fun fitTextSize(paint: Paint, text: String, bounds: Rect): Float {

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/BgIconRenderer.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/BgIconRenderer.kt
@@ -1,0 +1,50 @@
+package app.aaps.plugins.main.general.persistentNotification
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
+import androidx.core.graphics.drawable.IconCompat
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BgIconRenderer @Inject constructor() {
+
+    private companion object {
+
+        const val SIZE_PX = 96
+        const val PADDING_PX = 8
+        const val MIN_TEXT_SIZE_PX = 8f
+    }
+
+    fun render(text: String): IconCompat {
+        val bitmap = Bitmap.createBitmap(SIZE_PX, SIZE_PX, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textAlign = Paint.Align.CENTER
+        }
+        val bounds = Rect()
+        paint.textSize = fitTextSize(paint, text, bounds)
+        val x = SIZE_PX / 2f
+        val y = SIZE_PX / 2f - bounds.exactCenterY()
+        canvas.drawText(text, x, y, paint)
+        return IconCompat.createWithBitmap(bitmap)
+    }
+
+    private fun fitTextSize(paint: Paint, text: String, bounds: Rect): Float {
+        val maxSide = SIZE_PX - 2 * PADDING_PX
+        var size = SIZE_PX.toFloat()
+        while (size > MIN_TEXT_SIZE_PX) {
+            paint.textSize = size
+            paint.getTextBounds(text, 0, text.length, bounds)
+            if (bounds.width() <= maxSide && bounds.height() <= maxSide) break
+            size -= 2f
+        }
+        return size
+    }
+}

--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/persistentNotification/PersistentNotificationPlugin.kt
@@ -35,6 +35,8 @@ import app.aaps.core.interfaces.utils.DateUtil
 import app.aaps.core.interfaces.utils.DecimalFormatter
 import app.aaps.core.interfaces.utils.TrendCalculator
 import app.aaps.core.interfaces.utils.fabric.FabricPrivacy
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.core.objects.extensions.apsAdjustedTargetMgdl
 import app.aaps.core.objects.extensions.generateCOBString
 import app.aaps.core.objects.extensions.round
@@ -74,7 +76,9 @@ class PersistentNotificationPlugin @Inject constructor(
     private val persistenceLayer: PersistenceLayer,
     private val processedDeviceStatusData: ProcessedDeviceStatusData,
     private val dateUtil: DateUtil,
-    private val trendCalculator: TrendCalculator
+    private val trendCalculator: TrendCalculator,
+    private val preferences: Preferences,
+    private val bgIconRenderer: BgIconRenderer
 ) : PluginBase(
     PluginDescription()
         .mainType(PluginType.GENERAL)
@@ -144,6 +148,7 @@ class PersistentNotificationPlugin @Inject constructor(
         var line1: String?
         var line2: String? = null
         var line3: String? = null
+        var iconBgText: String? = null
         var unreadConversationBuilder: NotificationCompat.CarExtender.UnreadConversation.Builder? = null
         if (profileFunction.isProfileValid("Notification")) {
             val lastBG = iobCobCalculator.ads.lastBg()
@@ -151,7 +156,8 @@ class PersistentNotificationPlugin @Inject constructor(
             if (lastBG != null) {
                 val trendSymbol = (trendCalculator.getTrendArrow(iobCobCalculator.ads)
                     ?.takeIf { it != TrendArrow.NONE } ?: TrendArrow.FLAT).symbol
-                line1 = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated) + " " + trendSymbol
+                iconBgText = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated)
+                line1 = iconBgText + " " + trendSymbol
                 if (glucoseStatus != null) {
                     line1 += " " + profileUtil.fromMgdlToSignedStringInUnits(glucoseStatus.delta)
                 } else {
@@ -239,7 +245,12 @@ class PersistentNotificationPlugin @Inject constructor(
         builder.setOngoing(true)
         builder.setOnlyAlertOnce(true)
         builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-        builder.setSmallIcon(iconsProvider.getNotificationIcon())
+        val bgText = iconBgText
+        if (preferences.get(BooleanKey.NotificationShowBgOnIcon) && bgText != null) {
+            builder.setSmallIcon(bgIconRenderer.render(bgText))
+        } else {
+            builder.setSmallIcon(iconsProvider.getNotificationIcon())
+        }
         builder.setContentTitle(line1)
         if (line2 != null) builder.setContentText(line2)
         if (line3 != null) builder.setSubText(line3)

--- a/ui/src/main/kotlin/app/aaps/ui/search/BuiltInSearchables.kt
+++ b/ui/src/main/kotlin/app/aaps/ui/search/BuiltInSearchables.kt
@@ -183,7 +183,8 @@ class BuiltInSearchables @Inject constructor(
             BooleanKey.AlertCarbsRequired,
             BooleanKey.AlertUrgentAsAndroidNotification,
             BooleanKey.AlertIncreaseVolume,
-            BooleanKey.AlertOverrideDoNotDisturb
+            BooleanKey.AlertOverrideDoNotDisturb,
+            BooleanKey.NotificationShowBgOnIcon
         ),
         icon = Icons.Default.Notifications
     )


### PR DESCRIPTION
Adding a new preference to allow the user to view their BG in the notification icon.

The main motivation behind this change is so you can see your BG in the status bar, without having to pull down the notification shade:
<img width="352" height="57" alt="image" src="https://github.com/user-attachments/assets/e7f5171f-8d8b-4643-92df-7cc548d96feb" />

This is done by adding a new `BooleanKey#NotificationShowBgOnIcon` enum value, with shared preferences key being `"notification_show_bg_on_icon"`.

The setting falls under the "Local Alerts" group.

When the preference is enabled, it replaces the persistent notification's small icon (`NotificationCompat.Builder#setSmallIcon`) with an icon created inside `BgIconRenderer`. The icon itself is a notification `IconCompat` created from a `Bitmap` of size 96x96. The `IconCompat` is also cached, folllowing what the existing `IconBitmapRenderer` does.

This bitmap is safe on memory because:
1. Size is tiny. Size: 96×96 ARGB_8888 = ~36 KB per bitmap
2. Lifetime is short, each overview update replaces the previous notification, so at most one or two are alive at once; GC handles them.
3. The icon itself is cached and only updates when the value changes.


**Screenshots:**
|Light|Dark|
|---|---|
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/d8458b0f-8df1-46c8-8c88-3bac409afda4" />| <img width="200" alt="image" src="https://github.com/user-attachments/assets/0668a729-9ff7-4253-98e0-266bf73edeec" />|

|<img width="200" alt="image" src="https://github.com/user-attachments/assets/11ad76cd-7b00-4a0a-9954-651c64c36d3e" />|<img width="200" alt="Screenshot_20260825_111754" src="https://github.com/user-attachments/assets/7f0649e2-d5cf-441c-a792-988991626033" />|<img width="200" alt="Screenshot_20260825_111459" src="https://github.com/user-attachments/assets/763bfaab-29a4-4a1b-b33d-ff69b1392dd6" />|<img width="200" alt="Screenshot_20260825_111446" src="https://github.com/user-attachments/assets/522e593f-20dd-4f8c-921e-59633a20a677" />|
