### PR TITLE
Parse longs from NightScout response with defensive approach

### DIFF
--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/LongJsonDeserializer.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/LongJsonDeserializer.kt
@@ -1,0 +1,33 @@
+package app.aaps.core.nssdk.networking
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.lang.reflect.Type
+
+class LongJsonDeserializer : JsonDeserializer<Long?> {
+
+    override fun deserialize(json: JsonElement?, typeOfT: Type?, context: JsonDeserializationContext?): Long? =
+        json.toLongOrNull("Long value")
+}
+
+internal fun JsonElement?.toLongOrNull(name: String): Long? {
+    if (this == null || isJsonNull) return null
+    if (!isJsonPrimitive) throw JsonParseException("$name is not a number")
+
+    return try {
+        val value = asString.toBigDecimal()
+        if (value <= MIN_LONG_EXCLUSIVE || value >= MAX_LONG_EXCLUSIVE) {
+            throw ArithmeticException()
+        }
+        value.toLong()
+    } catch (error: NumberFormatException) {
+        throw JsonParseException("$name is not a number", error)
+    } catch (error: ArithmeticException) {
+        throw JsonParseException("$name is outside the Long range", error)
+    }
+}
+
+private val MIN_LONG_EXCLUSIVE = "-9223372036854775809".toBigDecimal()
+private val MAX_LONG_EXCLUSIVE = "9223372036854775808".toBigDecimal()

--- a/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/NetworkStackBuilder.kt
+++ b/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/networking/NetworkStackBuilder.kt
@@ -100,7 +100,10 @@ internal object NetworkStackBuilder {
             JSONObject(json.asJsonObject.toString())
         }
     private fun provideGson(): Gson = GsonBuilder().also {
+        val longJsonDeserializer = LongJsonDeserializer()
         it.registerTypeAdapter(JSONObject::class.java, deserializer)
+        it.registerTypeAdapter(Long::class.java, longJsonDeserializer)
+        it.registerTypeAdapter(Long::class.javaObjectType, longJsonDeserializer)
     }.create()
 
     private const val OK_HTTP_CACHE_SIZE = 10L * 1024 * 1024

--- a/core/nssdk/src/test/kotlin/app/aaps/core/nssdk/networking/LongJsonDeserializerTest.kt
+++ b/core/nssdk/src/test/kotlin/app/aaps/core/nssdk/networking/LongJsonDeserializerTest.kt
@@ -1,0 +1,77 @@
+package app.aaps.core.nssdk.networking
+
+import app.aaps.core.nssdk.remotemodel.LastModified
+import app.aaps.core.nssdk.remotemodel.NSResponse
+import app.aaps.core.nssdk.remotemodel.RemoteEntry
+import com.google.common.truth.Truth.assertThat
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParseException
+import com.google.gson.reflect.TypeToken
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class LongJsonDeserializerTest {
+
+    private val gson: Gson = GsonBuilder().run {
+        val longJsonDeserializer = LongJsonDeserializer()
+        registerTypeAdapter(Long::class.java, longJsonDeserializer)
+        registerTypeAdapter(Long::class.javaObjectType, longJsonDeserializer)
+        create()
+    }
+
+    @Test
+    fun readsDecimalRemoteEntryDate() {
+        val responseType = object : TypeToken<NSResponse<List<RemoteEntry>>>() {}.type
+        val response = gson.fromJson<NSResponse<List<RemoteEntry>>>(
+            """{"result":[{"date":1783235730809.793}]}""",
+            responseType
+        )
+
+        assertThat(response.result?.single()?.date).isEqualTo(1_783_235_730_809L)
+    }
+
+    @Test
+    fun readsDecimalPrimitiveLong() {
+        val lastModified = gson.fromJson(
+            """{"collections":{"entries":1757000496856.75}}""",
+            LastModified::class.java
+        )
+
+        assertThat(lastModified.collections.entries).isEqualTo(1_757_000_496_856L)
+    }
+
+    @Test
+    fun truncatesNegativeDecimalAndScientificNotation() {
+        val values = gson.fromJson(
+            """{"first":-123.9,"second":1.757000496856E12}""",
+            LongValues::class.java
+        )
+
+        assertThat(values.first).isEqualTo(-123L)
+        assertThat(values.second).isEqualTo(1_757_000_496_856L)
+    }
+
+    @Test
+    fun readsNullOptionalLong() {
+        val value = gson.fromJson("""{"value":null}""", OptionalLongValue::class.java)
+
+        assertThat(value.value).isNull()
+    }
+
+    @Test
+    fun rejectsValueOutsideLongRange() {
+        assertThrows<JsonParseException> {
+            gson.fromJson("""{"value":1E100000000}""", OptionalLongValue::class.java)
+        }
+    }
+
+    private data class LongValues(
+        val first: Long,
+        val second: Long
+    )
+
+    private data class OptionalLongValue(
+        val value: Long?
+    )
+}


### PR DESCRIPTION
When doing a full sync of treatment data using the nightscout client v3, the client fails to parse the `v3/lastModified` response.

The respone from my NightScout instance had a `$collections.entries` value of `1788779742621.0386` which is not a long, and it leads to a `java.lang.NumberFormatException`.

This could be because I have Trio and AndroidAPS both uploading to my NightScout server, but regardless of the scenario - I believe the client should be defensive with parsing the lastModified response.

This change adds a custom type adapter (`LongJsonDeserializer`) to serialize the `LastModifed#Collections` instance with defensive parsing of the expected `Long` values, and also for some other longs such as the date which comes down as a decimal/float from NS.

I have also added unit tests for this new `LongJsonDeserializer`.

Example error stacktrace for reference:
1. 
```
[DefaultDispatcher-worker-2]: [LoadLastModificationWorker.doWorkAndLog():35]: Error: 
  com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected a long but was 1788779742621.0386 at line 1 column 121 path $.result.collections.entries
  	at com.google.gson.internal.bind.TypeAdapters$13.read(TypeAdapters.java:415)
  	at com.google.gson.internal.bind.TypeAdapters$13.read(TypeAdapters.java:405)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:517)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:517)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:517)
  	at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:40)
  	at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:27)
  	at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:246)
  	at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:156)
  	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:584)
  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
  	at java.lang.Thread.run(Thread.java:1119)
  Caused by: java.lang.NumberFormatException: Expected a long but was 1788779742621.0386 at line 1 column 121 path $.result.collections.entries
  	at com.google.gson.stream.JsonReader.nextLong(JsonReader.java:1110)
  	at com.google.gson.internal.bind.TypeAdapters$13.read(TypeAdapters.java:413)
  	... 18 common frames omitted
```

2.
```
[DefaultDispatcher-worker-15]: [LoadBgWorker.doWorkAndLog():98]: Error: 
  com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected a long but was 1783235730809.793 at line 1 column 78591 path $.result[222].date
  	at com.google.gson.internal.bind.TypeAdapters$13.read(TypeAdapters.java:415)
  	at com.google.gson.internal.bind.TypeAdapters$13.read(TypeAdapters.java:405)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:517)
  	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
  	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:84)
  	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:64)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$2.readIntoField(ReflectiveTypeAdapterFactory.java:271)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:559)
  	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:
```