### PR TITLE
CI: keep signing passwords intact when they contain shell characters

### DIFF
--- a/.github/workflows/aaps-ci.yml
+++ b/.github/workflows/aaps-ci.yml
@@ -64,35 +64,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decode Secrets Keystore Set and Oauth2 to Env
+        env:
+          # Secrets arrive as environment variables. They must not be pasted into
+          # the script text, because bash then parses them as source: any $,
+          # backtick, quote or newline inside a password changes or truncates the
+          # value before it is ever used, and jarsigner then blames the password.
+          S_KEYSTORE_SET: ${{ secrets.KEYSTORE_SET }}
+          S_KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          S_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          S_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          S_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          S_GDRIVE_OAUTH2: ${{ secrets.GDRIVE_OAUTH2 }}
         run: |
-          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+          # The heredoc form of GITHUB_ENV keeps any value intact, newlines
+          # included. The delimiter is random so that no value can close the
+          # block early and add variables of its own.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit() { printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"; }
+          # Values cut out of KEYSTORE_SET are not registered secrets, so the
+          # runner does not hide them in the log unless we ask it to.
+          emit_masked() { echo "::add-mask::$2"; emit "$1" "$2"; }
+
+          if [ -n "$S_KEYSTORE_SET" ]; then
             echo "🔐 Decoding KEYSTORE_SET..."
-            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+            DECODED=$(printf '%s' "$S_KEYSTORE_SET" | base64 -d)
 
-            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
-            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
-            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
-            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
-
-            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
-            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
-
-            echo "::add-mask::$KEYSTORE_BASE64"
-            echo "::add-mask::$KEYSTORE_PASSWORD"
-            echo "::add-mask::$KEY_ALIAS"
-            echo "::add-mask::$KEY_PASSWORD"
+            emit_masked KEYSTORE_BASE64   "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+            emit_masked KEYSTORE_PASSWORD "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+            emit_masked KEY_ALIAS         "$(printf '%s' "$DECODED" | cut -d'|' -f3)"
+            emit_masked KEY_PASSWORD      "$(printf '%s' "$DECODED" | cut -d'|' -f4)"
 
             echo "✅ Keystore parameters extracted from KEYSTORE_SET"
           else
             echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
-            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+            emit KEYSTORE_BASE64   "$S_KEYSTORE_BASE64"
+            emit KEYSTORE_PASSWORD "$S_KEYSTORE_PASSWORD"
+            emit KEY_ALIAS         "$S_KEY_ALIAS"
+            emit KEY_PASSWORD      "$S_KEY_PASSWORD"
           fi
-          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
+          emit GDRIVE_OAUTH2 "$S_GDRIVE_OAUTH2"
 
       - name: Check Secrets
         run: |
@@ -157,17 +167,19 @@ jobs:
 
       - name: Decode GDrive OAuth2 secrets
         run: |
+          # GDRIVE_OAUTH2 is already in the environment from the decode step
+          # above, so nothing has to be pasted into the script text here either.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit_masked() {
+            echo "::add-mask::$2"
+            printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"
+          }
+
           echo "🔐 Decoding GDRIVE_OAUTH2..."
-          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
+          DECODED=$(printf '%s' "$GDRIVE_OAUTH2" | base64 -d)
 
-          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
-          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-
-          echo "::add-mask::$GDRIVE_CLIENT_ID"
-          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-
-          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
-          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
+          emit_masked GDRIVE_CLIENT_ID     "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+          emit_masked GDRIVE_REFRESH_TOKEN "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
 
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -24,35 +24,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decode Secrets Keystore Set and Oauth2 to Env
+        env:
+          # Secrets arrive as environment variables. They must not be pasted into
+          # the script text, because bash then parses them as source: any $,
+          # backtick, quote or newline inside a password changes or truncates the
+          # value before it is ever used, and jarsigner then blames the password.
+          S_KEYSTORE_SET: ${{ secrets.KEYSTORE_SET }}
+          S_KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          S_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          S_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          S_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          S_GDRIVE_OAUTH2: ${{ secrets.GDRIVE_OAUTH2 }}
         run: |
-          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+          # The heredoc form of GITHUB_ENV keeps any value intact, newlines
+          # included. The delimiter is random so that no value can close the
+          # block early and add variables of its own.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit() { printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"; }
+          # Values cut out of KEYSTORE_SET are not registered secrets, so the
+          # runner does not hide them in the log unless we ask it to.
+          emit_masked() { echo "::add-mask::$2"; emit "$1" "$2"; }
+
+          if [ -n "$S_KEYSTORE_SET" ]; then
             echo "🔐 Decoding KEYSTORE_SET..."
-            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+            DECODED=$(printf '%s' "$S_KEYSTORE_SET" | base64 -d)
 
-            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
-            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
-            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
-            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
-
-            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
-            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
-
-            echo "::add-mask::$KEYSTORE_BASE64"
-            echo "::add-mask::$KEYSTORE_PASSWORD"
-            echo "::add-mask::$KEY_ALIAS"
-            echo "::add-mask::$KEY_PASSWORD"
+            emit_masked KEYSTORE_BASE64   "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+            emit_masked KEYSTORE_PASSWORD "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+            emit_masked KEY_ALIAS         "$(printf '%s' "$DECODED" | cut -d'|' -f3)"
+            emit_masked KEY_PASSWORD      "$(printf '%s' "$DECODED" | cut -d'|' -f4)"
 
             echo "✅ Keystore parameters extracted from KEYSTORE_SET"
           else
             echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
-            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+            emit KEYSTORE_BASE64   "$S_KEYSTORE_BASE64"
+            emit KEYSTORE_PASSWORD "$S_KEYSTORE_PASSWORD"
+            emit KEY_ALIAS         "$S_KEY_ALIAS"
+            emit KEY_PASSWORD      "$S_KEY_PASSWORD"
           fi
-          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
+          emit GDRIVE_OAUTH2 "$S_GDRIVE_OAUTH2"
 
       - name: Check Secrets
         run: |
@@ -117,18 +127,20 @@ jobs:
 
       - name: Decode GDrive OAuth2 secrets
         run: |
+          # GDRIVE_OAUTH2 is already in the environment from the decode step
+          # above, so nothing has to be pasted into the script text here either.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit_masked() {
+            echo "::add-mask::$2"
+            printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"
+          }
+
           echo "🔐 Decoding GDRIVE_OAUTH2..."
-          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
-          
-          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
-          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-          
-          echo "::add-mask::$GDRIVE_CLIENT_ID"
-          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-          
-          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
-          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
-          
+          DECODED=$(printf '%s' "$GDRIVE_OAUTH2" | base64 -d)
+
+          emit_masked GDRIVE_CLIENT_ID     "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+          emit_masked GDRIVE_REFRESH_TOKEN "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 
       - name: Retrieving Google Drive access token
@@ -309,5 +321,3 @@ jobs:
       workflow_name: 'Branch CI'
       keep_runs: 30
       keep_threshold: 10
-
-

--- a/.github/workflows/cherry-pick-ci.yml
+++ b/.github/workflows/cherry-pick-ci.yml
@@ -104,35 +104,45 @@ jobs:
           echo "✅ All commits cherry-picked."
 
       - name: Decode Secrets Keystore Set and Oauth2 to Env
+        env:
+          # Secrets arrive as environment variables. They must not be pasted into
+          # the script text, because bash then parses them as source: any $,
+          # backtick, quote or newline inside a password changes or truncates the
+          # value before it is ever used, and jarsigner then blames the password.
+          S_KEYSTORE_SET: ${{ secrets.KEYSTORE_SET }}
+          S_KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          S_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          S_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          S_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          S_GDRIVE_OAUTH2: ${{ secrets.GDRIVE_OAUTH2 }}
         run: |
-          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+          # The heredoc form of GITHUB_ENV keeps any value intact, newlines
+          # included. The delimiter is random so that no value can close the
+          # block early and add variables of its own.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit() { printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"; }
+          # Values cut out of KEYSTORE_SET are not registered secrets, so the
+          # runner does not hide them in the log unless we ask it to.
+          emit_masked() { echo "::add-mask::$2"; emit "$1" "$2"; }
+
+          if [ -n "$S_KEYSTORE_SET" ]; then
             echo "🔐 Decoding KEYSTORE_SET..."
-            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+            DECODED=$(printf '%s' "$S_KEYSTORE_SET" | base64 -d)
 
-            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
-            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
-            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
-            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
-
-            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
-            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
-
-            echo "::add-mask::$KEYSTORE_BASE64"
-            echo "::add-mask::$KEYSTORE_PASSWORD"
-            echo "::add-mask::$KEY_ALIAS"
-            echo "::add-mask::$KEY_PASSWORD"
+            emit_masked KEYSTORE_BASE64   "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+            emit_masked KEYSTORE_PASSWORD "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+            emit_masked KEY_ALIAS         "$(printf '%s' "$DECODED" | cut -d'|' -f3)"
+            emit_masked KEY_PASSWORD      "$(printf '%s' "$DECODED" | cut -d'|' -f4)"
 
             echo "✅ Keystore parameters extracted from KEYSTORE_SET"
           else
             echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
-            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+            emit KEYSTORE_BASE64   "$S_KEYSTORE_BASE64"
+            emit KEYSTORE_PASSWORD "$S_KEYSTORE_PASSWORD"
+            emit KEY_ALIAS         "$S_KEY_ALIAS"
+            emit KEY_PASSWORD      "$S_KEY_PASSWORD"
           fi
-          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
+          emit GDRIVE_OAUTH2 "$S_GDRIVE_OAUTH2"
 
       - name: Check Secrets
         run: |
@@ -197,18 +207,20 @@ jobs:
 
       - name: Decode GDrive OAuth2 secrets
         run: |
+          # GDRIVE_OAUTH2 is already in the environment from the decode step
+          # above, so nothing has to be pasted into the script text here either.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit_masked() {
+            echo "::add-mask::$2"
+            printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"
+          }
+
           echo "🔐 Decoding GDRIVE_OAUTH2..."
-          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
-          
-          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
-          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-          
-          echo "::add-mask::$GDRIVE_CLIENT_ID"
-          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-          
-          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
-          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
-          
+          DECODED=$(printf '%s' "$GDRIVE_OAUTH2" | base64 -d)
+
+          emit_masked GDRIVE_CLIENT_ID     "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+          emit_masked GDRIVE_REFRESH_TOKEN "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 
       - name: Retrieving Google Drive access token

--- a/.github/workflows/keystore-export.yml
+++ b/.github/workflows/keystore-export.yml
@@ -9,37 +9,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decode Secrets Keystore Set and Oauth2 ZIP_PASSWORD to Env
+        env:
+          # Secrets arrive as environment variables. They must not be pasted into
+          # the script text, because bash then parses them as source: any $,
+          # backtick, quote or newline inside a password changes or truncates the
+          # value before it is ever used. Here that value is also written into
+          # keyStoreInfo.txt, so a mangled one is handed back to the user as the
+          # password of record for their signing key.
+          S_KEYSTORE_SET: ${{ secrets.KEYSTORE_SET }}
+          S_KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          S_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          S_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          S_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          S_GDRIVE_OAUTH2: ${{ secrets.GDRIVE_OAUTH2 }}
+          S_ZIP_PASSWORD: ${{ secrets.ZIP_PASSWORD }}
         run: |
-          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+          # The heredoc form of GITHUB_ENV keeps any value intact, newlines
+          # included. The delimiter is random so that no value can close the
+          # block early and add variables of its own.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit() { printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"; }
+          # Values cut out of KEYSTORE_SET are not registered secrets, so the
+          # runner does not hide them in the log unless we ask it to.
+          emit_masked() { echo "::add-mask::$2"; emit "$1" "$2"; }
+
+          if [ -n "$S_KEYSTORE_SET" ]; then
             echo "🔐 Decoding KEYSTORE_SET..."
-            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+            DECODED=$(printf '%s' "$S_KEYSTORE_SET" | base64 -d)
 
-            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
-            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
-            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
-            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
-
-            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
-            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
-            echo "KEYSTORE_SET=${{ secrets.KEYSTORE_SET }}" >> $GITHUB_ENV
-
-            echo "::add-mask::$KEYSTORE_BASE64"
-            echo "::add-mask::$KEYSTORE_PASSWORD"
-            echo "::add-mask::$KEY_ALIAS"
-            echo "::add-mask::$KEY_PASSWORD"
+            emit_masked KEYSTORE_BASE64   "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+            emit_masked KEYSTORE_PASSWORD "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+            emit_masked KEY_ALIAS         "$(printf '%s' "$DECODED" | cut -d'|' -f3)"
+            emit_masked KEY_PASSWORD      "$(printf '%s' "$DECODED" | cut -d'|' -f4)"
+            emit KEYSTORE_SET "$S_KEYSTORE_SET"
 
             echo "✅ Keystore parameters extracted from KEYSTORE_SET"
           else
             echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
-            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+            emit KEYSTORE_BASE64   "$S_KEYSTORE_BASE64"
+            emit KEYSTORE_PASSWORD "$S_KEYSTORE_PASSWORD"
+            emit KEY_ALIAS         "$S_KEY_ALIAS"
+            emit KEY_PASSWORD      "$S_KEY_PASSWORD"
           fi
-          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
-          echo "ZIP_PASSWORD=${{ secrets.ZIP_PASSWORD }}" >> $GITHUB_ENV
+          emit GDRIVE_OAUTH2 "$S_GDRIVE_OAUTH2"
+          emit ZIP_PASSWORD "$S_ZIP_PASSWORD"
 
       - name: Check Secrets
         run: |
@@ -105,18 +118,20 @@ jobs:
 
       - name: Decode GDrive OAuth2 secrets
         run: |
+          # GDRIVE_OAUTH2 is already in the environment from the decode step
+          # above, so nothing has to be pasted into the script text here either.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit_masked() {
+            echo "::add-mask::$2"
+            printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"
+          }
+
           echo "🔐 Decoding GDRIVE_OAUTH2..."
-          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
-          
-          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
-          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-          
-          echo "::add-mask::$GDRIVE_CLIENT_ID"
-          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-          
-          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
-          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
-          
+          DECODED=$(printf '%s' "$GDRIVE_OAUTH2" | base64 -d)
+
+          emit_masked GDRIVE_CLIENT_ID     "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+          emit_masked GDRIVE_REFRESH_TOKEN "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 
       - name: Retrieving Google Drive access token

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -42,35 +42,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decode Secrets Keystore Set and Oauth2 to Env
+        env:
+          # Secrets arrive as environment variables. They must not be pasted into
+          # the script text, because bash then parses them as source: any $,
+          # backtick, quote or newline inside a password changes or truncates the
+          # value before it is ever used, and jarsigner then blames the password.
+          S_KEYSTORE_SET: ${{ secrets.KEYSTORE_SET }}
+          S_KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          S_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          S_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          S_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          S_GDRIVE_OAUTH2: ${{ secrets.GDRIVE_OAUTH2 }}
         run: |
-          if [ -n "${{ secrets.KEYSTORE_SET }}" ]; then
+          # The heredoc form of GITHUB_ENV keeps any value intact, newlines
+          # included. The delimiter is random so that no value can close the
+          # block early and add variables of its own.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit() { printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"; }
+          # Values cut out of KEYSTORE_SET are not registered secrets, so the
+          # runner does not hide them in the log unless we ask it to.
+          emit_masked() { echo "::add-mask::$2"; emit "$1" "$2"; }
+
+          if [ -n "$S_KEYSTORE_SET" ]; then
             echo "🔐 Decoding KEYSTORE_SET..."
-            DECODED=$(echo "${{ secrets.KEYSTORE_SET }}" | base64 -d)
+            DECODED=$(printf '%s' "$S_KEYSTORE_SET" | base64 -d)
 
-            KEYSTORE_BASE64=$(echo "$DECODED" | cut -d'|' -f1)
-            KEYSTORE_PASSWORD=$(echo "$DECODED" | cut -d'|' -f2)
-            KEY_ALIAS=$(echo "$DECODED" | cut -d'|' -f3)
-            KEY_PASSWORD=$(echo "$DECODED" | cut -d'|' -f4)
-
-            echo "KEYSTORE_BASE64=$KEYSTORE_BASE64" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD" >> $GITHUB_ENV
-            echo "KEY_ALIAS=$KEY_ALIAS" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=$KEY_PASSWORD" >> $GITHUB_ENV
-
-            echo "::add-mask::$KEYSTORE_BASE64"
-            echo "::add-mask::$KEYSTORE_PASSWORD"
-            echo "::add-mask::$KEY_ALIAS"
-            echo "::add-mask::$KEY_PASSWORD"
+            emit_masked KEYSTORE_BASE64   "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+            emit_masked KEYSTORE_PASSWORD "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+            emit_masked KEY_ALIAS         "$(printf '%s' "$DECODED" | cut -d'|' -f3)"
+            emit_masked KEY_PASSWORD      "$(printf '%s' "$DECODED" | cut -d'|' -f4)"
 
             echo "✅ Keystore parameters extracted from KEYSTORE_SET"
           else
             echo "ℹ️ KEYSTORE_SET not provided, using separate secrets."
-            echo "KEYSTORE_BASE64=${{ secrets.KEYSTORE_BASE64 }}" >> $GITHUB_ENV
-            echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-            echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-            echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
+            emit KEYSTORE_BASE64   "$S_KEYSTORE_BASE64"
+            emit KEYSTORE_PASSWORD "$S_KEYSTORE_PASSWORD"
+            emit KEY_ALIAS         "$S_KEY_ALIAS"
+            emit KEY_PASSWORD      "$S_KEY_PASSWORD"
           fi
-          echo "GDRIVE_OAUTH2=${{ secrets.GDRIVE_OAUTH2 }}" >> $GITHUB_ENV
+          emit GDRIVE_OAUTH2 "$S_GDRIVE_OAUTH2"
 
       - name: Check Secrets
         run: |
@@ -135,18 +145,20 @@ jobs:
 
       - name: Decode GDrive OAuth2 secrets
         run: |
+          # GDRIVE_OAUTH2 is already in the environment from the decode step
+          # above, so nothing has to be pasted into the script text here either.
+          DELIM="AAPS_EOF_$(openssl rand -hex 16)"
+          emit_masked() {
+            echo "::add-mask::$2"
+            printf '%s<<%s\n%s\n%s\n' "$1" "$DELIM" "$2" "$DELIM" >> "$GITHUB_ENV"
+          }
+
           echo "🔐 Decoding GDRIVE_OAUTH2..."
-          DECODED=$(echo "${{ secrets.GDRIVE_OAUTH2 }}" | base64 -d)
-          
-          GDRIVE_CLIENT_ID=$(echo "$DECODED" | cut -d'|' -f1)
-          GDRIVE_REFRESH_TOKEN=$(echo "$DECODED" | cut -d'|' -f2)
-          
-          echo "::add-mask::$GDRIVE_CLIENT_ID"
-          echo "::add-mask::$GDRIVE_REFRESH_TOKEN"
-          
-          echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID" >> $GITHUB_ENV
-          echo "GDRIVE_REFRESH_TOKEN=$GDRIVE_REFRESH_TOKEN" >> $GITHUB_ENV
-          
+          DECODED=$(printf '%s' "$GDRIVE_OAUTH2" | base64 -d)
+
+          emit_masked GDRIVE_CLIENT_ID     "$(printf '%s' "$DECODED" | cut -d'|' -f1)"
+          emit_masked GDRIVE_REFRESH_TOKEN "$(printf '%s' "$DECODED" | cut -d'|' -f2)"
+
           echo "✅ GDRIVE_CLIENT_ID and GDRIVE_REFRESH_TOKEN extracted from GDRIVE_OAUTH2"
 
       - name: Retrieving Google Drive access token


### PR DESCRIPTION
Rebased and extended version of #5064 by @GrantAdkins, who found the bug and wrote the fix. Credit for the diagnosis and the approach goes to them; this branch carries their change onto current `dev` and closes two gaps found while reviewing it.

## The bug

All five build workflows pasted secrets straight into the script text:

```yaml
echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
```

GitHub replaces `${{ }}` before bash runs, so bash reads the password as source code. Any `$`, backtick, quote or newline in a password changes or cuts short the value before it is ever used:

```console
$ P='mU3PftciJU&Xy$9zAb!c'                # 20 chars
$ eval "echo \"KEYSTORE_PASSWORD=$P\""
KEYSTORE_PASSWORD=mU3PftciJU&XyzAb!c      # 18 chars, $9 became nothing
```

jarsigner then fails with `Keystore was tampered with, or password was incorrect`, which blames the one input that was correct. A changed value also no longer matches the registered secret, so the runner can no longer hide it in the log.

`keystore-export.yml` is the worst case: it writes the password into `keyStoreInfo.txt` inside the exported zip, so a broken value is given back to the user as the recorded password of their signing key.

Only the free-form secrets are really at risk (`KEYSTORE_PASSWORD`, `KEY_PASSWORD`, `KEY_ALIAS`, `ZIP_PASSWORD`). `KEYSTORE_SET`, `KEYSTORE_BASE64` and `GDRIVE_OAUTH2` are base64, and that alphabet has no shell characters. They are moved over anyway so the whole step follows one rule.

## The fix

Secrets come in through `env:` and are written to `GITHUB_ENV` in heredoc form, which keeps any value as it is, newlines included. This is what the newer `ios-testflight.yml` already does.

Two things on top of #5064:

**A random heredoc delimiter.** #5064 used a fixed `__AAPS_EOF__`. A value that contains that line closes the block early, which is the same bug one level down. Same value, both versions:

```
fixed delimiter __AAPS_EOF__:
   KEYSTORE_PASSWORD = 'pw'
   INJECTED = 'yes'

random delimiter:
   KEYSTORE_PASSWORD = 'pw\n__AAPS_EOF__\nINJECTED=yes'
```

**The `Decode GDrive OAuth2 secrets` step too.** It had the same pattern and was not covered. It now reads `$GDRIVE_OAUTH2` from the environment, which the step above already sets. There is no `${{ secrets.* }}` left inside any `run:` body.

## Why the block is still duplicated five times

This looked like the moment to pull it into a composite action. It is not. A local action (`uses: ./.github/actions/...`) can only be read from a checked-out tree, and in four of the five workflows the decode step runs *before* `actions/checkout`. The checkout that follows is of any PR ref (`pr-ci.yml`) or of a tree with upstream commits already cherry-picked in (`cherry-pick-ci.yml`), so the shared file would come from a tree the PR author controls and would run with the signing secrets in scope. Today the script text comes from the workflow file at the dispatched ref, which cannot be changed that way. A reusable workflow does not help either, because it runs as a separate job and its env vars do not reach the caller.

So fixes to this block have to be applied five times by hand. That is the cheaper problem.

## Testing

- All five files parse, each still has one decode step and one GDrive step with the expected `env:` keys.
- The rewritten step body was run against hostile values in bash, 13/13 pass: the reported `mU3PftciJU&Xy$9zAb!c`, a value with every shell metacharacter, values with newlines, a value trying to close the heredoc, values that look like `echo` flags (`-n`, `-e\t...`), and the `KEYSTORE_SET` split path.
- Downstream behaviour is unchanged. The exported variable names are the same, and `keystore-export.yml`'s later `[ -n "$KEYSTORE_SET" ]` still sees an unset variable on the fallback path.

Still worth one real dispatch of `branch-ci.yml` with a `$` in `KEYSTORE_PASSWORD` before this is trusted.

Closes #5064.
