### PR TITLE
Use Android live updates for the persistent notification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -231,6 +231,7 @@ dependencies {
             "pumpcontrolImplementation"(project(it.path))
         }
 
+    implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.process)
 
     testImplementation(project(":shared:tests"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
 
     <uses-permission-sdk-23 android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
+
     <!-- Remove legacy storage permissions pulled in by library manifest merge.
          App uses scoped storage / SAF (minSdk 31). -->
     <uses-permission

--- a/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
+++ b/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
@@ -170,13 +170,23 @@ class PersistentNotificationPlugin @Inject constructor(
         if (profileFunction.isProfileValid("Notification")) {
             val lastBG = iobCobCalculator.ads.lastBg()
             val glucoseStatus = glucoseStatusProvider.glucoseStatusData
+            val units = profileFunction.getUnits()
             if (lastBG != null) {
                 bgStatusChipText = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated)
-                bgMetric = Metric(
+                val fromMgdlToUnits = profileUtil.fromMgdlToUnits(lastBG.recalculated)
+                val metricValue: Metric.MetricValue = if (units == GlucoseUnit.MMOL) {
                     FixedFloat(
-                        profileUtil.fromMgdlToUnits(lastBG.recalculated).toFloat(),
-                        profileFunction.getUnits().displayLabel
-                    ),
+                        fromMgdlToUnits.round(1).toFloat(),
+                        units.displayLabel
+                    )
+                } else {
+                    FixedInt(
+                        fromMgdlToUnits.toInt(),
+                        units.displayLabel
+                    )
+                }
+                bgMetric = Metric(
+                    metricValue,
                     "BG"
                 )
                 val trendSymbol = (trendCalculator.getTrendArrow(iobCobCalculator.ads)
@@ -230,7 +240,6 @@ class PersistentNotificationPlugin @Inject constructor(
             // Build a RemoteInput for receiving voice input from devices
             val remoteInput = RemoteInput.Builder(EXTRA_VOICE_REPLY).build()
             // Build Android Auto message: IOB • COB • Target • Profile
-            val units = profileFunction.getUnits()
             var aaTarget = ""
             val tempTarget = persistenceLayer.getTemporaryTargetActiveAt(dateUtil.now())
             if (tempTarget != null) {

--- a/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
+++ b/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
@@ -5,7 +5,11 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
+import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.Metric
+import androidx.core.app.NotificationCompat.Metric.FixedFloat
+import androidx.core.app.NotificationCompat.MetricStyle
 import androidx.core.app.RemoteInput
 import app.aaps.core.data.model.GlucoseUnit
 import app.aaps.core.data.model.TrendArrow
@@ -160,14 +164,24 @@ class PersistentNotificationPlugin @Inject constructor(
         var line1: String?
         var line2: String? = null
         var line3: String? = null
+        var bgStatusChipText: String? = null
+        var bgMetric: Metric? = null
         var unreadConversationBuilder: NotificationCompat.CarExtender.UnreadConversation.Builder? = null
         if (profileFunction.isProfileValid("Notification")) {
             val lastBG = iobCobCalculator.ads.lastBg()
             val glucoseStatus = glucoseStatusProvider.glucoseStatusData
             if (lastBG != null) {
+                bgStatusChipText = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated)
+                bgMetric = Metric(
+                    FixedFloat(
+                        profileUtil.fromMgdlToUnits(lastBG.recalculated).toFloat(),
+                        profileFunction.getUnits().displayLabel
+                    ),
+                    "BG"
+                )
                 val trendSymbol = (trendCalculator.getTrendArrow(iobCobCalculator.ads)
                     ?.takeIf { it != TrendArrow.NONE } ?: TrendArrow.FLAT).symbol
-                line1 = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated) + " " + trendSymbol
+                line1 = "$bgStatusChipText $trendSymbol"
                 if (glucoseStatus != null) {
                     line1 += " " + profileUtil.fromMgdlToSignedStringInUnits(glucoseStatus.delta)
                 } else {
@@ -250,6 +264,11 @@ class PersistentNotificationPlugin @Inject constructor(
         if (includeAuto) lastAutoNotificationContent = content
         val builder = NotificationCompat.Builder(context, notificationHolder.channelID)
         builder.setOngoing(true)
+        applyLiveUpdate(
+            builder = builder,
+            bgStatusChipText = bgStatusChipText,
+            bgMetric = bgMetric
+        )
         builder.setOnlyAlertOnce(true)
         builder.setCategory(NotificationCompat.CATEGORY_STATUS)
         builder.setSmallIcon(iconsProvider.getNotificationIcon())
@@ -270,5 +289,24 @@ class PersistentNotificationPlugin @Inject constructor(
         val notification = builder.build()
         mNotificationManager.notify(notificationHolder.notificationID, notification)
         notificationHolder.notification = notification
+    }
+
+    private fun applyLiveUpdate(
+        builder: NotificationCompat.Builder,
+        bgStatusChipText: String?,
+        bgMetric: Metric?
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) return
+        builder.setRequestPromotedOngoing(true)
+        if (!bgStatusChipText.isNullOrBlank()) {
+            builder.setShortCriticalText(bgStatusChipText)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN && bgMetric != null) {
+            builder.setStyle(
+                MetricStyle()
+                    .addMetric(bgMetric)
+                    .setCriticalMetric(0)
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
+++ b/app/src/main/kotlin/app/aaps/persistentNotification/PersistentNotificationPlugin.kt
@@ -166,6 +166,7 @@ class PersistentNotificationPlugin @Inject constructor(
         var line3: String? = null
         var bgStatusChipText: String? = null
         var bgMetric: Metric? = null
+        var metricValue: Metric.MetricValue? = null
         var unreadConversationBuilder: NotificationCompat.CarExtender.UnreadConversation.Builder? = null
         if (profileFunction.isProfileValid("Notification")) {
             val lastBG = iobCobCalculator.ads.lastBg()
@@ -174,7 +175,7 @@ class PersistentNotificationPlugin @Inject constructor(
             if (lastBG != null) {
                 bgStatusChipText = profileUtil.fromMgdlToStringInUnits(lastBG.recalculated)
                 val fromMgdlToUnits = profileUtil.fromMgdlToUnits(lastBG.recalculated)
-                val metricValue: Metric.MetricValue = if (units == GlucoseUnit.MMOL) {
+                metricValue = if (units == GlucoseUnit.MMOL) {
                     FixedFloat(
                         fromMgdlToUnits.round(1).toFloat(),
                         units.displayLabel
@@ -185,10 +186,6 @@ class PersistentNotificationPlugin @Inject constructor(
                         units.displayLabel
                     )
                 }
-                bgMetric = Metric(
-                    metricValue,
-                    "BG"
-                )
                 val trendSymbol = (trendCalculator.getTrendArrow(iobCobCalculator.ads)
                     ?.takeIf { it != TrendArrow.NONE } ?: TrendArrow.FLAT).symbol
                 line1 = "$bgStatusChipText $trendSymbol"
@@ -213,6 +210,12 @@ class PersistentNotificationPlugin @Inject constructor(
             val cobInfo = iobCobCalculator.getCobInfo("PersistentNotificationPlugin")
             line2 =
                 rh.gs(app.aaps.core.ui.R.string.treatments_iob_label_string) + " " + rh.gs(R.string.notification_iob_short, bolusIob.iob + basalIob.basaliob) + " • " + rh.gs(app.aaps.core.ui.R.string.cob) + ": " + cobInfo.generateCOBString(decimalFormatter)
+            metricValue?.let {
+                bgMetric = Metric(
+                    it,
+                    line2,
+                )
+            }
             line3 = profileName
             /// For Android Auto
             val msgReadIntent = Intent()


### PR DESCRIPTION
For devices running android 17 (sdk 37) and above, we can use the Android live udpates feature to show the persistent notification. More info in the android documentation about live updates: https://developer.android.com/develop/ui/compose/notifications/live-update.

This PR takes the existing persistent notification in the `PersistentNotificationPlugin` and applies live update using the `NotificationCompat.MetricStyle` to show the BG as a `NotificationCompat.Metric` with a `FixedFloat` or `FixedInt` value and the associated unit `"BG (mg/dL)"` or `"BG (mmol/L)"`.

The existing notificataion data is still shown in the notification.

The live update shows a chip in the status bar:
|mmol/L|mg/dL|
|---|---|
|<img width="375" height="72" alt="image" src="https://github.com/user-attachments/assets/7d73bc41-ecbb-4272-ba07-f1f8287cc4bc" />|<img width="378" height="67" alt="image" src="https://github.com/user-attachments/assets/f9231638-af50-4e71-8a9b-992f1ebd05bb" />|
<img width="200" alt="image" src="https://github.com/user-attachments/assets/93561d31-3e30-482a-b9d1-e639a0411517" />

And the notification shows as a regular notification in the notification list, but as a 'live update' notification:
|mmol/L|mg/dL|
|---|---|
<img width="200" alt="image" src="https://github.com/user-attachments/assets/1659c39a-ec2b-4237-98f9-70fe026282a0" />|<img width="200" alt="image" src="https://github.com/user-attachments/assets/48a6cda9-9016-4a6e-915d-b1f3361bdf2b" />|

And on the lockscreen it appears as a persistent live update, which updates with the persistent notification:
|mmol/L|mg/dL|
|---|---|
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c967947a-a68e-4ecd-a4c7-711b8ab53495" />|<img width="200" alt="image" src="https://github.com/user-attachments/assets/18fba736-3308-4181-a363-3856e407b1e6" />|

Works on android auto:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/1c02df42-2e33-4f1d-8ad0-c26f9ca46d43" />


This PR supersedes #5097